### PR TITLE
CAS-336 Capture referral rejection reason for temporary accommodation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -187,7 +187,15 @@ class AssessmentController(
 
     val serializedData = objectMapper.writeValueAsString(assessmentRejection.document)
 
-    val assessmentAuthResult = assessmentService.rejectAssessment(user, assessmentId, serializedData, assessmentRejection.rejectionRationale)
+    val assessmentAuthResult =
+      assessmentService.rejectAssessment(
+        user,
+        assessmentId,
+        serializedData,
+        assessmentRejection.rejectionRationale,
+        assessmentRejection.referralRejectionReasonId,
+        assessmentRejection.isWithdrawn,
+      )
 
     val assessmentValidationResult = when (assessmentAuthResult) {
       is AuthorisableActionResult.Success -> assessmentAuthResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -342,6 +342,9 @@ class TemporaryAccommodationAssessmentEntity(
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   var summaryData: String,
   isWithdrawn: Boolean,
+  @ManyToOne
+  @JoinColumn(name = "referral_rejection_reason_id")
+  var referralRejectionReason: ReferralRejectionReasonEntity?,
   dueAt: OffsetDateTime?,
 ) : AssessmentEntity(
   id,

--- a/src/main/resources/db/migration/all/20240426124413__add_referral_rejection_reason_id_to_cas3_application.sql
+++ b/src/main/resources/db/migration/all/20240426124413__add_referral_rejection_reason_id_to_cas3_application.sql
@@ -1,0 +1,4 @@
+ALTER TABLE temporary_accommodation_assessments
+    ADD COLUMN referral_rejection_reason_id UUID;
+ALTER TABLE temporary_accommodation_assessments
+    ADD FOREIGN KEY (referral_rejection_reason_id) REFERENCES referral_rejection_reasons(id);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2729,6 +2729,11 @@ components:
           $ref: '#/components/schemas/AnyValue'
         rejectionRationale:
           type: string
+        referralRejectionReasonId:
+          type: string
+          format: uuid
+        isWithdrawn:
+          type: boolean
       required:
         - document
         - rejectionRationale

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7371,6 +7371,11 @@ components:
           $ref: '#/components/schemas/AnyValue'
         rejectionRationale:
           type: string
+        referralRejectionReasonId:
+          type: string
+          format: uuid
+        isWithdrawn:
+          type: boolean
       required:
         - document
         - rejectionRationale

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3294,6 +3294,11 @@ components:
           $ref: '#/components/schemas/AnyValue'
         rejectionRationale:
           type: string
+        referralRejectionReasonId:
+          type: string
+          format: uuid
+        isWithdrawn:
+          type: boolean
       required:
         - document
         - rejectionRationale

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2820,6 +2820,11 @@ components:
           $ref: '#/components/schemas/AnyValue'
         rejectionRationale:
           type: string
+        referralRejectionReasonId:
+          type: string
+          format: uuid
+        isWithdrawn:
+          type: boolean
       required:
         - document
         - rejectionRationale

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationAssessmentEntityFactory.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentCla
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -38,6 +39,7 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
   private var completedAt: Yielded<OffsetDateTime?> = { null }
   private var summaryData: Yielded<String> = { "{}" }
   private var dueAt: Yielded<OffsetDateTime?> = { null }
+  private var referralRejectionReason: Yielded<ReferralRejectionReasonEntity?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -130,6 +132,7 @@ class TemporaryAccommodationAssessmentEntityFactory : Factory<TemporaryAccommoda
     completedAt = this.completedAt(),
     summaryData = this.summaryData(),
     isWithdrawn = false,
+    referralRejectionReason = this.referralRejectionReason(),
     dueAt = this.dueAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentStateTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.util.UUID
 
 class AssessmentStateTest : IntegrationTestBase() {
   @Test
@@ -158,11 +159,19 @@ class AssessmentStateTest : IntegrationTestBase() {
   }
 
   private fun TemporaryAccommodationAssessmentEntity.reject(jwt: String) {
+    val referralRejectionReasonId = UUID.randomUUID()
+
+    referralRejectionReasonEntityFactory
+      .produceAndPersist {
+        withId(referralRejectionReasonId)
+        withIsActive(true)
+      }
+
     webTestClient.post()
       .uri("/assessments/${this.id}/rejection")
       .header("Authorization", "Bearer $jwt")
       .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .bodyValue(AssessmentRejection(document = {}, rejectionRationale = "Some reason or another"))
+      .bodyValue(AssessmentRejection(document = {}, rejectionRationale = "Some reason or another", referralRejectionReasonId, true))
       .exchange()
       .expectStatus()
       .is2xxSuccessful

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -46,6 +46,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -79,6 +80,7 @@ class AcceptAssessmentTest {
   private val assessmentRepositoryMock = mockk<AssessmentRepository>()
   private val assessmentClarificationNoteRepositoryMock = mockk<AssessmentClarificationNoteRepository>()
   private val assessmentReferralHistoryNoteRepositoryMock = mockk<AssessmentReferralHistoryNoteRepository>()
+  private val referralRejectionReasonRepositoryMock = mockk<ReferralRejectionReasonRepository>()
   private val jsonSchemaServiceMock = mockk<JsonSchemaService>()
   private val domainEventServiceMock = mockk<DomainEventService>()
   private val offenderServiceMock = mockk<OffenderService>()
@@ -99,6 +101,7 @@ class AcceptAssessmentTest {
     assessmentRepositoryMock,
     assessmentClarificationNoteRepositoryMock,
     assessmentReferralHistoryNoteRepositoryMock,
+    referralRejectionReasonRepositoryMock,
     jsonSchemaServiceMock,
     domainEventServiceMock,
     offenderServiceMock,


### PR DESCRIPTION
This PR [CAS-336](https://dsdmoj.atlassian.net/browse/CAS-336) is to:
- Extend the existing Api end point `/assessments/{assessmentId}/rejection` to accept the temporary accommodation parameters `referralRejectionReasonId` and `isWithdrawn`
- Save the referral assessment rejection reason in the DB

[CAS-336]: https://dsdmoj.atlassian.net/browse/CAS-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ