### PR TITLE
APS-735 If not in delius, referralHasArrival returns false

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeliusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeliusService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -13,6 +14,10 @@ class DeliusService(
   fun referralHasArrival(booking: BookingEntity): Boolean {
     val referralDetails = when (val clientResult = apDeliusContextApiClient.getReferralDetails(booking.crn, booking.id.toString())) {
       is ClientResult.Success -> clientResult.body
+      is ClientResult.Failure.StatusCode -> when (clientResult.status) {
+        HttpStatus.NOT_FOUND -> return false
+        else -> clientResult.throwException()
+      }
       is ClientResult.Failure -> clientResult.throwException()
     }
     return referralDetails.arrivedAt != null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DeliusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DeliusServiceTest.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -54,6 +56,36 @@ class DeliusServiceTest {
       val result = service.referralHasArrival(booking)
 
       assertThat(result).isFalse
+    }
+
+    @Test
+    fun `referralHasArrival returns false if 404 returned`() {
+      every { apDeliusContextApiClient.getReferralDetails(booking.crn, booking.id.toString()) } returns
+        ClientResult.Failure.StatusCode(
+          method = HttpMethod.GET,
+          path = "/",
+          status = HttpStatus.NOT_FOUND,
+          body = "the body",
+        )
+
+      val result = service.referralHasArrival(booking)
+
+      assertThat(result).isFalse
+    }
+
+    @Test
+    fun `referralHasArrival throw exception if failure other than 404 returned`() {
+      every { apDeliusContextApiClient.getReferralDetails(booking.crn, booking.id.toString()) } returns
+        ClientResult.Failure.StatusCode(
+          method = HttpMethod.GET,
+          path = "/",
+          status = HttpStatus.BAD_REQUEST,
+          body = "the body",
+        )
+
+      assertThatThrownBy {
+        service.referralHasArrival(booking)
+      }.hasMessage("Unable to complete GET request to /: 400 BAD_REQUEST")
     }
   }
 }


### PR DESCRIPTION
There are currently several reasons why a placement may not have a corresponding referral in delius:

* referral did exist in delius but was hard deleted on placement withdrawal
* domain event processing failed (e.g. inactive index offence issue)

In these cases instead of throwing an error when checking if the referral has an arrival, we instead return false