### PR TITLE
Revert "Fix/nomis user create race condition"

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NomisUserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NomisUserEntity.kt
@@ -2,10 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.hibernate.annotations.CreationTimestamp
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import org.springframework.transaction.annotation.Transactional
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Entity
@@ -16,36 +13,6 @@ import javax.persistence.Table
 @Repository
 interface NomisUserRepository : JpaRepository<NomisUserEntity, UUID> {
   fun findByNomisUsername(nomisUserName: String): NomisUserEntity?
-
-  @Modifying
-  @Transactional
-  @Query(
-    value = """
-          INSERT INTO nomis_user (id, name, nomis_username, nomis_staff_id, account_type, email, is_enabled, is_active, active_caseload_id)
-          VALUES (:id, :name, :nomisUsername, :nomisStaffId, :accountType, :email, :isEnabled, :isActive, :activeCaseloadId)
-          ON CONFLICT (nomis_username) DO UPDATE SET
-          name = EXCLUDED.name,
-          nomis_staff_id = EXCLUDED.nomis_staff_id,
-          account_type = EXCLUDED.account_type,
-          email = EXCLUDED.email,
-          is_enabled = EXCLUDED.is_enabled,
-          is_active = EXCLUDED.is_active,
-          active_caseload_id = EXCLUDED.active_caseload_id
-          RETURNING *
-      """,
-    nativeQuery = true,
-  )
-  fun saveOrUpdate(
-    id: UUID,
-    name: String,
-    nomisUsername: String,
-    nomisStaffId: Long,
-    accountType: String,
-    email: String?,
-    isEnabled: Boolean,
-    isActive: Boolean,
-    activeCaseloadId: String?,
-  ): NomisUserEntity
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/NomisUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/NomisUserService.kt
@@ -44,16 +44,18 @@ class NomisUserService(
       return existingUser
     }
 
-    return userRepository.saveOrUpdate(
-      id = UUID.randomUUID(),
-      name = "${nomisUserDetails.firstName} ${nomisUserDetails.lastName}",
-      nomisUsername = normalisedUsername,
-      nomisStaffId = nomisUserDetails.staffId,
-      accountType = nomisUserDetails.accountType,
-      email = nomisUserDetails.primaryEmail,
-      isEnabled = nomisUserDetails.enabled,
-      isActive = nomisUserDetails.active,
-      activeCaseloadId = nomisUserDetails.activeCaseloadId,
+    return userRepository.save(
+      NomisUserEntity(
+        id = UUID.randomUUID(),
+        name = "${nomisUserDetails.firstName} ${nomisUserDetails.lastName}",
+        nomisUsername = normalisedUsername,
+        nomisStaffId = nomisUserDetails.staffId,
+        accountType = nomisUserDetails.accountType,
+        email = nomisUserDetails.primaryEmail,
+        isEnabled = nomisUserDetails.enabled,
+        isActive = nomisUserDetails.active,
+        activeCaseloadId = nomisUserDetails.activeCaseloadId,
+      ),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NomisUserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NomisUserEntityFactory.kt
@@ -53,18 +53,6 @@ class NomisUserEntityFactory : Factory<NomisUserEntity> {
     this.email = { email }
   }
 
-  fun withAccountType(accountType: String) = apply {
-    this.accountType = { accountType }
-  }
-
-  fun withEnabled(enabled: Boolean) = apply {
-    this.isEnabled = { enabled }
-  }
-
-  fun withActive(active: Boolean) = apply {
-    this.isActive = { active }
-  }
-
   override fun produce(): NomisUserEntity = NomisUserEntity(
     id = this.id(),
     nomisUsername = this.nomisUsername(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/NomisUserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/NomisUserServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.NomisUserRolesApiClient
@@ -64,19 +65,7 @@ class NomisUserServiceTest {
         )
         // setup repository
         every { mockUserRepository.findByNomisUsername(username) } returns oldUserData
-        verify(exactly = 0) {
-          mockUserRepository.saveOrUpdate(
-            id = any(),
-            name = any(),
-            nomisUsername = any(),
-            nomisStaffId = any(),
-            accountType = any(),
-            email = any(),
-            isEnabled = any(),
-            isActive = any(),
-            activeCaseloadId = any(),
-          )
-        }
+        verify(exactly = 0) { mockUserRepository.save(any()) }
 
         assertThat(userService.getUserForRequest()).matches {
           it.nomisUsername == username &&
@@ -152,28 +141,7 @@ class NomisUserServiceTest {
         )
         // setup repository
         every { mockUserRepository.findByNomisUsername(username) } returns null
-        every {
-          mockUserRepository.saveOrUpdate(
-            id = any(),
-            name = any(),
-            nomisUsername = any(),
-            nomisStaffId = any(),
-            accountType = any(),
-            email = any(),
-            isEnabled = any(),
-            isActive = any(),
-            activeCaseloadId = any(),
-          )
-        } returns NomisUserEntityFactory()
-          .withNomisUsername(username)
-          .withName("Jim Jimmerson")
-          .withNomisStaffCode(5678)
-          .withAccountType("CLOSED")
-          .withEmail("example@example.com")
-          .withEnabled(false)
-          .withActive(false)
-          .withActiveCaseloadId("456")
-          .produce()
+        every { mockUserRepository.save(any()) } answers { it.invocation.args[0] as NomisUserEntity }
 
         assertThat(userService.getUserForRequest()).matches {
           it.nomisUsername == username &&


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-approved-premises-api#1858

It seems that though the tests passed we get an error locally:

```
org.springframework.dao.InvalidDataAccessApiUsageException: Modifying queries can only use void or int/Integer as return type! Offending method: public abstract uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity 
```

Though production appears to work with an existing assessor accessing their applications, and we have no new exceptions it must surely be present should a new user be created. This suggests we should role it back quickly to avoid an issue.

The problem itself suggests that the `@modifying` flag must return a void or int, and we return an entity as to avoid having to do another query to find the record. Slightly interesting that this was able to compile given that response type violation. 

Given this has happened once, having to do another query on every creation to find the newly created record would be possible but is yet another query to make. Perhaps in a second attempt we can try that out.