### PR TITLE
CAS1 E2Es: Use NPX playwright install over docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
           path: build/reports/tests
   cas1_e2e_tests:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.41.2-focal
+      - image: cimg/base:stable
     parallelism: 4
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
@@ -255,6 +255,9 @@ jobs:
           name: Update npm
           command: 'npm install -g npm@9.8.1'
       - node/install-packages
+      - run:
+          name: Install Playwright
+          command: npx playwright install      
       - run:
           name: E2E Check
           command: |            


### PR DESCRIPTION
If we use the docker image we have to manually ensure it is kept up to date with the version in the CAS1 UI repo's playwright/test version but if we use NPX then this will be automated