### PR TITLE
APS-799 Remove feature flags

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -47,7 +47,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AppealService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
@@ -89,7 +88,6 @@ class ApplicationsController(
   private val placementRequestService: PlacementRequestService,
   private val requestForPlacementService: RequestForPlacementService,
   private val withdrawableTransformer: WithdrawableTransformer,
-  private val featureFlagService: FeatureFlagService,
 ) : ApplicationsApiDelegate {
 
   override fun applicationsGet(xServiceName: ServiceName?): ResponseEntity<List<ApplicationSummary>> {
@@ -433,13 +431,7 @@ class ApplicationsController(
     }
 
     val transformedDocuments = when (application) {
-      is ApprovedPremisesApplicationEntity -> {
-        if (featureFlagService.getBooleanFlag("cas1-remove-document-conviction-id-filters", default = false)) {
-          documentTransformer.transformToApiUnfiltered(documents)
-        } else {
-          documentTransformer.transformToApiFiltered(documents, application.convictionId)
-        }
-      }
+      is ApprovedPremisesApplicationEntity -> documentTransformer.transformToApiUnfiltered(documents)
       is TemporaryAccommodationApplicationEntity -> documentTransformer.transformToApiFiltered(documents, application.convictionId)
       else -> throw RuntimeException("Unsupported Application type: ${application::class.qualifiedName}")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -142,7 +142,6 @@ class BookingService(
   private val assessmentService: AssessmentService,
   private val cas1BookingEmailService: Cas1BookingEmailService,
   private val deliusService: DeliusService,
-  private val featureFlagService: FeatureFlagService,
 ) {
   val approvedPremisesBookingAppealedCancellationReasonId: UUID =
     UUID.fromString("acba3547-ab22-442d-acec-2652e49895f2")
@@ -1141,10 +1140,7 @@ class BookingService(
       userMayDirectlyWithdraw = userAccessService.userMayCancelBooking(user, booking),
       blockingReason = if (booking.hasArrivals()) {
         BlockingReason.ArrivalRecordedInCas1
-      } else if (
-        featureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", default = false) &&
-        deliusService.referralHasArrival(booking)
-      ) {
+      } else if (deliusService.referralHasArrival(booking)) {
         BlockingReason.ArrivalRecordedInDelius
       } else {
         null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -124,7 +124,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CruService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeliusService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.GetBookingForPremisesResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
@@ -182,7 +181,6 @@ class BookingServiceTest {
   private val mockUserAccessService = mockk<UserAccessService>()
   private val mockAssessmentService = mockk<AssessmentService>()
   private val mockCas1BookingEmailService = mockk<Cas1BookingEmailService>()
-  private val mockFeatureFlagService = mockk<FeatureFlagService>()
   private val mockDeliusService = mockk<DeliusService>()
 
   fun createBookingService(arrivedAndDepartedDomainEventsDisabled: Boolean): BookingService {
@@ -223,7 +221,6 @@ class BookingServiceTest {
       userAccessService = mockUserAccessService,
       assessmentService = mockAssessmentService,
       cas1BookingEmailService = mockCas1BookingEmailService,
-      featureFlagService = mockFeatureFlagService,
       deliusService = mockDeliusService,
     )
   }
@@ -6870,7 +6867,6 @@ class BookingServiceTest {
       )
 
       every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
-      every { mockFeatureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", false) } returns true
 
       val result = bookingService.getWithdrawableState(booking, user)
 
@@ -6888,7 +6884,6 @@ class BookingServiceTest {
       )
 
       every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
-      every { mockFeatureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", false) } returns true
       every { mockDeliusService.referralHasArrival(booking) } returns false
 
       val result = bookingService.getWithdrawableState(booking, user)
@@ -6903,7 +6898,6 @@ class BookingServiceTest {
         .produce()
 
       every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
-      every { mockFeatureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", false) } returns true
       every { mockDeliusService.referralHasArrival(booking) } returns false
 
       val result = bookingService.getWithdrawableState(booking, user)
@@ -6919,7 +6913,6 @@ class BookingServiceTest {
         .produce()
 
       every { mockUserAccessService.userMayCancelBooking(user, booking) } returns canWithdraw
-      every { mockFeatureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", false) } returns true
       every { mockDeliusService.referralHasArrival(booking) } returns false
 
       val result = bookingService.getWithdrawableState(booking, user)
@@ -6935,7 +6928,6 @@ class BookingServiceTest {
         .produce()
 
       every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
-      every { mockFeatureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", false) } returns true
       every { mockDeliusService.referralHasArrival(booking) } returns false
 
       val result = bookingService.getWithdrawableState(booking, user)
@@ -6956,7 +6948,6 @@ class BookingServiceTest {
       )
 
       every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
-      every { mockFeatureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", false) } returns true
 
       val result = bookingService.getWithdrawableState(booking, user)
 
@@ -6970,28 +6961,11 @@ class BookingServiceTest {
         .produce()
 
       every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
-      every { mockFeatureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", false) } returns true
       every { mockDeliusService.referralHasArrival(booking) } returns true
 
       val result = bookingService.getWithdrawableState(booking, user)
 
       assertThat(result.blockingReason).isEqualTo(BlockingReason.ArrivalRecordedInDelius)
-    }
-
-    @Test
-    fun `getWithdrawableState doesn't check delius status if feature flag disabled`() {
-      val booking = BookingEntityFactory()
-        .withPremises(premises)
-        .produce()
-
-      every { mockUserAccessService.userMayCancelBooking(user, booking) } returns true
-      every { mockFeatureFlagService.getBooleanFlag("cas1-check-delius-arrival-status-on-withdrawal", false) } returns false
-
-      val result = bookingService.getWithdrawableState(booking, user)
-
-      assertThat(result.blockingReason).isNull()
-
-      verify { mockDeliusService wasNot Called }
     }
   }
 


### PR DESCRIPTION
This PR removes two feature flags for features that have been live for over a week without issues:

* cas1-remove-document-conviction-id-filters
* cas1-check-delius-arrival-status-on-withdrawal