### PR TITLE
APS-735 Check Placement Arrival Status in Delius on Withdrawal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummaries
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ReferralDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.UserAccess
 
@@ -41,5 +42,9 @@ class ApDeliusContextApiClient(
   fun getUserAccessForCrns(deliusUsername: String, crns: List<String>) = getRequest<UserAccess> {
     path = "/users/access?username=$deliusUsername"
     body = crns
+  }
+
+  fun getReferralDetails(crn: String, bookingId: String) = getRequest<ReferralDetail> {
+    path = "/probation-case/$crn/referrals/$bookingId"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
@@ -77,3 +77,7 @@ data class MappaDetail(
 data class CaseSummaries(
   var cases: List<CaseSummary>,
 )
+
+data class ReferralDetail(
+  val arrivedAt: ZonedDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeliusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeliusService.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+
+@Service
+class DeliusService(
+  private val apDeliusContextApiClient: ApDeliusContextApiClient,
+) {
+
+  fun referralHasArrival(booking: BookingEntity): Boolean {
+    val referralDetails = when (val clientResult = apDeliusContextApiClient.getReferralDetails(booking.crn, booking.id.toString())) {
+      is ClientResult.Success -> clientResult.body
+      is ClientResult.Failure -> clientResult.throwException()
+    }
+    return referralDetails.arrivedAt != null
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -280,4 +280,5 @@ data class WithdrawableDatePeriod(
 
 enum class BlockingReason {
   ArrivalRecordedInCas1,
+  ArrivalRecordedInDelius,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -124,10 +124,15 @@ data class WithdrawableTree(
   val rootNode: WithdrawableTreeNode,
 ) {
   fun notes(): List<String> {
+    val blockedReasons = rootNode.blockedReasons()
     val notes = mutableListOf<String>()
 
-    if (rootNode.isBlocked()) {
+    if (blockedReasons.contains(BlockingReason.ArrivalRecordedInCas1)) {
       notes.add("1 or more placements cannot be withdrawn as they have an arrival")
+    }
+
+    if (blockedReasons.contains(BlockingReason.ArrivalRecordedInDelius)) {
+      notes.add("1 or more placements cannot be withdrawn as they have an arrival recorded in Delius")
     }
 
     return notes
@@ -166,6 +171,10 @@ data class WithdrawableTreeNode(
   private fun isBlockAncestorWithdrawals() = status.blockingReason != null
 
   fun isBlocked(): Boolean = isBlockAncestorWithdrawals() || children.any { it.isBlocked() }
+
+  fun blockedReasons(): Set<BlockingReason> {
+    return setOfNotNull(status.blockingReason) + children.flatMap { it.blockedReasons() }.toSet()
+  }
 
   override fun toString(): String {
     return "\n\n${render(0)}\n"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -61,6 +61,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var caseManagerUserDetails: Yielded<Cas1ApplicationUserDetailsEntity?> = { null }
   private var noticeType: Yielded<Cas1ApplicationTimelinessCategory?> = { null }
 
+  fun withDefaults() = apply {
+    withCreatedByUser(UserEntityFactory().withDefaults().produce())
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulGetReferralDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -3134,6 +3135,12 @@ class BookingTest : IntegrationTestBase() {
             val cancellationReason = cancellationReasonEntityFactory.produceAndPersist {
               withServiceScope("*")
             }
+
+            APDeliusContext_mockSuccessfulGetReferralDetails(
+              crn = booking.crn,
+              bookingId = booking.id.toString(),
+              arrivedAt = null,
+            )
 
             webTestClient.post()
               .uri("/premises/${booking.premises.id}/bookings/${booking.id}/cancellations")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -3168,43 +3168,6 @@ class BookingTest : IntegrationTestBase() {
         }
       }
     }
-
-    @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
-    fun `Create Confirmation on Approved Premises Booking returns OK with correct body when user has one of roles MANAGER, MATCHER`(
-      role: UserRole,
-    ) {
-      `Given a User`(roles = listOf(role)) { userEntity, jwt ->
-        val booking = bookingEntityFactory.produceAndPersist {
-          withYieldedPremises {
-            approvedPremisesEntityFactory.produceAndPersist {
-              withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-              withYieldedProbationRegion {
-                probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-              }
-            }
-          }
-          withServiceName(ServiceName.approvedPremises)
-        }
-
-        webTestClient.post()
-          .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
-          .header("Authorization", "Bearer $jwt")
-          .bodyValue(
-            NewConfirmation(
-              notes = null,
-            ),
-          )
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
-          .jsonPath("$.dateTime").value(withinSeconds(5L), OffsetDateTime::class.java)
-          .jsonPath("$.notes").isEqualTo(null)
-          .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
-      }
-    }
   }
 
   @Test
@@ -4126,6 +4089,43 @@ class BookingTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isUnauthorized
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+  fun `Create Confirmation on Approved Premises Booking returns OK with correct body when user has one of roles MANAGER, MATCHER`(
+    role: UserRole,
+  ) {
+    `Given a User`(roles = listOf(role)) { userEntity, jwt ->
+      val booking = bookingEntityFactory.produceAndPersist {
+        withYieldedPremises {
+          approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+        }
+        withServiceName(ServiceName.approvedPremises)
+      }
+
+      webTestClient.post()
+        .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewConfirmation(
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
+        .jsonPath("$.dateTime").value(withinSeconds(5L), OffsetDateTime::class.java)
+        .jsonPath("$.notes").isEqualTo(null)
+        .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -186,7 +186,7 @@ class WithdrawalTest : IntegrationTestBase() {
 
             createPlacementRequest(application, isWithdrawn = true)
 
-            val placementApplication = createPlacementApplication(application, DatePeriod(nowPlusDays(50), duration = 6))
+            val placementApplication = createPlacementApplication(application, DateSpan(nowPlusDays(50), duration = 6))
             createPlacementRequest(application, placementApplication = placementApplication)
 
             val expected = Withdrawables(
@@ -247,15 +247,15 @@ class WithdrawalTest : IntegrationTestBase() {
 
             val submittedPlacementApplication1 = createPlacementApplication(
               application,
-              datePeriods = listOf(
-                DatePeriod(nowPlusDays(1), duration = 5),
-                DatePeriod(nowPlusDays(10), duration = 10),
+              dateSpans = listOf(
+                DateSpan(nowPlusDays(1), duration = 5),
+                DateSpan(nowPlusDays(10), duration = 10),
               ),
             )
 
             val submittedPlacementApplication2 = createPlacementApplication(
               application,
-              DatePeriod(nowPlusDays(50), duration = 6),
+              DateSpan(nowPlusDays(50), duration = 6),
             )
 
             createPlacementApplication(
@@ -266,31 +266,31 @@ class WithdrawalTest : IntegrationTestBase() {
 
             createPlacementApplication(
               application,
-              DatePeriod(LocalDate.now(), duration = 2),
+              DateSpan(LocalDate.now(), duration = 2),
               reallocatedAt = OffsetDateTime.now(),
             )
 
             val applicationWithAcceptedDecision = createPlacementApplication(
               application,
-              DatePeriod(nowPlusDays(50), duration = 6),
+              DateSpan(nowPlusDays(50), duration = 6),
               decision = PlacementApplicationDecision.ACCEPTED,
             )
 
             createPlacementApplication(
               application,
-              DatePeriod(now(), duration = 2),
+              DateSpan(now(), duration = 2),
               decision = PlacementApplicationDecision.WITHDRAW,
             )
 
             createPlacementApplication(
               application,
-              DatePeriod(now(), duration = 2),
+              DateSpan(now(), duration = 2),
               decision = PlacementApplicationDecision.WITHDRAWN_BY_PP,
             )
 
             val applicationWithRejectedDecision = createPlacementApplication(
               application,
-              DatePeriod(nowPlusDays(50), duration = 6),
+              DateSpan(nowPlusDays(50), duration = 6),
               decision = PlacementApplicationDecision.REJECTED,
             )
 
@@ -353,7 +353,7 @@ class WithdrawalTest : IntegrationTestBase() {
               val (application, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
               val (otherApplication, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
-              val placementApplication1 = createPlacementApplication(application, DatePeriod(now(), duration = 2))
+              val placementApplication1 = createPlacementApplication(application, DateSpan(now(), duration = 2))
               val placementRequest1 = createPlacementRequest(application, placementApplication = placementApplication1)
               val booking1NoArrival = createBooking(
                 application = application,
@@ -368,7 +368,7 @@ class WithdrawalTest : IntegrationTestBase() {
 
               val placementApplication2 = createPlacementApplication(
                 application,
-                DatePeriod(now(), duration = 2),
+                DateSpan(now(), duration = 2),
                 allocatedTo = requestForPlacementAssessor,
               )
 
@@ -461,7 +461,7 @@ class WithdrawalTest : IntegrationTestBase() {
           `Given an Offender` { offenderDetails, _ ->
             val (application, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
-            val placementApplication1 = createPlacementApplication(application, DatePeriod(now(), duration = 2))
+            val placementApplication1 = createPlacementApplication(application, DateSpan(now(), duration = 2))
             val placementRequest1 = createPlacementRequest(application, placementApplication = placementApplication1)
             val booking1NoArrival = createBooking(
               application = application,
@@ -475,7 +475,7 @@ class WithdrawalTest : IntegrationTestBase() {
 
             val placementApplication2 = createPlacementApplication(
               application,
-              DatePeriod(now(), duration = 2),
+              DateSpan(now(), duration = 2),
               allocatedTo = requestForPlacementAssessor,
             )
 
@@ -603,7 +603,7 @@ class WithdrawalTest : IntegrationTestBase() {
             )
             val (otherApplication, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
-            val placementApplication1 = createPlacementApplication(application, DatePeriod(now(), duration = 2))
+            val placementApplication1 = createPlacementApplication(application, DateSpan(now(), duration = 2))
             val placementRequest1 = createPlacementRequest(application, placementApplication = placementApplication1)
             val booking1NoArrival = createBooking(
               application = application,
@@ -615,7 +615,7 @@ class WithdrawalTest : IntegrationTestBase() {
 
             val placementApplication2NoBookingBeingAssessed = createPlacementApplication(
               application,
-              DatePeriod(nowPlusDays(2), duration = 2),
+              DateSpan(nowPlusDays(2), duration = 2),
               allocatedTo = requestForPlacementAssessor,
               decision = null,
             )
@@ -756,7 +756,7 @@ class WithdrawalTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, _ ->
           val (application, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
-          val placementApplication = createPlacementApplication(application, DatePeriod(now(), duration = 2))
+          val placementApplication = createPlacementApplication(application, DateSpan(now(), duration = 2))
           val placementRequest = createPlacementRequest(application, placementApplication = placementApplication)
           val bookingWithArrival = createBooking(
             application = application,
@@ -805,7 +805,7 @@ class WithdrawalTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, _ ->
           val (application, assessment) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
-          val placementApplication1 = createPlacementApplication(application, DatePeriod(now(), duration = 2))
+          val placementApplication1 = createPlacementApplication(application, DateSpan(now(), duration = 2))
           val placementRequest1 = createPlacementRequest(application, placementApplication = placementApplication1)
           val booking1NoArrival = createBooking(
             application = application,
@@ -824,7 +824,7 @@ class WithdrawalTest : IntegrationTestBase() {
           )
           addBookingToPlacementRequest(placementRequest2, booking2NoArrival)
 
-          val placementApplication2 = createPlacementApplication(application, DatePeriod(now(), duration = 2))
+          val placementApplication2 = createPlacementApplication(application, DateSpan(now(), duration = 2))
           val placementRequest3 = createPlacementRequest(application, placementApplication = placementApplication2)
           val booking3NoArrival = createBooking(
             application = application,
@@ -905,7 +905,7 @@ class WithdrawalTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, _ ->
           val (application, assessment) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
-          val placementApplication1 = createPlacementApplication(application, DatePeriod(now(), duration = 2))
+          val placementApplication1 = createPlacementApplication(application, DateSpan(now(), duration = 2))
           val placementRequest1 = createPlacementRequest(application, placementApplication = placementApplication1)
           val booking1Adhoc = createBooking(
             application = application,
@@ -1346,12 +1346,12 @@ class WithdrawalTest : IntegrationTestBase() {
     return application
   }
 
-  data class DatePeriod(val start: LocalDate, val duration: Int)
+  private data class DateSpan(val start: LocalDate, val duration: Int)
 
   private fun createPlacementApplication(
     application: ApprovedPremisesApplicationEntity,
-    datePeriod: DatePeriod? = null,
-    datePeriods: List<DatePeriod> = emptyList(),
+    dateSpan: DateSpan? = null,
+    dateSpans: List<DateSpan> = emptyList(),
     isSubmitted: Boolean = true,
     reallocatedAt: OffsetDateTime? = null,
     decision: PlacementApplicationDecision? = PlacementApplicationDecision.ACCEPTED,
@@ -1373,7 +1373,7 @@ class WithdrawalTest : IntegrationTestBase() {
     }
 
     if (isSubmitted) {
-      val dates = (listOfNotNull(datePeriod) + datePeriods).map {
+      val dates = (listOfNotNull(dateSpan) + dateSpans).map {
         placementDateFactory.produceAndPersist {
           withPlacementApplication(placementApplication)
           withExpectedArrival(it.start)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -9,9 +9,19 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Case
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummaries
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ReferralDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.UserAccess
+import java.time.ZonedDateTime
+
+fun IntegrationTestBase.APDeliusContext_mockSuccessfulGetReferralDetails(crn: String, bookingId: String, arrivedAt: ZonedDateTime?) =
+  mockSuccessfulGetCallWithJsonResponse(
+    url = "/probation-case/$crn/referrals/$bookingId",
+    responseBody = ReferralDetail(
+      arrivedAt = arrivedAt,
+    ),
+  )
 
 fun IntegrationTestBase.APDeliusContext_mockSuccessfulStaffMembersCall(staffMember: StaffMember, qCode: String) =
   mockSuccessfulGetCallWithJsonResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DeliusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DeliusServiceTest.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ReferralDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeliusService
+import java.time.ZonedDateTime
+
+class DeliusServiceTest {
+
+  private val apDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
+
+  private val service = DeliusService(apDeliusContextApiClient)
+
+  @Nested
+  inner class ReferralHasArrival {
+
+    val booking = BookingEntityFactory()
+      .withDefaults()
+      .produce()
+
+    @Test
+    fun `referralHasArrival returns true if has arrival`() {
+      every { apDeliusContextApiClient.getReferralDetails(booking.crn, booking.id.toString()) } returns
+        ClientResult.Success(
+          HttpStatus.OK,
+          ReferralDetail(
+            arrivedAt = ZonedDateTime.now(),
+          ),
+        )
+
+      val result = service.referralHasArrival(booking)
+
+      assertThat(result).isTrue
+    }
+
+    @Test
+    fun `referralHasArrival returns false if no arrival`() {
+      every { apDeliusContextApiClient.getReferralDetails(booking.crn, booking.id.toString()) } returns
+        ClientResult.Success(
+          HttpStatus.OK,
+          ReferralDetail(
+            arrivedAt = null,
+          ),
+        )
+
+      val result = service.referralHasArrival(booking)
+
+      assertThat(result).isFalse
+    }
+  }
+}


### PR DESCRIPTION
When building the Cas1 Withdrawable Tree for a placement we now check the status of the placement in delius wrt. arrivals. If the placement has been marked as arrived in delius we ‘block’ the withdrawal as we would if the placement was marked as arrived in CAS1. We also include a specific note in the withdrawal tree indicating that 1 or placements have arrivals marked in delius and as such can’t be withdrawn.

Use of this functionality is controlled by the “cas1-check-delius-withdrawal-status” feature flag, which will return false by default

There is no caching on the delius referrals endpoint that we use to retrieve this data. Caching wouldn’t make sense in this context because we always want the latest state wrt. arrivals. If we find that the endpoint is being invoked too often we could look at either

1) caching a response that indicates there is an arrival (assuming this is easy with redis integration)
2) write the delius arrival on the booking entity itself (or via a new table)

Both of these approaches assume that once marked as a arrived in delius this can’t be undone (e.g. if the person was marked as arrived by accident)