### PR TITLE
APS-558: Seed AP staff users

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApStaffUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApStaffUsersSeedJob.kt
@@ -5,7 +5,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-
+/**
+ * Seeds users, without touching roles and qualifications.
+ *
+ *  If you want to set roles and qualifications as part of
+ *  the seeding then look at UsersSeedJob.
+ */
 class ApStaffUsersSeedJob(
   fileName: String,
   private val userService: UserService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApStaffUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApStaffUsersSeedJob.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.util.UUID
+
+class ApStaffUsersSeedJob(
+  fileName: String,
+  private val userService: UserService,
+) : SeedJob<ApStaffUserSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "deliusUsername",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = ApStaffUserSeedCsvRow(
+    deliusUsername = columns["deliusUsername"]!!.trim().uppercase(),
+  )
+
+  @SuppressWarnings("TooGenericExceptionThrown", "TooGenericExceptionCaught")
+  override fun processRow(row: ApStaffUserSeedCsvRow) {
+    log.info("Processing AP Staff seeding for ${row.deliusUsername}")
+
+    val user = try {
+      userService.getExistingUserOrCreate(row.deliusUsername)
+    } catch (exception: Exception) {
+      throw RuntimeException("Could not get user ${row.deliusUsername}", exception)
+    }
+  }
+}
+
+data class ApStaffUserSeedCsvRow(
+  val deliusUsername: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApStaffUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApStaffUsersSeedJob.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
 
-import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class ApStaffUsersSeedJob(
   fileName: String,
   private val userService: UserService,
+  private val seedLogger: SeedLogger,
 ) : SeedJob<ApStaffUserSeedCsvRow>(
   id = UUID.randomUUID(),
   fileName = fileName,
@@ -14,7 +17,6 @@ class ApStaffUsersSeedJob(
     "deliusUsername",
   ),
 ) {
-  private val log = LoggerFactory.getLogger(this::class.java)
 
   override fun deserializeRow(columns: Map<String, String>) = ApStaffUserSeedCsvRow(
     deliusUsername = columns["deliusUsername"]!!.trim().uppercase(),
@@ -22,13 +24,21 @@ class ApStaffUsersSeedJob(
 
   @SuppressWarnings("TooGenericExceptionThrown", "TooGenericExceptionCaught")
   override fun processRow(row: ApStaffUserSeedCsvRow) {
-    log.info("Processing AP Staff seeding for ${row.deliusUsername}")
+    seedLogger.info("Processing AP Staff seeding for ${row.deliusUsername}")
 
     val user = try {
       userService.getExistingUserOrCreate(row.deliusUsername)
     } catch (exception: Exception) {
       throw RuntimeException("Could not get user ${row.deliusUsername}", exception)
     }
+    seedLogger.info(seedingReport(user))
+  }
+
+  private fun seedingReport(user: UserEntity): String {
+    val ageInMinutes = ChronoUnit.MINUTES.between(user.createdAt, OffsetDateTime.now())
+    val actionTaken = if (ageInMinutes > 1) "Found pre-existing" else "Seeded"
+
+    return "-> $actionTaken: ${user.deliusUsername} (created $ageInMinutes mins ago)"
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
@@ -6,7 +6,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import java.util.UUID
-
+/**
+ * Seeds users, along with their roles and qualifications.
+ *
+ *  NB: this clears roles and qualifications.
+ *
+ *  If you want to seed users without touching the pre-existing
+ *  roles/qualifications of pre-existing users, then consider
+ *  using ApStaffUsersSeedJob.
+ */
 class UsersSeedJob(
   fileName: String,
   private val useRolesForServices: List<ServiceName>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApStaffUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesBookingCancelSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesBookingSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApprovedPremisesOfflineApplicationsSeedJob
@@ -154,6 +155,10 @@ class SeedService(
         SeedFileType.user -> UsersSeedJob(
           filename,
           ServiceName.values().toList(),
+          applicationContext.getBean(UserService::class.java),
+        )
+        SeedFileType.approvedPremisesApStaffUsers -> ApStaffUsersSeedJob(
+          filename,
           applicationContext.getBean(UserService::class.java),
         )
         SeedFileType.nomisUsers -> NomisUsersSeedJob(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -160,6 +160,7 @@ class SeedService(
         SeedFileType.approvedPremisesApStaffUsers -> ApStaffUsersSeedJob(
           filename,
           applicationContext.getBean(UserService::class.java),
+          seedLogger,
         )
         SeedFileType.nomisUsers -> NomisUsersSeedJob(
           filename,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3616,6 +3616,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings
         - approved_premises_cancel_bookings

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8258,6 +8258,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings
         - approved_premises_cancel_bookings

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4181,6 +4181,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings
         - approved_premises_cancel_bookings

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3707,6 +3707,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings
         - approved_premises_cancel_bookings

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -69,6 +69,10 @@ class UserEntityFactory : Factory<UserEntity> {
     this.email = { email }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime?) = apply {
+    this.createdAt = { createdAt }
+  }
+
   fun withTelephoneNumber(telephoneNumber: String?) = apply {
     this.telephoneNumber = { telephoneNumber }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApStaffUsersSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApStaffUsersSeedJobTest.kt
@@ -1,0 +1,109 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.ApStaffUserSeedCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class APStaffUsersSeedJobTest : SeedTestBase() {
+  @Test
+  fun `Attempting to seed a non existent user logs an error`() {
+    CommunityAPI_mockNotFoundOffenderDetailsCall("INVALID-USER")
+
+    withCsv(
+      "invalid-user",
+      apStaffUserSeedCsvRowsToCsv(
+        listOf(
+          ApStaffUserSeedCsvRowFactory()
+            .withDeliusUsername("INVALID-USER")
+            .produce(),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesApStaffUsers, "invalid-user")
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message.contains("Error on row 1:") &&
+        it.throwable != null &&
+        it.throwable.cause != null &&
+        it.throwable.message!!.contains("Could not get user INVALID-USER") &&
+        it.throwable.cause!!.message!!.contains("Unable to complete GET request to /secure/staff/username/INVALID-USER")
+    }
+  }
+
+  @Test
+  fun `Attempting to seed a real but currently unknown user succeeds`() {
+    val probationRegion = probationRegionEntityFactory.produceAndPersist {
+      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+    }
+
+    val probationRegionDeliusMapping = probationAreaProbationRegionMappingFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+    }
+
+    CommunityAPI_mockSuccessfulStaffUserDetailsCall(
+      StaffUserDetailsFactory()
+        .withUsername("UNKNOWN-USER")
+        .withStaffIdentifier(6789)
+        .withProbationAreaCode(probationRegionDeliusMapping.probationAreaDeliusCode)
+        .produce(),
+    )
+
+    withCsv(
+      "unknown-user",
+      apStaffUserSeedCsvRowsToCsv(
+        listOf(
+          ApStaffUserSeedCsvRowFactory()
+            .withDeliusUsername("unknown-user")
+            .produce(),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesApStaffUsers, "unknown-user")
+
+    val persistedUser = userRepository.findByDeliusUsername("UNKNOWN-USER")
+
+    assertThat(persistedUser).isNotNull
+    assertThat(persistedUser!!.deliusStaffIdentifier).isEqualTo(6789)
+  }
+
+  private fun apStaffUserSeedCsvRowsToCsv(rows: List<ApStaffUserSeedCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "deliusUsername",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.deliusUsername)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}
+
+class ApStaffUserSeedCsvRowFactory : Factory<ApStaffUserSeedCsvRow> {
+  private var deliusUsername: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+
+  fun withDeliusUsername(deliusUsername: String) = apply {
+    this.deliusUsername = { deliusUsername }
+  }
+
+  override fun produce() = ApStaffUserSeedCsvRow(
+    deliusUsername = this.deliusUsername(),
+  )
+}


### PR DESCRIPTION
We have a list of 1,248 AP Staff who are set up correctly in Delius. We're going to seed them.

They don't need any internal roles or qualifications. Some of the AP staff being seeding will already 
be present in the service and some of those will have existing Roles and Qualifications.

We need to be confident that we aren't clearing those Roles and Qualifications.

In fact this is why we are introducing the new `ApStaffUsersSeedJob` rather than
using the `UsersSeedJob` -- which does clear those roles and qualifications.