### PR TITLE
CAS1 E2ES: Reinstate Playwright docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
           path: build/reports/tests
   cas1_e2e_tests:
     docker:
-      - image: cimg/base:stable
+      - image: mcr.microsoft.com/playwright:v1.41.2-focal
     parallelism: 4
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:


### PR DESCRIPTION
https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1856
attempted to remove the dependency on the Playwright Docker image but
ultimately failed. I couldn't workout how to fully install all the
dependencies needed without using the docker image. This means we will
have to avoid updating the version of Playwright/test in the UI repo
unless we also update the docker image here