### PR TITLE
[APS-563] Account for afternoon and non-working-day submissions in deadline calculations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskDeadlineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskDeadlineService.kt
@@ -6,11 +6,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
+import java.time.LocalTime
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.toJavaDuration
+import java.time.ZonedDateTime
 
 @Service
 class TaskDeadlineService(
@@ -18,44 +18,81 @@ class TaskDeadlineService(
 ) {
   fun getDeadline(assessment: AssessmentEntity): OffsetDateTime? {
     val application = assessment.application
+    val effectiveApplicationCreatedAt = assessment.createdAt.slewedToWorkingPattern()
+
     return when {
-      application !is ApprovedPremisesApplicationEntity -> null
-      application.noticeType == Cas1ApplicationTimelinessCategory.emergency -> emergencyAssessmentDueDateTime(assessment)
-      application.noticeType == Cas1ApplicationTimelinessCategory.shortNotice -> addWorkingDays(assessment.createdAt, ASSESSMENT_SHORT_NOTICE_TIMEFRAME)
-      else -> addWorkingDays(assessment.createdAt, ASSESSMENT_STANDARD_TIMEFRAME)
+      application !is ApprovedPremisesApplicationEntity ->
+        null
+
+      application.noticeType == Cas1ApplicationTimelinessCategory.emergency ->
+        effectiveApplicationCreatedAt.plusHours(ASSESSMENT_EMERGENCY_TIMEFRAME_HOURS)
+
+      application.noticeType == Cas1ApplicationTimelinessCategory.shortNotice ->
+        addWorkingDays(effectiveApplicationCreatedAt, ASSESSMENT_SHORT_NOTICE_TIMEFRAME_WORKDAYS)
+
+      else ->
+        addWorkingDays(effectiveApplicationCreatedAt, ASSESSMENT_STANDARD_TIMEFRAME_WORKDAYS)
     }
   }
 
   fun getDeadline(placementRequest: PlacementRequestEntity): OffsetDateTime {
     val application = placementRequest.application
+    val effectivePlacementRequestCreatedAt = placementRequest.createdAt.slewedToWorkingPattern()
+
     return when {
-      application.noticeType == Cas1ApplicationTimelinessCategory.emergency -> placementRequest.createdAt
-      application.noticeType == Cas1ApplicationTimelinessCategory.shortNotice -> addWorkingDays(placementRequest.createdAt, PLACEMENT_REQUEST_SHORT_NOTICE_TIMEFRAME)
-      application.isEsapApplication -> placementRequest.createdAt
-      else -> addWorkingDays(placementRequest.createdAt, PLACEMENT_REQUEST_STANDARD_TIMEFRAME)
+      application.noticeType == Cas1ApplicationTimelinessCategory.emergency ->
+        effectivePlacementRequestCreatedAt
+
+      application.noticeType == Cas1ApplicationTimelinessCategory.shortNotice ->
+        addWorkingDays(effectivePlacementRequestCreatedAt, PLACEMENT_REQUEST_SHORT_NOTICE_TIMEFRAME_WORKDAYS)
+
+      application.isEsapApplication ->
+        effectivePlacementRequestCreatedAt
+
+      else ->
+        addWorkingDays(effectivePlacementRequestCreatedAt, PLACEMENT_REQUEST_STANDARD_TIMEFRAME_WORKDAYS)
     }
   }
 
   fun getDeadline(placementApplication: PlacementApplicationEntity): OffsetDateTime {
-    return addWorkingDays(placementApplication.submittedAt!!, PLACEMENT_APPLICATION_TIMEFRAME)
+    val effectivePlacementApplicationSubmittedAt = placementApplication.submittedAt!!.slewedToWorkingPattern()
+
+    return addWorkingDays(effectivePlacementApplicationSubmittedAt, PLACEMENT_APPLICATION_TIMEFRAME_WORKDAYS)
   }
 
-  fun addWorkingDays(date: OffsetDateTime, workingDays: Int): OffsetDateTime = workingDayService.addWorkingDays(date.toLocalDate(), workingDays).toLocalDateTime()
+  private fun addWorkingDays(date: OffsetDateTime, workingDays: Int): OffsetDateTime =
+    workingDayService
+      .addWorkingDays(date.toLocalDate(), workingDays)
+      .atTime(date.toOffsetTime())
 
-  private fun emergencyAssessmentDueDateTime(assessment: AssessmentEntity): OffsetDateTime {
-    return if (assessment.createdAt.hour < 13) {
-      assessment.createdAt.plus(2.hours.toJavaDuration()).toInstant().atOffset(ZoneOffset.UTC)
+  private fun ZonedDateTime.isWorkingDay() = this.toLocalDate().isWorkingDay(workingDayService.bankHolidays)
+  private fun ZonedDateTime.isBeforeSameWorkingDayDeadline() = this.toLocalTime().isBefore(SAME_WORKING_DAY_DEADLINE_TIME)
+
+  private fun OffsetDateTime.slewedToWorkingPattern(): OffsetDateTime {
+    val zonedDateTime = this.toZonedDateTime().withZoneSameInstant(GB_LOCAL_TIMEZONE)
+    return if (zonedDateTime.isWorkingDay() && zonedDateTime.isBeforeSameWorkingDayDeadline()) {
+      zonedDateTime.withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
     } else {
-      val nextWorkingDay = workingDayService.nextWorkingDay(assessment.createdAt.toLocalDate())
-      nextWorkingDay.atTime(11, 0).atOffset(ZoneOffset.UTC)
+      workingDayService
+        .nextWorkingDay(zonedDateTime.toLocalDate())
+        .atTime(WORKING_DAY_START_TIME)
+        .atZone(GB_LOCAL_TIMEZONE)
+        .withZoneSameInstant(ZoneOffset.UTC)
+        .toOffsetDateTime()
     }
   }
 
   companion object {
-    const val ASSESSMENT_STANDARD_TIMEFRAME = 10
-    const val ASSESSMENT_SHORT_NOTICE_TIMEFRAME = 2
-    const val PLACEMENT_REQUEST_STANDARD_TIMEFRAME = 5
-    const val PLACEMENT_REQUEST_SHORT_NOTICE_TIMEFRAME = 2
-    const val PLACEMENT_APPLICATION_TIMEFRAME = 10
+    private const val ASSESSMENT_STANDARD_TIMEFRAME_WORKDAYS = 10
+    private const val ASSESSMENT_SHORT_NOTICE_TIMEFRAME_WORKDAYS = 2
+    private const val ASSESSMENT_EMERGENCY_TIMEFRAME_HOURS = 2L
+    private const val PLACEMENT_REQUEST_STANDARD_TIMEFRAME_WORKDAYS = 5
+    private const val PLACEMENT_REQUEST_SHORT_NOTICE_TIMEFRAME_WORKDAYS = 2
+    private const val PLACEMENT_APPLICATION_TIMEFRAME_WORKDAYS = 10
+
+    private val SAME_WORKING_DAY_DEADLINE_TIME: LocalTime = LocalTime.of(13, 0)
+    private val WORKING_DAY_START_TIME: LocalTime = LocalTime.of(9, 0)
+
+    private val GB_LOCAL_TIMEZONE = ZoneId.of("Europe/London")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TaskDueMigrationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TaskDueMigrationJobTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -62,19 +63,22 @@ class TaskDueMigrationJobTest : IntegrationTestBase() {
     assessments.forEach {
       val updatedAssessment = assessmentTestRepository.findByIdOrNull(it.id)!!
       assertThat(updatedAssessment.dueAt).isNotNull()
-      assertThat(updatedAssessment.dueAt).isEqualTo(taskDeadlineService.getDeadline(it))
+      assertThat(updatedAssessment.dueAt?.roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+        .isEqualTo(taskDeadlineService.getDeadline(it)?.roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
     }
 
     placementRequests.forEach {
       val updatedPlacementRequest = placementRequestRepository.findByIdOrNull(it.id)!!
       assertThat(updatedPlacementRequest.dueAt).isNotNull()
-      assertThat(updatedPlacementRequest.dueAt).isEqualTo(taskDeadlineService.getDeadline(it))
+      assertThat(updatedPlacementRequest.dueAt?.roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+        .isEqualTo(taskDeadlineService.getDeadline(it).roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
     }
 
     placementApplications.forEach {
       val updatedPlacementApplication = placementApplicationRepository.findByIdOrNull(it.id)!!
       assertThat(updatedPlacementApplication.dueAt).isNotNull()
-      assertThat(updatedPlacementApplication.dueAt).isEqualTo(taskDeadlineService.getDeadline(it))
+      assertThat(updatedPlacementApplication.dueAt?.roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+        .isEqualTo(taskDeadlineService.getDeadline(it).roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskDeadlineServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskDeadlineServiceTest.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TimeService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import java.time.OffsetDateTime
 
-@SuppressWarnings("MagicNumber")
 class TaskDeadlineServiceTest {
   private val taskDeadlineService = TaskDeadlineService(
     // this treats all weekends as non-working days with no bank holidays
@@ -60,12 +59,57 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Monday 3pm. 14 days later, given two weekends
-      "2023-01-02T15:00:00Z,2023-01-16T00:00:00Z",
-      // Friday 3pm. 14 days later, given two weekends
-      "2023-01-06T15:00:00Z,2023-01-20T00:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T11:00:00Z,2023-01-16T09:00:00Z",
+      // Sunday 12:59pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T12:59:59Z,2023-01-16T09:00:00Z",
+      // Sunday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T13:00:00Z,2023-01-16T09:00:00Z",
+      // Sunday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T14:00:00Z,2023-01-16T09:00:00Z",
+      // Monday 11am. 10 working days later, so two weeks on Monday
+      "2023-01-02T11:00:00Z,2023-01-16T11:00:00Z",
+      // Monday 12:59pm. 10 working days later, so two weeks on Monday
+      "2023-01-02T12:59:59Z,2023-01-16T12:59:59Z",
+      // Monday 1pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-01-02T13:00:00Z,2023-01-17T09:00:00Z",
+      // Monday 2pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-01-02T14:00:00Z,2023-01-17T09:00:00Z",
+      // Thursday 2pm. 10 working days after 9am on the next working day (Friday), so two weeks on Friday
+      "2023-01-05T14:00:00Z,2023-01-20T09:00:00Z",
+      // Friday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-06T14:00:00Z,2023-01-23T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T10:00:00Z,2023-06-19T08:00:00Z",
+      // Sunday 12:59pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T11:59:59Z,2023-06-19T08:00:00Z",
+      // Sunday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T12:00:00Z,2023-06-19T08:00:00Z",
+      // Sunday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T13:00:00Z,2023-06-19T08:00:00Z",
+      // Monday 11am. 10 working days later, so two weeks on Monday
+      "2023-06-05T10:00:00Z,2023-06-19T10:00:00Z",
+      // Monday 12:59pm. 10 working days later, so two weeks on Monday
+      "2023-06-05T11:59:59Z,2023-06-19T11:59:59Z",
+      // Monday 1pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-06-05T12:00:00Z,2023-06-20T08:00:00Z",
+      // Monday 2pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-06-05T13:00:00Z,2023-06-20T08:00:00Z",
+      // Thursday 2pm. 10 working days after 9am on the next working day (Friday), so two weeks on Friday
+      "2023-06-08T13:00:00Z,2023-06-23T08:00:00Z",
+      // Friday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-09T13:00:00Z,2023-06-26T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-03-24T13:00:00Z,2023-04-10T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-10-27T12:00:00Z,2023-11-13T09:00:00Z",
     )
-    fun `getDeadline for a standard assessment returns created date plus 10 working days`(
+    fun `getDeadline for a standard assessment returns created date plus 10 working days, or 10 working days after 9am on the next working day if after 1pm or a non-working day`(
       createdAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -82,12 +126,57 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Monday 3pm. 2 days later
-      "2023-01-02T15:00:00Z,2023-01-04T00:00:00Z",
-      // Friday 3pm. 4 days later, given the weekend
-      "2023-01-06T15:00:00Z,2023-01-10T00:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-01T11:00:00Z,2023-01-04T09:00:00Z",
+      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-01T12:59:59Z,2023-01-04T09:00:00Z",
+      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-01T13:00:00Z,2023-01-04T09:00:00Z",
+      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-01T14:00:00Z,2023-01-04T09:00:00Z",
+      // Monday 11am. 2 working days later (Wednesday)
+      "2023-01-02T11:00:00Z,2023-01-04T11:00:00Z",
+      // Monday 12:59pm. 2 working days later (Wednesday)
+      "2023-01-02T12:59:59Z,2023-01-04T12:59:59Z",
+      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
+      "2023-01-02T13:00:00Z,2023-01-05T09:00:00Z",
+      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
+      "2023-01-02T14:00:00Z,2023-01-05T09:00:00Z",
+      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
+      "2023-01-05T14:00:00Z,2023-01-10T09:00:00Z",
+      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-06T14:00:00Z,2023-01-11T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-04T10:00:00Z,2023-06-07T08:00:00Z",
+      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-04T11:59:59Z,2023-06-07T08:00:00Z",
+      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-04T12:00:00Z,2023-06-07T08:00:00Z",
+      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-04T13:00:00Z,2023-06-07T08:00:00Z",
+      // Monday 11am. 2 working days later (Wednesday)
+      "2023-06-05T10:00:00Z,2023-06-07T10:00:00Z",
+      // Monday 12:59pm. 2 working days later (Wednesday)
+      "2023-06-05T11:59:59Z,2023-06-07T11:59:59Z",
+      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
+      "2023-06-05T12:00:00Z,2023-06-08T08:00:00Z",
+      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
+      "2023-06-05T13:00:00Z,2023-06-08T08:00:00Z",
+      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
+      "2023-06-08T13:00:00Z,2023-06-13T08:00:00Z",
+      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-09T13:00:00Z,2023-06-14T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-03-24T13:00:00Z,2023-03-29T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-10-27T12:00:00Z,2023-11-01T09:00:00Z",
     )
-    fun `getDeadline for a short notice assessment returns created date plus 2 working days`(
+    fun `getDeadline for a short notice assessment returns created date plus 2 working days, or 2 working days after 9am on the next working day if after 1pm or a non-working day`(
       createdAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -103,18 +192,53 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Sunday 11am. Created date plus 2 hours
-      "2023-01-01T11:00:00Z,2023-01-01T13:00:00Z",
-      // Sunday 12:59am. Created date plus 2 hours
-      "2023-01-01T12:59:59Z,2023-01-01T14:59:59Z",
-      // Sunday 13:00pm. 11am Next working day
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 11am next working day (Monday)
+      "2023-01-01T11:00:00Z,2023-01-02T11:00:00Z",
+      // Sunday 12:59pm. 11am next working day (Monday)
+      "2023-01-01T12:59:59Z,2023-01-02T11:00:00Z",
+      // Sunday 1pm. 11am next working day (Monday)
       "2023-01-01T13:00:00Z,2023-01-02T11:00:00Z",
-      // Sunday 3pm. 11am Next working day
+      // Sunday 2pm. 11am next working day (Monday)
       "2023-01-01T14:00:00Z,2023-01-02T11:00:00Z",
-      // Friday 3pm. 11am Next working day (after the weekend)
+      // Monday 11am. Created date plus 2 hours
+      "2023-01-02T11:00:00Z,2023-01-02T13:00:00Z",
+      // Monday 12:59pm. Created date plus 2 hours
+      "2023-01-02T12:59:59Z,2023-01-02T14:59:59Z",
+      // Monday 1pm. next working day (Tuesday)
+      "2023-01-02T13:00:00Z,2023-01-03T11:00:00Z",
+      // Monday 2pm. 11am next working day (Tuesday)
+      "2023-01-02T14:00:00Z,2023-01-03T11:00:00Z",
+      // Friday 2pm. 11am next working day (Monday)
       "2023-01-06T14:00:00Z,2023-01-09T11:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 11am next working day (Monday)
+      "2023-06-04T10:00:00Z,2023-06-05T10:00:00Z",
+      // Sunday 12:59pm. 11am next working day (Monday)
+      "2023-06-04T11:59:59Z,2023-06-05T10:00:00Z",
+      // Sunday 1pm. 11am next working day (Monday)
+      "2023-06-04T12:00:00Z,2023-06-05T10:00:00Z",
+      // Sunday 2pm. 11am next working day (Monday)
+      "2023-06-04T13:00:00Z,2023-06-05T10:00:00Z",
+      // Monday 11am. Created date plus 2 hours
+      "2023-06-05T10:00:00Z,2023-06-05T12:00:00Z",
+      // Monday 12:59pm. Created date plus 2 hours
+      "2023-06-05T11:59:59Z,2023-06-05T13:59:59Z",
+      // Monday 1pm. 11am next working day (Tuesday)
+      "2023-06-05T12:00:00Z,2023-06-06T10:00:00Z",
+      // Monday 2pm. 11am next working day (Tuesday)
+      "2023-06-05T13:00:00Z,2023-06-06T10:00:00Z",
+      // Friday 2pm. 11am next working day (Monday)
+      "2023-06-09T13:00:00Z,2023-06-12T10:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 11am next working day (Monday)
+      "2023-03-24T13:00:00Z,2023-03-27T10:00:00Z",
+      // BST -> GMT: Friday 1pm. 11am next working day (Monday)
+      "2023-10-27T12:00:00Z,2023-10-30T11:00:00Z",
     )
-    fun `getDeadline for an emergency assessment, 2 hours or 11am next working day if after 1pm`(
+    fun `getDeadline for an emergency assessment returns created date plus 2 hours, or 11am next working day if after 1pm or a non-working day`(
       createdAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -134,14 +258,57 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Sunday 3pm, 5 days later
-      "2023-01-01T15:00:00Z,2023-01-06T00:00:00Z",
-      // Monday 3pm. 7 days later, given the weekend
-      "2023-01-02T15:00:00Z,2023-01-09T00:00:00Z",
-      // Tuesday 3pm. 7 days later, given the weekend
-      "2023-01-03T15:00:00Z,2023-01-10T00:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-01-01T11:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-01-01T12:59:59Z,2023-01-09T09:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-01-01T13:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-01-01T14:00:00Z,2023-01-09T09:00:00Z",
+      // Monday 11am. 5 working days later, so a week on Monday
+      "2023-01-02T11:00:00Z,2023-01-09T11:00:00Z",
+      // Monday 12:59pm. 5 working days later, so a week on Monday
+      "2023-01-02T12:59:59Z,2023-01-09T12:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so a week on Tuesday
+      "2023-01-02T13:00:00Z,2023-01-10T09:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so a week on Tuesday
+      "2023-01-02T14:00:00Z,2023-01-10T09:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so a week on Friday
+      "2023-01-05T14:00:00Z,2023-01-13T09:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-01-06T14:00:00Z,2023-01-16T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-06-04T10:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-06-04T11:59:59Z,2023-06-12T08:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-06-04T12:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-06-04T13:00:00Z,2023-06-12T08:00:00Z",
+      // Monday 11am. 5 working days later, so a week on Monday
+      "2023-06-05T10:00:00Z,2023-06-12T10:00:00Z",
+      // Monday 12:59pm. 5 working days later, so a week on Monday
+      "2023-06-05T11:59:59Z,2023-06-12T11:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so a week on Tuesday
+      "2023-06-05T12:00:00Z,2023-06-13T08:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so a week on Tuesday
+      "2023-06-05T13:00:00Z,2023-06-13T08:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so a week on Friday
+      "2023-06-08T13:00:00Z,2023-06-16T08:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-06-09T13:00:00Z,2023-06-19T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-03-24T13:00:00Z,2023-04-03T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 5 working days after 9am on the next working day (Monday), so a week on Monday
+      "2023-10-27T12:00:00Z,2023-11-06T09:00:00Z",
     )
-    fun `getDeadline for a standard placement request returns created date plus 5 working days`(
+    fun `getDeadline for a standard placement request returns created date plus 5 working days, or 5 working days after 9am on the next working day if after 1pm or a non-working day`(
       createdAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -158,14 +325,57 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Monday 3pm. 2 days later
-      "2023-01-02T15:00:00Z,2023-01-04T00:00:00Z",
-      // Tuesday 3pm. 2 days later
-      "2023-01-03T15:00:00Z,2023-01-05T00:00:00Z",
-      // Friday 3pm. 4 days later given the weekend
-      "2023-01-06T15:00:00Z,2023-01-10T00:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-01T11:00:00Z,2023-01-04T09:00:00Z",
+      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-01T12:59:59Z,2023-01-04T09:00:00Z",
+      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-01T13:00:00Z,2023-01-04T09:00:00Z",
+      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-01T14:00:00Z,2023-01-04T09:00:00Z",
+      // Monday 11am. 2 working days later (Wednesday)
+      "2023-01-02T11:00:00Z,2023-01-04T11:00:00Z",
+      // Monday 12:59pm. 2 working days later (Wednesday)
+      "2023-01-02T12:59:59Z,2023-01-04T12:59:59Z",
+      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
+      "2023-01-02T13:00:00Z,2023-01-05T09:00:00Z",
+      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
+      "2023-01-02T14:00:00Z,2023-01-05T09:00:00Z",
+      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
+      "2023-01-05T14:00:00Z,2023-01-10T09:00:00Z",
+      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-01-06T14:00:00Z,2023-01-11T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-04T10:00:00Z,2023-06-07T08:00:00Z",
+      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-04T11:59:59Z,2023-06-07T08:00:00Z",
+      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-04T12:00:00Z,2023-06-07T08:00:00Z",
+      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-04T13:00:00Z,2023-06-07T08:00:00Z",
+      // Monday 11am. 2 working days later (Wednesday)
+      "2023-06-05T10:00:00Z,2023-06-07T10:00:00Z",
+      // Monday 12:59pm. 2 working days later (Wednesday)
+      "2023-06-05T11:59:59Z,2023-06-07T11:59:59Z",
+      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
+      "2023-06-05T12:00:00Z,2023-06-08T08:00:00Z",
+      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
+      "2023-06-05T13:00:00Z,2023-06-08T08:00:00Z",
+      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
+      "2023-06-08T13:00:00Z,2023-06-13T08:00:00Z",
+      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-06-09T13:00:00Z,2023-06-14T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-03-24T13:00:00Z,2023-03-29T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
+      "2023-10-27T12:00:00Z,2023-11-01T09:00:00Z",
     )
-    fun `getDeadline for a short notice placement request returns created date plus 2 working days `(
+    fun `getDeadline for a short notice placement request returns created date plus 2 working days, or 2 working days after 9am on the next working day if after 1pm or a non-working day`(
       createdAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -182,16 +392,53 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Monday 3pm. Same date/time
-      "2023-01-02T15:00:00Z,2023-01-02T15:00:00Z",
-      // Tuesday 3pm. Same date/time
-      "2023-01-03T15:00:00Z,2023-01-03T15:00:00Z",
-      // Friday 3pm. Same date/time
-      "2023-01-06T15:35:00Z,2023-01-06T15:35:00Z",
-      // Saturday 1pm. Same date/time
-      "2023-01-07T13:00:00Z,2023-01-07T13:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 9am next working day (Monday)
+      "2023-01-01T11:00:00Z,2023-01-02T09:00:00Z",
+      // Sunday 12:59pm. 9am next working day (Monday)
+      "2023-01-01T12:59:59Z,2023-01-02T09:00:00Z",
+      // Sunday 1pm. 9am next working day (Monday)
+      "2023-01-01T13:00:00Z,2023-01-02T09:00:00Z",
+      // Sunday 2pm. 9am next working day (Monday)
+      "2023-01-01T14:00:00Z,2023-01-02T09:00:00Z",
+      // Monday 11am. Created date (immediately)
+      "2023-01-02T11:00:00Z,2023-01-02T11:00:00Z",
+      // Monday 12:59pm. Created date (immediately)
+      "2023-01-02T12:59:59Z,2023-01-02T12:59:59Z",
+      // Monday 1pm. next working day (Tuesday)
+      "2023-01-02T13:00:00Z,2023-01-03T09:00:00Z",
+      // Monday 2pm. 9am next working day (Tuesday)
+      "2023-01-02T14:00:00Z,2023-01-03T09:00:00Z",
+      // Friday 2pm. 9am next working day (Monday)
+      "2023-01-06T14:00:00Z,2023-01-09T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 9am next working day (Monday)
+      "2023-06-04T10:00:00Z,2023-06-05T08:00:00Z",
+      // Sunday 12:59pm. 9am next working day (Monday)
+      "2023-06-04T11:59:59Z,2023-06-05T08:00:00Z",
+      // Sunday 1pm. 9am next working day (Monday)
+      "2023-06-04T12:00:00Z,2023-06-05T08:00:00Z",
+      // Sunday 2pm. 9am next working day (Monday)
+      "2023-06-04T13:00:00Z,2023-06-05T08:00:00Z",
+      // Monday 11am. Created date (immediately)
+      "2023-06-05T10:00:00Z,2023-06-05T10:00:00Z",
+      // Monday 12:59pm. Created date (immediately)
+      "2023-06-05T11:59:59Z,2023-06-05T11:59:59Z",
+      // Monday 1pm. 9am next working day (Tuesday)
+      "2023-06-05T12:00:00Z,2023-06-06T08:00:00Z",
+      // Monday 2pm. 9am next working day (Tuesday)
+      "2023-06-05T13:00:00Z,2023-06-06T08:00:00Z",
+      // Friday 2pm. 9am next working day (Monday)
+      "2023-06-09T13:00:00Z,2023-06-12T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 9am next working day (Monday)
+      "2023-03-24T13:00:00Z,2023-03-27T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 9am next working day (Monday)
+      "2023-10-27T12:00:00Z,2023-10-30T09:00:00Z",
     )
-    fun `getDeadline for an emergency placement request returns created date`(
+    fun `getDeadline for an emergency placement request returns created date, or 9am on the next working day if after 1pm or a non-working day`(
       createdAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -208,16 +455,53 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Monday 3pm. Same date/time
-      "2023-01-02T15:00:00Z,2023-01-02T15:00:00Z",
-      // Tuesday 3pm. Same date/time
-      "2023-01-03T15:00:00Z,2023-01-03T15:00:00Z",
-      // Friday 3pm. Same date/time
-      "2023-01-06T15:35:00Z,2023-01-06T15:35:00Z",
-      // Saturday 1pm. Same date/time
-      "2023-01-07T13:00:00Z,2023-01-07T13:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 9am next working day (Monday)
+      "2023-01-01T11:00:00Z,2023-01-02T09:00:00Z",
+      // Sunday 12:59pm. 9am next working day (Monday)
+      "2023-01-01T12:59:59Z,2023-01-02T09:00:00Z",
+      // Sunday 1pm. 9am next working day (Monday)
+      "2023-01-01T13:00:00Z,2023-01-02T09:00:00Z",
+      // Sunday 2pm. 9am next working day (Monday)
+      "2023-01-01T14:00:00Z,2023-01-02T09:00:00Z",
+      // Monday 11am. Created date (immediately)
+      "2023-01-02T11:00:00Z,2023-01-02T11:00:00Z",
+      // Monday 12:59pm. Created date (immediately)
+      "2023-01-02T12:59:59Z,2023-01-02T12:59:59Z",
+      // Monday 1pm. next working day (Tuesday)
+      "2023-01-02T13:00:00Z,2023-01-03T09:00:00Z",
+      // Monday 2pm. 9am next working day (Tuesday)
+      "2023-01-02T14:00:00Z,2023-01-03T09:00:00Z",
+      // Friday 2pm. 9am next working day (Monday)
+      "2023-01-06T14:00:00Z,2023-01-09T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 9am next working day (Monday)
+      "2023-06-04T10:00:00Z,2023-06-05T08:00:00Z",
+      // Sunday 12:59pm. 9am next working day (Monday)
+      "2023-06-04T11:59:59Z,2023-06-05T08:00:00Z",
+      // Sunday 1pm. 9am next working day (Monday)
+      "2023-06-04T12:00:00Z,2023-06-05T08:00:00Z",
+      // Sunday 2pm. 9am next working day (Monday)
+      "2023-06-04T13:00:00Z,2023-06-05T08:00:00Z",
+      // Monday 11am. Created date (immediately)
+      "2023-06-05T10:00:00Z,2023-06-05T10:00:00Z",
+      // Monday 12:59pm. Created date (immediately)
+      "2023-06-05T11:59:59Z,2023-06-05T11:59:59Z",
+      // Monday 1pm. 9am next working day (Tuesday)
+      "2023-06-05T12:00:00Z,2023-06-06T08:00:00Z",
+      // Monday 2pm. 9am next working day (Tuesday)
+      "2023-06-05T13:00:00Z,2023-06-06T08:00:00Z",
+      // Friday 2pm. 9am next working day (Monday)
+      "2023-06-09T13:00:00Z,2023-06-12T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 9am next working day (Monday)
+      "2023-03-24T13:00:00Z,2023-03-27T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 9am next working day (Monday)
+      "2023-10-27T12:00:00Z,2023-10-30T09:00:00Z",
     )
-    fun `getDeadline for an ESAP placement request returns created date`(
+    fun `getDeadline for an ESAP placement request returns created date, or 9am on the next working day if after 1pm or a non-working day`(
       createdAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -238,12 +522,57 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Monday 3pm. 14 days later, given two weekends
-      "2023-01-02T15:00:00Z,2023-01-16T00:00:00Z",
-      // Friday 3pm. 14 days later, given two weekends
-      "2023-01-06T15:00:00Z,2023-01-20T00:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T11:00:00Z,2023-01-16T09:00:00Z",
+      // Sunday 12:59pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T12:59:59Z,2023-01-16T09:00:00Z",
+      // Sunday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T13:00:00Z,2023-01-16T09:00:00Z",
+      // Sunday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T14:00:00Z,2023-01-16T09:00:00Z",
+      // Monday 11am. 10 working days later, so two weeks on Monday
+      "2023-01-02T11:00:00Z,2023-01-16T11:00:00Z",
+      // Monday 12:59pm. 10 working days later, so two weeks on Monday
+      "2023-01-02T12:59:59Z,2023-01-16T12:59:59Z",
+      // Monday 1pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-01-02T13:00:00Z,2023-01-17T09:00:00Z",
+      // Monday 2pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-01-02T14:00:00Z,2023-01-17T09:00:00Z",
+      // Thursday 2pm. 10 working days after 9am on the next working day (Friday), so two weeks on Friday
+      "2023-01-05T14:00:00Z,2023-01-20T09:00:00Z",
+      // Friday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-06T14:00:00Z,2023-01-23T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T10:00:00Z,2023-06-19T08:00:00Z",
+      // Sunday 12:59pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T11:59:59Z,2023-06-19T08:00:00Z",
+      // Sunday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T12:00:00Z,2023-06-19T08:00:00Z",
+      // Sunday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T13:00:00Z,2023-06-19T08:00:00Z",
+      // Monday 11am. 10 working days later, so two weeks on Monday
+      "2023-06-05T10:00:00Z,2023-06-19T10:00:00Z",
+      // Monday 12:59pm. 10 working days later, so two weeks on Monday
+      "2023-06-05T11:59:59Z,2023-06-19T11:59:59Z",
+      // Monday 1pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-06-05T12:00:00Z,2023-06-20T08:00:00Z",
+      // Monday 2pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-06-05T13:00:00Z,2023-06-20T08:00:00Z",
+      // Thursday 2pm. 10 working days after 9am on the next working day (Friday), so two weeks on Friday
+      "2023-06-08T13:00:00Z,2023-06-23T08:00:00Z",
+      // Friday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-09T13:00:00Z,2023-06-26T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-03-24T13:00:00Z,2023-04-10T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-10-27T12:00:00Z,2023-11-13T09:00:00Z",
     )
-    fun `getDeadline for a standard placement application returns submitted date plus 10 working days`(
+    fun `getDeadline for a standard placement application returns submitted date plus 10 working days, or 10 working days after 9am on the next working day if after 1pm or a non-working day`(
       submittedAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -260,12 +589,57 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Monday 3pm. 14 days later, given two weekends
-      "2023-01-02T15:00:00Z,2023-01-16T00:00:00Z",
-      // Friday 3pm. 14 days later, given two weekends
-      "2023-01-06T15:00:00Z,2023-01-20T00:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T11:00:00Z,2023-01-16T09:00:00Z",
+      // Sunday 12:59pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T12:59:59Z,2023-01-16T09:00:00Z",
+      // Sunday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T13:00:00Z,2023-01-16T09:00:00Z",
+      // Sunday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T14:00:00Z,2023-01-16T09:00:00Z",
+      // Monday 11am. 10 working days later, so two weeks on Monday
+      "2023-01-02T11:00:00Z,2023-01-16T11:00:00Z",
+      // Monday 12:59pm. 10 working days later, so two weeks on Monday
+      "2023-01-02T12:59:59Z,2023-01-16T12:59:59Z",
+      // Monday 1pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-01-02T13:00:00Z,2023-01-17T09:00:00Z",
+      // Monday 2pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-01-02T14:00:00Z,2023-01-17T09:00:00Z",
+      // Thursday 2pm. 10 working days after 9am on the next working day (Friday), so two weeks on Friday
+      "2023-01-05T14:00:00Z,2023-01-20T09:00:00Z",
+      // Friday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-06T14:00:00Z,2023-01-23T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T10:00:00Z,2023-06-19T08:00:00Z",
+      // Sunday 12:59pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T11:59:59Z,2023-06-19T08:00:00Z",
+      // Sunday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T12:00:00Z,2023-06-19T08:00:00Z",
+      // Sunday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T13:00:00Z,2023-06-19T08:00:00Z",
+      // Monday 11am. 10 working days later, so two weeks on Monday
+      "2023-06-05T10:00:00Z,2023-06-19T10:00:00Z",
+      // Monday 12:59pm. 10 working days later, so two weeks on Monday
+      "2023-06-05T11:59:59Z,2023-06-19T11:59:59Z",
+      // Monday 1pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-06-05T12:00:00Z,2023-06-20T08:00:00Z",
+      // Monday 2pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-06-05T13:00:00Z,2023-06-20T08:00:00Z",
+      // Thursday 2pm. 10 working days after 9am on the next working day (Friday), so two weeks on Friday
+      "2023-06-08T13:00:00Z,2023-06-23T08:00:00Z",
+      // Friday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-09T13:00:00Z,2023-06-26T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-03-24T13:00:00Z,2023-04-10T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-10-27T12:00:00Z,2023-11-13T09:00:00Z",
     )
-    fun `getDeadline for a short notice placement application returns submitted date plus 10 working days`(
+    fun `getDeadline for a short notice placement application returns submitted date plus 10 working days, or 10 working days after 9am on the next working day if after 1pm or a non-working day`(
       submittedAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {
@@ -282,12 +656,57 @@ class TaskDeadlineServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      // Monday 3pm. 14 days later, given two weekends
-      "2023-01-02T15:00:00Z,2023-01-16T00:00:00Z",
-      // Friday 3pm. 14 days later, given two weekends
-      "2023-01-06T15:00:00Z,2023-01-20T00:00:00Z",
+      // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
+      // Sunday 11am. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T11:00:00Z,2023-01-16T09:00:00Z",
+      // Sunday 12:59pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T12:59:59Z,2023-01-16T09:00:00Z",
+      // Sunday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T13:00:00Z,2023-01-16T09:00:00Z",
+      // Sunday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-01T14:00:00Z,2023-01-16T09:00:00Z",
+      // Monday 11am. 10 working days later, so two weeks on Monday
+      "2023-01-02T11:00:00Z,2023-01-16T11:00:00Z",
+      // Monday 12:59pm. 10 working days later, so two weeks on Monday
+      "2023-01-02T12:59:59Z,2023-01-16T12:59:59Z",
+      // Monday 1pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-01-02T13:00:00Z,2023-01-17T09:00:00Z",
+      // Monday 2pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-01-02T14:00:00Z,2023-01-17T09:00:00Z",
+      // Thursday 2pm. 10 working days after 9am on the next working day (Friday), so two weeks on Friday
+      "2023-01-05T14:00:00Z,2023-01-20T09:00:00Z",
+      // Friday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-01-06T14:00:00Z,2023-01-23T09:00:00Z",
+
+      // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
+      // Sunday 11am. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T10:00:00Z,2023-06-19T08:00:00Z",
+      // Sunday 12:59pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T11:59:59Z,2023-06-19T08:00:00Z",
+      // Sunday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T12:00:00Z,2023-06-19T08:00:00Z",
+      // Sunday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-04T13:00:00Z,2023-06-19T08:00:00Z",
+      // Monday 11am. 10 working days later, so two weeks on Monday
+      "2023-06-05T10:00:00Z,2023-06-19T10:00:00Z",
+      // Monday 12:59pm. 10 working days later, so two weeks on Monday
+      "2023-06-05T11:59:59Z,2023-06-19T11:59:59Z",
+      // Monday 1pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-06-05T12:00:00Z,2023-06-20T08:00:00Z",
+      // Monday 2pm. 10 working days after 9am on the next working day (Tuesday), so two weeks on Tuesday
+      "2023-06-05T13:00:00Z,2023-06-20T08:00:00Z",
+      // Thursday 2pm. 10 working days after 9am on the next working day (Friday), so two weeks on Friday
+      "2023-06-08T13:00:00Z,2023-06-23T08:00:00Z",
+      // Friday 2pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-06-09T13:00:00Z,2023-06-26T08:00:00Z",
+
+      // Multi-timezone drifting!!
+      // GMT -> BST: Friday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-03-24T13:00:00Z,2023-04-10T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 10 working days after 9am on the next working day (Monday), so two weeks on Monday
+      "2023-10-27T12:00:00Z,2023-11-13T09:00:00Z",
     )
-    fun `getDeadline for an emergency placement application returns submitted date plus 10 working days`(
+    fun `getDeadline for an emergency placement application returns submitted date plus 10 working days, or 10 working days after 9am on the next working day if after 1pm or a non-working day`(
       submittedAt: OffsetDateTime,
       expectedDeadline: OffsetDateTime,
     ) {


### PR DESCRIPTION
> See [APS-563 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-563).

This PR makes sure that all applications that are submitted after 1pm on a working day or on a non-working day (weekends or bank holidays) have their effective submission date set to 9am on the next working day before performing the deadline calculation. This prevents time from being effectively lost due to out-of-hours submissions.

This working pattern adjustment is timezone-aware: it correctly accounts for both winter (GMT/UTC) time and summer time (BST/UTC+1), as well as the weekends where the clocks change.