### PR TITLE
APS-774 filter out docs with null name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/GroupedDocuments.kt
@@ -11,7 +11,7 @@ data class GroupedDocuments(
 
 data class Document(
   val id: String?,
-  val documentName: String,
+  val documentName: String?,
   val author: String?,
   val type: DocumentType,
   val extendedDescription: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DocumentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DocumentTransformer.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Document
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DocumentLevel
@@ -9,12 +10,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Document
 
 @Component
 class DocumentTransformer {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
   fun transformToApi(groupedDocuments: GroupedDocuments, convictionId: Long): List<Document> {
-    val offenderDocuments = documentsWithIds(groupedDocuments.documents).map {
+    val offenderDocuments = documentsWithIdsAndNames(groupedDocuments.documents).map {
       Document(
         id = it.id!!,
         level = DocumentLevel.offender,
-        fileName = it.documentName,
+        fileName = it.documentName!!,
         createdAt = it.createdAt.toInstant(ZoneOffset.UTC),
         typeCode = it.type.code,
         typeDescription = it.type.description,
@@ -26,11 +30,11 @@ class DocumentTransformer {
       .firstOrNull { it.convictionId == convictionId.toString() }
 
     val convictionDocuments = if (documentsForConvictionId != null) {
-      documentsWithIds(documentsForConvictionId.documents).map {
+      documentsWithIdsAndNames(documentsForConvictionId.documents).map {
         Document(
           id = it.id!!,
           level = DocumentLevel.conviction,
-          fileName = it.documentName,
+          fileName = it.documentName!!,
           createdAt = it.createdAt.toInstant(ZoneOffset.UTC),
           typeCode = it.type.code,
           typeDescription = it.type.description,
@@ -44,7 +48,19 @@ class DocumentTransformer {
     return offenderDocuments + convictionDocuments
   }
 
-  // Filter out any documents without IDs - at the moment, we don't have a way of fetching documents without IDs
-  // This fixes the nullability problem we have previously had with documents with no ID
-  fun documentsWithIds(documents: List<CommunityApiDocument>) = documents.filter { it.id != null }
+  /**
+   * If a document doesn't have an ID we have no way to retrieve it for download, so it's filtered out
+   *
+   * If a document doesn't have a name, we have no way to determine what the file should be called on download,
+   * or what file extension (e.g. pdf) should be used. This rarely occurs.
+   */
+  private fun documentsWithIdsAndNames(documents: List<CommunityApiDocument>): List<CommunityApiDocument> {
+    documents
+      .filter { it.documentName == null }
+      .forEach {
+        log.warn("Filtering out document with id ${it.id} because it doesn't have a name")
+      }
+
+    return documents.filter { it.id != null && it.documentName != null }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DocumentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DocumentFactory.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 
 class DocumentFactory : Factory<Document> {
   private var id: Yielded<String?> = { UUID.randomUUID().toString() }
-  private var documentName: Yielded<String> = { "${randomStringMultiCaseWithNumbers(5)}.pdf" }
+  private var documentName: Yielded<String?> = { "${randomStringMultiCaseWithNumbers(5)}.pdf" }
   private var author: Yielded<String?> = { randomStringMultiCaseWithNumbers(4) }
   private var typeCode: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
   private var typeDescription: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
@@ -24,7 +24,7 @@ class DocumentFactory : Factory<Document> {
     this.id = { id }
   }
 
-  fun withDocumentName(documentName: String) = apply {
+  fun withDocumentName(documentName: String?) = apply {
     this.documentName = { documentName }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DocumentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DocumentTransformerTest.kt
@@ -15,7 +15,103 @@ class DocumentTransformerTest {
   private val documentTransformer = DocumentTransformer()
 
   @Test
-  fun `transformToApi transforms correctly - filters out convictions other than one specified`() {
+  fun `transformToApi transforms correctly`() {
+    val groupedDocuments = GroupedDocumentsFactory()
+      .withOffenderLevelDocument(
+        DocumentFactory()
+          .withId(UUID.fromString("b0df5ec4-5685-4b02-8a95-91b6da80156f").toString())
+          .withDocumentName("offender_level_doc.pdf")
+          .withTypeCode("TYPE-1")
+          .withTypeDescription("Type 1 Description")
+          .withCreatedAt(LocalDateTime.parse("2022-12-07T11:40:00"))
+          .withExtendedDescription("Extended Description 1")
+          .produce(),
+      )
+      .withConvictionLevelDocument(
+        "12345",
+        DocumentFactory()
+          .withId(UUID.fromString("457af8a5-82b1-449a-ad03-032b39435865").toString())
+          .withDocumentName("conviction_level_doc.pdf")
+          .withoutAuthor()
+          .withTypeCode("TYPE-2")
+          .withTypeDescription("Type 2 Description")
+          .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
+          .withExtendedDescription("Extended Description 2")
+          .produce(),
+      )
+      .produce()
+
+    val result = documentTransformer.transformToApi(groupedDocuments, 12345)
+
+    assertThat(result).containsExactlyInAnyOrder(
+      Document(
+        id = UUID.fromString("b0df5ec4-5685-4b02-8a95-91b6da80156f").toString(),
+        level = DocumentLevel.offender,
+        fileName = "offender_level_doc.pdf",
+        createdAt = Instant.parse("2022-12-07T11:40:00Z"),
+        typeCode = "TYPE-1",
+        typeDescription = "Type 1 Description",
+        description = "Extended Description 1",
+      ),
+      Document(
+        id = UUID.fromString("457af8a5-82b1-449a-ad03-032b39435865").toString(),
+        level = DocumentLevel.conviction,
+        fileName = "conviction_level_doc.pdf",
+        createdAt = Instant.parse("2022-12-07T10:40:00Z"),
+        typeCode = "TYPE-2",
+        typeDescription = "Type 2 Description",
+        description = "Extended Description 2",
+      ),
+    )
+  }
+
+  @Test
+  fun `transformToApi filters out convictions other than one specified`() {
+    val groupedDocuments = GroupedDocumentsFactory()
+      .withOffenderLevelDocument(
+        DocumentFactory()
+          .withId(UUID.fromString("b0df5ec4-5685-4b02-8a95-91b6da80156f").toString())
+          .withDocumentName("offender_level_doc.pdf")
+          .withTypeCode("TYPE-1")
+          .withTypeDescription("Type 1 Description")
+          .withCreatedAt(LocalDateTime.parse("2022-12-07T11:40:00"))
+          .withExtendedDescription("Extended Description 1")
+          .produce(),
+      )
+      .withConvictionLevelDocument(
+        "12345",
+        DocumentFactory()
+          .withId(UUID.fromString("457af8a5-82b1-449a-ad03-032b39435865").toString())
+          .withDocumentName("conviction_level_doc.pdf")
+          .withoutAuthor()
+          .withTypeCode("TYPE-2")
+          .withTypeDescription("Type 2 Description")
+          .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
+          .withExtendedDescription("Extended Description 2")
+          .produce(),
+      )
+      .withConvictionLevelDocument(
+        "6789",
+        DocumentFactory()
+          .withId(UUID.fromString("e20589b3-7f83-4502-a0df-c8dd645f3f44").toString())
+          .withDocumentName("conviction_level_doc_2.pdf")
+          .withTypeCode("TYPE-2")
+          .withTypeDescription("Type 2 Description")
+          .withCreatedAt(LocalDateTime.parse("2022-12-07T10:40:00"))
+          .withExtendedDescription("Extended Description 2")
+          .produce(),
+      )
+      .produce()
+
+    val result = documentTransformer.transformToApi(groupedDocuments, 12345)
+
+    assertThat(result).hasSize(2)
+    assertThat(result[0].fileName).isEqualTo("offender_level_doc.pdf")
+    assertThat(result[1].fileName).isEqualTo("conviction_level_doc.pdf")
+  }
+
+  @Test
+  fun `transformToApi filters out docs with no id`() {
     val groupedDocuments = GroupedDocumentsFactory()
       .withOffenderLevelDocument(
         DocumentFactory()
@@ -65,25 +161,8 @@ class DocumentTransformerTest {
 
     val result = documentTransformer.transformToApi(groupedDocuments, 12345)
 
-    assertThat(result).containsExactlyInAnyOrder(
-      Document(
-        id = UUID.fromString("b0df5ec4-5685-4b02-8a95-91b6da80156f").toString(),
-        level = DocumentLevel.offender,
-        fileName = "offender_level_doc.pdf",
-        createdAt = Instant.parse("2022-12-07T11:40:00Z"),
-        typeCode = "TYPE-1",
-        typeDescription = "Type 1 Description",
-        description = "Extended Description 1",
-      ),
-      Document(
-        id = UUID.fromString("457af8a5-82b1-449a-ad03-032b39435865").toString(),
-        level = DocumentLevel.conviction,
-        fileName = "conviction_level_doc.pdf",
-        createdAt = Instant.parse("2022-12-07T10:40:00Z"),
-        typeCode = "TYPE-2",
-        typeDescription = "Type 2 Description",
-        description = "Extended Description 2",
-      ),
-    )
+    assertThat(result).hasSize(2)
+    assertThat(result[0].fileName).isEqualTo("offender_level_doc.pdf")
+    assertThat(result[1].fileName).isEqualTo("conviction_level_doc.pdf")
   }
 }


### PR DESCRIPTION
We have observed rare cases where the community API has returned a document without a name specified.

This commit filters out such documents as we cannot automatically generate a filename without knowing the file extension/type, which is not provided.