### PR TITLE
APS-725 Reconfigure Tier Web Client to support seed job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -103,10 +103,10 @@ class WebClientConfiguration(
   @Bean(name = ["hmppsTierApiWebClient"])
   fun hmppsTierApiWebClient(
     clientRegistrations: ClientRegistrationRepository,
-    authorizedClients: OAuth2AuthorizedClientRepository,
+    authorizedClientManager: OAuth2AuthorizedClientManager,
     @Value("\${services.hmpps-tier.base-url}") hmppsTierApiBaseUrl: String,
   ): WebClient {
-    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
     oauth2Client.setDefaultClientRegistrationId("hmpps-tier")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
@@ -111,7 +111,7 @@ class Cas1DuplicateApplicationSeedJob(
       user = null,
     )
 
-    log.info("Have duplicated application $applicationIdToDuplicate as $newApplicationEntity.id")
+    log.info("Have duplicated application $applicationIdToDuplicate as ${newApplicationEntity.id}")
   }
 }
 


### PR DESCRIPTION
This commit reconfigures the Tier API Web Client to allow it to be used for requests originating from seed jobs (i.e. requests that didn’t originate from an API call the CAS API).

This is similar to the change made for Prisons API on commit 3709d82769b1da4917678cb61f68a8262c65e523