### PR TITLE
(APS-728) Allow a booking to be viewed if key worker no longer at premises

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
@@ -1,0 +1,96 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
+
+class StaffMemberServiceTest {
+  private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
+  private val staffMemberService = StaffMemberService(mockApDeliusContextApiClient)
+
+  private val qCode = "Qcode"
+
+  @Nested
+  inner class GetStaffMemberByCode {
+    @Test
+    fun `it returns a staff member`() {
+      val staffMembers = ContextStaffMemberFactory().produceMany().take(5).toList()
+
+      every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = StaffMembersPage(
+          content = staffMembers,
+        ),
+      )
+
+      val result = staffMemberService.getStaffMemberByCode(staffMembers[2].code, qCode)
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      result as AuthorisableActionResult.Success
+
+      assertThat(result.entity).isEqualTo(staffMembers[2])
+    }
+  }
+
+  @Test
+  fun `it returns Unauthorised when Delius returns Unauthorised`() {
+    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Failure.StatusCode(
+      HttpMethod.GET,
+      "/staff-members/code",
+      HttpStatus.UNAUTHORIZED,
+      body = null,
+    )
+
+    val result = staffMemberService.getStaffMemberByCode("code", qCode)
+
+    assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+  }
+
+  @Test
+  fun `it returns NotFound when Delius returns NotFound`() {
+    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Failure.StatusCode(
+      HttpMethod.GET,
+      "/staff-members/code",
+      HttpStatus.NOT_FOUND,
+      body = null,
+    )
+
+    val result = staffMemberService.getStaffMemberByCode("code", qCode)
+
+    assertThat(result is AuthorisableActionResult.NotFound).isTrue
+    result as AuthorisableActionResult.NotFound
+
+    assertThat(result.id).isEqualTo(qCode)
+    assertThat(result.entityType).isEqualTo("QCode")
+  }
+
+  @Test
+  fun `it returns a NotFound when a staff member for the QCode cannot me found`() {
+    val staffMembers = ContextStaffMemberFactory().produceMany().take(5).toList()
+
+    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Success(
+      status = HttpStatus.OK,
+      body = StaffMembersPage(
+        content = staffMembers,
+      ),
+    )
+
+    val result = staffMemberService.getStaffMemberByCode("code", qCode)
+
+    assertThat(result is AuthorisableActionResult.NotFound).isTrue
+    result as AuthorisableActionResult.NotFound
+
+    assertThat(result.id).isEqualTo("code")
+    assertThat(result.entityType).isEqualTo("Staff Code")
+  }
+}


### PR DESCRIPTION
If we can't find a keyworker for a specific booking, we want to fail silently rather than blowing up. As this is still somewhat of an issue, we still want to alert Sentry. Going forward, we'll want to handle when keyworkers leave a premises as well as be able to handle transfers etc.