### PR TITLE
CAS2-326: Add an Assessment to Status Updates

### DIFF
--- a/detekt-baseline-main.xml
+++ b/detekt-baseline-main.xml
@@ -120,7 +120,7 @@
     <ID>EmptyClassBlock:Cas2Application.kt$Cas2Application${ }</ID>
     <ID>EmptyClassBlock:Cas2ApplicationAllOf.kt$Cas2ApplicationAllOf${ }</ID>
     <ID>EmptyClassBlock:Cas2ApplicationStatus.kt$Cas2ApplicationStatus${ }</ID>
-    <ID>EmptyClassBlock:Cas2ApplicationStatusUpdate.kt$Cas2ApplicationStatusUpdate${ }</ID>
+    <ID>EmptyClassBlock:Cas2AssessmentStatusUpdate.kt$Cas2ApplicationStatusUpdate${ }</ID>
     <ID>EmptyClassBlock:Cas2ApplicationStatusUpdatedEvent.kt$Cas2ApplicationStatusUpdatedEvent${ }</ID>
     <ID>EmptyClassBlock:Cas2ApplicationStatusUpdatedEventAllOf.kt$Cas2ApplicationStatusUpdatedEventAllOf${ }</ID>
     <ID>EmptyClassBlock:Cas2ApplicationStatusUpdatedEventDetails.kt$Cas2ApplicationStatusUpdatedEventDetails${ }</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -61,6 +61,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
         authorize(HttpMethod.PUT, "/cas2/assessments/**", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/assessments/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
+        authorize(HttpMethod.POST, "/cas2/assessments/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasAnyRole("LICENCE_CA", "POM", "CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/AssessmentsController.kt
@@ -1,17 +1,23 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import org.zalando.problem.AbstractThrowableProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.AssessmentsCas2Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ExternalUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.StatusUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.AssessmentsTransformer
 import java.util.UUID
 
@@ -19,6 +25,8 @@ import java.util.UUID
 class AssessmentsController(
   private val assessmentService: AssessmentService,
   private val assessmentsTransformer: AssessmentsTransformer,
+  private val statusUpdateService: StatusUpdateService,
+  private val externalUserService: ExternalUserService,
 ) : AssessmentsCas2Delegate {
 
   override fun assessmentsAssessmentIdGet(assessmentId: UUID): ResponseEntity<Cas2Assessment> {
@@ -59,5 +67,45 @@ class AssessmentsController(
     return ResponseEntity.ok(
       assessmentsTransformer.transformJpaToApiRepresentation(updatedAssessment),
     )
+  }
+
+  override fun assessmentsAssessmentIdStatusUpdatesPost(
+    assessmentId: UUID,
+    statusUpdate: Cas2AssessmentStatusUpdate,
+  ): ResponseEntity<Unit> {
+    val result = statusUpdateService.createForAssessment(
+      assessmentId = assessmentId,
+      statusUpdate = statusUpdate,
+      assessor = externalUserService.getUserForRequest(),
+    )
+
+    processAuthorisationFor(assessmentId, result)
+      .run { processValidation(this as ValidatableActionResult<Cas2StatusUpdateEntity>) }
+
+    return ResponseEntity(HttpStatus.CREATED)
+  }
+
+  private fun <EntityType> processAuthorisationFor(
+    assessmentId: UUID,
+    result: AuthorisableActionResult<ValidatableActionResult<EntityType>>,
+  ): Any {
+    return when (result) {
+      is AuthorisableActionResult.NotFound -> throwProblem(NotFoundProblem(assessmentId, "Cas2Application"))
+      is AuthorisableActionResult.Unauthorised -> throwProblem(ForbiddenProblem())
+      is AuthorisableActionResult.Success -> result.entity
+    }
+  }
+
+  private fun throwProblem(problem: AbstractThrowableProblem) {
+    throw problem
+  }
+
+  private fun <EntityType : Any> processValidation(validationResult: ValidatableActionResult<EntityType>): Any {
+    return when (validationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throwProblem(BadRequestProblem(errorDetail = validationResult.message))
+      is ValidatableActionResult.FieldValidationError -> throwProblem(BadRequestProblem(invalidParams = validationResult.validationMessages))
+      is ValidatableActionResult.ConflictError -> throwProblem(ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message))
+      is ValidatableActionResult.Success -> validationResult.entity
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service
 import org.zalando.problem.AbstractThrowableProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.SubmissionsCas2Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2ApplicationNote
@@ -114,7 +114,7 @@ class SubmissionsController(
 
   override fun submissionsApplicationIdStatusUpdatesPost(
     applicationId: UUID,
-    statusUpdate: Cas2ApplicationStatusUpdate,
+    statusUpdate: Cas2AssessmentStatusUpdate,
   ): ResponseEntity<Unit> {
     val result = statusUpdateService.create(
       applicationId = applicationId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2AssessmentEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.hibernate.annotations.OrderBy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
@@ -8,6 +9,7 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Repository
@@ -30,6 +32,10 @@ data class Cas2AssessmentEntity(
   var nacroReferralId: String? = null,
 
   var assessorName: String? = null,
+
+  @OneToMany(mappedBy = "assessment")
+  @OrderBy(clause = "createdAt DESC")
+  var statusUpdates: MutableList<Cas2StatusUpdateEntity>? = null,
 ) {
   override fun toString() = "Cas2AssessmentEntity: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
@@ -1,7 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
@@ -17,6 +20,11 @@ import javax.persistence.Table
 @Repository
 interface Cas2StatusUpdateRepository : JpaRepository<Cas2StatusUpdateEntity, UUID> {
   fun findFirstByApplicationIdOrderByCreatedAtDesc(applicationId: UUID): Cas2StatusUpdateEntity?
+
+  @Query(
+    "SELECT su FROM Cas2StatusUpdateEntity su WHERE su.assessment IS NULL",
+  )
+  fun findAllStatusUpdatesWithoutAssessment(pageable: Pageable?): Slice<Cas2StatusUpdateEntity>
 }
 
 @Entity
@@ -40,7 +48,7 @@ data class Cas2StatusUpdateEntity(
 
   @ManyToOne
   @JoinColumn(name = "assessment_id")
-  val assessment: Cas2AssessmentEntity? = null,
+  var assessment: Cas2AssessmentEntity? = null,
 
   @OneToMany(mappedBy = "statusUpdate")
   val statusUpdateDetails: List<Cas2StatusUpdateDetailEntity>? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/StatusUpdateEntity.kt
@@ -38,6 +38,10 @@ data class Cas2StatusUpdateEntity(
   @JoinColumn(name = "application_id")
   val application: Cas2ApplicationEntity,
 
+  @ManyToOne
+  @JoinColumn(name = "assessment_id")
+  val assessment: Cas2AssessmentEntity? = null,
+
   @OneToMany(mappedBy = "statusUpdate")
   val statusUpdateDetails: List<Cas2StatusUpdateDetailEntity>? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas2StatusUpdateMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas2StatusUpdateMigrationJob.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
+
+class Cas2StatusUpdateMigrationJob(
+  private val statusUpdateRepository: Cas2StatusUpdateRepository,
+  private val transactionTemplate: TransactionTemplate,
+  private val pageSize: Int,
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = true
+
+  override fun process() {
+    log.info("Starting Cas2 Status Update Migration process...")
+
+    var hasNext = true
+    var slice: Slice<Cas2StatusUpdateEntity>
+    var page = 1
+
+    while (hasNext) {
+      log.info("Getting page $page for max page size $pageSize")
+      slice = statusUpdateRepository.findAllStatusUpdatesWithoutAssessment(PageRequest.of(0, pageSize))
+      slice.content.forEach { statusUpdate ->
+        transactionTemplate.executeWithoutResult {
+          log.info("Adding assessment to Status Update ${statusUpdate.id}")
+          statusUpdate.assessment = statusUpdate.application.assessment
+          statusUpdateRepository.save(
+            statusUpdate,
+          )
+        }
+      }
+      hasNext = slice.hasNext()
+      page += 1
+    }
+    log.info("CAS2 Status Update Migration process complete!")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2ApplicationsSeedJob.kt
@@ -114,6 +114,7 @@ class Cas2ApplicationsSeedJob(
       Cas2StatusUpdateEntity(
         id = UUID.randomUUID(),
         application = application,
+        assessment = application.assessment,
         assessor = assessor,
         description = status.description,
         label = status.label,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2AutoScript.kt
@@ -116,6 +116,7 @@ class Cas2AutoScript(
       Cas2StatusUpdateEntity(
         id = UUID.randomUUID(),
         application = application,
+        assessment = application.assessment,
         assessor = assessor,
         description = status.description,
         label = status.label,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingReposi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1BackfillUs
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1UserDetailsMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2StatusUpdateMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas3UpdateApplicationOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
@@ -87,6 +89,12 @@ class MigrationJobService(
           applicationContext.getBean(Cas2AssessmentRepository::class.java),
           applicationContext.getBean(Cas2ApplicationRepository::class.java),
           transactionTemplate,
+        )
+
+        MigrationJobType.cas2StatusUpdatesWithAssessments -> Cas2StatusUpdateMigrationJob(
+          applicationContext.getBean(Cas2StatusUpdateRepository::class.java),
+          transactionTemplate,
+          pageSize,
         )
 
         MigrationJobType.cas1UserDetails -> Cas1UserDetailsMigrationJob(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
@@ -4,6 +4,7 @@ import com.amazonaws.services.sns.model.NotFoundException
 import io.sentry.Sentry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEventDetails
@@ -15,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
@@ -44,6 +46,7 @@ object Constants {
 @Service("Cas2StatusUpdateService")
 class StatusUpdateService(
   private val applicationRepository: Cas2ApplicationRepository,
+  private val assessmentRepository: Cas2AssessmentRepository,
   private val statusUpdateRepository: Cas2StatusUpdateRepository,
   private val statusUpdateDetailRepository: Cas2StatusUpdateDetailRepository,
   private val domainEventService: DomainEventService,
@@ -63,6 +66,7 @@ class StatusUpdateService(
 
   @SuppressWarnings("ReturnCount")
   @Transactional
+  @Deprecated("Use the new createForAssessment")
   fun create(
     applicationId: UUID,
     statusUpdate: Cas2AssessmentStatusUpdate,
@@ -97,6 +101,7 @@ class StatusUpdateService(
       Cas2StatusUpdateEntity(
         id = UUID.randomUUID(),
         application = application,
+        assessment = application.assessment,
         assessor = assessor,
         statusId = status.id,
         description = status.description,
@@ -117,6 +122,70 @@ class StatusUpdateService(
     }
 
     sendEmailStatusUpdated(application.createdByUser, application, createdStatusUpdate)
+
+    createStatusUpdatedDomainEvent(createdStatusUpdate, statusDetails)
+
+    return AuthorisableActionResult.Success(
+      ValidatableActionResult.Success(createdStatusUpdate),
+    )
+  }
+
+  @SuppressWarnings("ReturnCount")
+  fun createForAssessment(
+    assessmentId: UUID,
+    statusUpdate: Cas2AssessmentStatusUpdate,
+    assessor: ExternalUserEntity,
+  ): AuthorisableActionResult<ValidatableActionResult<Cas2StatusUpdateEntity>> {
+    val assessment = assessmentRepository.findByIdOrNull(assessmentId)
+      ?: return AuthorisableActionResult.NotFound()
+
+    val status = findActiveStatusByName(statusUpdate.newStatus)
+      ?: return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("The status ${statusUpdate.newStatus} is not valid"),
+      )
+
+    val statusDetails = if (statusUpdate.newStatusDetails.isNullOrEmpty()) {
+      emptyList()
+    } else {
+      statusUpdate.newStatusDetails.map { detail ->
+        status.findStatusDetailOnStatus(detail)
+          ?: return AuthorisableActionResult.Success(
+            ValidatableActionResult.GeneralValidationError("The status detail $detail is not valid"),
+          )
+      }
+    }
+
+    if (ValidationErrors().any()) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.FieldValidationError(ValidationErrors()),
+      )
+    }
+
+    val createdStatusUpdate = statusUpdateRepository.save(
+      Cas2StatusUpdateEntity(
+        id = UUID.randomUUID(),
+        assessment = assessment,
+        application = assessment.application,
+        assessor = assessor,
+        statusId = status.id,
+        description = status.description,
+        label = status.label,
+        createdAt = OffsetDateTime.now(),
+      ),
+    )
+
+    statusDetails.forEach { detail ->
+      statusUpdateDetailRepository.save(
+        Cas2StatusUpdateDetailEntity(
+          id = UUID.randomUUID(),
+          statusDetailId = detail.id,
+          statusUpdate = createdStatusUpdate,
+          label = detail.label,
+        ),
+      )
+    }
+
+    sendEmailStatusUpdated(assessment.application.createdByUser, assessment.application, createdStatusUpdate)
 
     createStatusUpdatedDomainEvent(createdStatusUpdate, statusDetails)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.ExternalUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
@@ -57,7 +57,7 @@ class StatusUpdateService(
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun isValidStatus(statusUpdate: Cas2ApplicationStatusUpdate): Boolean {
+  fun isValidStatus(statusUpdate: Cas2AssessmentStatusUpdate): Boolean {
     return findActiveStatusByName(statusUpdate.newStatus) != null
   }
 
@@ -65,7 +65,7 @@ class StatusUpdateService(
   @Transactional
   fun create(
     applicationId: UUID,
-    statusUpdate: Cas2ApplicationStatusUpdate,
+    statusUpdate: Cas2AssessmentStatusUpdate,
     assessor: ExternalUserEntity,
   ): AuthorisableActionResult<ValidatableActionResult<Cas2StatusUpdateEntity>> {
     val application = applicationRepository.findSubmittedApplicationById(applicationId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -17,6 +17,7 @@ class ApplicationsTransformer(
   private val nomisUserTransformer: NomisUserTransformer,
   private val statusUpdateTransformer: StatusUpdateTransformer,
   private val timelineEventsTransformer: TimelineEventsTransformer,
+  private val assessmentsTransformer: AssessmentsTransformer,
 ) {
 
   fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult):
@@ -35,6 +36,7 @@ class ApplicationsTransformer(
       type = "CAS2",
       telephoneNumber = jpa.telephoneNumber,
       statusUpdates = jpa.statusUpdates?.map { statusUpdate -> statusUpdateTransformer.transformJpaToApi(statusUpdate) },
+      assessment = if (jpa.assessment != null) assessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
       timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/AssessmentsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/AssessmentsTransformer.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 
 @Component("Cas2AssessmentsTransformer")
-class AssessmentsTransformer {
+class AssessmentsTransformer(private val statusUpdateTransformer: StatusUpdateTransformer) {
   fun transformJpaToApiRepresentation(
     jpaAssessment: Cas2AssessmentEntity,
   ): Cas2Assessment {
@@ -13,6 +13,7 @@ class AssessmentsTransformer {
       jpaAssessment.id,
       jpaAssessment.nacroReferralId,
       jpaAssessment.assessorName,
+      jpaAssessment.statusUpdates?.map { update -> statusUpdateTransformer.transformJpaToApi(update) },
     )
   }
 }

--- a/src/main/resources/db/migration/all/20240509091500__add_status_updates_to_assessments.sql
+++ b/src/main/resources/db/migration/all/20240509091500__add_status_updates_to_assessments.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION;
+-- add a nullable foreign key for assessments
+ALTER TABLE cas_2_status_updates
+ADD COLUMN assessment_id UUID;
+
+ALTER TABLE cas_2_status_updates
+ADD FOREIGN KEY (assessment_id) REFERENCES cas_2_assessments (id);
+
+-- index on the assessment id
+CREATE INDEX ON cas_2_status_updates(assessment_id);
+COMMIT;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2570,6 +2570,10 @@ components:
           type: string
         assessorName:
           type: string
+        statusUpdates:
+          type: array
+          items:
+            $ref: '_shared.yml#/components/schemas/Cas2StatusUpdate'
       required:
         - id
     UpdateCas2Assessment:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1701,6 +1701,8 @@ components:
               type: array
               items:
                 $ref: '_shared.yml#/components/schemas/Cas2StatusUpdate'
+            assessment:
+              $ref: '#/components/schemas/Cas2Assessment'
             timelineEvents:
               type: array
               items:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1989,7 +1989,7 @@ components:
         - id
         - name
         - label
-    Cas2ApplicationStatusUpdate:
+    Cas2AssessmentStatusUpdate:
       type: object
       properties:
         newStatus:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3645,6 +3645,7 @@ components:
         - update_application_ap_areas
         - update_task_due_dates
         - update_cas2_applications_with_assessments
+        - update_cas2_status_updates_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -328,7 +328,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '_shared.yml#/components/schemas/Cas2ApplicationStatusUpdate'
+              $ref: '_shared.yml#/components/schemas/Cas2AssessmentStatusUpdate'
         required: true
       responses:
         200:

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -223,6 +223,41 @@ paths:
                 $ref: '_shared.yml#/components/schemas/Problem'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /assessments/{assessmentId}/status-updates:
+    post:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: Creates a status update on an assessment
+      parameters:
+        - name: assessmentId
+          in: path
+          description: ID of the assessment whose status is to be updated
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Information on the new status to be applied
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/Cas2AssessmentStatusUpdate'
+        required: true
+      responses:
+        200:
+          description: successfully created the status update
+        400:
+          description: status update has already been submitted
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /submissions:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6402,6 +6402,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2StatusUpdate'
+            assessment:
+              $ref: '#/components/schemas/Cas2Assessment'
             timelineEvents:
               type: array
               items:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7271,6 +7271,10 @@ components:
           type: string
         assessorName:
           type: string
+        statusUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdate'
       required:
         - id
     UpdateCas2Assessment:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6690,7 +6690,7 @@ components:
         - id
         - name
         - label
-    Cas2ApplicationStatusUpdate:
+    Cas2AssessmentStatusUpdate:
       type: object
       properties:
         newStatus:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8346,6 +8346,7 @@ components:
         - update_application_ap_areas
         - update_task_due_dates
         - update_cas2_applications_with_assessments
+        - update_cas2_status_updates_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4245,6 +4245,7 @@ components:
         - update_application_ap_areas
         - update_task_due_dates
         - update_cas2_applications_with_assessments
+        - update_cas2_status_updates_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3170,6 +3170,10 @@ components:
           type: string
         assessorName:
           type: string
+        statusUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdate'
       required:
         - id
     UpdateCas2Assessment:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2301,6 +2301,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2StatusUpdate'
+            assessment:
+              $ref: '#/components/schemas/Cas2Assessment'
             timelineEvents:
               type: array
               items:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -225,6 +225,41 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /assessments/{assessmentId}/status-updates:
+    post:
+      tags:
+        - Operations on submitted CAS2 applications (Assessors)
+      summary: Creates a status update on an assessment
+      parameters:
+        - name: assessmentId
+          in: path
+          description: ID of the assessment whose status is to be updated
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Information on the new status to be applied
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Cas2AssessmentStatusUpdate'
+        required: true
+      responses:
+        200:
+          description: successfully created the status update
+        400:
+          description: status update has already been submitted
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /submissions:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -330,7 +330,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/Cas2ApplicationStatusUpdate'
+              $ref: '#/components/schemas/Cas2AssessmentStatusUpdate'
         required: true
       responses:
         200:
@@ -2554,7 +2554,7 @@ components:
         - id
         - name
         - label
-    Cas2ApplicationStatusUpdate:
+    Cas2AssessmentStatusUpdate:
       type: object
       properties:
         newStatus:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3736,6 +3736,7 @@ components:
         - update_application_ap_areas
         - update_task_due_dates
         - update_cas2_applications_with_assessments
+        - update_cas2_status_updates_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2661,6 +2661,10 @@ components:
           type: string
         assessorName:
           type: string
+        statusUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdate'
       required:
         - id
     UpdateCas2Assessment:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1792,6 +1792,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2StatusUpdate'
+            assessment:
+              $ref: '#/components/schemas/Cas2Assessment'
             timelineEvents:
               type: array
               items:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2080,7 +2080,7 @@ components:
         - id
         - name
         - label
-    Cas2ApplicationStatusUpdate:
+    Cas2AssessmentStatusUpdate:
       type: object
       properties:
         newStatus:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2AssessmentEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -17,6 +18,7 @@ class Cas2AssessmentEntityFactory : Factory<Cas2AssessmentEntity> {
   }
   private var nacroReferralId: String? = null
   private var assessorName: String? = null
+  private var statusUpdates: MutableList<Cas2StatusUpdateEntity> = mutableListOf()
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -24,6 +26,10 @@ class Cas2AssessmentEntityFactory : Factory<Cas2AssessmentEntity> {
 
   fun withApplication(application: Cas2ApplicationEntity) = apply {
     this.application = { application }
+  }
+
+  fun withStatusUpdates(statusUpdates: MutableList<Cas2StatusUpdateEntity>) = apply {
+    this.statusUpdates = statusUpdates
   }
 
   fun withNacroReferralId(id: String) = apply {
@@ -40,5 +46,6 @@ class Cas2AssessmentEntityFactory : Factory<Cas2AssessmentEntity> {
     application = this.application(),
     nacroReferralId = this.nacroReferralId,
     assessorName = this.assessorName,
+    statusUpdates = this.statusUpdates,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
@@ -14,6 +15,7 @@ import java.util.UUID
 class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var assessor: Yielded<ExternalUserEntity> = { ExternalUserEntityFactory().produce() }
+  private var assessment: Yielded<Cas2AssessmentEntity?> = { null }
   private var application: Yielded<Cas2ApplicationEntity>? = null
   private var statusId: Yielded<UUID> = { Cas2ApplicationStatusSeeding.statusList().random().id }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
@@ -27,6 +29,10 @@ class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
 
   fun withAssessor(assessor: ExternalUserEntity) = apply {
     this.assessor = { assessor }
+  }
+
+  fun withAssessment(assessment: Cas2AssessmentEntity) = apply {
+    this.assessment = { assessment }
   }
 
   fun withApplication(application: Cas2ApplicationEntity) = apply {
@@ -57,6 +63,7 @@ class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
     id = this.id(),
     assessor = this.assessor(),
     application = this.application?.invoke() ?: error("Must provide a submitted application"),
+    assessment = this.assessment(),
     statusId = this.statusId(),
     createdAt = this.createdAt(),
     label = this.label(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2MigrateStatusUpdatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2MigrateStatusUpdatesTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearMocks
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2MigrateStatusUpdatesTest : MigrationJobTestBase() {
+
+  @SpykBean
+  lateinit var realStatusUpdateRepository: Cas2StatusUpdateRepository
+
+  @AfterEach
+  fun afterEach() {
+    // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
+    // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
+    // Manually clearing after each test seems to fix this.
+    clearMocks(realStatusUpdateRepository)
+  }
+
+  @Test
+  fun `Should add assessments for CAS2 Status Updates that don't have one and returns 202 response`() {
+    `Given a CAS2 POM User` { userEntity, _ ->
+      `Given a CAS2 Assessor` { assessor, _ ->
+        val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withAddedAt(OffsetDateTime.now())
+          withId(UUID.randomUUID())
+        }
+
+        // set up the application and assessment that we check
+        val submittedApplication = createApplicationEntity(applicationSchema, userEntity, OffsetDateTime.now().minusDays(1))
+
+        val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+          withApplication(submittedApplication)
+        }
+
+        // create the status updates so there are two pages
+        val assessmentIds = mutableListOf<UUID>()
+        repeat(12) {
+          assessmentIds.add(
+            cas2StatusUpdateEntityFactory.produceAndPersist {
+              withApplication(submittedApplication)
+              withAssessor(assessor)
+            }.id,
+          )
+        }
+
+        migrationJobService.runMigrationJob(MigrationJobType.cas2StatusUpdatesWithAssessments, 10)
+
+        assessmentIds.forEach {
+          val updatedStatusUpdate = realStatusUpdateRepository.findById(it)
+          Assertions.assertThat(updatedStatusUpdate.get().assessment!!.id).isEqualTo(assessment.id)
+        }
+      }
+    }
+  }
+
+  private fun createApplicationEntity(applicationSchema: Cas2ApplicationJsonSchemaEntity, userEntity: NomisUserEntity, submittedAt: OffsetDateTime?) =
+    cas2ApplicationEntityFactory.produceAndPersist {
+      withId(UUID.randomUUID())
+      withApplicationSchema(applicationSchema)
+      withCreatedByUser(userEntity)
+      withData("{}")
+      withSubmittedAt(submittedAt)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.fail
 import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
@@ -96,7 +96,7 @@ class Cas2StatusUpdateTest(
             .uri("/cas2/submissions/${application.id}/status-updates")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
-              Cas2ApplicationStatusUpdate(newStatus = "moreInfoRequested"),
+              Cas2AssessmentStatusUpdate(newStatus = "moreInfoRequested"),
             )
             .exchange()
             .expectStatus()
@@ -133,7 +133,7 @@ class Cas2StatusUpdateTest(
           .uri("/cas2/submissions/66f7127a-fe03-4b66-8378-5c0b048490f8/status-updates")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
-            Cas2ApplicationStatusUpdate(newStatus = "moreInfoRequested"),
+            Cas2AssessmentStatusUpdate(newStatus = "moreInfoRequested"),
           )
           .exchange()
           .expectStatus()
@@ -156,7 +156,7 @@ class Cas2StatusUpdateTest(
             .uri("/cas2/submissions/${application.id}/status-updates")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
-              Cas2ApplicationStatusUpdate(newStatus = "invalidStatus"),
+              Cas2AssessmentStatusUpdate(newStatus = "invalidStatus"),
             )
             .exchange()
             .expectStatus()
@@ -191,7 +191,7 @@ class Cas2StatusUpdateTest(
               .uri("/cas2/submissions/${application.id}/status-updates")
               .header("Authorization", "Bearer $jwt")
               .bodyValue(
-                Cas2ApplicationStatusUpdate(
+                Cas2AssessmentStatusUpdate(
                   newStatus = "offerDeclined",
                   newStatusDetails = listOf("changeOfCircumstances"),
                 ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
 import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
@@ -89,6 +88,10 @@ class Cas2StatusUpdateTest(
             withSubmittedAt(OffsetDateTime.now())
           }
 
+          val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+            withApplication(application)
+          }
+
           Assertions.assertThat(realStatusUpdateRepository.count()).isEqualTo(0)
           Assertions.assertThat(realStatusUpdateDetailRepository.count()).isEqualTo(0)
 
@@ -105,10 +108,10 @@ class Cas2StatusUpdateTest(
           Assertions.assertThat(realStatusUpdateRepository.count()).isEqualTo(1)
 
           val persistedStatusUpdate = realStatusUpdateRepository.findFirstByApplicationIdOrderByCreatedAtDesc(application.id)
-          Assertions.assertThat(persistedStatusUpdate).isNotNull
+          Assertions.assertThat(persistedStatusUpdate!!.assessment!!.id).isEqualTo(assessment.id)
 
           val appliedStatus = Cas2ApplicationStatusSeeding.statusList()
-            .find { status -> status.id == persistedStatusUpdate?.statusId ?: fail("The expected StatusUpdate was not persisted") }
+            .find { status -> status.id == persistedStatusUpdate.statusId }
 
           Assertions.assertThat(appliedStatus!!.name).isEqualTo("moreInfoRequested")
         }
@@ -185,6 +188,10 @@ class Cas2StatusUpdateTest(
               withNomsNumber("123NOMS")
             }
 
+            val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+              withApplication(application)
+            }
+
             Assertions.assertThat(realStatusUpdateRepository.count()).isEqualTo(0)
 
             webTestClient.post()
@@ -205,7 +212,7 @@ class Cas2StatusUpdateTest(
 
             val persistedStatusUpdate =
               realStatusUpdateRepository.findFirstByApplicationIdOrderByCreatedAtDesc(application.id)
-            Assertions.assertThat(persistedStatusUpdate).isNotNull
+            Assertions.assertThat(persistedStatusUpdate!!.assessment!!.id).isEqualTo(assessment.id)
 
             val persistedStatusDetailUpdate =
               realStatusUpdateDetailRepository.findFirstByStatusUpdateIdOrderByCreatedAtDesc(persistedStatusUpdate!!.id)
@@ -213,7 +220,7 @@ class Cas2StatusUpdateTest(
 
             val appliedStatus = Cas2ApplicationStatusSeeding.statusList()
               .find { status ->
-                status.id == (persistedStatusUpdate?.statusId ?: fail("The expected StatusUpdate was not persisted"))
+                status.id == persistedStatusUpdate.statusId
               }
 
             Assertions.assertThat(appliedStatus!!.name).isEqualTo("offerDeclined")
@@ -251,6 +258,235 @@ class Cas2StatusUpdateTest(
         // verify that the persisted domain event contains the expected status details
         val expected = listOf(Cas2StatusDetail("changeOfCircumstances", "Change of circumstances"))
         Assertions.assertThat(domainEventFromJson.eventDetails.newStatus.statusDetails).isEqualTo(expected)
+      }
+    }
+  }
+
+  @Nested
+  inner class OnAssessments {
+    @Nested
+    inner class ControlsOnInternalUsers {
+      @Test
+      fun `creating a status update is forbidden to internal users based on role`() {
+        val jwt = jwtAuthHelper.createClientCredentialsJwt(
+          username = "username",
+          authSource = "nomis",
+          roles = listOf("ROLE_POM"),
+        )
+
+        webTestClient.post()
+          .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/status-updates")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @Nested
+    inner class MissingJwt {
+      @Test
+      fun `creating a status update without JWT returns 401`() {
+        webTestClient.post()
+          .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/status-updates")
+          .exchange()
+          .expectStatus()
+          .isUnauthorized
+      }
+    }
+
+    @Nested
+    inner class PostToCreate {
+      @Test
+      fun `Create status update returns 201 and creates StatusUpdate when given status is valid`() {
+        val assessmentId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+        `Given a CAS2 Assessor`() { _, jwt ->
+          `Given a CAS2 POM User` { applicant, _ ->
+            val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+            val application = cas2ApplicationEntityFactory.produceAndPersist {
+              withCreatedByUser(applicant)
+              withApplicationSchema(jsonSchema)
+              withSubmittedAt(OffsetDateTime.now())
+            }
+
+            cas2AssessmentEntityFactory.produceAndPersist {
+              withApplication(application)
+              withId(assessmentId)
+            }
+
+            Assertions.assertThat(realStatusUpdateRepository.count()).isEqualTo(0)
+            Assertions.assertThat(realStatusUpdateDetailRepository.count()).isEqualTo(0)
+
+            webTestClient.post()
+              .uri("/cas2/assessments/$assessmentId/status-updates")
+              .header("Authorization", "Bearer $jwt")
+              .bodyValue(
+                Cas2AssessmentStatusUpdate(newStatus = "moreInfoRequested"),
+              )
+              .exchange()
+              .expectStatus()
+              .isCreated
+
+            Assertions.assertThat(realStatusUpdateRepository.count()).isEqualTo(1)
+
+            val persistedStatusUpdate = realStatusUpdateRepository.findFirstByApplicationIdOrderByCreatedAtDesc(application.id)
+            Assertions.assertThat(persistedStatusUpdate!!.assessment!!.id).isEqualTo(assessmentId)
+
+            val appliedStatus = Cas2ApplicationStatusSeeding.statusList()
+              .find { status ->
+                status.id == persistedStatusUpdate.statusId
+              }
+            Assertions.assertThat(appliedStatus!!.name).isEqualTo("moreInfoRequested")
+
+            // verify that generated 'application.status-updated' domain event links
+            // to the CAS2 domain
+            val expectedFrontEndUrl = applicationUrlTemplate.replace("#id", application.id.toString())
+            val persistedDomainEvent = domainEventRepository.findFirstByOrderByCreatedAtDesc()
+            val domainEventFromJson = objectMapper.readValue(
+              persistedDomainEvent!!.data,
+              Cas2ApplicationStatusUpdatedEvent::class.java,
+            )
+            Assertions.assertThat(domainEventFromJson.eventDetails.applicationUrl)
+              .isEqualTo(expectedFrontEndUrl)
+          }
+        }
+      }
+
+      @Test
+      fun `Create status update returns 404 when assessment not found`() {
+        `Given a CAS2 Assessor`() { _, jwt ->
+          webTestClient.post()
+            .uri("/cas2/assessments/66f7127a-fe03-4b66-8378-5c0b048490f8/status-updates")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              Cas2AssessmentStatusUpdate(newStatus = "moreInfoRequested"),
+            )
+            .exchange()
+            .expectStatus()
+            .isNotFound
+        }
+      }
+
+      @Test
+      fun `Create status update returns 400 when new status NOT valid`() {
+        `Given a CAS2 Assessor`() { _, jwt ->
+          `Given a CAS2 POM User` { applicant, _ ->
+            val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+            val application = cas2ApplicationEntityFactory.produceAndPersist {
+              withCreatedByUser(applicant)
+              withApplicationSchema(jsonSchema)
+              withSubmittedAt(OffsetDateTime.now())
+            }
+
+            val assessmemt = cas2AssessmentEntityFactory.produceAndPersist {
+              withApplication(application)
+            }
+
+            webTestClient.post()
+              .uri("/cas2/assessments/${assessmemt.id}/status-updates")
+              .header("Authorization", "Bearer $jwt")
+              .bodyValue(
+                Cas2AssessmentStatusUpdate(newStatus = "invalidStatus"),
+              )
+              .exchange()
+              .expectStatus()
+              .isBadRequest
+              .expectBody()
+              .jsonPath("$.detail").isEqualTo("The status invalidStatus is not valid")
+          }
+        }
+      }
+
+      @Nested
+      inner class WithStatusDetail {
+        @Test
+        fun `Create status update returns 201 and creates StatusUpdate when given status and detail are valid, and sends an email to the referrer`() {
+          val assessmentId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+          val submittedAt = OffsetDateTime.now()
+
+          `Given a CAS2 Assessor`() { _, jwt ->
+            `Given a CAS2 POM User` { applicant, _ ->
+              val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+              val application = cas2ApplicationEntityFactory.produceAndPersist {
+                withCreatedByUser(applicant)
+                withApplicationSchema(jsonSchema)
+                withSubmittedAt(submittedAt)
+                withNomsNumber("123NOMS")
+              }
+
+              val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+                withId(assessmentId)
+                withApplication(application)
+              }
+
+              Assertions.assertThat(realStatusUpdateRepository.count()).isEqualTo(0)
+
+              webTestClient.post()
+                .uri("/cas2/assessments/$assessmentId/status-updates")
+                .header("Authorization", "Bearer $jwt")
+                .bodyValue(
+                  Cas2AssessmentStatusUpdate(
+                    newStatus = "offerDeclined",
+                    newStatusDetails = listOf("changeOfCircumstances"),
+                  ),
+                )
+                .exchange()
+                .expectStatus()
+                .isCreated
+
+              Assertions.assertThat(realStatusUpdateRepository.count()).isEqualTo(1)
+              Assertions.assertThat(realStatusUpdateDetailRepository.count()).isEqualTo(1)
+
+              val persistedStatusUpdate =
+                realStatusUpdateRepository.findFirstByApplicationIdOrderByCreatedAtDesc(application.id)
+              Assertions.assertThat(persistedStatusUpdate!!.assessment!!.id).isEqualTo(assessmentId)
+
+              val persistedStatusDetailUpdate =
+                realStatusUpdateDetailRepository.findFirstByStatusUpdateIdOrderByCreatedAtDesc(persistedStatusUpdate!!.id)
+              Assertions.assertThat(persistedStatusDetailUpdate).isNotNull
+
+              val appliedStatus = Cas2ApplicationStatusSeeding.statusList()
+                .find { status ->
+                  status.id == persistedStatusUpdate.statusId
+                }
+
+              Assertions.assertThat(appliedStatus!!.name).isEqualTo("offerDeclined")
+              Assertions.assertThat(appliedStatus.statusDetails?.find { detail -> detail.id == persistedStatusDetailUpdate?.statusDetailId })
+                .isNotNull()
+
+              emailAsserter.assertEmailsRequestedCount(1)
+              emailAsserter.assertEmailRequested(
+                toEmailAddress = applicant.email!!,
+                templateId = "ef4dc5e3-b1f1-4448-a545-7a936c50fc3a",
+                personalisation = mapOf(
+                  "applicationStatus" to "Offer declined or withdrawn",
+                  "dateStatusChanged" to submittedAt.toLocalDate().toCas2UiFormat(), // This needs to be something else
+                  "timeStatusChanged" to submittedAt.toCas2UiFormattedHourOfDay(),
+                  "nomsNumber" to "123NOMS",
+                  "applicationType" to "Home Detention Curfew (HDC)",
+                  "applicationUrl" to applicationOverviewUrlTemplate.replace("#id", application.id.toString()),
+                ),
+                replyToEmailId = notifyConfig.emailAddresses.cas2ReplyToId,
+              )
+
+              // verify that generated 'application.status-updated' domain event links
+              // to the CAS2 domain
+              val expectedFrontEndUrl = applicationUrlTemplate.replace("#id", application.id.toString())
+              val persistedDomainEvent = domainEventRepository.findFirstByOrderByCreatedAtDesc()
+              val domainEventFromJson = objectMapper.readValue(
+                persistedDomainEvent!!.data,
+                Cas2ApplicationStatusUpdatedEvent::class.java,
+              )
+              Assertions.assertThat(domainEventFromJson.eventDetails.applicationUrl)
+                .isEqualTo(expectedFrontEndUrl)
+
+              // verify that the persisted domain event contains the expected status details
+              val expected = listOf(Cas2StatusDetail("changeOfCircumstances", "Change of circumstances"))
+              Assertions.assertThat(domainEventFromJson.eventDetails.newStatus.statusDetails).isEqualTo(expected)
+            }
+          }
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2SubmissionTest.kt
@@ -404,18 +404,21 @@ class Cas2SubmissionTest(
 
             val update1 = cas2StatusUpdateEntityFactory.produceAndPersist {
               withApplication(applicationEntity)
+              withAssessment(assessmentEntity)
               withAssessor(assessor)
               withLabel("1st update")
             }
 
             val update2 = cas2StatusUpdateEntityFactory.produceAndPersist {
               withApplication(applicationEntity)
+              withAssessment(assessmentEntity)
               withAssessor(assessor)
               withLabel("2nd update")
             }
 
             val update3 = cas2StatusUpdateEntityFactory.produceAndPersist {
               withApplication(applicationEntity)
+              withAssessment(assessmentEntity)
               withAssessor(assessor)
               withStatusId(UUID.fromString("9a381bc6-22d3-41d6-804d-4e49f428c1de"))
               withLabel("3rd update")
@@ -473,6 +476,9 @@ class Cas2SubmissionTest(
             }
 
             Assertions.assertThat(responseBody.statusUpdates!!.map { update -> update.label })
+              .isEqualTo(listOf("3rd update", "2nd update", "1st update"))
+
+            Assertions.assertThat(responseBody.assessment.statusUpdates!!.map { update -> update.label })
               .isEqualTo(listOf("3rd update", "2nd update", "1st update"))
 
             Assertions.assertThat(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/StatusUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/StatusUpdateServiceTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.ExternalUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationStatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
@@ -88,7 +88,7 @@ class StatusUpdateServiceTest {
     description = "",
     isActive = true,
   )
-  private val applicationStatusUpdate = Cas2ApplicationStatusUpdate(newStatus = activeStatus.name)
+  private val applicationStatusUpdate = Cas2AssessmentStatusUpdate(newStatus = activeStatus.name)
 
   val statusDetail = Cas2PersistedApplicationStatusDetail(
     id = UUID.fromString("390e81d4-2ace-4e76-a9e3-5efa47be606e"),
@@ -105,7 +105,7 @@ class StatusUpdateServiceTest {
     ),
     isActive = true,
   )
-  private val applicationStatusUpdateWithDetail = Cas2ApplicationStatusUpdate(
+  private val applicationStatusUpdateWithDetail = Cas2AssessmentStatusUpdate(
     newStatus = activeStatusWithDetail.name,
     newStatusDetails = listOf(statusDetail.name),
   )
@@ -124,14 +124,14 @@ class StatusUpdateServiceTest {
 
     @Test
     fun `returns true when the given newStatus is valid`() {
-      val validUpdate = Cas2ApplicationStatusUpdate(newStatus = "activeStatusName")
+      val validUpdate = Cas2AssessmentStatusUpdate(newStatus = "activeStatusName")
 
       assertThat(statusUpdateService.isValidStatus(validUpdate)).isTrue()
     }
 
     @Test
     fun `returns false when the given newStatus is NOT valid`() {
-      val invalidUpdate = Cas2ApplicationStatusUpdate(newStatus = "invalidStatus")
+      val invalidUpdate = Cas2AssessmentStatusUpdate(newStatus = "invalidStatus")
 
       assertThat(statusUpdateService.isValidStatus(invalidUpdate)).isFalse()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/StatusUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/StatusUpdateServiceTest.kt
@@ -13,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2Status
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
@@ -21,10 +22,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Pe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
@@ -45,6 +48,7 @@ class StatusUpdateServiceTest {
   private val mockApplicationRepository = mockk<Cas2ApplicationRepository>()
   private val mockStatusUpdateRepository = mockk<Cas2StatusUpdateRepository>()
   private val mockStatusUpdateDetailRepository = mockk<Cas2StatusUpdateDetailRepository>()
+  private val mockAssessmentRepository = mockk<Cas2AssessmentRepository>()
   private val assessor = ExternalUserEntityFactory()
     .withUsername("JOHN_SMITH_NACRO")
     .withName("John Smith")
@@ -64,12 +68,14 @@ class StatusUpdateServiceTest {
     .withNomsNumber("NOMSABC")
     .produce()
   private val applicationId = application.id
+  val assessment = Cas2AssessmentEntityFactory().withApplication(application).produce()
   private val mockStatusFinder = mockk<Cas2PersistedApplicationStatusFinder>()
   private val applicationUrlTemplate = "http://example.com/application-status-updated/#eventId"
   private val applicationOverviewUrlTemplate = "http://example.com/application/#id/overview"
 
   private val statusUpdateService = StatusUpdateService(
     mockApplicationRepository,
+    mockAssessmentRepository,
     mockStatusUpdateRepository,
     mockStatusUpdateDetailRepository,
     mockDomainEventService,
@@ -151,6 +157,8 @@ class StatusUpdateServiceTest {
           .withStatusId(activeStatus.id)
           .produce()
 
+        application.assessment = assessment
+
         every { mockApplicationRepository.findSubmittedApplicationById(applicationId) } answers
           {
             application
@@ -182,7 +190,7 @@ class StatusUpdateServiceTest {
       }
 
       @Test
-      fun `asks the domain event service to create a status-updated event`() {
+      fun `saves and asks the domain event service to create a status-updated event`() {
         statusUpdateService.create(
           applicationId = applicationId,
           statusUpdate = applicationStatusUpdate,
@@ -213,6 +221,14 @@ class StatusUpdateServiceTest {
                 description = "The prison offender manager (POM) must provide information requested for the application to progress.",
                 statusDetails = emptyList(),
               )
+            },
+          )
+        }
+
+        verify {
+          mockStatusUpdateRepository.save(
+            match {
+              it.assessment!!.id == assessment.id
             },
           )
         }
@@ -416,6 +432,311 @@ class StatusUpdateServiceTest {
         fun `does NOT ask the domain event service to create a status-updated event`() {
           statusUpdateService.create(
             applicationId = applicationId,
+            statusUpdate = applicationStatusUpdate,
+            assessor = assessor,
+          )
+
+          verify(exactly = 0) {
+            mockDomainEventService.saveCas2ApplicationStatusUpdatedDomainEvent(any())
+          }
+
+          verify(exactly = 0) { mockEmailNotificationService.sendEmail(any(), any(), any()) }
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class CreateForAssessment {
+
+    @Nested
+    inner class WhenSuccessful {
+
+      @BeforeEach
+      fun setUp() {
+        val cas2StatusUpdateEntity = Cas2StatusUpdateEntityFactory()
+          .withApplication(application)
+          .withAssessor(assessor)
+          .withStatusId(activeStatus.id)
+          .produce()
+
+        every { mockAssessmentRepository.findByIdOrNull(assessment.id) } answers
+          {
+            assessment
+          }
+
+        every { mockStatusUpdateRepository.save(any()) } answers
+          {
+            cas2StatusUpdateEntity
+          }
+
+        every { mockDomainEventService.saveCas2ApplicationStatusUpdatedDomainEvent(any()) } answers { }
+
+        every { mockNotifyConfig.templates.cas2ApplicationStatusUpdated } returns "abc123"
+
+        every {
+          mockEmailNotificationService.sendCas2Email(
+            recipientEmailAddress = applicant.email!!,
+            templateId = "abc123",
+            personalisation = mapOf(
+              "applicationStatus" to cas2StatusUpdateEntity.label,
+              "dateStatusChanged" to cas2StatusUpdateEntity.createdAt.toLocalDate().toCas2UiFormat(),
+              "timeStatusChanged" to cas2StatusUpdateEntity.createdAt.toCas2UiFormattedHourOfDay(),
+              "nomsNumber" to "NOMSABC",
+              "applicationType" to "Home Detention Curfew (HDC)",
+              "applicationUrl" to "http://example.com/application/$applicationId/overview",
+            ),
+          )
+        } just Runs
+      }
+
+      @Test
+      fun `saves and asks the domain event service to create a status-updated event`() {
+        statusUpdateService.createForAssessment(
+          assessmentId = assessment.id,
+          statusUpdate = applicationStatusUpdate,
+          assessor = assessor,
+        )
+
+        verify {
+          mockDomainEventService.saveCas2ApplicationStatusUpdatedDomainEvent(
+            match {
+              it.crn == "CRN123" &&
+                it.applicationId == applicationId &&
+                it.data.eventType == EventType.applicationStatusUpdated &&
+                it.data.eventDetails.applicationId == applicationId &&
+                it.data.eventDetails.applicationUrl == "http://example.com/application-status-updated/#eventId" &&
+                it.data.eventDetails.updatedBy == ExternalUser(
+                username = "JOHN_SMITH_NACRO",
+                name = "John Smith",
+                email = "john@nacro.example.com",
+                origin = "NACRO",
+              ) &&
+                it.data.eventDetails.personReference == PersonReference(
+                crn = "CRN123",
+                noms = "NOMSABC",
+              ) &&
+                it.data.eventDetails.newStatus == Cas2Status(
+                name = "moreInfoRequested",
+                label = "More information requested",
+                description = "The prison offender manager (POM) must provide information requested for the application to progress.",
+                statusDetails = emptyList(),
+              )
+            },
+          )
+        }
+
+        verify {
+          mockStatusUpdateRepository.save(
+            match {
+              it.assessment!!.id == assessment.id
+            },
+          )
+        }
+      }
+    }
+
+    @Nested
+    inner class WhenUnsuccessful {
+
+      @BeforeEach
+      fun setUp() {
+        every { mockAssessmentRepository.findByIdOrNull(assessment.id) } answers
+          {
+            null
+          }
+      }
+
+      @Test
+      fun `does NOT ask the domain event service to create a status-updated event`() {
+        statusUpdateService.createForAssessment(
+          assessmentId = assessment.id,
+          statusUpdate = applicationStatusUpdate,
+          assessor = assessor,
+        )
+
+        verify(exactly = 0) {
+          mockDomainEventService.saveCas2ApplicationStatusUpdatedDomainEvent(any())
+        }
+
+        verify(exactly = 0) { mockEmailNotificationService.sendEmail(any(), any(), any()) }
+      }
+    }
+
+    @Nested
+    inner class WithStatusDetail {
+      @Nested
+      inner class WhenSuccessful {
+
+        @BeforeEach
+        fun setUp() {
+          val cas2StatusUpdateEntity = Cas2StatusUpdateEntityFactory()
+            .withApplication(application)
+            .withAssessment(assessment)
+            .withAssessor(assessor)
+            .withStatusId(activeStatusWithDetail.id)
+            .produce()
+
+          val cas2StatusUpdateDetailEntity = Cas2StatusUpdateDetailEntity(
+            id = UUID.randomUUID(),
+            statusUpdate = cas2StatusUpdateEntity,
+            statusDetailId = statusDetail.id,
+            label = statusDetail.label,
+          )
+
+          every { mockAssessmentRepository.findByIdOrNull(assessment.id) } answers
+            {
+              assessment
+            }
+
+          every { mockStatusUpdateRepository.save(any()) } answers
+            {
+              cas2StatusUpdateEntity
+            }
+
+          every { mockStatusUpdateDetailRepository.save(any()) } answers
+            {
+              cas2StatusUpdateDetailEntity
+            }
+
+          every { mockDomainEventService.saveCas2ApplicationStatusUpdatedDomainEvent(any()) } answers { }
+
+          every { mockNotifyConfig.templates.cas2ApplicationStatusUpdated } returns "abc123"
+
+          every {
+            mockEmailNotificationService.sendCas2Email(
+              recipientEmailAddress = applicant.email!!,
+              templateId = "abc123",
+              personalisation = mapOf(
+                "applicationStatus" to cas2StatusUpdateEntity.label,
+                "dateStatusChanged" to cas2StatusUpdateEntity.createdAt.toLocalDate().toCas2UiFormat(),
+                "timeStatusChanged" to cas2StatusUpdateEntity.createdAt.toCas2UiFormattedHourOfDay(),
+                "applicationType" to "Home Detention Curfew (HDC)",
+                "nomsNumber" to "NOMSABC",
+                "applicationUrl" to "http://example.com/application/$applicationId/overview",
+              ),
+            )
+          } just Runs
+        }
+
+        @Test
+        fun `saves a status update entity with detail and emits a domain event`() {
+          every { mockStatusTransformer.transformStatusDetailListToDetailItemList(listOf(statusDetail)) } returns listOf(
+            Cas2StatusDetail("exampleStatusDetail", ""),
+          )
+
+          statusUpdateService.createForAssessment(
+            assessmentId = assessment.id,
+            statusUpdate = applicationStatusUpdateWithDetail,
+            assessor = assessor,
+          )
+
+          verify {
+            mockStatusUpdateRepository.save(
+              match {
+                it.statusId == activeStatusWithDetail.id
+              },
+            )
+          }
+
+          verify {
+            mockStatusUpdateDetailRepository.save(
+              match {
+                it.statusDetailId == statusDetail.id &&
+                  it.label == statusDetail.label
+              },
+            )
+          }
+
+          verify {
+            mockDomainEventService.saveCas2ApplicationStatusUpdatedDomainEvent(
+              match {
+                it.crn == "CRN123" &&
+                  it.applicationId == applicationId &&
+                  it.data.eventType == EventType.applicationStatusUpdated &&
+                  it.data.eventDetails.applicationId == applicationId &&
+                  it.data.eventDetails.applicationUrl == "http://example.com/application-status-updated/#eventId" &&
+                  it.data.eventDetails.updatedBy == ExternalUser(
+                  username = "JOHN_SMITH_NACRO",
+                  name = "John Smith",
+                  email = "john@nacro.example.com",
+                  origin = "NACRO",
+                ) &&
+                  it.data.eventDetails.personReference == PersonReference(
+                  crn = "CRN123",
+                  noms = "NOMSABC",
+                ) &&
+                  it.data.eventDetails.newStatus == Cas2Status(
+                  name = "offerDeclined",
+                  label = "Offer declined or withdrawn",
+                  description = "The accommodation offered has been declined or withdrawn.",
+                  statusDetails = listOf(
+                    Cas2StatusDetail("exampleStatusDetail", ""),
+                  ),
+                )
+              },
+            )
+          }
+        }
+
+        @Test
+        fun `alerts Sentry when the Referrer does not have an email`() {
+          val submittedApplicationWithNoReferrerEmail = Cas2ApplicationEntityFactory()
+            .withCreatedByUser(NomisUserEntityFactory().withEmail(null).produce())
+            .withCrn("CRN123")
+            .withNomsNumber("NOMSABC")
+            .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+            .produce()
+
+          val assessmentWithNoEmail = Cas2AssessmentEntityFactory()
+            .withApplication(submittedApplicationWithNoReferrerEmail).produce()
+
+          every { mockAssessmentRepository.findByIdOrNull(assessmentWithNoEmail.id) } answers
+            {
+              assessmentWithNoEmail
+            }
+
+          mockkStatic(Sentry::class)
+
+          every {
+            Sentry.captureException(
+              RuntimeException(
+                "Email not found for User ${submittedApplicationWithNoReferrerEmail.createdByUser.id}. " +
+                  "Unable to send email when updating status of Application ${submittedApplicationWithNoReferrerEmail.id}",
+                NotFoundException("Email not found for User ${submittedApplicationWithNoReferrerEmail.createdByUser.id}"),
+              ),
+            )
+          } returns SentryId.EMPTY_ID
+
+          statusUpdateService.createForAssessment(
+            assessmentId = assessmentWithNoEmail.id,
+            statusUpdate = applicationStatusUpdateWithDetail,
+            assessor = assessor,
+          )
+
+          verify(exactly = 1) {
+            Sentry.captureException(
+              any(),
+            )
+          }
+        }
+      }
+
+      @Nested
+      inner class WhenUnsuccessful {
+
+        @BeforeEach
+        fun setUp() {
+          every { mockAssessmentRepository.findByIdOrNull(assessment.id) } answers
+            {
+              null
+            }
+        }
+
+        @Test
+        fun `does NOT ask the domain event service to create a status-updated event`() {
+          statusUpdateService.createForAssessment(
+            assessmentId = assessment.id,
             statusUpdate = applicationStatusUpdate,
             assessor = assessor,
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/AssessmentsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/AssessmentsTransformerTest.kt
@@ -1,18 +1,30 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas2
 
+import io.mockk.every
+import io.mockk.mockk
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.AssessmentsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
 
 class AssessmentsTransformerTest {
-  private val assessmentEntity = Cas2AssessmentEntityFactory().produce()
-
-  private val assessmentsTransformer = AssessmentsTransformer()
+  private val mockStatusUpdateEntity = mockk<Cas2StatusUpdateEntity>()
+  private val assessmentEntity = Cas2AssessmentEntityFactory()
+    .withNacroReferralId("NACRO_ID")
+    .withAssessorName("Firsty Lasty")
+    .withStatusUpdates(mutableListOf(mockStatusUpdateEntity, mockStatusUpdateEntity))
+    .produce()
+  private val mockStatusUpdateTransformer = mockk<StatusUpdateTransformer>()
+  private val mockStatusUpdateApi = mockk<Cas2StatusUpdate>()
+  private val assessmentsTransformer = AssessmentsTransformer(mockStatusUpdateTransformer)
 
   @Test
   fun `transforms an assessment entity`() {
+    every { mockStatusUpdateTransformer.transformJpaToApi(mockStatusUpdateEntity) } returns mockStatusUpdateApi
     val transformation = assessmentsTransformer.transformJpaToApiRepresentation(assessmentEntity)
 
     Assertions.assertThat(transformation).isEqualTo(
@@ -20,6 +32,7 @@ class AssessmentsTransformerTest {
         assessmentEntity.id,
         assessmentEntity.nacroReferralId,
         assessmentEntity.assessorName,
+        listOf(mockStatusUpdateApi, mockStatusUpdateApi),
       ),
     )
   }


### PR DESCRIPTION
We previously began some work on CAS2 to introduce the concept of an Assessment - [there's more info in this ADR](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/doc/architecture/decisions/0021-introduce-cas2-assessments.md). 

Having an Assessment concept will allow us to eventually simplify the increasingly complex ApplicationEntity, and allow for some logic on the status of Applications to be decoupled from statuses given by Assessors. [More info on the ticket here](https://dsdmoj.atlassian.net/browse/CAS2-325).

This PR aims to begin work to re-point Status Updates from Applications, to Assessments.

Status Updates are updates given by Assessors on the state of their work on the Assessing side of things. They are more like a record of an event - we keep a list of them over time. They currently have a ManyToOne relationship to Applications, but we want to start hanging them on to Assessments.

In order not to break the frontend, this will be a phased approach. Here's a rough diagram of what we will do https://miro.com/app/board/uXjVMTHREds=/?moveToWidget=3458764587502385174&cot=14

This PR keeps all the existing architecture around Status Updates as they relate to Applications, AND introduces them to Assessments.

![Screenshot 2024-05-02 at 14 38 31](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/a8e0870b-b87a-47e7-a840-751b03996575)

DB level
1. Add a foreign key to the status_updates table to connect them with Assessments
2. Introduce a manual migration to back fill these foreign keys for old status updates
3. Add the `assessment` as a field onto StatusUpdateEntity and vice versa for AssessmentEntity

![Screenshot 2024-05-02 at 16 20 10](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/16647486/d3d5ca58-673b-4aad-9760-78cef3b82a93)

API level
1. There is a new endpoint under `/assessments/{assessmentId}/status-updates` for the UI to start POST-ing status updates too.

Service level
1. any time a Status Update is created, whether via the Application or Assessment, an Assessment will be added to it.

## next phases

1. Run the manual migration to backfill all production status updates
On the UI:
1. Use the new POST endpoint to create status updates
2. Get the status updates via the Assessment for the Assessor view of the application 

Once that has merged, on the API:
1. remove the POST creating status updates via an Application
2. remove the service layer method to create status updates via an Application
3. remove status updates as top level field from `Cas2Submission` model because the UI can now get them via the Assessment on that model.

I think for now we need to keep the OneToMany relationship with the Application because the Referrers views and queries still need to get Status Updates, so we'll keep this relationship until we undertake refactoring of the ApplicationEntity.







