### PR TITLE
[APS-751] Fix applications getting stuck in the 'further information requested' state when a decision is made while a clarification note is pending

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt
@@ -23,16 +23,16 @@ class AssessmentListener {
 
   @PreUpdate
   fun preUpdate(assessment: ApprovedPremisesAssessmentEntity) {
-    if ((assessment.application as ApprovedPremisesApplicationEntity).status == ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION) {
+    val application = assessment.application as ApprovedPremisesApplicationEntity
+
+    if (application.status == ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION && assessment.decision == null) {
       return
     } else if (assessment.decision == null && assessment.data != null) {
-      (assessment.application as ApprovedPremisesApplicationEntity).status =
-        ApprovedPremisesApplicationStatus.ASSESSMENT_IN_PROGRESS
+      application.status = ApprovedPremisesApplicationStatus.ASSESSMENT_IN_PROGRESS
     } else if (assessment.decision == AssessmentDecision.ACCEPTED) {
-      val application = (assessment.application as ApprovedPremisesApplicationEntity)
       application.status = applicationGetStatusFromArrivalDate(application)
     } else if (assessment.decision == AssessmentDecision.REJECTED) {
-      (assessment.application as ApprovedPremisesApplicationEntity).status = ApprovedPremisesApplicationStatus.REJECTED
+      application.status = ApprovedPremisesApplicationStatus.REJECTED
     }
   }
 

--- a/src/main/resources/db/migration/all/20240515124313__update_incorrect_request_further_information_statuses_where_a_decision_is_made.sql
+++ b/src/main/resources/db/migration/all/20240515124313__update_incorrect_request_further_information_statuses_where_a_decision_is_made.sql
@@ -1,0 +1,79 @@
+-- Applications where the assessment is inapplicable -> `INAPPLICABLE`
+UPDATE approved_premises_applications
+SET status = 'PENDING_PLACEMENT_REQUEST'
+WHERE status = 'REQUESTED_FURTHER_INFORMATION'
+AND is_inapplicable = true;
+
+-- Applications where the assessment is withdrawn -> `WITHDRAWN`
+UPDATE approved_premises_applications
+SET status = 'PENDING_PLACEMENT_REQUEST'
+WHERE id IN (
+    SELECT assessments.application_id
+    FROM assessments
+    INNER JOIN bookings ON bookings.application_id = assessments.application_id
+    WHERE assessments.decision = 'ACCEPTED'
+    AND assessments.reallocated_at IS NULL
+)
+AND status = 'REQUESTED_FURTHER_INFORMATION'
+AND is_withdrawn = true;
+
+-- Applications where a booking exists -> `PLACEMENT_ALLOCATED`
+UPDATE approved_premises_applications
+SET status = 'PLACEMENT_ALLOCATED'
+WHERE id IN (
+    SELECT assessments.application_id
+    FROM assessments
+    INNER JOIN bookings ON bookings.application_id = assessments.application_id
+    WHERE assessments.decision = 'ACCEPTED'
+    AND assessments.reallocated_at IS NULL
+)
+AND status = 'REQUESTED_FURTHER_INFORMATION';
+
+-- Applications where a placement application exists with an `ACCEPTED` status -> `AWAITING_PLACEMENT`
+UPDATE approved_premises_applications
+SET status = 'AWAITING_PLACEMENT'
+WHERE id IN (
+    SELECT assessments.application_id
+    FROM assessments
+    INNER JOIN placement_applications ON placement_applications.application_id = assessments.application_id
+    WHERE assessments.decision = 'ACCEPTED'
+    AND assessments.reallocated_at IS NULL
+    AND placement_applications.decision = 'ACCEPTED'
+)
+AND status = 'REQUESTED_FURTHER_INFORMATION';
+
+-- Applications where a placement request exists and the application has an arrival date -> `AWAITING_PLACEMENT`
+UPDATE approved_premises_applications
+SET status = 'AWAITING_PLACEMENT'
+WHERE id IN (
+    SELECT assessments.application_id
+    FROM assessments
+    INNER JOIN placement_requests ON placement_requests.assessment_id = assessments.id
+    AND placement_requests.application_id = assessments.application_id
+    WHERE assessments.decision = 'ACCEPTED'
+    AND assessments.reallocated_at IS NULL
+)
+AND status = 'REQUESTED_FURTHER_INFORMATION'
+AND arrival_date IS NOT NULL;
+
+-- Other applications where the assessment has been accepted -> `PENDING PLACEMENT REQUEST`
+UPDATE approved_premises_applications
+SET status = 'PENDING_PLACEMENT_REQUEST'
+WHERE id IN (
+    SELECT application_id
+    FROM assessments
+    WHERE decision = 'ACCEPTED'
+    AND reallocated_at IS NULL
+)
+AND status = 'REQUESTED_FURTHER_INFORMATION';
+
+-- Applications where the assessment has been rejected -> `REJECTED`
+UPDATE approved_premises_applications
+SET status = 'REJECTED'
+WHERE id IN (
+    SELECT application_id
+    FROM assessments
+    WHERE decision = 'REJECTED'
+    AND reallocated_at IS NULL
+)
+AND status = 'REQUESTED_FURTHER_INFORMATION';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentClarificationNoteEntityFactory.kt
@@ -44,7 +44,7 @@ class AssessmentClarificationNoteEntityFactory : Factory<AssessmentClarification
     this.response = { response }
   }
 
-  fun withResponseReceivedOn(responseReceivedOn: LocalDate) = apply {
+  fun withResponseReceivedOn(responseReceivedOn: LocalDate?) = apply {
     this.responseReceivedOn = { responseReceivedOn }
   }
 


### PR DESCRIPTION
> See [APS-751 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-751).

This PR fixes the bug introduced in #1805 which prevents any state transition when the current state is `REQUESTED_FURTHER_INFORMATION`. This prevents an update to the assessment from changing the status, but also prevents a decision being made changing the status, which is incorrect.

A test has been introduced that verifies the expected behaviour as outlined in #1805 to make sure that this change does not cause the original bug to reappear.

Additionally, a Flyway migration has been added to update any applications that have been affected by this bug.