### PR TITLE
CAS2-437 move SQL logic to database VIEW

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ApplicationsController.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
@@ -50,7 +50,7 @@ class ApplicationsController(
 
     prisonCode?.let { if (prisonCode != user.activeCaseloadId) throw ForbiddenProblem() }
 
-    val pageCriteria = PageCriteria("created_at", SortDirection.desc, page)
+    val pageCriteria = PageCriteria("createdAt", SortDirection.desc, page)
 
     val (applications, metadata) = applicationService.getApplications(prisonCode, isSubmitted, user, pageCriteria)
 
@@ -137,14 +137,14 @@ class ApplicationsController(
     return ResponseEntity.ok(getPersonDetailAndTransform(updatedApplication, user))
   }
 
-  private fun getPersonNamesAndTransformToSummaries(applicationSummaries: List<Cas2ApplicationSummary>):
+  private fun getPersonNamesAndTransformToSummaries(applicationSummaries: List<Cas2ApplicationSummaryEntity>):
     List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary> {
-    val crns = applicationSummaries.map { it.getCrn() }
+    val crns = applicationSummaries.map { it.crn }
 
     val personNamesMap = offenderService.getMapOfPersonNamesAndCrns(crns)
 
     return applicationSummaries.map { application ->
-      applicationsTransformer.transformJpaSummaryToSummary(application, personNamesMap[application.getCrn()]!!)
+      applicationsTransformer.transformJpaSummaryToSummary(application, personNamesMap[application.crn]!!)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
@@ -58,7 +58,7 @@ class SubmissionsController(
     }
 
     val sortDirection = SortDirection.asc
-    val sortBy = "submitted_at"
+    val sortBy = "submittedAt"
 
     val (applications, metadata) = applicationService.getAllSubmittedApplicationsForAssessor(PageCriteria(sortBy, sortDirection, page))
 
@@ -174,14 +174,14 @@ class SubmissionsController(
     nomisUserService.getUserForRequest()
   }
 
-  private fun getPersonNamesAndTransformToSummaries(applicationSummaries: List<Cas2ApplicationSummary>):
+  private fun getPersonNamesAndTransformToSummaries(applicationSummaries: List<Cas2ApplicationSummaryEntity>):
     List<Cas2SubmittedApplicationSummary> {
-    val crns = applicationSummaries.map { it.getCrn() }
+    val crns = applicationSummaries.map { it.crn }
 
     val personNamesMap = offenderService.getMapOfPersonNamesAndCrns(crns)
 
     return applicationSummaries.map { application ->
-      submissionsTransformer.transformJpaSummaryToApiRepresentation(application, personNamesMap[application.getCrn()]!!)
+      submissionsTransformer.transformJpaSummaryToApiRepresentation(application, personNamesMap[application.crn]!!)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationSummaryEntity.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface ApplicationSummaryRepository : JpaRepository<Cas2ApplicationSummaryEntity, String> {
+  fun findByUserId(userId: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
+
+  fun findByUserIdAndSubmittedAtIsNotNull(userId: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
+
+  fun findByUserIdAndSubmittedAtIsNull(userId: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
+
+  fun findByPrisonCode(prisonCode: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
+
+  fun findByPrisonCodeAndSubmittedAtIsNotNull(prisonCode: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
+
+  fun findByPrisonCodeAndSubmittedAtIsNull(prisonCode: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
+
+  fun findBySubmittedAtIsNotNull(pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
+}
+
+@Entity
+@Table(name = "cas_2_application_live_summary")
+data class Cas2ApplicationSummaryEntity(
+  @Id
+  val id: UUID,
+  val crn: String,
+  @Column(name = "noms_number")
+  var nomsNumber: String,
+  @Column(name = "created_by_user_id")
+  val userId: String,
+  @Column(name = "name")
+  val userName: String,
+  @Column(name = "created_at")
+  val createdAt: OffsetDateTime,
+  @Column(name = "submitted_at")
+  var submittedAt: OffsetDateTime?,
+  @Column(name = "hdc_eligibility_date")
+  var hdcEligibilityDate: LocalDate? = null,
+  @Column(name = "label")
+  var latestStatusUpdateLabel: String? = null,
+  @Column(name = "status_id")
+  var latestStatusUpdateStatusId: String? = null,
+  @Column(name = "referring_prison_code")
+  val prisonCode: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -28,7 +28,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplicationSummary as ApiTemporaryAccommodationApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary as DomainApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary as DomainApprovedPremisesApplicationSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary as DomainCas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity as DomainTemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationSummary as DomainTemporaryAccommodationApplicationSummary
 
@@ -171,13 +170,6 @@ class ApplicationsTransformer(
     return when {
       latestAssessment?.clarificationNotes?.any { it.response == null } == true -> ApplicationStatus.requestedFurtherInformation
       entity.submittedAt !== null -> ApplicationStatus.submitted
-      else -> ApplicationStatus.inProgress
-    }
-  }
-
-  private fun getStatusFromSummary(entity: DomainCas2ApplicationSummary): ApplicationStatus {
-    return when {
-      entity.getSubmittedAt() != null -> ApplicationStatus.submitted
       else -> ApplicationStatus.inProgress
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -5,10 +5,11 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import java.util.UUID
 
 @Component("Cas2ApplicationsTransformer")
 class ApplicationsTransformer(
@@ -42,22 +43,22 @@ class ApplicationsTransformer(
   }
 
   fun transformJpaSummaryToSummary(
-    jpaSummary: Cas2ApplicationSummary,
+    jpaSummary: Cas2ApplicationSummaryEntity,
     personName: String,
   ): uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary {
     return uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
       .Cas2ApplicationSummary(
-        id = jpaSummary.getId(),
-        createdByUserId = jpaSummary.getCreatedByUserId(),
-        createdByUserName = jpaSummary.getCreatedByUserName(),
-        createdAt = jpaSummary.getCreatedAt().toInstant(),
-        submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
+        id = jpaSummary.id,
+        createdByUserId = UUID.fromString(jpaSummary.userId),
+        createdByUserName = jpaSummary.userName,
+        createdAt = jpaSummary.createdAt.toInstant(),
+        submittedAt = jpaSummary.submittedAt?.toInstant(),
         status = getStatusFromSummary(jpaSummary),
         latestStatusUpdate = statusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(jpaSummary),
         type = "CAS2",
-        hdcEligibilityDate = jpaSummary.getHdcEligibilityDate(),
-        crn = jpaSummary.getCrn(),
-        nomsNumber = jpaSummary.getNomsNumber(),
+        hdcEligibilityDate = jpaSummary.hdcEligibilityDate,
+        crn = jpaSummary.crn,
+        nomsNumber = jpaSummary.nomsNumber,
         personName = personName,
       )
   }
@@ -70,9 +71,9 @@ class ApplicationsTransformer(
     return ApplicationStatus.inProgress
   }
 
-  private fun getStatusFromSummary(summary: Cas2ApplicationSummary): ApplicationStatus {
+  private fun getStatusFromSummary(summary: Cas2ApplicationSummaryEntity): ApplicationStatus {
     return when {
-      summary.getSubmittedAt() != null -> ApplicationStatus.submitted
+      summary.submittedAt != null -> ApplicationStatus.submitted
       else -> ApplicationStatus.inProgress
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/StatusUpdateTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/StatusUpdateTransformer.kt
@@ -4,10 +4,11 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LatestCas2StatusUpdate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExternalUserTransformer
+import java.util.UUID
 
 @Component("Cas2StatusUpdateTransformer")
 class StatusUpdateTransformer(
@@ -38,11 +39,11 @@ class StatusUpdateTransformer(
     )
   }
 
-  fun transformJpaSummaryToLatestStatusUpdateApi(jpa: Cas2ApplicationSummary): LatestCas2StatusUpdate? {
-    if (jpa.getLatestStatusUpdateStatusId() !== null) {
+  fun transformJpaSummaryToLatestStatusUpdateApi(jpa: Cas2ApplicationSummaryEntity): LatestCas2StatusUpdate? {
+    if (jpa.latestStatusUpdateStatusId !== null) {
       return LatestCas2StatusUpdate(
-        statusId = jpa.getLatestStatusUpdateStatusId()!!,
-        label = jpa.getLatestStatusUpdateLabel()!!,
+        statusId = UUID.fromString(jpa.latestStatusUpdateStatusId!!),
+        label = jpa.latestStatusUpdateLabel!!,
       )
     } else {
       return null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -6,11 +6,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpda
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import java.util.UUID
 
 @Component("Cas2SubmittedApplicationTransformer")
 class SubmissionsTransformer(
@@ -46,17 +47,17 @@ class SubmissionsTransformer(
   }
 
   fun transformJpaSummaryToApiRepresentation(
-    jpaSummary: Cas2ApplicationSummary,
+    jpaSummary: Cas2ApplicationSummaryEntity,
     personName: String,
   ): Cas2SubmittedApplicationSummary {
     return Cas2SubmittedApplicationSummary(
-      id = jpaSummary.getId(),
+      id = jpaSummary.id,
       personName = personName,
-      createdByUserId = jpaSummary.getCreatedByUserId(),
-      createdAt = jpaSummary.getCreatedAt().toInstant(),
-      submittedAt = jpaSummary.getSubmittedAt()?.toInstant(),
-      crn = jpaSummary.getCrn(),
-      nomsNumber = jpaSummary.getNomsNumber(),
+      createdByUserId = UUID.fromString(jpaSummary.userId),
+      createdAt = jpaSummary.createdAt.toInstant(),
+      submittedAt = jpaSummary.submittedAt?.toInstant(),
+      crn = jpaSummary.crn,
+      nomsNumber = jpaSummary.nomsNumber,
     )
   }
 

--- a/src/main/resources/db/migration/all/20240515100000__create_cas_2_summary_views.sql
+++ b/src/main/resources/db/migration/all/20240515100000__create_cas_2_summary_views.sql
@@ -1,0 +1,38 @@
+-- create application summary view
+DROP VIEW IF EXISTS cas_2_application_summary;
+CREATE VIEW cas_2_application_summary AS SELECT
+    CAST(a.id AS TEXT),
+    a.crn,
+    a.noms_number,
+    CAST(a.created_by_user_id AS TEXT),
+    nu.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    asu.label,
+    CAST(asu.status_id AS TEXT),
+    a.referring_prison_code,
+    a.conditional_release_date
+FROM cas_2_applications a
+LEFT JOIN (SELECT DISTINCT ON (application_id) su.application_id, su.label, su.status_id
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+    ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id;
+
+-- create application summary view for live (i.e. unexpired) applications
+DROP VIEW IF EXISTS cas_2_application_live_summary;
+CREATE VIEW cas_2_application_live_summary AS SELECT
+    a.id,
+    a.crn,
+    a.noms_number,
+    a.created_by_user_id,
+    a.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    a.label,
+    a.status_id,
+    a.referring_prison_code
+FROM cas_2_application_summary a
+WHERE (a.conditional_release_date IS NULL OR a.conditional_release_date >= current_date);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/SubmissionsTransformerTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmissionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.TimelineEventsTransformer
-import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -120,18 +119,19 @@ class SubmissionsTransformerTest {
   inner class TransformJpaSummaryToCas2SubmittedSummary {
     @Test
     fun `transforms submitted summary application to API summary representation `() {
-      val applicationSummary = object : Cas2ApplicationSummary {
-        override fun getId() = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809")
-        override fun getCrn() = "CRN123"
-        override fun getNomsNumber() = "NOMS456"
-        override fun getCreatedByUserId() = UUID.fromString("836a9460-b177-433a-a0d9-262509092c9f")
-        override fun getCreatedByUserName() = "first last"
-        override fun getCreatedAt() = Timestamp(Instant.parse("2023-04-19T13:25:00+01:00").toEpochMilli())
-        override fun getSubmittedAt() = Timestamp(Instant.parse("2023-04-19T13:25:30+01:00").toEpochMilli())
-        override fun getHdcEligibilityDate() = LocalDate.parse("2023-04-29")
-        override fun getLatestStatusUpdateLabel(): String? = null
-        override fun getLatestStatusUpdateStatusId(): UUID? = null
-      }
+      val applicationSummary = Cas2ApplicationSummaryEntity(
+        id = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809"),
+        crn = "CRN123",
+        nomsNumber = "NOMS456",
+        userId = "836a9460-b177-433a-a0d9-262509092c9f",
+        userName = "first last",
+        createdAt = OffsetDateTime.parse("2023-04-19T13:25:00+01:00"),
+        submittedAt = OffsetDateTime.parse("2023-04-19T13:25:30+01:00"),
+        hdcEligibilityDate = LocalDate.parse("2023-04-29"),
+        latestStatusUpdateLabel = null,
+        latestStatusUpdateStatusId = null,
+        prisonCode = "BRI",
+      )
 
       val expectedSubmittedApplicationSummary = Cas2SubmittedApplicationSummary(
         id = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809"),


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/CAS2-437

TLDR: this PR removes some of the complex and common SQL logic out of the application layer into a database VIEW which can then be used with [JPA query methods](https://docs.spring.io/spring-data/jpa/reference/jpa/query-methods.html).

The /cas2/applications endpoint is used by the frontend to provision the referrer dashboards.

Recently those dashboards have been extended with new logic such as fetching results by page, prison code and submitted/not submitted. Our approach was to add new query methods with mostly duplicate SQL each time. We knew this wasn’t going to be too sustainable but with national roll out planned we pushed through and compounded the problem.

[We now want to add in another piece of logic to automatically filter out old applications from one of those pages.](https://dsdmoj.atlassian.net/browse/CAS2-380?atlOrigin=eyJpIjoiMDc3NWQ2NjlkMmU5NGMxZmI0MzQ3NTk5NTliZTk3NmYiLCJwIjoiaiJ9) 

At this point we want to pause adding new features and refactor how this data is queried. This should make the codebase easier to read, harder for bugs to appear and easier to extend with new features.

Database views and JPA query methods have been investigated and deemed an alternative way to read sets of applications in differing states.