### PR TITLE
APS-558: Simplify seeding outcome report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApStaffUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/ApStaffUsersSeedJob.kt
@@ -40,10 +40,9 @@ class ApStaffUsersSeedJob(
   }
 
   private fun seedingReport(user: UserEntity): String {
-    val ageInMinutes = ChronoUnit.MINUTES.between(user.createdAt, OffsetDateTime.now())
-    val actionTaken = if (ageInMinutes > 1) "Found pre-existing" else "Seeded"
-
-    return "-> $actionTaken: ${user.deliusUsername} (created $ageInMinutes mins ago)"
+    val timestamp = user.updatedAt ?: user.createdAt
+    val ageInMinutes = ChronoUnit.MINUTES.between(timestamp, OffsetDateTime.now())
+    return "-> User record for: ${user.deliusUsername} last updated $ageInMinutes mins ago"
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -73,6 +73,10 @@ class UserEntityFactory : Factory<UserEntity> {
     this.createdAt = { createdAt }
   }
 
+  fun withUpdatedAt(updatedAt: OffsetDateTime?) = apply {
+    this.updatedAt = { updatedAt }
+  }
+
   fun withTelephoneNumber(telephoneNumber: String?) = apply {
     this.telephoneNumber = { telephoneNumber }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApStaffUsersSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApStaffUsersSeedJobTest.kt
@@ -85,14 +85,14 @@ class APStaffUsersSeedJobTest : SeedTestBase() {
 
     assertThat(logEntries).anyMatch {
       it.level == "info" &&
-        it.message.contains("Seeded: UNKNOWN-USER")
+        it.message.contains("User record for: UNKNOWN-USER last updated")
     }
   }
 
   @Test fun `Seeding a pre-existing user leaves roles and qualifications untouched`() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("PRE-EXISTING-USER")
-      withCreatedAt(OffsetDateTime.now().minusDays(3))
+      withUpdatedAt(OffsetDateTime.now().minusDays(3))
       withYieldedProbationRegion {
         probationRegionEntityFactory.produceAndPersist {
           withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
@@ -144,7 +144,7 @@ class APStaffUsersSeedJobTest : SeedTestBase() {
 
     assertThat(logEntries).anyMatch {
       it.level == "info" &&
-        it.message.contains("Found pre-existing: PRE-EXISTING-USER")
+        it.message.contains("User record for: PRE-EXISTING-USER last updated")
     }
   }
 


### PR DESCRIPTION
Tweak to the AP Staff User seeding.

It turns out that 9,224 of our 10,137 users are missing the created_at property, as this was added quite recently. However, every record has an `updated_at` property set.

As it seems to be tricky to set `User.updatedAt` in our test fixtures, I've simplified the way the outcome is reported. We no longer attempt to use the timestamp to derive whether the record was created or previously existed. We now make do with saying when the record was created or updated.