### PR TITLE
APS-794 Fix CAS1 Request for Placement PA Status Transform

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -121,11 +121,15 @@ data class PlacementApplicationEntity(
 
   /**
    * Supporting multiple dates in a single Placement Application is legacy behaviour. Any new
-   * placement application will only ever one and only one date in this collection
+   * placement application will have one and only one date in this collection
    */
   @OneToMany(mappedBy = "placementApplication")
   var placementDates: MutableList<PlacementDateEntity>,
 
+  /**
+   * Supporting multiple placements requests in a single Placement Application is legacy behaviour. Any new
+   * placement application will have one and only one Placement Request in this collection
+   */
   @OneToMany(mappedBy = "placementApplication")
   var placementRequests: MutableList<PlacementRequestEntity>,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -77,7 +77,7 @@ class RequestForPlacementTransformer(
 
   private fun PlacementApplicationEntity.deriveStatus(): RequestForPlacementStatus = when {
     this.isWithdrawn() -> RequestForPlacementStatus.requestWithdrawn
-    this.application.getLatestBooking() != null -> RequestForPlacementStatus.placementBooked
+    this.placementRequests.any { pr -> pr.hasActiveBooking() } -> RequestForPlacementStatus.placementBooked
     this.decision == PlacementApplicationDecision.REJECTED -> RequestForPlacementStatus.requestRejected
     this.decision == PlacementApplicationDecision.ACCEPTED -> RequestForPlacementStatus.awaitingMatch
     this.isSubmitted() -> RequestForPlacementStatus.requestSubmitted

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
@@ -144,7 +144,7 @@ class RequestForPlacementTransformerTest {
         .withPlacementRequirements(placementRequirements)
         .produce()
         .apply {
-          application.placementRequests = mutableListOf(this)
+          placementApplication.placementRequests = mutableListOf(this)
         }
 
       val premises = ApprovedPremisesEntityFactory()


### PR DESCRIPTION
Previously we used placements on the application as a whole to determine if a placement_application’s status is ‘placementBooked’. This commit fixes that and instead uses the placements associated with the specific placement_application to determine this.