### PR TITLE
Temporarily disable some optimistic locking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -36,7 +36,6 @@ import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.PrimaryKeyJoinColumn
 import javax.persistence.Table
-import javax.persistence.Version
 import kotlin.time.Duration.Companion.days
 import kotlin.time.toKotlinDuration
 
@@ -310,7 +309,8 @@ abstract class ApplicationEntity(
 
   var nomsNumber: String?,
 
-  @Version
+  // This is in place for optimistic locking (using @Version). We have temporarily disabled this
+  // functionality whilst we put protections in the CAS1 UI to reduce duplicate form submissions
   var version: Long = 1,
 ) {
   fun getLatestAssessment(): AssessmentEntity? = this.assessments.maxByOrNull { it.createdAt }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -28,7 +28,6 @@ import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.PrimaryKeyJoinColumn
 import javax.persistence.Table
-import javax.persistence.Version
 
 @Repository
 interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
@@ -272,7 +271,8 @@ abstract class AssessmentEntity(
 
   var dueAt: OffsetDateTime?,
 
-  @Version
+  // This is in place for optimistic locking (using @Version). We have temporarily disabled this
+  // functionality whilst we put protections in the CAS1 UI to reduce duplicate form submissions
   var version: Long = 1,
 )
 


### PR DESCRIPTION
This commit disables optimistic locking for the Application and Assessment Entities until we add double-click protection into the UI.

With these protections in place we’re seeing several errors occuring because, presumbaly, users are inadvertently double click on submit buttons. This is happening during applicaton and assessment ‘multi form’ pages in which case there isn’t any harm to let subsequent POSTs to overwrite prior POSTs. Regardless, there are scenarios where double clicks could lead to an inconsistent data model, so we should aim to re-enable optimistic locking as soon as we can ensure we can do it without minimising user disruption.