### PR TITLE
APS-791 Add missing indexes for FK columns

### DIFF
--- a/src/main/resources/db/migration/all/20240515143555__add_missing_indexes_to_fks.sql
+++ b/src/main/resources/db/migration/all/20240515143555__add_missing_indexes_to_fks.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ON domain_events(assessment_id);
+CREATE INDEX ON assessment_clarification_notes(assessment_id);
+CREATE INDEX ON appeals(application_id);


### PR DESCRIPTION
There are several FKs used in reports or hibernate relationships that are not indexed. This commit adds those missing indexes