### PR TITLE
CAS-372 Create Api endpoint for types of prison release

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LocalAuthority
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NonArrivalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PrisonReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationDeliveryUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralRejectionReason
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PrisonReleaseTypeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
@@ -38,6 +40,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthori
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PrisonReleaseTypeTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ReferralRejectionReasonTransformer
@@ -67,8 +70,10 @@ class ReferenceDataController(
   private val nonArrivalReasonTransformer: NonArrivalReasonTransformer,
   private val probationDeliveryUnitTransformer: ProbationDeliveryUnitTransformer,
   private val referralRejectionReasonTransformer: ReferralRejectionReasonTransformer,
+  private val prisonReleaseTypeTransformer: PrisonReleaseTypeTransformer,
   private val apAreaRepository: ApAreaRepository,
   private val apAreaTransformer: ApAreaTransformer,
+  private val prisonReleaseTypeRepository: PrisonReleaseTypeRepository,
 ) : ReferenceDataApiDelegate {
 
   override fun referenceDataCharacteristicsGet(xServiceName: ServiceName?, includeInactive: Boolean?): ResponseEntity<List<Characteristic>> {
@@ -188,5 +193,16 @@ class ReferenceDataController(
     }
 
     return ResponseEntity.ok(referralRejectionReasons.map(referralRejectionReasonTransformer::transformJpaToApi))
+  }
+
+  override fun referenceDataPrisonReleaseTypesGet(
+    xServiceName: ServiceName?,
+  ): ResponseEntity<List<PrisonReleaseType>> {
+    val prisonReleaseTypes = when (xServiceName != null) {
+      true -> prisonReleaseTypeRepository.findAllByServiceScope(xServiceName.value)
+      else -> prisonReleaseTypeRepository.findAll(Sort.by(Sort.Direction.ASC, "sortOrder"))
+    }
+
+    return ResponseEntity.ok(prisonReleaseTypes.map(prisonReleaseTypeTransformer::transformJpaToApi))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PrisonReleaseTypeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PrisonReleaseTypeEntity.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface PrisonReleaseTypeRepository : JpaRepository<PrisonReleaseTypeEntity, UUID> {
+  @Query("SELECT m FROM PrisonReleaseTypeEntity m WHERE m.serviceScope = :serviceName OR m.serviceScope = '*' ORDER BY m.sortOrder")
+  fun findAllByServiceScope(serviceName: String): List<PrisonReleaseTypeEntity>
+
+  @Query("SELECT m FROM PrisonReleaseTypeEntity m WHERE m.serviceScope = :serviceName OR m.serviceScope = '*' AND m.isActive = true ORDER BY m.sortOrder")
+  fun findActiveByServiceScope(serviceName: String): List<PrisonReleaseTypeEntity>
+
+  @Query("SELECT m FROM PrisonReleaseTypeEntity m WHERE m.isActive = true ORDER BY m.sortOrder")
+  fun findActive(): List<PrisonReleaseTypeEntity>
+}
+
+@Entity
+@Table(name = "prison_release_types")
+data class PrisonReleaseTypeEntity(
+  @Id
+  val id: UUID,
+  val name: String,
+  val isActive: Boolean,
+  val serviceScope: String,
+  val sortOrder: Int,
+) {
+  override fun toString() = "PrisonReleaseTypeEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PrisonReleaseTypeTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PrisonReleaseTypeTransformer.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PrisonReleaseType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PrisonReleaseTypeEntity
+
+@Component
+class PrisonReleaseTypeTransformer {
+  fun transformJpaToApi(jpa: PrisonReleaseTypeEntity) = PrisonReleaseType(
+    id = jpa.id,
+    name = jpa.name,
+    isActive = jpa.isActive,
+    serviceScope = jpa.serviceScope,
+  )
+}

--- a/src/main/resources/db/migration/all/20240503124516__prison_release_types_table.sql
+++ b/src/main/resources/db/migration/all/20240503124516__prison_release_types_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE prison_release_types (
+    id UUID NOT NULL,
+    name TEXT NOT NULL,
+    is_active BOOL NOT NULL,
+    service_scope TEXT NOT NULL,
+    sort_order integer NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE (name)
+);
+
+INSERT INTO prison_release_types(id,name,is_active,service_scope,sort_order) VALUES
+    ('82ce603b-a7d1-4e65-bab5-ed750917840a','Conditional release date (CRD) licence',true,'temporary-accommodation',1),
+    ('f750a14e-a815-49d8-a70d-901734c16f27','End of custody supervised licence (ECSL)',true,'temporary-accommodation',2),
+    ('9ffa8a3a-bd8a-472b-9302-3e97c433eec7','Licence, following fixed-term recall',true,'temporary-accommodation',3),
+    ('9b887b63-02f0-4441-b609-abf5f44fd261','Licence, following standard recall',true,'temporary-accommodation',4),
+    ('d8fa5a15-bddf-4f51-ac0f-4c8f7ed5dfd8','Parole',true,'temporary-accommodation',5),
+    ('740f6dd5-1ec2-493b-893e-ca2406464e36','Post sentence supervision (PSS)',true,'temporary-accommodation',6);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4420,6 +4420,24 @@ components:
         - name
         - serviceScope
         - isActive
+    PrisonReleaseType:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Post sentence supervision (PSS)
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
     CacheType:
       type: string
       enum:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2912,6 +2912,33 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /reference-data/prison-release-types:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all prison release types
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only prison release types for this service will be returned
+          schema:
+            $ref: '_shared.yml#/components/schemas/ServiceName'
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/PrisonReleaseType'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /tasks:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2914,6 +2914,33 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /reference-data/prison-release-types:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all prison release types
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: false
+          description: If given, only prison release types for this service will be returned
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PrisonReleaseType'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /tasks:
     get:
       tags:
@@ -9053,6 +9080,24 @@ components:
         name:
           type: string
           example: There was not enough time to place them
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
+    PrisonReleaseType:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Post sentence supervision (PSS)
         serviceScope:
           type: string
         isActive:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4985,6 +4985,24 @@ components:
         - name
         - serviceScope
         - isActive
+    PrisonReleaseType:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Post sentence supervision (PSS)
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
     CacheType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4511,6 +4511,24 @@ components:
         - name
         - serviceScope
         - isActive
+    PrisonReleaseType:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Post sentence supervision (PSS)
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
     CacheType:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PrisonReleaseTypeEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PrisonReleaseTypeEntityFactory.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PrisonReleaseTypeEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class PrisonReleaseTypeEntityFactory : Factory<PrisonReleaseTypeEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var isActive: Yielded<Boolean> = { true }
+  private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
+  private var sortOrder: Yielded<Int> = { randomInt(0, 1000) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withIsActive(isActive: Boolean) = apply {
+    this.isActive = { isActive }
+  }
+
+  fun withServiceScope(serviceScope: String) = apply {
+    this.serviceScope = { serviceScope }
+  }
+
+  fun withSortOrder(sortOrder: Int) = apply {
+    this.sortOrder = { sortOrder }
+  }
+
+  override fun produce(): PrisonReleaseTypeEntity = PrisonReleaseTypeEntity(
+    id = this.id(),
+    name = this.name(),
+    isActive = this.isActive(),
+    serviceScope = this.serviceScope(),
+    sortOrder = this.sortOrder(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -80,6 +80,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PostCodeDistrictEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PrisonReleaseTypeEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationAreaProbationRegionMappingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
@@ -154,6 +155,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistrictEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PrisonReleaseTypeEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PrisonReleaseTypeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationAreaProbationRegionMappingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
@@ -522,6 +525,9 @@ abstract class IntegrationTestBase {
   lateinit var referralRejectionReasonRepository: ReferralRejectionReasonRepository
 
   @Autowired
+  lateinit var prisonReleaseTypeRepository: PrisonReleaseTypeRepository
+
+  @Autowired
   lateinit var emailAsserter: EmailNotificationAsserter
 
   @Autowired
@@ -594,6 +600,7 @@ abstract class IntegrationTestBase {
   lateinit var appealEntityFactory: PersistedFactory<AppealEntity, UUID, AppealEntityFactory>
   lateinit var cas1ApplicationUserDetailsEntityFactory: PersistedFactory<Cas1ApplicationUserDetailsEntity, UUID, Cas1ApplicationUserDetailsEntityFactory>
   lateinit var referralRejectionReasonEntityFactory: PersistedFactory<ReferralRejectionReasonEntity, UUID, ReferralRejectionReasonEntityFactory>
+  lateinit var prisonReleaseTypeEntityFactory: PersistedFactory<PrisonReleaseTypeEntity, UUID, PrisonReleaseTypeEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -695,6 +702,7 @@ abstract class IntegrationTestBase {
     appealEntityFactory = PersistedFactory({ AppealEntityFactory() }, appealTestRepository)
     cas1ApplicationUserDetailsEntityFactory = PersistedFactory({ Cas1ApplicationUserDetailsEntityFactory() }, cas1ApplicationUserDetailsRepository)
     referralRejectionReasonEntityFactory = PersistedFactory({ ReferralRejectionReasonEntityFactory() }, referralRejectionReasonRepository)
+    prisonReleaseTypeEntityFactory = PersistedFactory({ PrisonReleaseTypeEntityFactory() }, prisonReleaseTypeRepository)
   }
 
   fun mockClientCredentialsJwtRequest(


### PR DESCRIPTION
This [PR CAS-372](https://dsdmoj.atlassian.net/browse/CAS-372) is to add new endpoint to referral data for prison release types. The type for temporary accommodation will be:

- Conditional release date (CRD) licence
- End of custody supervised licence (ECSL)
- Licence, following fixed-term recall
- Licence, following standard recall
- Parole
- Post sentence supervision (PSS)