### PR TITLE
APS-753 add isDirectlyWithdrawable flag to request for placements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -54,8 +54,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestForPlacementService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AppealTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
@@ -82,7 +82,7 @@ class ApplicationsController(
   private val documentTransformer: DocumentTransformer,
   private val assessmentService: AssessmentService,
   private val userService: UserService,
-  private val withdrawableService: WithdrawableService,
+  private val cas1WithdrawableService: Cas1WithdrawableService,
   private val appealService: AppealService,
   private val appealTransformer: AppealTransformer,
   private val placementRequestService: PlacementRequestService,
@@ -315,7 +315,7 @@ class ApplicationsController(
 
     return ResponseEntity.ok(
       extractEntityFromCasResult(
-        withdrawableService.withdrawApplication(
+        cas1WithdrawableService.withdrawApplication(
           applicationId = applicationId,
           user = user,
           withdrawalReason = body.reason.value,
@@ -569,7 +569,7 @@ class ApplicationsController(
       throw RuntimeException("Unsupported Application type: ${application::class.qualifiedName}")
     }
 
-    val withdrawables = withdrawableService.allWithdrawables(application, user)
+    val withdrawables = cas1WithdrawableService.allWithdrawables(application, user)
 
     return ResponseEntity.ok(
       withdrawables.map { entity ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -335,7 +335,7 @@ class ApplicationsController(
   }
 
   override fun applicationsApplicationIdRequestsForPlacementGet(applicationId: UUID): ResponseEntity<List<RequestForPlacement>> {
-    val requestsForPlacement = when (val result = requestForPlacementService.getRequestsForPlacementByApplication(applicationId)) {
+    val requestsForPlacement = when (val result = requestForPlacementService.getRequestsForPlacementByApplication(applicationId, userService.getUserForRequest())) {
       is AuthorisableActionResult.Success -> result.entity
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
@@ -350,7 +350,7 @@ class ApplicationsController(
   ): ResponseEntity<RequestForPlacement> {
     val application = applicationService.getApplication(applicationId) ?: throw NotFoundProblem(applicationId, "Application")
 
-    val requestForPlacement = when (val result = requestForPlacementService.getRequestForPlacement(application, requestForPlacementId)) {
+    val requestForPlacement = when (val result = requestForPlacementService.getRequestForPlacement(application, requestForPlacementId, userService.getUserForRequest())) {
       is AuthorisableActionResult.Success -> result.entity
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "RequestForPlacement")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -569,7 +569,7 @@ class ApplicationsController(
       throw RuntimeException("Unsupported Application type: ${application::class.qualifiedName}")
     }
 
-    val withdrawables = cas1WithdrawableService.allWithdrawables(application, user)
+    val withdrawables = cas1WithdrawableService.allDirectlyWithdrawables(application, user)
 
     return ResponseEntity.ok(
       withdrawables.map { entity ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementApplicationsController.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementApplicationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
@@ -36,7 +36,7 @@ class PlacementApplicationsController(
   private val placementApplicationService: PlacementApplicationService,
   private val placementApplicationTransformer: PlacementApplicationTransformer,
   private val objectMapper: ObjectMapper,
-  private val withdrawalService: WithdrawableService,
+  private val withdrawalService: Cas1WithdrawableService,
 ) : PlacementApplicationsApiDelegate {
   override fun placementApplicationsPost(newPlacementApplication: NewPlacementApplication): ResponseEntity<PlacementApplication> {
     val user = userService.getUserForRequest()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -36,7 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService.PlacementRequestAndCancellations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingNotMadeTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NewPlacementRequestBookingConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestDetailTransformer
@@ -56,7 +56,7 @@ class PlacementRequestsController(
   private val bookingService: BookingService,
   private val bookingConfirmationTransformer: NewPlacementRequestBookingConfirmationTransformer,
   private val bookingNotMadeTransformer: BookingNotMadeTransformer,
-  private val withdrawableService: WithdrawableService,
+  private val cas1WithdrawableService: Cas1WithdrawableService,
 ) : PlacementRequestsApiDelegate {
 
   override fun placementRequestsGet(): ResponseEntity<List<PlacementRequest>> {
@@ -197,7 +197,7 @@ class PlacementRequestsController(
     }
 
     val placementRequestAndCancellations = extractEntityFromCasResult(
-      withdrawableService.withdrawPlacementRequest(
+      cas1WithdrawableService.withdrawPlacementRequest(
         id,
         user,
         reason,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -74,7 +74,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RoomService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedDetailTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedSummaryTransformer
@@ -132,7 +132,7 @@ class PremisesController(
   private val bedDetailTransformer: BedDetailTransformer,
   private val calendarTransformer: CalendarTransformer,
   private val dateChangeTransformer: DateChangeTransformer,
-  private val withdrawableService: WithdrawableService,
+  private val cas1WithdrawableService: Cas1WithdrawableService,
 ) : PremisesApiDelegate {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -533,7 +533,7 @@ class PremisesController(
 
     when (booking.premises) {
       is ApprovedPremisesEntity -> {
-        val result = withdrawableService.withdrawBooking(
+        val result = cas1WithdrawableService.withdrawBooking(
           booking = booking,
           user = user,
           cancelledAt = body.date,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 import javax.transaction.Transactional
 
 @Service
-class WithdrawableService(
+class Cas1WithdrawableService(
   private val applicationService: ApplicationService,
   private val placementRequestService: PlacementRequestService,
   private val placementApplicationService: PlacementApplicationService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -55,6 +55,22 @@ class Cas1WithdrawableService(
       .toSet()
   }
 
+  fun isDirectlyWithdrawable(placementRequest: PlacementRequestEntity, user: UserEntity): Boolean {
+    return allDirectlyWithdrawables(
+      application = placementRequest.application,
+      user = user,
+    )
+      .any { it.type == WithdrawableEntityType.PlacementRequest && it.id == placementRequest.id }
+  }
+
+  fun isDirectlyWithdrawable(placementApplication: PlacementApplicationEntity, user: UserEntity): Boolean {
+    return allDirectlyWithdrawables(
+      application = placementApplication.application,
+      user = user,
+    )
+      .any { it.type == WithdrawableEntityType.PlacementApplication && it.id == placementApplication.id }
+  }
+
   @Transactional
   fun withdrawApplication(
     applicationId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -31,7 +31,7 @@ class Cas1WithdrawableService(
 ) {
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
-  fun allWithdrawables(
+  fun allDirectlyWithdrawables(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,
   ): Set<WithdrawableEntity> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -17,6 +17,7 @@ class RequestForPlacementTransformer(
 ) {
   fun transformPlacementApplicationEntityToApi(
     placementApplicationEntity: PlacementApplicationEntity,
+    canBeDirectlyWithdrawn: Boolean,
   ) = RequestForPlacement(
     id = placementApplicationEntity.id,
     createdByUserId = placementApplicationEntity.createdByUser.id,
@@ -27,13 +28,14 @@ class RequestForPlacementTransformer(
     submittedAt = placementApplicationEntity.submittedAt?.toInstant(),
     requestReviewedAt = placementApplicationEntity.decisionMadeAt?.toInstant(),
     document = placementApplicationEntity.document?.let(objectMapper::readTree),
-    canBeDirectlyWithdrawn = false,
+    canBeDirectlyWithdrawn = canBeDirectlyWithdrawn,
     withdrawalReason = placementApplicationEntity.withdrawalReason?.apiValue,
     status = placementApplicationEntity.deriveStatus(),
   )
 
   fun transformPlacementRequestEntityToApi(
     placementRequestEntity: PlacementRequestEntity,
+    canBeDirectlyWithdrawn: Boolean,
   ) = RequestForPlacement(
     id = placementRequestEntity.id,
     createdByUserId = placementRequestEntity.application.createdByUser.id,
@@ -49,7 +51,7 @@ class RequestForPlacementTransformer(
     submittedAt = placementRequestEntity.createdAt.toInstant(),
     requestReviewedAt = placementRequestEntity.assessment.submittedAt?.toInstant(),
     document = null,
-    canBeDirectlyWithdrawn = false,
+    canBeDirectlyWithdrawn = canBeDirectlyWithdrawn,
     withdrawalReason = placementRequestEntity.withdrawalReason?.apiValue,
     status = placementRequestEntity.deriveStatus(),
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -27,6 +27,7 @@ class RequestForPlacementTransformer(
     submittedAt = placementApplicationEntity.submittedAt?.toInstant(),
     requestReviewedAt = placementApplicationEntity.decisionMadeAt?.toInstant(),
     document = placementApplicationEntity.document?.let(objectMapper::readTree),
+    canBeDirectlyWithdrawn = false,
     withdrawalReason = placementApplicationEntity.withdrawalReason?.apiValue,
     status = placementApplicationEntity.deriveStatus(),
   )
@@ -48,6 +49,7 @@ class RequestForPlacementTransformer(
     submittedAt = placementRequestEntity.createdAt.toInstant(),
     requestReviewedAt = placementRequestEntity.assessment.submittedAt?.toInstant(),
     document = null,
+    canBeDirectlyWithdrawn = false,
     withdrawalReason = placementRequestEntity.withdrawalReason?.apiValue,
     status = placementRequestEntity.deriveStatus(),
   )

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3842,6 +3842,11 @@ components:
           format: date-time
         document:
           $ref: '#/components/schemas/AnyValue'
+        canBeDirectlyWithdrawn:
+          description: |
+            If true, the user making this request can withdraw this request for placement. 
+            If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application.
+          type: boolean
         isWithdrawn:
           type: boolean
         withdrawalReason:
@@ -3858,6 +3863,7 @@ components:
         - id
         - createdByUserId
         - createdAt
+        - canBeDirectlyWithdrawn
         - isWithdrawn
         - type
         - placementDates

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8484,6 +8484,11 @@ components:
           format: date-time
         document:
           $ref: '#/components/schemas/AnyValue'
+        canBeDirectlyWithdrawn:
+          description: |
+            If true, the user making this request can withdraw this request for placement. 
+            If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application.
+          type: boolean
         isWithdrawn:
           type: boolean
         withdrawalReason:
@@ -8500,6 +8505,7 @@ components:
         - id
         - createdByUserId
         - createdAt
+        - canBeDirectlyWithdrawn
         - isWithdrawn
         - type
         - placementDates

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4407,6 +4407,11 @@ components:
           format: date-time
         document:
           $ref: '#/components/schemas/AnyValue'
+        canBeDirectlyWithdrawn:
+          description: |
+            If true, the user making this request can withdraw this request for placement. 
+            If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application.
+          type: boolean
         isWithdrawn:
           type: boolean
         withdrawalReason:
@@ -4423,6 +4428,7 @@ components:
         - id
         - createdByUserId
         - createdAt
+        - canBeDirectlyWithdrawn
         - isWithdrawn
         - type
         - placementDates

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3933,6 +3933,11 @@ components:
           format: date-time
         document:
           $ref: '#/components/schemas/AnyValue'
+        canBeDirectlyWithdrawn:
+          description: |
+            If true, the user making this request can withdraw this request for placement. 
+            If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application.
+          type: boolean
         isWithdrawn:
           type: boolean
         withdrawalReason:
@@ -3949,6 +3954,7 @@ components:
         - id
         - createdByUserId
         - createdAt
+        - canBeDirectlyWithdrawn
         - isWithdrawn
         - type
         - placementDates

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1Cas1WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1Cas1WithdrawableServiceTest.kt
@@ -24,11 +24,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableTreeBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableTreeOperations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableDatePeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableState
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableTreeNode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
@@ -37,7 +37,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class Cas1WithdrawableServiceTest {
+class Cas1Cas1WithdrawableServiceTest {
   private val applicationService = mockk<ApplicationService>()
   private val placementRequestService = mockk<PlacementRequestService>()
   private val placementApplicationService = mockk<PlacementApplicationService>()
@@ -45,7 +45,7 @@ class Cas1WithdrawableServiceTest {
   private val cas1WithdrawableTreeBuilder = mockk<Cas1WithdrawableTreeBuilder>()
   private val cas1WithdrawableTreeOperations = mockk<Cas1WithdrawableTreeOperations>()
 
-  private val withdrawableService = WithdrawableService(
+  private val cas1WithdrawableService = Cas1WithdrawableService(
     applicationService,
     placementRequestService,
     placementApplicationService,
@@ -82,7 +82,7 @@ class Cas1WithdrawableServiceTest {
         ),
       )
 
-    val result = withdrawableService.allWithdrawables(application, user)
+    val result = cas1WithdrawableService.allWithdrawables(application, user)
 
     assertThat(result).hasSize(1)
 
@@ -166,7 +166,7 @@ class Cas1WithdrawableServiceTest {
         ),
       )
 
-    val result = withdrawableService.allWithdrawables(application, user)
+    val result = cas1WithdrawableService.allWithdrawables(application, user)
 
     assertThat(result).hasSize(5)
     assertThat(result).anyMatch { it.id == appWithdrawableId }
@@ -245,7 +245,7 @@ class Cas1WithdrawableServiceTest {
         ),
       )
 
-    val result = withdrawableService.allWithdrawables(application, user)
+    val result = cas1WithdrawableService.allWithdrawables(application, user)
 
     assertThat(result).hasSize(2)
     assertThat(result).anyMatch { it.id == placementRequest2WithdrawableId }
@@ -282,7 +282,7 @@ class Cas1WithdrawableServiceTest {
         )
       } returns Unit
 
-      val result = withdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
+      val result = cas1WithdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
 
       assertThat(result is CasResult.Success)
 
@@ -311,7 +311,7 @@ class Cas1WithdrawableServiceTest {
           .withCreatedByUser(user)
           .produce()
 
-      val result = withdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
+      val result = cas1WithdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
 
       assertThat(result is CasResult.GeneralValidationError)
     }
@@ -329,7 +329,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForApp(application, user) } returns tree
 
-      val result = withdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
+      val result = cas1WithdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
 
       assertThat(result is CasResult.Unauthorised).isTrue()
     }
@@ -347,7 +347,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForApp(application, user) } returns tree
 
-      val result = withdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
+      val result = cas1WithdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue()
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Application is not in a withdrawable state")
@@ -374,7 +374,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForApp(application, user) } returns tree
 
-      val result = withdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
+      val result = cas1WithdrawableService.withdrawApplication(application.id, user, withdrawalReason, withdrawalOtherReason)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue()
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Application withdrawal is blocked")
@@ -429,7 +429,7 @@ class Cas1WithdrawableServiceTest {
         cas1WithdrawableTreeOperations.withdrawDescendantsOfRootNode(tree, context)
       } returns Unit
 
-      val result = withdrawableService.withdrawPlacementRequest(placementRequest.id, user, withdrawalReason)
+      val result = cas1WithdrawableService.withdrawPlacementRequest(placementRequest.id, user, withdrawalReason)
 
       assertThat(result is CasResult.Success)
 
@@ -459,7 +459,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForPlacementReq(placementRequest, user) } returns tree
 
-      val result = withdrawableService.withdrawPlacementRequest(placementRequest.id, user, withdrawalReason)
+      val result = cas1WithdrawableService.withdrawPlacementRequest(placementRequest.id, user, withdrawalReason)
 
       assertThat(result is CasResult.Unauthorised).isTrue()
     }
@@ -477,7 +477,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForPlacementReq(placementRequest, user) } returns tree
 
-      val result = withdrawableService.withdrawPlacementRequest(placementRequest.id, user, withdrawalReason)
+      val result = cas1WithdrawableService.withdrawPlacementRequest(placementRequest.id, user, withdrawalReason)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue()
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Request for Placement is not in a withdrawable state")
@@ -504,7 +504,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForPlacementReq(placementRequest, user) } returns tree
 
-      val result = withdrawableService.withdrawPlacementRequest(placementRequest.id, user, withdrawalReason)
+      val result = cas1WithdrawableService.withdrawPlacementRequest(placementRequest.id, user, withdrawalReason)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue()
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Request for Placement withdrawal is blocked")
@@ -545,7 +545,7 @@ class Cas1WithdrawableServiceTest {
         cas1WithdrawableTreeOperations.withdrawDescendantsOfRootNode(tree, context)
       } returns Unit
 
-      val result = withdrawableService.withdrawPlacementApplication(placementApplication.id, user, withdrawalReason)
+      val result = cas1WithdrawableService.withdrawPlacementApplication(placementApplication.id, user, withdrawalReason)
 
       assertThat(result is CasResult.Success)
 
@@ -575,7 +575,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForPlacementApp(placementApplication, user) } returns tree
 
-      val result = withdrawableService.withdrawPlacementApplication(placementApplication.id, user, withdrawalReason)
+      val result = cas1WithdrawableService.withdrawPlacementApplication(placementApplication.id, user, withdrawalReason)
 
       assertThat(result is CasResult.Unauthorised).isTrue()
     }
@@ -593,7 +593,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForPlacementApp(placementApplication, user) } returns tree
 
-      val result = withdrawableService.withdrawPlacementApplication(placementApplication.id, user, withdrawalReason)
+      val result = cas1WithdrawableService.withdrawPlacementApplication(placementApplication.id, user, withdrawalReason)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue()
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Request for Placement is not in a withdrawable state")
@@ -620,7 +620,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForPlacementApp(placementApplication, user) } returns tree
 
-      val result = withdrawableService.withdrawPlacementApplication(placementApplication.id, user, withdrawalReason)
+      val result = cas1WithdrawableService.withdrawPlacementApplication(placementApplication.id, user, withdrawalReason)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue()
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Request for Placement withdrawal is blocked")
@@ -661,7 +661,7 @@ class Cas1WithdrawableServiceTest {
         cas1WithdrawableTreeOperations.withdrawDescendantsOfRootNode(tree, context)
       } returns Unit
 
-      val result = withdrawableService.withdrawBooking(booking, user, cancelledAt, userProvidedReason, notes, otherReason)
+      val result = cas1WithdrawableService.withdrawBooking(booking, user, cancelledAt, userProvidedReason, notes, otherReason)
 
       assertThat(result is CasResult.Success)
 
@@ -692,7 +692,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForBooking(booking, user) } returns tree
 
-      val result = withdrawableService.withdrawBooking(booking, user, cancelledAt, userProvidedReason, notes, otherReason)
+      val result = cas1WithdrawableService.withdrawBooking(booking, user, cancelledAt, userProvidedReason, notes, otherReason)
 
       assertThat(result is CasResult.Unauthorised).isTrue()
     }
@@ -708,7 +708,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForBooking(booking, user) } returns tree
 
-      val result = withdrawableService.withdrawBooking(booking, user, cancelledAt, userProvidedReason, notes, otherReason)
+      val result = cas1WithdrawableService.withdrawBooking(booking, user, cancelledAt, userProvidedReason, notes, otherReason)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue()
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Placement is not in a withdrawable state")
@@ -725,7 +725,7 @@ class Cas1WithdrawableServiceTest {
 
       every { cas1WithdrawableTreeBuilder.treeForBooking(booking, user) } returns tree
 
-      val result = withdrawableService.withdrawBooking(booking, user, cancelledAt, userProvidedReason, notes, otherReason)
+      val result = cas1WithdrawableService.withdrawBooking(booking, user, cancelledAt, userProvidedReason, notes, otherReason)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue()
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Placement withdrawal is blocked")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1Cas1WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1Cas1WithdrawableServiceTest.kt
@@ -65,7 +65,7 @@ class Cas1Cas1WithdrawableServiceTest {
     .produce()
 
   @Test
-  fun `allWithdrawables correctly maps for given tree node`() {
+  fun `allDirectlyWithdrawables correctly maps for given tree node`() {
     val appId = UUID.randomUUID()
 
     every {
@@ -82,7 +82,7 @@ class Cas1Cas1WithdrawableServiceTest {
         ),
       )
 
-    val result = cas1WithdrawableService.allWithdrawables(application, user)
+    val result = cas1WithdrawableService.allDirectlyWithdrawables(application, user)
 
     assertThat(result).hasSize(1)
 
@@ -98,7 +98,7 @@ class Cas1Cas1WithdrawableServiceTest {
   }
 
   @Test
-  fun `allWithdrawables only returns entities the user can withdraw`() {
+  fun `allDirectlyWithdrawables only returns entities the user can withdraw`() {
     val appWithdrawableId = UUID.randomUUID()
     val placementRequest1WithdrawableId = UUID.randomUUID()
     val placementRequestWithdrawableButNotPermittedId = UUID.randomUUID()
@@ -166,7 +166,7 @@ class Cas1Cas1WithdrawableServiceTest {
         ),
       )
 
-    val result = cas1WithdrawableService.allWithdrawables(application, user)
+    val result = cas1WithdrawableService.allDirectlyWithdrawables(application, user)
 
     assertThat(result).hasSize(5)
     assertThat(result).anyMatch { it.id == appWithdrawableId }
@@ -177,7 +177,7 @@ class Cas1Cas1WithdrawableServiceTest {
   }
 
   @Test
-  fun `allWithdrawables doesn't return entities that are blocking, or ancestors of blocking`() {
+  fun `allDirectlyWithdrawables doesn't return entities that are blocking, or ancestors of blocking`() {
     val appWithdrawableButBlockedId = UUID.randomUUID()
     val placementRequest1WithdrawableButBlockedId = UUID.randomUUID()
     val placementRequestWithdrawableButNotPermittedId = UUID.randomUUID()
@@ -245,7 +245,7 @@ class Cas1Cas1WithdrawableServiceTest {
         ),
       )
 
-    val result = cas1WithdrawableService.allWithdrawables(application, user)
+    val result = cas1WithdrawableService.allDirectlyWithdrawables(application, user)
 
     assertThat(result).hasSize(2)
     assertThat(result).anyMatch { it.id == placementRequest2WithdrawableId }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
@@ -76,7 +76,7 @@ class RequestForPlacementTransformerTest {
         .withWithdrawalReason(randomOf(PlacementApplicationWithdrawalReason.entries))
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication)
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.id).isEqualTo(placementApplication.id)
       assertThat(result.createdByUserId).isEqualTo(placementApplication.createdByUser.id)
@@ -107,7 +107,7 @@ class RequestForPlacementTransformerTest {
         .withWithdrawalReason(randomOf(PlacementApplicationWithdrawalReason.entries))
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication)
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestWithdrawn)
     }
@@ -158,7 +158,7 @@ class RequestForPlacementTransformerTest {
           placementRequest.booking = this
         }
 
-      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication)
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.placementBooked)
     }
@@ -177,7 +177,7 @@ class RequestForPlacementTransformerTest {
         .withDecision(PlacementApplicationDecision.REJECTED)
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication)
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestRejected)
     }
@@ -194,7 +194,7 @@ class RequestForPlacementTransformerTest {
         .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication)
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestSubmitted)
     }
@@ -210,9 +210,47 @@ class RequestForPlacementTransformerTest {
         .withApplication(application)
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication)
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.awaitingMatch)
+    }
+
+    @Test
+    fun `canBeDirectlyWithdrawn is false`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .produce()
+
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(
+        placementApplication,
+        canBeDirectlyWithdrawn = false,
+      )
+
+      assertThat(result.canBeDirectlyWithdrawn).isEqualTo(false)
+    }
+
+    @Test
+    fun `canBeDirectlyWithdrawn is true`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .produce()
+
+      val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(
+        placementApplication,
+        canBeDirectlyWithdrawn = true,
+      )
+
+      assertThat(result.canBeDirectlyWithdrawn).isEqualTo(true)
     }
   }
 
@@ -241,7 +279,7 @@ class RequestForPlacementTransformerTest {
         .withWithdrawalReason(randomOf(PlacementRequestWithdrawalReason.entries))
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest)
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.id).isEqualTo(placementRequest.id)
       assertThat(result.createdByUserId).isEqualTo(placementRequest.application.createdByUser.id)
@@ -281,7 +319,7 @@ class RequestForPlacementTransformerTest {
         .withWithdrawalReason(randomOf(PlacementRequestWithdrawalReason.entries))
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest)
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestWithdrawn)
     }
@@ -321,7 +359,7 @@ class RequestForPlacementTransformerTest {
           placementRequest.booking = this
         }
 
-      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest)
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.placementBooked)
     }
@@ -357,7 +395,7 @@ class RequestForPlacementTransformerTest {
         .withPlacementApplication(placementApplication)
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest)
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestRejected)
     }
@@ -391,7 +429,7 @@ class RequestForPlacementTransformerTest {
         .withPlacementApplication(placementApplication)
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest)
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestSubmitted)
     }
@@ -424,9 +462,69 @@ class RequestForPlacementTransformerTest {
         .withPlacementApplication(placementApplication)
         .produce()
 
-      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest)
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.awaitingMatch)
+    }
+
+    @Test
+    fun `canBeDirectlyWithdrawn is false`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .produce()
+
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(
+        placementRequest,
+        canBeDirectlyWithdrawn = false,
+      )
+
+      assertThat(result.canBeDirectlyWithdrawn).isEqualTo(false)
+    }
+
+    @Test
+    fun `canBeDirectlyWithdrawn is true`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .produce()
+
+      val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(
+        placementRequest,
+        canBeDirectlyWithdrawn = true,
+      )
+
+      assertThat(result.canBeDirectlyWithdrawn).isEqualTo(true)
     }
   }
 }


### PR DESCRIPTION
Currently the code in the Cas1WithdrawalService.isDirectlyWithdrawable function retrieves the complete set of WithdrawableEntities for the whole application, despite only being concerned with WithdrawableEntities for the specific placement request/placement application. This will become a performance issue if/when we start calling external APIs to determine if an entity is withdrawable (as is planned). Before any such change is made we should modify this methods to test against a subset of the tree (i.e. where the root node is placement application/placement request)