### PR TITLE
CAS2-440 soft delete by status

### DIFF
--- a/src/main/resources/db/migration/all/20240528084000__create_live_view.sql
+++ b/src/main/resources/db/migration/all/20240528084000__create_live_view.sql
@@ -1,0 +1,44 @@
+-- replace application summary views
+CREATE OR REPLACE VIEW cas_2_application_summary AS SELECT
+    CAST(a.id AS TEXT),
+    a.crn,
+    a.noms_number,
+    CAST(a.created_by_user_id AS TEXT),
+    nu.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    asu.label,
+    CAST(asu.status_id AS TEXT),
+    a.referring_prison_code,
+    a.conditional_release_date,
+    asu.created_at AS status_created_at
+FROM cas_2_applications a
+LEFT JOIN (SELECT DISTINCT ON (application_id) su.application_id, su.label, su.status_id, su.created_at
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+    ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id;
+
+CREATE OR REPLACE VIEW cas_2_application_live_summary AS SELECT
+    a.id,
+    a.crn,
+    a.noms_number,
+    a.created_by_user_id,
+    a.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    a.label,
+    a.status_id,
+    a.referring_prison_code
+FROM cas_2_application_summary a
+WHERE (a.conditional_release_date IS NULL OR a.conditional_release_date >= current_date)
+AND a.status_id IS NULL
+   OR (a.status_id = '004e2419-9614-4c1e-a207-a8418009f23d' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Referral withdrawn
+    OR (a.status_id = 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Referral cancelled
+    OR (a.status_id = '89458555-3219-44a2-9584-c4f715d6b565' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Awaiting arrival
+    OR (a.status_id NOT IN ('004e2419-9614-4c1e-a207-a8418009f23d',
+           'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9',
+           '89458555-3219-44a2-9584-c4f715d6b565'));
+


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/CAS2-440

**User Story**
As a referrer
I want old applications to disappear from my dashboards
So that they do not clutter up the space

**Description**
This feature will automatically hide applications from dashboards once certain criteria are met. 

**Acceptance Criteria**
API: Soft delete submitted applications once a period of 14 days has elapsed from when the following statuses were applied to them:

- Referral withdrawn
- Referral cancelled
- Awaiting arrival