### PR TITLE
Fix/nomis user create race condition

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NomisUserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NomisUserEntity.kt
@@ -2,7 +2,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.CreationTimestamp
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Entity
@@ -13,6 +16,36 @@ import javax.persistence.Table
 @Repository
 interface NomisUserRepository : JpaRepository<NomisUserEntity, UUID> {
   fun findByNomisUsername(nomisUserName: String): NomisUserEntity?
+
+  @Modifying
+  @Transactional
+  @Query(
+    value = """
+          INSERT INTO nomis_user (id, name, nomis_username, nomis_staff_id, account_type, email, is_enabled, is_active, active_caseload_id)
+          VALUES (:id, :name, :nomisUsername, :nomisStaffId, :accountType, :email, :isEnabled, :isActive, :activeCaseloadId)
+          ON CONFLICT (nomis_username) DO UPDATE SET
+          name = EXCLUDED.name,
+          nomis_staff_id = EXCLUDED.nomis_staff_id,
+          account_type = EXCLUDED.account_type,
+          email = EXCLUDED.email,
+          is_enabled = EXCLUDED.is_enabled,
+          is_active = EXCLUDED.is_active,
+          active_caseload_id = EXCLUDED.active_caseload_id
+          RETURNING *
+      """,
+    nativeQuery = true,
+  )
+  fun saveOrUpdate(
+    id: UUID,
+    name: String,
+    nomisUsername: String,
+    nomisStaffId: Long,
+    accountType: String,
+    email: String?,
+    isEnabled: Boolean,
+    isActive: Boolean,
+    activeCaseloadId: String?,
+  ): NomisUserEntity
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/NomisUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/NomisUserService.kt
@@ -44,18 +44,16 @@ class NomisUserService(
       return existingUser
     }
 
-    return userRepository.save(
-      NomisUserEntity(
-        id = UUID.randomUUID(),
-        name = "${nomisUserDetails.firstName} ${nomisUserDetails.lastName}",
-        nomisUsername = normalisedUsername,
-        nomisStaffId = nomisUserDetails.staffId,
-        accountType = nomisUserDetails.accountType,
-        email = nomisUserDetails.primaryEmail,
-        isEnabled = nomisUserDetails.enabled,
-        isActive = nomisUserDetails.active,
-        activeCaseloadId = nomisUserDetails.activeCaseloadId,
-      ),
+    return userRepository.saveOrUpdate(
+      id = UUID.randomUUID(),
+      name = "${nomisUserDetails.firstName} ${nomisUserDetails.lastName}",
+      nomisUsername = normalisedUsername,
+      nomisStaffId = nomisUserDetails.staffId,
+      accountType = nomisUserDetails.accountType,
+      email = nomisUserDetails.primaryEmail,
+      isEnabled = nomisUserDetails.enabled,
+      isActive = nomisUserDetails.active,
+      activeCaseloadId = nomisUserDetails.activeCaseloadId,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NomisUserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NomisUserEntityFactory.kt
@@ -53,6 +53,18 @@ class NomisUserEntityFactory : Factory<NomisUserEntity> {
     this.email = { email }
   }
 
+  fun withAccountType(accountType: String) = apply {
+    this.accountType = { accountType }
+  }
+
+  fun withEnabled(enabled: Boolean) = apply {
+    this.isEnabled = { enabled }
+  }
+
+  fun withActive(active: Boolean) = apply {
+    this.isActive = { active }
+  }
+
   override fun produce(): NomisUserEntity = NomisUserEntity(
     id = this.id(),
     nomisUsername = this.nomisUsername(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/NomisUserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/NomisUserServiceTest.kt
@@ -6,7 +6,6 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.NomisUserRolesApiClient
@@ -65,7 +64,19 @@ class NomisUserServiceTest {
         )
         // setup repository
         every { mockUserRepository.findByNomisUsername(username) } returns oldUserData
-        verify(exactly = 0) { mockUserRepository.save(any()) }
+        verify(exactly = 0) {
+          mockUserRepository.saveOrUpdate(
+            id = any(),
+            name = any(),
+            nomisUsername = any(),
+            nomisStaffId = any(),
+            accountType = any(),
+            email = any(),
+            isEnabled = any(),
+            isActive = any(),
+            activeCaseloadId = any(),
+          )
+        }
 
         assertThat(userService.getUserForRequest()).matches {
           it.nomisUsername == username &&
@@ -141,7 +152,28 @@ class NomisUserServiceTest {
         )
         // setup repository
         every { mockUserRepository.findByNomisUsername(username) } returns null
-        every { mockUserRepository.save(any()) } answers { it.invocation.args[0] as NomisUserEntity }
+        every {
+          mockUserRepository.saveOrUpdate(
+            id = any(),
+            name = any(),
+            nomisUsername = any(),
+            nomisStaffId = any(),
+            accountType = any(),
+            email = any(),
+            isEnabled = any(),
+            isActive = any(),
+            activeCaseloadId = any(),
+          )
+        } returns NomisUserEntityFactory()
+          .withNomisUsername(username)
+          .withName("Jim Jimmerson")
+          .withNomisStaffCode(5678)
+          .withAccountType("CLOSED")
+          .withEmail("example@example.com")
+          .withEnabled(false)
+          .withActive(false)
+          .withActiveCaseloadId("456")
+          .produce()
 
         assertThat(userService.getUserForRequest()).matches {
           it.nomisUsername == username &&


### PR DESCRIPTION
NomisUser creation now uses an idempotent database save.

We were seeing that a user was able to get stuck in a race condition and see an error[1]. They were eventually able to recover after trying again.

This happened because the code does three things:

1. Checks if the user is there
2. If it is there, check for differences to two fields (possibly update) and return early
3. If it isn’t there we create a new record

The code ran twice (see SQL logs [1]) and both threads were able to get to step 3 at the same time. The latest request failed with a database uniqueness error on Nomis username and probably showed the user an error.

To address this we use the new `saveOrUpdate` method which will handle that error and perform an update instead.

This felt a better approach than:

1. Removing the database validation entirely
2. Adding in slow database locking[2] on a high traffic endpoint
3. Leaving it to throw a rare error for the user

The following is a test added to `NomisUserServiceTest` that replicates the failure scenario before this change is applied. Due to the mocking required the test can’t meaningfully be kept:

```
@Nested
  inner class GetUserForUsername {

    @Test
    fun `test getUserForUsername with concurrent calls`() = runBlocking {
      val username = "SOMEPERSON"
      // setup auth service
      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
      every { mockHttpAuthService.getNomisPrincipalOrThrow() } returns mockPrincipal
      every { mockPrincipal.token.tokenValue } returns "abc123"
      every { mockPrincipal.name } returns username

      // Assuming NomisUserEntity has a constructor that takes a username
      val newUserData = NomisUserDetailFactory()
        .withUsername(username)
        .withFirstName("Jim")
        .withLastName("Jimmerson")
        .withStaffId(5678)
        .withAccountType("CLOSED")
        .withEmail("example@example.com")
        .withEnabled(false)
        .withActive(false)
        .withActiveCaseloadId("456")
        .produce()

      every { mockNomisUserRolesApiClient.getUserDetails("abc123") } returns ClientResult.Success(
        HttpStatus.OK,
        newUserData,
      )
      every { mockUserRepository.findByNomisUsername(username) } returns null

      // Throw an exception when save is called for the second time and onwards
      var saveCallCount = 0
      every { mockUserRepository.save(any()) } answers {
        if (++saveCallCount > 1) {
          throw org.springframework.dao.DataIntegrityViolationException("Unique index or primary key violation")
        }
        it.invocation.args[0] as NomisUserEntity
      }

      val tasks = List(5) {
        launch {
          try {
            val result = userService.getUserForUsername(username, "abc123")
            assertEquals(username, result.nomisUsername)
          } catch (e: org.springframework.dao.DataIntegrityViolationException) {
            println("*** FAILURE")
          }
        }
      }

      tasks.forEach { it.join() }
    }
  }
```

[1] https://mojdt.slack.com/archives/C05FN6Y2CSV/p1715087044061189
[2] https://www.baeldung.com/spring-transactional-propagation-isolation#5-serializable-isolation