### PR TITLE
CAS2-380 added conditional release date filter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -61,6 +61,7 @@ LEFT JOIN
 ON a.id = asu.application_id
 JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.created_by_user_id = :userId
+AND (a.conditional_release_date IS NULL OR a.conditional_release_date >= current_date)
 ORDER BY createdAt DESC
 """,
     countQuery =
@@ -87,6 +88,7 @@ FROM cas_2_applications a
 ON a.id = asu.application_id
 JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.referring_prison_code = :prisonCode
+AND (a.conditional_release_date IS NULL OR a.conditional_release_date >= current_date)
 ORDER BY createdAt DESC
 """,
     countQuery =
@@ -114,6 +116,7 @@ ON a.id = asu.application_id
 JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.created_by_user_id = :userId
 AND a.submitted_at IS NOT NULL
+AND a.conditional_release_date >= current_date
 ORDER BY createdAt DESC
 """,
     countQuery =
@@ -142,6 +145,7 @@ ON a.id = asu.application_id
 JOIN nomis_users nu ON nu.id = a.created_by_user_id
 WHERE a.referring_prison_code = :prisonCode
 AND a.submitted_at IS NOT NULL
+AND a.conditional_release_date >= current_date
 ORDER BY createdAt DESC
 """,
     countQuery =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
@@ -99,8 +99,8 @@ class Cas2ApplicationsSeedJob(
       application.apply {
         referringPrisonCode = row.referringPrisonCode
         preferredAreas = "Bristol | Newcastle"
-        hdcEligibilityDate = LocalDate.parse("2024-02-28")
-        conditionalReleaseDate = LocalDate.parse("2024-02-22")
+        hdcEligibilityDate = LocalDate.now()
+        conditionalReleaseDate = LocalDate.now().plusMonths(2)
         telephoneNumber = "0800 123 456"
       },
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -102,8 +102,8 @@ class Cas2AutoScript(
       application.apply {
         referringPrisonCode = "BRI"
         preferredAreas = "Luton | Hertford"
-        hdcEligibilityDate = LocalDate.parse("2024-02-28")
-        conditionalReleaseDate = LocalDate.parse("2024-02-22")
+        hdcEligibilityDate = LocalDate.now()
+        conditionalReleaseDate = LocalDate.now().plusMonths(2)
         telephoneNumber = "0800 123 456"
       },
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -36,6 +36,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var assessment: Yielded<Cas2AssessmentEntity?> = { null }
   private var referringPrisonCode: Yielded<String?> = { null }
   private var hdcEligibilityDate: Yielded<LocalDate?> = { null }
+  private var conditionalReleaseDate: Yielded<LocalDate?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -105,6 +106,10 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.hdcEligibilityDate = { hdcEligibilityDate }
   }
 
+  fun withConditionalReleaseDate(conditionalReleaseDate: LocalDate) = apply {
+    this.conditionalReleaseDate = { conditionalReleaseDate }
+  }
+
   override fun produce(): Cas2ApplicationEntity = Cas2ApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -122,5 +127,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     assessment = this.assessment(),
     referringPrisonCode = this.referringPrisonCode(),
     hdcEligibilityDate = this.hdcEligibilityDate(),
+    conditionalReleaseDate = this.conditionalReleaseDate(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
@@ -150,8 +150,8 @@ class SeedCas2ApplicationTest : SeedTestBase() {
     assertThat(persistedApplication.assessment).isNotNull()
     assertThat(persistedApplication.referringPrisonCode).isEqualTo("EXAMPLE_CODE")
     assertThat(persistedApplication.preferredAreas).isEqualTo("Bristol | Newcastle")
-    assertThat(persistedApplication.hdcEligibilityDate).isEqualTo(LocalDate.parse("2024-02-28"))
-    assertThat(persistedApplication.conditionalReleaseDate).isEqualTo(LocalDate.parse("2024-02-22"))
+    assertThat(persistedApplication.hdcEligibilityDate).isEqualTo(LocalDate.now())
+    assertThat(persistedApplication.conditionalReleaseDate).isEqualTo(LocalDate.now().plusMonths(2))
     assertThat(persistedApplication.telephoneNumber).isEqualTo("0800 123 456")
   }
 


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/CAS2-380

Soft delete submitted applications once their CRD date has been reached.

Referrer dashboards only.