### PR TITLE
CAS2-465:  Restrict offender search to within the user's active prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/PeopleController.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Offender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
@@ -29,11 +30,14 @@ class PeopleController(
   private val oaSysSectionsTransformer: OASysSectionsTransformer,
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
+  private val nomisUserService: NomisUserService,
 ) : PeopleCas2Delegate {
   private val log = LoggerFactory.getLogger(this::class.java)
 
   override fun peopleSearchGet(nomsNumber: String): ResponseEntity<Person> {
-    val probationOffenderResult = offenderService.getPersonByNomsNumber(nomsNumber)
+    val currentUser = nomisUserService.getUserForRequest()
+
+    val probationOffenderResult = offenderService.getPersonByNomsNumber(nomsNumber, currentUser)
 
     when (probationOffenderResult) {
       is ProbationOffenderSearchResult.NotFound -> throw NotFoundProblem(nomsNumber, "Offender")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
@@ -216,8 +216,15 @@ class OffenderService(
     val inmateDetail = when (inmateDetailResponse) {
       is ClientResult.Success -> inmateDetailResponse.body
       is ClientResult.Failure.StatusCode -> when (inmateDetailResponse.status) {
-        HttpStatus.NOT_FOUND -> return AuthorisableActionResult.NotFound()
-        HttpStatus.FORBIDDEN -> return AuthorisableActionResult.Unauthorised()
+        HttpStatus.NOT_FOUND -> {
+          logFailedResponse(inmateDetailResponse)
+          return AuthorisableActionResult.NotFound()
+        }
+
+        HttpStatus.FORBIDDEN -> {
+          logFailedResponse(inmateDetailResponse)
+          return AuthorisableActionResult.Unauthorised()
+        }
         else -> {
           logFailedResponse(inmateDetailResponse)
           null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/OffenderService.kt
@@ -69,10 +69,7 @@ class OffenderService(
       val probationOffenderDetail = probationOffenderDetailList[0]
 
       // check for restrictions or exclusions
-      val isLao = probationOffenderDetail.currentExclusion == true || probationOffenderDetail.currentRestriction == true
-      if (isLao) {
-        return ProbationOffenderSearchResult.Forbidden(nomsNumber)
-      }
+      if (hasRestrictionOrExclusion(probationOffenderDetail)) return ProbationOffenderSearchResult.Forbidden(nomsNumber)
 
       // check inmate details from Prison API
       val inmateDetails = getInmateDetailsForProbationOffender(probationOffenderDetail)
@@ -85,6 +82,10 @@ class OffenderService(
         ProbationOffenderSearchResult.Forbidden(nomsNumber)
       }
     }
+  }
+
+  private fun hasRestrictionOrExclusion(probationOffenderDetail: ProbationOffenderDetail): Boolean {
+    return probationOffenderDetail.currentExclusion == true || probationOffenderDetail.currentRestriction == true
   }
 
   private fun isOffenderSamePrisonAsUser(inmateDetail: InmateDetail?, currentUser: NomisUserEntity): Boolean {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
@@ -1,27 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
 
-import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationOffenderDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockNotFoundSearchCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockServerErrorSearchCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockSuccessfulOffenderSearchCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.IDs
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.OffenderProfile
-import java.time.LocalDate
 
 class Cas2PersonSearchTest : IntegrationTestBase() {
   @Nested
@@ -66,85 +52,6 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Searching for a NOMIS ID that does not exist returns 404`() {
-      mockClientCredentialsJwtRequest()
-
-      `Given a CAS2 POM User` { userEntity, jwt ->
-        wiremockServer.stubFor(
-          get(WireMock.urlEqualTo("/search?nomsNumber=nomsNumber"))
-            .willReturn(
-              aResponse()
-                .withHeader("Content-Type", "application/json")
-                .withStatus(404),
-            ),
-        )
-
-        webTestClient.get()
-          .uri("/cas2/people/search?nomsNumber=nomsNumber")
-          .header("Authorization", "Bearer $jwt")
-          .exchange().expectStatus()
-          .isNotFound
-      }
-    }
-
-    @Test
-    fun `Searching for a NOMIS ID returns OK with correct body`() {
-      `Given a CAS2 POM User` { userEntity, jwt ->
-        val offender = ProbationOffenderDetailFactory()
-          .withOtherIds(IDs(crn = "CRN", nomsNumber = "NOMS321", pncNumber = "PNC123"))
-          .withFirstName("James")
-          .withSurname("Someone")
-          .withDateOfBirth(
-            LocalDate
-              .parse("1985-05-05"),
-          )
-          .withGender("Male")
-          .withOffenderProfile(OffenderProfile(nationality = "English"))
-          .produce()
-
-        val inmateDetail = InmateDetailFactory().withOffenderNo("NOMS321")
-          .withCustodyStatus(InmateStatus.IN)
-          .withAssignedLivingUnit(
-            AssignedLivingUnit(
-              agencyId = "BRI",
-              locationId = 5,
-              description = "B-2F-004",
-              agencyName = "HMP Bristol",
-            ),
-          )
-          .produce()
-
-        ProbationOffenderSearchAPI_mockSuccessfulOffenderSearchCall("NOMS321", listOf(offender))
-        PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
-
-        webTestClient.get()
-          .uri("/cas2/people/search?nomsNumber=NOMS321")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .json(
-            objectMapper.writeValueAsString(
-              FullPerson(
-                type = PersonType.fullPerson,
-                crn = "CRN",
-                name = "James Someone",
-                dateOfBirth = LocalDate.parse("1985-05-05"),
-                sex = "Male",
-                status = PersonStatus.inCustody,
-                nomsNumber = "NOMS321",
-                pncNumber = "PNC123",
-                nationality = "English",
-                isRestricted = false,
-                prisonName = "HMP Bristol",
-              ),
-            ),
-          )
-      }
-    }
-
-    @Test
     fun `Searching for a NOMIS ID returns Unauthorised error when it is unauthorized`() {
       `Given a CAS2 POM User` { userEntity, jwt ->
         ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall()
@@ -159,7 +66,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Searching for a NOMIS ID returns Unauthorised error when it is not found`() {
+    fun `Searching for a NOMIS ID returns 404 error when it is not found`() {
       `Given a CAS2 POM User` { userEntity, jwt ->
         ProbationOffenderSearchAPI_mockNotFoundSearchCall()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonSearchTest.kt
@@ -3,93 +3,169 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationOffenderDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.PrisonAPI_mockSuccessfulInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockNotFoundSearchCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockServerErrorSearchCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ProbationOffenderSearchAPI_mockSuccessfulOffenderSearchCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.IDs
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.OffenderProfile
+import java.time.LocalDate
 
 class Cas2PersonSearchTest : IntegrationTestBase() {
   @Nested
   inner class PeopleSearchGet {
-    @Test
-    fun `Searching by NOMIS ID without a JWT returns 401`() {
-      webTestClient.get()
-        .uri("/cas2/people/search?nomsNumber=nomsNumber").exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
 
-    @Test
-    fun `Searching for a NOMIS ID with a non-Delius or NOMIS JWT returns 403`() {
-      val jwt = jwtAuthHelper.createClientCredentialsJwt(
-        username = "username",
-        authSource = "other source",
-      )
+    @Nested
+    inner class WhenThereIsAnError {
+      @Test
+      fun `Searching by NOMIS ID without a JWT returns 401`() {
+        webTestClient.get()
+          .uri("/cas2/people/search?nomsNumber=nomsNumber").exchange()
+          .expectStatus()
+          .isUnauthorized
+      }
 
-      webTestClient.get()
-        .uri("/cas2/people/search?nomsNumber=nomsNumber")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `Searching for a NOMIS ID without ROLE_POM returns 403`() {
-      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
-        subject = "username",
-        authSource = "nomis",
-        roles = listOf("ROLE_OTHER"),
-      )
-
-      webTestClient.get()
-        .uri("/cas2/people/search?nomsNumber=nomsNumber")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `Searching for a NOMIS ID returns Unauthorised error when it is unauthorized`() {
-      `Given a CAS2 POM User` { userEntity, jwt ->
-        ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall()
+      @Test
+      fun `Searching for a NOMIS ID with a non-Delius or NOMIS JWT returns 403`() {
+        val jwt = jwtAuthHelper.createClientCredentialsJwt(
+          username = "username",
+          authSource = "other source",
+        )
 
         webTestClient.get()
-          .uri("/cas2/people/search?nomsNumber=NOMS321")
+          .uri("/cas2/people/search?nomsNumber=nomsNumber")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
           .isForbidden
       }
-    }
 
-    @Test
-    fun `Searching for a NOMIS ID returns 404 error when it is not found`() {
-      `Given a CAS2 POM User` { userEntity, jwt ->
-        ProbationOffenderSearchAPI_mockNotFoundSearchCall()
+      @Test
+      fun `Searching for a NOMIS ID without ROLE_POM returns 403`() {
+        val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+          subject = "username",
+          authSource = "nomis",
+          roles = listOf("ROLE_OTHER"),
+        )
 
         webTestClient.get()
-          .uri("/cas2/people/search?nomsNumber=NOMS321")
+          .uri("/cas2/people/search?nomsNumber=nomsNumber")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
-          .isNotFound
+          .isForbidden
+      }
+
+      @Test
+      fun `Searching for a NOMIS ID returns Unauthorised error when it is unauthorized`() {
+        `Given a CAS2 POM User` { userEntity, jwt ->
+          ProbationOffenderSearchAPI_mockForbiddenOffenderSearchCall()
+
+          webTestClient.get()
+            .uri("/cas2/people/search?nomsNumber=NOMS321")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isForbidden
+        }
+      }
+
+      @Test
+      fun `Searching for a NOMIS ID returns 404 error when it is not found`() {
+        `Given a CAS2 POM User` { userEntity, jwt ->
+          ProbationOffenderSearchAPI_mockNotFoundSearchCall()
+
+          webTestClient.get()
+            .uri("/cas2/people/search?nomsNumber=NOMS321")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isNotFound
+        }
+      }
+
+      @Test
+      fun `Searching for a NOMIS ID returns server error when there is a server error`() {
+        `Given a CAS2 POM User` { userEntity, jwt ->
+          ProbationOffenderSearchAPI_mockServerErrorSearchCall()
+
+          webTestClient.get()
+            .uri("/cas2/people/search?nomsNumber=NOMS321")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .is5xxServerError
+        }
       }
     }
 
-    @Test
-    fun `Searching for a NOMIS ID returns server error when there is a server error`() {
-      `Given a CAS2 POM User` { userEntity, jwt ->
-        ProbationOffenderSearchAPI_mockServerErrorSearchCall()
+    @Nested
+    inner class WhenSuccessful {
+      @Test
+      fun `Searching for a NOMIS ID returns OK with correct body`() {
+        `Given a CAS2 POM User` { userEntity, jwt ->
+          val offender = ProbationOffenderDetailFactory()
+            .withOtherIds(IDs(crn = "CRN", nomsNumber = "NOMS321", pncNumber = "PNC123"))
+            .withFirstName("James")
+            .withSurname("Someone")
+            .withDateOfBirth(
+              LocalDate
+                .parse("1985-05-05"),
+            )
+            .withGender("Male")
+            .withOffenderProfile(OffenderProfile(nationality = "English"))
+            .produce()
 
-        webTestClient.get()
-          .uri("/cas2/people/search?nomsNumber=NOMS321")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .is5xxServerError
+          val inmateDetail = InmateDetailFactory().withOffenderNo("NOMS321")
+            .withCustodyStatus(InmateStatus.IN)
+            .withAssignedLivingUnit(
+              AssignedLivingUnit(
+                agencyId = "BRI",
+                locationId = 5,
+                description = "B-2F-004",
+                agencyName = "HMP Bristol",
+              ),
+            )
+            .produce()
+
+          ProbationOffenderSearchAPI_mockSuccessfulOffenderSearchCall("NOMS321", listOf(offender))
+          PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
+
+          webTestClient.get()
+            .uri("/cas2/people/search?nomsNumber=NOMS321")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                FullPerson(
+                  type = PersonType.fullPerson,
+                  crn = "CRN",
+                  name = "James Someone",
+                  dateOfBirth = LocalDate.parse("1985-05-05"),
+                  sex = "Male",
+                  status = PersonStatus.inCustody,
+                  nomsNumber = "NOMS321",
+                  pncNumber = "PNC123",
+                  nationality = "English",
+                  isRestricted = false,
+                  prisonName = "HMP Bristol",
+                ),
+              ),
+            )
+        }
       }
     }
   }


### PR DESCRIPTION
Can be merged after this Tools update https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/67 ✅ 
And this UI update https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/700 ✅  
And this API update https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1879 ✅ 

_As a POM 
When I try to create an application
With a prison number for a person who is not within my active prison
Then I am not allowed to continue_

This PR checks the inmate detail's `agencyId` against the user's `activeAgencyId`. If they are not within the same prison, then we return an unauthorised error.

More info about when this check is done and where data is from here in Confluence https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4887511138/Integration+APIs+for+offender+data

More info about where a Nomis users caseload is set here:
https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4881088539/How+to+set+a+user+s+active+caseload+aka+prison+in+dev+test


AFTER THIS HAD MERGED:

Our test referrers in dev (LCA and POM) and any of our dev/test users will need to have their prison set to Moorland, [following instructions here](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4881088539/How+to+set+a+user+s+active+caseload+aka+prison+in+dev+test)