### PR TITLE
APS-756: Suppress link to assessment in timeline event for ASSESSMENT_ALLOCATED

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -83,7 +83,9 @@ class ApplicationTimelineTransformer(
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> listOfNotNull(
         appealUrlOrNull(domainEventSummary),
       )
-      DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED -> listOfNotNull(
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
+      -> listOfNotNull(
         applicationUrlOrNull(domainEventSummary),
       )
       else -> listOfNotNull(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -264,6 +264,43 @@ class ApplicationTimelineTransformerTest {
   }
 
   @Test
+  fun `transformDomainEventSummaryToTimelineEvent does not include assessment URL for ASSESSMENT_ALLOCATED`() {
+    val assessmentId = UUID.randomUUID()
+    val applicationId = UUID.randomUUID()
+
+    val domainEvent = DomainEventSummaryImpl(
+      id = UUID.randomUUID().toString(),
+      type = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
+      occurredAt = OffsetDateTime.now(),
+      bookingId = null,
+      applicationId = applicationId,
+      assessmentId = assessmentId,
+      premisesId = null,
+      appealId = null,
+      triggeredByUser = null,
+    )
+
+    every { mockDomainEventDescriber.getDescription(domainEvent) } returns "Some event"
+
+    Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent).associatedUrls)
+      .containsOnly(
+        TimelineEventAssociatedUrl(TimelineEventUrlType.application, "http://somehost:3000/applications/$applicationId"),
+      )
+
+    Assertions.assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
+      TimelineEvent(
+        id = domainEvent.id,
+        type = TimelineEventType.approvedPremisesAssessmentAllocated,
+        occurredAt = domainEvent.occurredAt.toInstant(),
+        associatedUrls = listOf(
+          TimelineEventAssociatedUrl(TimelineEventUrlType.application, "http://somehost:3000/applications/$applicationId"),
+        ),
+        content = "Some event",
+      ),
+    )
+  }
+
+  @Test
   fun `transformDomainEventSummaryToTimelineEvent adds all possible url types`() {
     val applicationId = UUID.randomUUID()
     val assessmentId = UUID.randomUUID()


### PR DESCRIPTION
We don't want to provide links to in-progress assessments.

See APS-756: https://dsdmoj.atlassian.net/browse/APS-756