### PR TITLE
Only return unarchived bedspace count from getPremisessSummary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -60,6 +60,8 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
           LEFT JOIN p.localAuthorityArea la
         WHERE 
           pr.id = :regionId
+        AND 
+          (b.endDate IS NULL OR b.endDate > CURRENT_DATE)
         GROUP BY p.id, p.name, p.addressLine1, p.addressLine2, p.postcode, pdu.name, p.status, la.name
       """,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -68,6 +68,112 @@ class PremisesSummaryTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Get all CAS3 Premises returns a bedspace count of 3 when there are 3 bedspaces with no end date and one 1 with an end date in the past`() {
+    `Given a User` { user, jwt ->
+      val uuid = UUID.randomUUID()
+
+      val expectedCas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withProbationRegion(user.probationRegion)
+        withId(uuid)
+        withAddressLine1("221 Baker Street")
+        withAddressLine2("221B")
+        withPostcode("NW1 6XE")
+        withStatus(PropertyStatus.active)
+        withYieldedProbationDeliveryUnit {
+          probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(user.probationRegion)
+          }
+        }
+        withService("CAS3")
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { expectedCas3Premises }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(3) {
+        withYieldedRoom { room }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedRoom { room }
+        withEndDate { LocalDate.now().minusWeeks(1) }
+      }
+
+      webTestClient.get()
+        .uri("/premises/summary")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("$[0].id").isEqualTo(uuid.toString())
+        .jsonPath("$[0].addressLine1").isEqualTo("221 Baker Street")
+        .jsonPath("$[0].addressLine2").isEqualTo("221B")
+        .jsonPath("$[0].postcode").isEqualTo("NW1 6XE")
+        .jsonPath("$[0].status").isEqualTo("active")
+        .jsonPath("$[0].pdu").isEqualTo(expectedCas3Premises.probationDeliveryUnit!!.name)
+        .jsonPath("$[0].bedCount").isEqualTo(3)
+        .jsonPath("$.length()").isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun `Get all CAS3 Premises returns a bedspace count of 4 when there are 3 bedspaces with no end date and one 1 with an end date in the future`() {
+    `Given a User` { user, jwt ->
+      val uuid = UUID.randomUUID()
+
+      val expectedCas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withProbationRegion(user.probationRegion)
+        withId(uuid)
+        withAddressLine1("221 Baker Street")
+        withAddressLine2("221B")
+        withPostcode("NW1 6XE")
+        withStatus(PropertyStatus.active)
+        withYieldedProbationDeliveryUnit {
+          probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(user.probationRegion)
+          }
+        }
+        withService("CAS3")
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withYieldedPremises { expectedCas3Premises }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(3) {
+        withYieldedRoom { room }
+      }
+
+      bedEntityFactory.produceAndPersistMultiple(1) {
+        withYieldedRoom { room }
+        withEndDate { LocalDate.now().plusWeeks(1) }
+      }
+
+      webTestClient.get()
+        .uri("/premises/summary")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("$[0].id").isEqualTo(uuid.toString())
+        .jsonPath("$[0].addressLine1").isEqualTo("221 Baker Street")
+        .jsonPath("$[0].addressLine2").isEqualTo("221B")
+        .jsonPath("$[0].postcode").isEqualTo("NW1 6XE")
+        .jsonPath("$[0].status").isEqualTo("active")
+        .jsonPath("$[0].pdu").isEqualTo(expectedCas3Premises.probationDeliveryUnit!!.name)
+        .jsonPath("$[0].bedCount").isEqualTo(4)
+        .jsonPath("$.length()").isEqualTo(1)
+    }
+  }
+
+  @Test
   fun `Get all Premises throws error with incorrect service name`() {
     `Given a User` { _, jwt ->
       webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -68,7 +68,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get all CAS3 Premises returns a bedspace count of 3 when there are 3 bedspaces with no end date and one 1 with an end date in the past`() {
+  fun `Get all CAS3 Premises returns bedspace count as expected when there is an archived bedspace`() {
     `Given a User` { user, jwt ->
       val uuid = UUID.randomUUID()
 
@@ -121,7 +121,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Get all CAS3 Premises returns a bedspace count of 4 when there are 3 bedspaces with no end date and one 1 with an end date in the future`() {
+  fun `Get all CAS3 Premises returns a bedspace count as expected when beds are active`() {
     `Given a User` { user, jwt ->
       val uuid = UUID.randomUUID()
 


### PR DESCRIPTION
Adds a condition to only include in the bedspace count returned from `premisesSummaryGet` the number of bedspaces with no end date or an end date in the future.