### PR TITLE
[APS-798] Show events associated with offline applications in the personal timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonalTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonalTimelineTransformer.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonalTimeli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 
 @Component
@@ -13,12 +14,20 @@ class PersonalTimelineTransformer(
   private val userTransformer: UserTransformer,
   private val personTransformer: PersonTransformer,
 ) {
-  fun transformApplicationsAndTimelineEvents(
+  fun transformApplicationTimelineModels(
     personInfoResult: PersonInfoResult,
-    applicationsAndTimelineEvents: Map<ApprovedPremisesApplicationEntity, List<TimelineEvent>>,
+    applicationTimelineModels: List<ApplicationTimelineModel>,
   ) = PersonalTimeline(
     person = personTransformer.transformModelToPersonApi(personInfoResult),
-    applications = applicationsAndTimelineEvents.map { transformApplication(it.key, it.value) },
+    applications = applicationTimelineModels.map { transformApplication(it.application, it.timelineEvents) },
+  )
+
+  private fun transformApplication(
+    application: BoxedApplication,
+    timelineEvents: List<TimelineEvent>,
+  ) = application.map(
+    { transformApplication(it, timelineEvents) },
+    { transformApplication(it, timelineEvents) },
   )
 
   private fun transformApplication(
@@ -32,4 +41,41 @@ class PersonalTimelineTransformer(
     createdBy = userTransformer.transformJpaToApi(application.createdByUser, ServiceName.approvedPremises),
     timelineEvents = timelineEvents,
   )
+
+  private fun transformApplication(
+    application: OfflineApplicationEntity,
+    timelineEvents: List<TimelineEvent>,
+  ) = ApplicationTimeline(
+    id = application.id,
+    createdAt = application.createdAt.toInstant(),
+    status = null,
+    isOfflineApplication = true,
+    createdBy = null,
+    timelineEvents = timelineEvents,
+  )
+}
+
+data class ApplicationTimelineModel(
+  val application: BoxedApplication,
+  val timelineEvents: List<TimelineEvent>,
+)
+
+sealed interface BoxedApplication {
+  val value: Any
+
+  fun <T> map(
+    regularApplicationFunc: (ApprovedPremisesApplicationEntity) -> T,
+    offlineApplicationFunc: (OfflineApplicationEntity) -> T,
+  ) = when (this) {
+    is Regular -> regularApplicationFunc(this.value)
+    is Offline -> offlineApplicationFunc(this.value)
+  }
+
+  data class Regular(override val value: ApprovedPremisesApplicationEntity) : BoxedApplication
+  data class Offline(override val value: OfflineApplicationEntity) : BoxedApplication
+
+  companion object {
+    fun of(value: ApprovedPremisesApplicationEntity) = Regular(value)
+    fun of(value: OfflineApplicationEntity) = Offline(value)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonalTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonalTimelineTransformer.kt
@@ -28,6 +28,7 @@ class PersonalTimelineTransformer(
     id = application.id,
     createdAt = application.createdAt.toInstant(),
     status = application.status.apiValue,
+    isOfflineApplication = false,
     createdBy = userTransformer.transformJpaToApi(application.createdByUser, ServiceName.approvedPremises),
     timelineEvents = timelineEvents,
   )

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3507,6 +3507,8 @@ components:
         createdAt:
           type: string
           format: date-time
+        isOfflineApplication:
+          type: boolean
         status:
           $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
         createdBy:
@@ -3518,8 +3520,7 @@ components:
       required:
         - id
         - createdAt
-        - status
-        - createdBy
+        - isOfflineApplication
         - timelineEvents
     TimelineEvent:
       type: object

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8181,6 +8181,8 @@ components:
         createdAt:
           type: string
           format: date-time
+        isOfflineApplication:
+          type: boolean
         status:
           $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
         createdBy:
@@ -8192,8 +8194,7 @@ components:
       required:
         - id
         - createdAt
-        - status
-        - createdBy
+        - isOfflineApplication
         - timelineEvents
     TimelineEvent:
       type: object

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4072,6 +4072,8 @@ components:
         createdAt:
           type: string
           format: date-time
+        isOfflineApplication:
+          type: boolean
         status:
           $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
         createdBy:
@@ -4083,8 +4085,7 @@ components:
       required:
         - id
         - createdAt
-        - status
-        - createdBy
+        - isOfflineApplication
         - timelineEvents
     TimelineEvent:
       type: object

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3598,6 +3598,8 @@ components:
         createdAt:
           type: string
           format: date-time
+        isOfflineApplication:
+          type: boolean
         status:
           $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
         createdBy:
@@ -3609,8 +3611,7 @@ components:
       required:
         - id
         - createdAt
-        - status
-        - createdBy
+        - isOfflineApplication
         - timelineEvents
     TimelineEvent:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
@@ -149,6 +149,7 @@ class PersonalTimelineTest : IntegrationTestBase() {
                       id = application.id,
                       createdAt = application.createdAt.toInstant(),
                       status = ApprovedPremisesApplicationStatus.started,
+                      isOfflineApplication = false,
                       createdBy = ApprovedPremisesUser(
                         qualifications = emptyList(),
                         roles = emptyList(),
@@ -272,6 +273,7 @@ class PersonalTimelineTest : IntegrationTestBase() {
                       id = application.id,
                       createdAt = application.createdAt.toInstant(),
                       status = ApprovedPremisesApplicationStatus.started,
+                      isOfflineApplication = false,
                       createdBy = ApprovedPremisesUser(
                         qualifications = emptyList(),
                         roles = emptyList(),

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -211,3 +211,4 @@ notify:
 feature-flags:
   local-overrides:
     cas1-email-use-cru-for-reply-to: true
+    cas1-provide-offline-application-events-in-personal-timeline: true


### PR DESCRIPTION
> See [APS-798 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-798).

This PR updates the behaviour of the `GET /people/{crn}/timeline` endpoint so that events for both regular applications and offline applications can be retrieved for a given CRN. The `cas1-provide-offline-application-events-in-personal-timeline` [feature flag](doc/architecture/decisions/0022-handling-feature-flags-with-flipt.md) can be used to configure this behaviour: when `false` (by default), the current behaviour of only showing events for regular applications will be applied.

To support this, the `ApplicationTimeline` API schema has been modified so that the `status` and `createdBy` properties are no longer required (as offline applications do not contain this information), and a new `isOfflineApplication` boolean property has been added.

The `PersonalTimelineTransformer` class has been modified to support offline applications. The data model used by the transformer has been changed to the newly-introduced `ApplicationTimelineModel` class, which consists of a `BoxedApplication` and a list of `TimelineEvent`s.

A `BoxedApplication` provides a typed wrapper around either an `ApprovedPremisesApplicationEntity` or an `OfflineApplicationEntity`, which can be used as follows:

```kotlin
val regularApplicationEntity = ApprovedPremisesApplicationEntityFactory().produce()
val boxedApplication1 = BoxedApplication.of(regularApplicationEntity)

val offlineApplicationEntity = OfflineApplicationEntityFactory().produce()
val boxedApplication2 = BoxedApplication.of(offlineApplicationEntity)

// Exposes regular application through `value`
println(boxedApplication1.value.status)
// Exposes offline application through `value`
println(boxedApplication2.value.service)

// Extract a value from either variant using `map`
val boxedApplication = randomChoice(boxedApplication1, boxedApplication2)
val applicationId = boxedApplication.map(
  ApprovedPremisesApplicationEntity::id,
  OfflineApplicationEntity::id,
)
```