### PR TITLE
APS-724 Increase prison api buffer size

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -258,8 +258,8 @@ case-notes-service-upstream-timeout-ms: 30000
 web-clients:
   # 0.7MB
   max-response-in-memory-size-bytes: 750000
-  # 1 MB
-  prison-api-max-response-in-memory-size-bytes: 1048576
+  # 2.5 MB
+  prison-api-max-response-in-memory-size-bytes: 2621440
 
 migration-job:
   throttle-enabled: true


### PR DESCRIPTION
This is to unblock a production issue for an application with a large number of alerts.

This is a short term fix and paging/limiting results and/or buffering efficiencies should be considered to resolve this correctly. A new endpoint would be needed on probation-integration context if paging/limiting was requried