### PR TITLE
APS-716 CAS1 Email Tidy in preparation for using CRU email address for Reply-To

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -434,16 +434,9 @@ class AssessmentService(
     if (application is ApprovedPremisesApplicationEntity) {
       saveCas1ApplicationAssessedDomainEvent(application, assessment, offenderDetails, staffDetails, placementDates)
 
+      assessmentEmailService.assessmentAccepted(savedAssessment)
+
       application.createdByUser.email?.let { email ->
-        emailNotificationService.sendEmail(
-          recipientEmailAddress = email,
-          templateId = notifyConfig.templates.assessmentAccepted,
-          personalisation = mapOf(
-            "name" to application.createdByUser.name,
-            "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
-            "crn" to application.crn,
-          ),
-        )
 
         if (createPlacementRequest) {
           emailNotificationService.sendEmail(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -52,6 +52,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
@@ -85,6 +86,7 @@ class AssessmentService(
   private val taskDeadlineService: TaskDeadlineService,
   private val assessmentEmailService: Cas1AssessmentEmailService,
   private val cas1AssessmentDomainEventService: Cas1AssessmentDomainEventService,
+  private val cas1PlacementRequestEmailService: Cas1PlacementRequestEmailService,
 ) {
   fun getVisibleAssessmentSummariesForUserCAS1(
     user: UserEntity,
@@ -436,17 +438,8 @@ class AssessmentService(
 
       assessmentEmailService.assessmentAccepted(savedAssessment)
 
-      application.createdByUser.email?.let { email ->
-
-        if (createPlacementRequest) {
-          emailNotificationService.sendEmail(
-            recipientEmailAddress = email,
-            templateId = notifyConfig.templates.placementRequestSubmitted,
-            personalisation = mapOf(
-              "crn" to application.crn,
-            ),
-          )
-        }
+      if (createPlacementRequest) {
+        cas1PlacementRequestEmailService.placementRequestSubmitted(application)
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentEmailService.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
@@ -48,6 +49,21 @@ class Cas1AssessmentEmailService(
           "name" to deallocatedUserEntity.name,
           "assessmentUrl" to assessmentUrlTemplate.resolve("id", assessmentId.toString()),
           "crn" to crn,
+        ),
+      )
+    }
+  }
+
+  fun assessmentAccepted(assessment: AssessmentEntity) {
+    val application = assessment.application
+    assessment.application.createdByUser.email?.let { email ->
+      emailNotificationService.sendEmail(
+        recipientEmailAddress = email,
+        templateId = notifyConfig.templates.assessmentAccepted,
+        personalisation = mapOf(
+          "name" to application.createdByUser.name,
+          "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
+          "crn" to application.crn,
         ),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentEmailService.kt
@@ -56,10 +56,25 @@ class Cas1AssessmentEmailService(
 
   fun assessmentAccepted(assessment: AssessmentEntity) {
     val application = assessment.application
-    assessment.application.createdByUser.email?.let { email ->
+    application.createdByUser.email?.let { email ->
       emailNotificationService.sendEmail(
         recipientEmailAddress = email,
         templateId = notifyConfig.templates.assessmentAccepted,
+        personalisation = mapOf(
+          "name" to application.createdByUser.name,
+          "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
+          "crn" to application.crn,
+        ),
+      )
+    }
+  }
+
+  fun assessmentRejected(assessment: AssessmentEntity) {
+    val application = assessment.application
+    application.createdByUser.email?.let { email ->
+      emailNotificationService.sendEmail(
+        recipientEmailAddress = email,
+        templateId = notifyConfig.templates.assessmentRejected,
         personalisation = mapOf(
           "name" to application.createdByUser.name,
           "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1EmailNotificationService.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
+
+@Service
+class Cas1EmailNotificationService(
+  private val emailNotificationService: EmailNotificationService,
+) : Cas1EmailNotifier {
+
+  override fun sendEmail(
+    recipientEmailAddress: String,
+    templateId: String,
+    personalisation: Map<String, *>,
+  ) {
+    emailNotificationService.sendEmail(
+      recipientEmailAddress,
+      templateId,
+      personalisation,
+    )
+  }
+
+  override fun sendEmails(
+    recipientEmailAddresses: Set<String>,
+    templateId: String,
+    personalisation: Map<String, *>,
+  ) {
+    emailNotificationService.sendEmails(
+      recipientEmailAddresses,
+      templateId,
+      personalisation,
+    )
+  }
+}
+
+interface Cas1EmailNotifier {
+  fun sendEmail(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>)
+
+  fun sendEmails(recipientEmailAddresses: Set<String>, templateId: String, personalisation: Map<String, *>)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestEmailService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
@@ -14,6 +15,21 @@ class Cas1PlacementRequestEmailService(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.application-timeline}") private val applicationTimelineUrlTemplate: UrlTemplate,
 ) {
+
+  fun placementRequestSubmitted(
+    application: ApprovedPremisesApplicationEntity,
+  ) {
+    application.createdByUser.email?.let { email ->
+      emailNotifier.sendEmail(
+        recipientEmailAddress = email,
+        templateId = notifyConfig.templates.placementRequestSubmitted,
+        personalisation = mapOf(
+          "crn" to application.crn,
+        ),
+      )
+    }
+  }
+
   fun placementRequestWithdrawn(
     placementRequest: PlacementRequestEntity,
     withdrawalTriggeredBy: WithdrawalTriggeredBy,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -2069,7 +2069,7 @@ class AssessmentTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Accept assessment with placement date returns 200, persists decision, creates and allocates a placement request, and emits domain events`() {
+    fun `Accept assessment with placement date returns 200, persists decision, creates and allocates a placement request, emits domain event and emails`() {
       `Given a User`(
         staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
       ) { userEntity, jwt ->
@@ -2183,6 +2183,10 @@ class AssessmentTest : IntegrationTestBase() {
               assertThat(persistedPlacementRequirements.essentialCriteria.map { it.propertyName }).containsExactlyInAnyOrderElementsOf(
                 placementRequirements.essentialCriteria.map { it.toString() },
               )
+
+              emailAsserter.assertEmailsRequestedCount(2)
+              emailAsserter.assertEmailRequested(application.createdByUser.email!!, notifyConfig.templates.assessmentAccepted)
+              emailAsserter.assertEmailRequested(application.createdByUser.email!!, notifyConfig.templates.placementRequestSubmitted)
             }
           }
         }
@@ -2190,7 +2194,7 @@ class AssessmentTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Accept assessment without placement date returns 200, persists decision, does not create a Placement Request, creates Placement Requirements and emits domain event`() {
+    fun `Accept assessment without placement date returns 200, persists decision, does not create a Placement Request, creates Placement Requirements, emits domain event and emails`() {
       `Given a User`(
         staffUserDetailsConfigBlock = { withProbationAreaCode("N21") },
       ) { userEntity, jwt ->
@@ -2286,6 +2290,9 @@ class AssessmentTest : IntegrationTestBase() {
               assertThat(persistedPlacementRequirements.essentialCriteria.map { it.propertyName }).containsExactlyInAnyOrderElementsOf(
                 placementRequirements.essentialCriteria.map { it.toString() },
               )
+
+              emailAsserter.assertEmailsRequestedCount(1)
+              emailAsserter.assertEmailRequested(application.createdByUser.email!!, notifyConfig.templates.assessmentAccepted)
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -2434,6 +2434,9 @@ class AssessmentTest : IntegrationTestBase() {
           SnsEventPersonReference("CRN", offenderDetails.otherIds.crn),
           SnsEventPersonReference("NOMS", offenderDetails.otherIds.nomsNumber!!),
         )
+
+        emailAsserter.assertEmailsRequestedCount(1)
+        emailAsserter.assertEmailRequested(application.createdByUser.email!!, notifyConfig.templates.assessmentRejected)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -85,6 +85,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessServic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertAssessmentHasSystemNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
@@ -112,6 +113,7 @@ class AssessmentServiceTest {
   private val taskDeadlineServiceMock = mockk<TaskDeadlineService>()
   private val assessmentEmailServiceMock = mockk<Cas1AssessmentEmailService>()
   private val cas1AssessmentDomainEventService = mockk<Cas1AssessmentDomainEventService>()
+  private val cas1PlacementRequestEmailService = mockk<Cas1PlacementRequestEmailService>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -135,6 +137,7 @@ class AssessmentServiceTest {
     taskDeadlineServiceMock,
     assessmentEmailServiceMock,
     cas1AssessmentDomainEventService,
+    cas1PlacementRequestEmailService,
   )
 
   @Test
@@ -2258,6 +2261,7 @@ class AssessmentServiceTest {
       taskDeadlineServiceMock,
       assessmentEmailServiceMock,
       cas1AssessmentDomainEventService,
+      cas1PlacementRequestEmailService,
     )
 
     private val user = UserEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -92,7 +92,7 @@ class AcceptAssessmentTest {
   private val userAllocator = mockk<UserAllocator>()
   private val objectMapperMock = mockk<ObjectMapper>()
   private val taskDeadlineServiceMock = mockk<TaskDeadlineService>()
-  private val assessmentEmailServiceMock = mockk<Cas1AssessmentEmailService>()
+  private val csa1AssessmentEmailServiceMock = mockk<Cas1AssessmentEmailService>()
   private val cas1AssessmentDomainEventService = mockk<Cas1AssessmentDomainEventService>()
 
   private val assessmentService = AssessmentService(
@@ -115,7 +115,7 @@ class AcceptAssessmentTest {
     objectMapperMock,
     UrlTemplate("http://frontend/applications/#id"),
     taskDeadlineServiceMock,
-    assessmentEmailServiceMock,
+    csa1AssessmentEmailServiceMock,
     cas1AssessmentDomainEventService,
   )
 
@@ -363,6 +363,8 @@ class AcceptAssessmentTest {
 
     every { emailNotificationServiceMock.sendEmail(any(), any(), any()) } just Runs
 
+    every { csa1AssessmentEmailServiceMock.assessmentAccepted(any()) } just Runs
+
     val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -382,14 +384,7 @@ class AcceptAssessmentTest {
     }
 
     verify(exactly = 1) {
-      emailNotificationServiceMock.sendEmail(
-        any(),
-        "ddf87b15-8866-4bad-a87b-47eba69eb6db",
-        match {
-          it["name"] == assessment.application.createdByUser.name &&
-            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
-        },
-      )
+      csa1AssessmentEmailServiceMock.assessmentAccepted(assessment)
     }
   }
 
@@ -449,6 +444,8 @@ class AcceptAssessmentTest {
 
     every { emailNotificationServiceMock.sendEmail(any(), any(), any()) } just Runs
 
+    every { csa1AssessmentEmailServiceMock.assessmentAccepted(any()) } just Runs
+
     val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, placementDates, notes)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -475,15 +472,7 @@ class AcceptAssessmentTest {
     }
 
     verify(exactly = 1) {
-      emailNotificationServiceMock.sendEmail(
-        any(),
-        "ddf87b15-8866-4bad-a87b-47eba69eb6db",
-        match {
-          it["crn"] == assessment.application.crn &&
-            it["name"] == assessment.application.createdByUser.name &&
-            (it["applicationUrl"] as String).matches(Regex("http://frontend/applications/[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}"))
-        },
-      )
+      csa1AssessmentEmailServiceMock.assessmentAccepted(assessment)
     }
 
     verify(exactly = 1) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
@@ -110,8 +109,6 @@ class AcceptAssessmentTest {
     communityApiClientMock,
     cruServiceMock,
     placementRequestServiceMock,
-    emailNotificationServiceMock,
-    NotifyConfig(),
     placementRequirementsServiceMock,
     userAllocator,
     objectMapperMock,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1EmailNotificationServiceTest.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1EmailNotificationService
+import java.util.UUID
+
+class Cas1EmailNotificationServiceTest {
+
+  private val emailNotificationService = mockk<EmailNotificationService>()
+
+  private val service = Cas1EmailNotificationService(emailNotificationService)
+
+  companion object {
+    const val RECIPIENT_1 = "recipient1@somewhere.com"
+    const val RECIPIENT_2 = "recipient2@somewhere.com"
+    val TEMPLATE_ID = UUID.randomUUID().toString()
+    val PERSONALISATION = mapOf(
+      "field1" to "value1",
+    )
+  }
+
+  @Test
+  fun `sendEmail delegates to EmailNotificationService`() {
+    every { emailNotificationService.sendEmail(RECIPIENT_1, TEMPLATE_ID, PERSONALISATION) } returns Unit
+
+    service.sendEmail(
+      RECIPIENT_1,
+      TEMPLATE_ID,
+      PERSONALISATION,
+    )
+
+    verify { emailNotificationService.sendEmail(RECIPIENT_1, TEMPLATE_ID, PERSONALISATION) }
+  }
+
+  @Test
+  fun `sendEmails delegates to EmailNotificationService`() {
+    every { emailNotificationService.sendEmails(setOf(RECIPIENT_1, RECIPIENT_2), TEMPLATE_ID, PERSONALISATION) } returns Unit
+
+    service.sendEmails(
+      setOf(RECIPIENT_1, RECIPIENT_2),
+      TEMPLATE_ID,
+      PERSONALISATION,
+    )
+
+    verify { emailNotificationService.sendEmails(setOf(RECIPIENT_1, RECIPIENT_2), TEMPLATE_ID, PERSONALISATION) }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestEmailServiceTest.kt
@@ -50,6 +50,35 @@ class Cas1PlacementRequestEmailServiceTest {
   )
 
   @Nested
+  inner class PlacementRequestCreated {
+
+    @Test
+    fun `placementRequestCreates doesnt send an email if not defined`() {
+      val application = createApplication(applicantEmail = null)
+
+      service.placementRequestSubmitted(application = application)
+
+      mockEmailNotificationService.assertNoEmailsRequested()
+    }
+
+    @Test
+    fun `placementRequestCreates sends an email if address defined`() {
+      val application = createApplication(applicantEmail = APPLICANT_EMAIL)
+
+      service.placementRequestSubmitted(application = application)
+
+      mockEmailNotificationService.assertEmailRequestCount(1)
+      mockEmailNotificationService.assertEmailRequested(
+        APPLICANT_EMAIL,
+        notifyConfig.templates.placementRequestSubmitted,
+        mapOf(
+          "crn" to CRN,
+        ),
+      )
+    }
+  }
+
+  @Nested
   inner class PlacementRequestWithdrawn {
 
     private val withdrawingUser = UserEntityFactory()


### PR DESCRIPTION
This PR ensures that all code sending emails for CAS1 do so via a specialised email service (e.g. Cas1AssessmentEmailService). This simplifies the subsequent changes required to ensure a CRU-specific reply-to email address is used for all CAS1 emails.