### PR TITLE
APS-725 Add Seed Job to duplicate an application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -268,6 +268,7 @@ class ApplicationsController(
           isInapplicable = body.isInapplicable,
           noticeType = body.noticeType,
         ),
+        userForRequest = user,
       )
 
       is UpdateTemporaryAccommodationApplication -> applicationService.updateTemporaryAccommodationApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApproved
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateTemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
@@ -167,7 +166,6 @@ class ApplicationsController(
   @Transactional
   override fun applicationsPost(body: NewApplication, xServiceName: ServiceName?, createWithRisks: Boolean?):
     ResponseEntity<Application> {
-    val deliusPrincipal = httpAuthService.getDeliusPrincipalOrThrow()
     val user = userService.getUserForRequest()
 
     val personInfo =
@@ -185,7 +183,6 @@ class ApplicationsController(
       xServiceName ?: ServiceName.approvedPremises,
       personInfo,
       user,
-      deliusPrincipal,
       body,
       createWithRisks,
     )
@@ -212,7 +209,6 @@ class ApplicationsController(
     serviceName: ServiceName,
     personInfo: PersonInfoResult.Success.Full,
     user: UserEntity,
-    deliusPrincipal: AuthAwareAuthenticationToken,
     body: NewApplication,
     createWithRisks: Boolean?,
   ): ValidatableActionResult<ApplicationEntity> = when (serviceName) {
@@ -220,7 +216,6 @@ class ApplicationsController(
       applicationService.createApprovedPremisesApplication(
         personInfo.offenderDetailSummary,
         user,
-        deliusPrincipal.token.tokenValue,
         body.convictionId,
         body.deliusEventNumber,
         body.offenceId,
@@ -233,7 +228,6 @@ class ApplicationsController(
           applicationService.createTemporaryAccommodationApplication(
             body.crn,
             user,
-            deliusPrincipal.token.tokenValue,
             body.convictionId,
             body.deliusEventNumber,
             body.offenceId,
@@ -383,7 +377,6 @@ class ApplicationsController(
           applicationId,
           submitApplication,
           username,
-          deliusPrincipal.token.tokenValue,
           apAreaId,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
@@ -73,7 +73,7 @@ class PeopleController(
   override fun peopleCrnRisksGet(crn: String): ResponseEntity<PersonRisks> {
     val principal = httpAuthService.getDeliusPrincipalOrThrow()
 
-    val risks = when (val risksResult = offenderService.getRiskByCrn(crn, principal.token.tokenValue, principal.name)) {
+    val risks = when (val risksResult = offenderService.getRiskByCrn(crn, principal.name)) {
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(crn, "Person")
       is AuthorisableActionResult.Success -> risksResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
@@ -1,0 +1,120 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
+import java.util.UUID
+
+/**
+ * Creates a duplicated version of an existing application, up to the point of submission.
+ *
+ * There are limitations to this approach:
+ *
+ * 1. Depending upon the age of the source application, the JSON data stored in 'data' may not be in the format
+ * expected by the latest version of the UI, and as such it may be not be possible to submit the application
+ * 2. The index offence event number for the source application must still be active, otherwise delius processing of events will fail
+ * 3. Unlike when a new application is created, fresh Risk data will not be retrieved from OASys.
+ * It is the user's responsibility to ensure this is up-to-date
+ *
+ * Given this, the seed job should be used judiciously and only in situations where it is not practical/reasonable
+ * for the user to recreate the application manually.
+ *
+ * Using this seed job against a given application should always be tested in pre-prod to ensure that all the pages
+ * of the application can be traversed, and the application can be submitted.
+ */
+class Cas1DuplicateApplicationSeedJob(
+  fileName: String,
+  private val applicationService: ApplicationService,
+  private val offenderService: OffenderService,
+) : SeedJob<Cas1DuplicateApplicationSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "application_id",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = Cas1DuplicateApplicationSeedCsvRow(
+    applicationId = UUID.fromString(columns["application_id"]!!.trim()),
+  )
+
+  override fun processRow(row: Cas1DuplicateApplicationSeedCsvRow) {
+    val applicationIdToDuplicate = row.applicationId
+
+    log.info("Duplicating application $applicationIdToDuplicate")
+
+    val sourceApplication = applicationService.getApplication(applicationIdToDuplicate)
+      ?: error("Could not find application if id $applicationIdToDuplicate")
+
+    if (sourceApplication !is ApprovedPremisesApplicationEntity) {
+      error("Application $applicationIdToDuplicate is not cas 1")
+    }
+
+    val personInfo =
+      when (
+        val personInfoResult = offenderService.getInfoForPerson(
+          crn = sourceApplication.crn,
+          deliusUsername = null,
+          ignoreLaoRestrictions = true,
+        )
+      ) {
+        is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> throw NotFoundProblem(
+          personInfoResult.crn,
+          "Offender",
+        )
+
+        is PersonInfoResult.Success.Restricted -> throw ForbiddenProblem()
+        is PersonInfoResult.Success.Full -> personInfoResult
+      }
+
+    val createdByUser = sourceApplication.createdByUser
+
+    val newApplicationEntity = extractEntityFromValidatableActionResult(
+      applicationService.createApprovedPremisesApplication(
+        offenderDetails = personInfo.offenderDetailSummary,
+        user = createdByUser,
+        convictionId = sourceApplication.convictionId,
+        deliusEventNumber = sourceApplication.eventNumber,
+        offenceId = sourceApplication.offenceId,
+        createWithRisks = true,
+      ),
+    )
+
+    applicationService.updateApprovedPremisesApplication(
+      applicationId = newApplicationEntity.id,
+      updateFields = ApplicationService.Cas1ApplicationUpdateFields(
+        isWomensApplication = sourceApplication.isWomensApplication,
+        isPipeApplication = null,
+        isEmergencyApplication = sourceApplication.isEmergencyApplication,
+        isEsapApplication = null,
+        apType = sourceApplication.apType.asApiType(),
+        releaseType = sourceApplication.releaseType,
+        arrivalDate = sourceApplication.arrivalDate?.toLocalDate(),
+        data = sourceApplication.data!!,
+        isInapplicable = sourceApplication.isInapplicable,
+        noticeType = sourceApplication.noticeType,
+      ),
+      createdByUser,
+    )
+
+    applicationService.addNoteToApplication(
+      applicationId = newApplicationEntity.id,
+      note = "Application automatically created by Application Support by duplicating existing application ${sourceApplication.id}",
+      user = null,
+    )
+
+    log.info("Have duplicated application $applicationIdToDuplicate as $newApplicationEntity.id")
+  }
+}
+
+data class Cas1DuplicateApplicationSeedCsvRow(
+  val applicationId: UUID,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -237,7 +237,6 @@ class ApplicationService(
   fun createApprovedPremisesApplication(
     offenderDetails: OffenderDetailSummary,
     user: UserEntity,
-    jwt: String,
     convictionId: Long?,
     deliusEventNumber: String?,
     offenceId: String?,
@@ -269,7 +268,7 @@ class ApplicationService(
     var riskRatings: PersonRisks? = null
 
     if (createWithRisks == true) {
-      val riskRatingsResult = offenderService.getRiskByCrn(crn, jwt, user.deliusUsername)
+      val riskRatingsResult = offenderService.getRiskByCrn(crn, user.deliusUsername)
 
       riskRatings = when (riskRatingsResult) {
         is AuthorisableActionResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"
@@ -359,7 +358,6 @@ class ApplicationService(
   fun createTemporaryAccommodationApplication(
     crn: String,
     user: UserEntity,
-    jwt: String,
     convictionId: Long?,
     deliusEventNumber: String?,
     offenceId: String?,
@@ -402,7 +400,7 @@ class ApplicationService(
         var riskRatings: PersonRisks? = null
 
         if (createWithRisks == true) {
-          val riskRatingsResult = offenderService.getRiskByCrn(crn, jwt, user.deliusUsername)
+          val riskRatingsResult = offenderService.getRiskByCrn(crn, user.deliusUsername)
 
           riskRatings = when (riskRatingsResult) {
             is AuthorisableActionResult.NotFound ->
@@ -687,7 +685,6 @@ class ApplicationService(
     applicationId: UUID,
     submitApplication: SubmitApprovedPremisesApplication,
     username: String,
-    jwt: String,
     apAreaId: UUID?,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     var application = applicationRepository.findByIdOrNullWithWriteLock(
@@ -789,7 +786,7 @@ class ApplicationService(
       this.noticeType = getNoticeType(submitApplication.noticeType, submitApplication.isEmergencyApplication, this)
     }
 
-    cas1ApplicationDomainEventService.applicationSubmitted(application, submitApplication, username, jwt)
+    cas1ApplicationDomainEventService.applicationSubmitted(application, submitApplication, username)
     assessmentService.createApprovedPremisesAssessment(application)
 
     application = applicationRepository.save(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -499,6 +499,7 @@ class ApplicationService(
   fun updateApprovedPremisesApplication(
     applicationId: UUID,
     updateFields: Cas1ApplicationUpdateFields,
+    userForRequest: UserEntity,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     val application = applicationRepository.findByIdOrNull(applicationId)?.let(jsonSchemaService::checkSchemaOutdated)
       ?: return AuthorisableActionResult.NotFound()
@@ -517,9 +518,7 @@ class ApplicationService(
       )
     }
 
-    val user = userService.getUserForRequest()
-
-    if (application.createdByUser != user) {
+    if (application.createdByUser != userForRequest) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -494,7 +494,13 @@ class OffenderService(
   ) = communityApiClient.getDocument(crn, documentId, outputStream)
 
   @SuppressWarnings("CyclomaticComplexMethod", "NestedBlockDepth", "ReturnCount")
-  fun getInfoForPerson(crn: String, deliusUsername: String, ignoreLaoRestrictions: Boolean): PersonInfoResult {
+  fun getInfoForPerson(
+    crn: String,
+    deliusUsername: String?,
+    ignoreLaoRestrictions: Boolean,
+  ): PersonInfoResult {
+    check(ignoreLaoRestrictions || deliusUsername != null) { "If ignoreLao is false, delius username must be provided " }
+
     val offenderResponse = offenderDetailsDataSource.getOffenderDetailSummary(crn)
 
     val offender = when (offenderResponse) {
@@ -512,7 +518,7 @@ class OffenderService(
     if (!ignoreLaoRestrictions) {
       if (offender.currentExclusion || offender.currentRestriction) {
         val access =
-          when (val accessResponse = offenderDetailsDataSource.getUserAccessForOffenderCrn(deliusUsername, crn)) {
+          when (val accessResponse = offenderDetailsDataSource.getUserAccessForOffenderCrn(deliusUsername!!, crn)) {
             is ClientResult.Success -> accessResponse.body
             is ClientResult.Failure.StatusCode -> {
               if (accessResponse.status.equals(HttpStatus.FORBIDDEN)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -271,10 +271,6 @@ class OffenderService(
     return AuthorisableActionResult.Success(inmateDetail)
   }
 
-  @Deprecated(message = "The 'jwt' parameter is no longer needed.", replaceWith = ReplaceWith(expression = "getRiskByCrn(crn, userDistinguishedName)"))
-  fun getRiskByCrn(crn: String, jwt: String, userDistinguishedName: String): AuthorisableActionResult<PersonRisks> =
-    getRiskByCrn(crn, userDistinguishedName)
-
   fun getRiskByCrn(crn: String, deliusUsername: String): AuthorisableActionResult<PersonRisks> {
     return when (getOffenderByCrn(crn, deliusUsername)) {
       is AuthorisableActionResult.NotFound -> AuthorisableActionResult.NotFound()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -49,6 +49,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingAdhocPropertySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DomainEventReplaySeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DuplicateApplicationSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1WithdrawPlacementRequestSeedJob
@@ -257,6 +258,12 @@ class SeedService(
         SeedFileType.approvedPremisesReplayDomainEvents -> Cas1DomainEventReplaySeedJob(
           filename,
           applicationContext.getBean(DomainEventService::class.java),
+        )
+
+        SeedFileType.approvedPremisesDuplicateApplication -> Cas1DuplicateApplicationSeedJob(
+          filename,
+          applicationContext.getBean(ApplicationService::class.java),
+          applicationContext.getBean(OffenderService::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -48,7 +48,6 @@ class Cas1ApplicationDomainEventService(
     application: ApprovedPremisesApplicationEntity,
     submitApplication: SubmitApprovedPremisesApplication,
     username: String,
-    jwt: String,
   ) {
     val domainEventId = UUID.randomUUID()
     val eventOccurredAt = OffsetDateTime.now()
@@ -70,7 +69,7 @@ class Cas1ApplicationDomainEventService(
       }
 
     val risks =
-      when (val riskResult = offenderService.getRiskByCrn(application.crn, jwt, username)) {
+      when (val riskResult = offenderService.getRiskByCrn(application.crn, username)) {
         is AuthorisableActionResult.Success -> riskResult.entity
         is AuthorisableActionResult.Unauthorised ->
           throw RuntimeException("Unable to get Risks when creating Application Submitted Domain Event: Unauthorised")

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3625,6 +3625,7 @@ components:
         - approved_premises_redact_assessment_details
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
+        - approved_premises_duplicate_application
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8267,6 +8267,7 @@ components:
         - approved_premises_redact_assessment_details
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
+        - approved_premises_duplicate_application
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4190,6 +4190,7 @@ components:
         - approved_premises_redact_assessment_details
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
+        - approved_premises_duplicate_application
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3716,6 +3716,7 @@ components:
         - approved_premises_redact_assessment_details
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
+        - approved_premises_duplicate_application
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedTestBase.kt
@@ -4,6 +4,7 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
@@ -25,16 +26,21 @@ abstract class SeedTestBase : IntegrationTestBase() {
   lateinit var mockSeedLogger: SeedLogger
   protected val logEntries = mutableListOf<LogEntry>()
 
+  private val log = LoggerFactory.getLogger(this::class.java)
+
   @BeforeEach
   fun setUp() {
     every { mockSeedLogger.info(any()) } answers {
       logEntries += LogEntry(it.invocation.args[0] as String, "info", null)
+      log.info(it.invocation.args[0] as String)
     }
     every { mockSeedLogger.error(any()) } answers {
       logEntries += LogEntry(it.invocation.args[0] as String, "error", null)
+      log.error(it.invocation.args[0] as String)
     }
     every { mockSeedLogger.error(any(), any()) } answers {
       logEntries += LogEntry(it.invocation.args[0] as String, "error", it.invocation.args[1] as Throwable)
+      log.info(it.invocation.args[0] as String, it.invocation.args[1] as Throwable)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/SeedCas1DuplicateApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/SeedCas1DuplicateApplicationTest.kt
@@ -1,0 +1,143 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulNeedsDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DuplicateApplicationSeedCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
+import java.time.OffsetDateTime
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedCas1DuplicateApplicationTest : SeedTestBase() {
+
+  @Autowired
+  lateinit var jsonSchemaService: JsonSchemaService
+
+  @Test
+  fun `Duplicate application and adds note`() {
+    `Given a User` { applicant, _ ->
+      `Given an Offender` { offenderDetails, _ ->
+
+        val sourceApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
+          withCreatedByUser(applicant)
+          withApplicationSchema(jsonSchemaService.getNewestSchema(ApprovedPremisesApplicationJsonSchemaEntity::class.java))
+          withSubmittedAt(OffsetDateTime.now())
+          withNomsNumber(offenderDetails.otherIds.nomsNumber)
+          withApArea(
+            apAreaEntityFactory.produceAndPersist {
+              withEmailAddress("apAreaEmail@test.com")
+            },
+          )
+          withIsEmergencyApplication(true)
+          withReleaseType("licence")
+        }
+
+        APDeliusContext_mockSuccessfulTeamsManagingCaseCall(
+          offenderDetails.otherIds.crn,
+          ManagingTeamsResponse(
+            teamCodes = listOf("TEAM1"),
+          ),
+        )
+
+        APOASysContext_mockSuccessfulNeedsDetailsCall(
+          offenderDetails.otherIds.crn,
+          NeedsDetailsFactory().produce(),
+        )
+
+        withCsv(
+          "valid-csv",
+          rowsToCsv(
+            listOf(
+              Cas1DuplicateApplicationSeedCsvRow(
+                applicationId = sourceApplication.id,
+              ),
+            ),
+          ),
+        )
+
+        seedService.seedData(SeedFileType.approvedPremisesDuplicateApplication, "valid-csv")
+
+        val newApplication = approvedPremisesApplicationRepository.findAll()
+          .filter { it.crn == sourceApplication.crn }
+          .first { it.id != sourceApplication.id }
+
+        assertThat(newApplication.crn).isEqualTo(sourceApplication.crn)
+        assertThat(newApplication.createdByUser.id).isEqualTo(sourceApplication.createdByUser.id)
+        assertThat(newApplication.data).isEqualTo(sourceApplication.data)
+        assertThat(newApplication.document).isNull()
+        assertThat(newApplication.schemaVersion.id).isEqualTo(sourceApplication.schemaVersion.id)
+        assertThat(newApplication.createdAt).isWithinTheLastMinute()
+        assertThat(newApplication.submittedAt).isNull()
+        assertThat(newApplication.isWomensApplication).isEqualTo(sourceApplication.isWomensApplication)
+        assertThat(newApplication.isEmergencyApplication).isEqualTo(sourceApplication.isEmergencyApplication)
+        assertThat(newApplication.apType).isEqualTo(sourceApplication.apType)
+        assertThat(newApplication.isInapplicable).isNull()
+        assertThat(newApplication.isWithdrawn).isEqualTo(false)
+        assertThat(newApplication.withdrawalReason).isNull()
+        assertThat(newApplication.otherWithdrawalReason).isNull()
+        assertThat(newApplication.convictionId).isEqualTo(sourceApplication.convictionId)
+        assertThat(newApplication.eventNumber).isEqualTo(sourceApplication.eventNumber)
+        assertThat(newApplication.offenceId).isEqualTo(sourceApplication.offenceId)
+        assertThat(newApplication.nomsNumber).isEqualTo(sourceApplication.nomsNumber)
+        assertThat(newApplication.teamCodes).hasSize(1)
+        assertThat(newApplication.teamCodes.map { it.teamCode }).containsOnly("TEAM1")
+        assertThat(newApplication.placementRequests).isEmpty()
+        assertThat(newApplication.releaseType).isEqualTo(sourceApplication.releaseType)
+        assertThat(newApplication.sentenceType).isEqualTo(sourceApplication.sentenceType)
+        assertThat(newApplication.situation).isEqualTo(sourceApplication.situation)
+        assertThat(newApplication.arrivalDate).isEqualTo(sourceApplication.arrivalDate)
+        assertThat(newApplication.name).isEqualTo("${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}")
+        assertThat(newApplication.targetLocation).isEqualTo(sourceApplication.targetLocation)
+        assertThat(newApplication.status).isEqualTo(ApprovedPremisesApplicationStatus.STARTED)
+        assertThat(newApplication.inmateInOutStatusOnSubmission).isEqualTo(sourceApplication.inmateInOutStatusOnSubmission)
+        assertThat(newApplication.apArea).isNull()
+        assertThat(newApplication.applicantUserDetails).isEqualTo(sourceApplication.applicantUserDetails)
+        assertThat(newApplication.caseManagerIsNotApplicant).isEqualTo(sourceApplication.caseManagerIsNotApplicant)
+        assertThat(newApplication.caseManagerUserDetails).isEqualTo(sourceApplication.caseManagerUserDetails)
+        assertThat(newApplication.noticeType).isEqualTo(Cas1ApplicationTimelinessCategory.emergency)
+
+        assertThat(newApplication.isEsapApplication).isEqualTo(sourceApplication.isEsapApplication)
+        assertThat(newApplication.isPipeApplication).isEqualTo(sourceApplication.isPipeApplication)
+
+        val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(newApplication.id)
+        assertThat(notes).hasSize(1)
+        assertThat(notes)
+          .extracting("body")
+          .contains(
+            "Application automatically created by Application Support by duplicating existing application ${sourceApplication.id}",
+          )
+      }
+    }
+  }
+
+  private fun rowsToCsv(rows: List<Cas1DuplicateApplicationSeedCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "application_id",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.applicationId.toString())
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -935,22 +935,23 @@ class ApplicationServiceTest {
             isInapplicable = null,
             noticeType = Cas1ApplicationTimelinessCategory.standard,
           ),
+          userForRequest = user,
         ) is AuthorisableActionResult.NotFound,
       ).isTrue
     }
 
     @Test
     fun `updateApprovedPremisesApplication returns Unauthorised when application doesn't belong to request user`() {
-      every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
+      every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
+
+      val otherUser = UserEntityFactory()
         .withDeliusUsername(username)
         .withYieldedProbationRegion {
           ProbationRegionEntityFactory()
             .withYieldedApArea { ApAreaEntityFactory().produce() }
             .produce()
-        }
-        .produce()
-      every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
-      every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
+        }.produce()
 
       assertThat(
         applicationService.updateApprovedPremisesApplication(
@@ -967,6 +968,7 @@ class ApplicationServiceTest {
             isInapplicable = null,
             noticeType = Cas1ApplicationTimelinessCategory.standard,
           ),
+          userForRequest = otherUser,
         ) is AuthorisableActionResult.Unauthorised,
       ).isTrue
     }
@@ -993,6 +995,7 @@ class ApplicationServiceTest {
           isInapplicable = null,
           noticeType = null,
         ),
+        userForRequest = user,
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1026,6 +1029,7 @@ class ApplicationServiceTest {
           isInapplicable = null,
           noticeType = Cas1ApplicationTimelinessCategory.emergency,
         ),
+        userForRequest = user,
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1059,6 +1063,7 @@ class ApplicationServiceTest {
           isInapplicable = null,
           noticeType = null,
         ),
+        userForRequest = user,
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1102,6 +1107,7 @@ class ApplicationServiceTest {
           isInapplicable = false,
           noticeType = Cas1ApplicationTimelinessCategory.emergency,
         ),
+        userForRequest = user,
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1157,6 +1163,7 @@ class ApplicationServiceTest {
           isInapplicable = false,
           noticeType = Cas1ApplicationTimelinessCategory.emergency,
         ),
+        userForRequest = user,
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -1218,6 +1225,7 @@ class ApplicationServiceTest {
           isInapplicable = false,
           noticeType = null,
         ),
+        userForRequest = user,
       )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -319,7 +319,7 @@ class ApplicationServiceTest {
       ),
     )
 
-    val result = applicationService.createApprovedPremisesApplication(offenderDetails, user, "jwt", null, null, null)
+    val result = applicationService.createApprovedPremisesApplication(offenderDetails, user, null, null, null)
 
     assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
     result as ValidatableActionResult.FieldValidationError
@@ -388,11 +388,11 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, "jwt", username) } returns AuthorisableActionResult.Success(
+    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
       riskRatings,
     )
 
-    val result = applicationService.createApprovedPremisesApplication(offenderDetails, user, "jwt", 123, "1", "A12HI")
+    val result = applicationService.createApprovedPremisesApplication(offenderDetails, user, 123, "1", "A12HI")
 
     assertThat(result is ValidatableActionResult.Success).isTrue
     result as ValidatableActionResult.Success
@@ -426,7 +426,6 @@ class ApplicationServiceTest {
     val actionResult = applicationService.createTemporaryAccommodationApplication(
       crn,
       user,
-      "jwt",
       123,
       "1",
       "A12HI",
@@ -461,7 +460,6 @@ class ApplicationServiceTest {
     val actionResult = applicationService.createTemporaryAccommodationApplication(
       crn,
       user,
-      "jwt",
       123,
       "1",
       "A12HI",
@@ -500,7 +498,6 @@ class ApplicationServiceTest {
     val actionResult = applicationService.createTemporaryAccommodationApplication(
       crn,
       user,
-      "jwt",
       123,
       "1",
       "A12HI",
@@ -542,7 +539,6 @@ class ApplicationServiceTest {
     val actionResult = applicationService.createTemporaryAccommodationApplication(
       crn,
       user,
-      "jwt",
       null,
       null,
       null,
@@ -619,14 +615,13 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, "jwt", username) } returns AuthorisableActionResult.Success(
+    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
       riskRatings,
     )
 
     val actionResult = applicationService.createTemporaryAccommodationApplication(
       crn,
       user,
-      "jwt",
       123,
       "1",
       "A12HI",
@@ -703,14 +698,13 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, "jwt", username) } returns AuthorisableActionResult.Success(
+    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
       riskRatings,
     )
 
     val actionResult = applicationService.createTemporaryAccommodationApplication(
       crn,
       user,
-      "jwt",
       123,
       "1",
       "A12HI",
@@ -786,14 +780,13 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, "jwt", username) } returns AuthorisableActionResult.Success(
+    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
       riskRatings,
     )
 
     val actionResult = applicationService.createTemporaryAccommodationApplication(
       crn,
       user,
-      "jwt",
       123,
       "1",
       "A12HI",
@@ -869,14 +862,13 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, "jwt", username) } returns AuthorisableActionResult.Success(
+    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
       riskRatings,
     )
 
     val actionResult = applicationService.createTemporaryAccommodationApplication(
       crn,
       user,
-      "jwt",
       123,
       "1",
       "A12HI",
@@ -1484,7 +1476,6 @@ class ApplicationServiceTest {
           applicationId,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
           null,
         ) is AuthorisableActionResult.NotFound,
       ).isTrue
@@ -1509,7 +1500,6 @@ class ApplicationServiceTest {
           applicationId,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
           null,
         ) is AuthorisableActionResult.Unauthorised,
       ).isTrue
@@ -1534,7 +1524,6 @@ class ApplicationServiceTest {
         applicationId,
         submitApprovedPremisesApplication,
         username,
-        "jwt",
         null,
       )
 
@@ -1569,7 +1558,6 @@ class ApplicationServiceTest {
         applicationId,
         submitApprovedPremisesApplication,
         username,
-        "jwt",
         null,
       )
 
@@ -1620,7 +1608,6 @@ class ApplicationServiceTest {
         applicationId,
         submitApprovedPremisesApplication,
         username,
-        "jwt",
         null,
       )
 
@@ -1671,7 +1658,6 @@ class ApplicationServiceTest {
         applicationId,
         submitApprovedPremisesApplication,
         username,
-        "jwt",
         null,
       )
 
@@ -1738,7 +1724,6 @@ class ApplicationServiceTest {
           applicationId,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
           user.probationRegion.id,
         )
 
@@ -1771,7 +1756,6 @@ class ApplicationServiceTest {
           application,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
         )
       }
 
@@ -1834,7 +1818,6 @@ class ApplicationServiceTest {
           applicationId,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
           user.probationRegion.id,
         )
 
@@ -1862,7 +1845,6 @@ class ApplicationServiceTest {
           application,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
         )
       }
 
@@ -1922,7 +1904,6 @@ class ApplicationServiceTest {
           applicationId,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
           user.probationRegion.id,
         )
 
@@ -1952,7 +1933,6 @@ class ApplicationServiceTest {
           application,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
         )
       }
 
@@ -2034,7 +2014,6 @@ class ApplicationServiceTest {
           applicationId,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
           user.probationRegion.id,
         )
 
@@ -2092,7 +2071,6 @@ class ApplicationServiceTest {
         applicationId,
         submitApprovedPremisesApplication,
         username,
-        "jwt",
         user.probationRegion.id,
       )
 
@@ -2124,7 +2102,6 @@ class ApplicationServiceTest {
           application,
           submitApprovedPremisesApplication,
           username,
-          "jwt",
         )
       } returns Unit
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -250,14 +250,14 @@ class OffenderServiceTest {
   fun `getRisksByCrn returns NotFound result when Community API Client returns 404`() {
     every { mockOffenderDetailsDataSource.getOffenderDetailSummary("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.NOT_FOUND, null)
 
-    assertThat(offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") is AuthorisableActionResult.NotFound).isTrue
+    assertThat(offenderService.getRiskByCrn("a-crn", "distinguished.name") is AuthorisableActionResult.NotFound).isTrue
   }
 
   @Test
   fun `getRisksByCrn throws when Community API Client returns other non-2xx status code`() {
     every { mockOffenderDetailsDataSource.getOffenderDetailSummary("a-crn") } returns StatusCode(HttpMethod.GET, "/secure/offenders/crn/a-crn", HttpStatus.BAD_REQUEST, null)
 
-    val exception = assertThrows<RuntimeException> { offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") }
+    val exception = assertThrows<RuntimeException> { offenderService.getRiskByCrn("a-crn", "distinguished.name") }
     assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/a-crn: 400 BAD_REQUEST")
   }
 
@@ -275,7 +275,7 @@ class OffenderServiceTest {
     every { mockOffenderDetailsDataSource.getOffenderDetailSummary("a-crn") } returns ClientResult.Success(HttpStatus.OK, resultBody)
     every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrn("distinguished.name", "a-crn") } returns ClientResult.Success(HttpStatus.OK, accessBody)
 
-    assertThat(offenderService.getRiskByCrn("a-crn", "jwt", "distinguished.name") is AuthorisableActionResult.Unauthorised).isTrue
+    assertThat(offenderService.getRiskByCrn("a-crn", "distinguished.name") is AuthorisableActionResult.Unauthorised).isTrue
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationDomainEventServiceTest.kt
@@ -142,7 +142,6 @@ class Cas1ApplicationDomainEventServiceTest {
       every {
         mockOffenderService.getRiskByCrn(
           application.crn,
-          any(),
           user.deliusUsername,
         )
       } returns AuthorisableActionResult.Success(
@@ -182,7 +181,6 @@ class Cas1ApplicationDomainEventServiceTest {
         application,
         submitApprovedPremisesApplication,
         username,
-        "jwt",
       )
 
       verify(exactly = 1) {


### PR DESCRIPTION
Note the following Javadoc provided on the Seed Job Class:

Creates a duplicated version of an existing application, up to the point of submission.
 
There are limitations to this approach:

1. Depending upon the age of the source application, the JSON data stored in 'data' may not be in the format expected by the latest version of the UI, and as such it may be not be possible to submit the application
2. The index offence event number for the source application must still be active, otherwise delius processing of events will fail
3. Unlike when a new application is created, fresh Risk data will not be retrieved from OASys. It is the user's responsibility to ensure this is up-to-date

Given this, the seed job should be used judiciously and only in situations where it is not practical/reasonable for the user to recreate the application manually.

Using this seed job against a given application should always be tested in pre-prod to ensure that all the pages of the application can be traversed, and the application can be submitted.