### PR TITLE
APS-735 Optimise how we determine if PA/PR withdrawable

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableServiceTest.kt
@@ -747,7 +747,7 @@ class Cas1WithdrawableServiceTest {
     @Test
     fun `is withdrawable`() {
       every {
-        cas1WithdrawableTreeBuilder.treeForApp(application, user)
+        cas1WithdrawableTreeBuilder.treeForPlacementApp(placementApplication, user)
       } returns
         WithdrawableTreeNode(
           applicationId = application.id,
@@ -765,7 +765,7 @@ class Cas1WithdrawableServiceTest {
     @Test
     fun `is not withdrawable`() {
       every {
-        cas1WithdrawableTreeBuilder.treeForApp(application, user)
+        cas1WithdrawableTreeBuilder.treeForPlacementApp(placementApplication, user)
       } returns
         WithdrawableTreeNode(
           applicationId = application.id,
@@ -806,7 +806,7 @@ class Cas1WithdrawableServiceTest {
     @Test
     fun `is withdrawable`() {
       every {
-        cas1WithdrawableTreeBuilder.treeForApp(application, user)
+        cas1WithdrawableTreeBuilder.treeForPlacementReq(placementRequest, user)
       } returns
         WithdrawableTreeNode(
           applicationId = application.id,
@@ -824,7 +824,7 @@ class Cas1WithdrawableServiceTest {
     @Test
     fun `is not withdrawable`() {
       every {
-        cas1WithdrawableTreeBuilder.treeForApp(application, user)
+        cas1WithdrawableTreeBuilder.treeForPlacementReq(placementRequest, user)
       } returns
         WithdrawableTreeNode(
           applicationId = application.id,


### PR DESCRIPTION
Update the ‘isDirectlyWithdrawable’ functions to only build a withdrawable tree for the entity of interest, instead of the whole application. This is a pre-requisite to adding in calls to delius to determine booking state, ensuring we don’t make any uneccessary calls