### PR TITLE
Fix timeline event type for CAS1

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -224,7 +224,7 @@ enum class DomainEventType(val typeName: String, val typeDescription: String, va
   APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED(
     Cas1EventType.requestForPlacementCreated.value,
     "An Approved Premises Request for Placement has been created",
-    TimelineEventType.approvedPremisesPlacementApplicationAllocated,
+    TimelineEventType.approvedPremisesRequestForPlacementCreated,
   ),
   CAS2_APPLICATION_SUBMITTED(
     Cas2EventType.applicationSubmitted.value,


### PR DESCRIPTION
APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED was incorrectly coded as a TimelineEventType.approvedPremisesPlacementApplicationAllocated