### PR TITLE
Update CAS1 E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ jobs:
       - run:
           name: Clone E2E repo
           command: |
-            git clone https://github.com/ministryofjustice/hmpps-approved-premises-e2e.git .
+            git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git .
       - run:
           name: Update npm
           command: 'npm install -g npm@9.8.1'
@@ -267,7 +267,7 @@ jobs:
             HMPPS_AUTH_PASSWORD="${!password}"
             HMPPS_AUTH_EMAIL="${!email}"
             HMPPS_AUTH_NAME="${!name}"
-            npm run test -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+            npm run test:e2e:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
       - store_artifacts:
           path: playwright-report
           destination: playwright-report


### PR DESCRIPTION
The CAS1 tests have moved from being a seperate repo to now being housed within the UI repo. 
This PR ensures that the post-merge tests for this repo run from the new location