### PR TITLE
CAS-322 Migrate CAS3 users PDU from nDelius when the user have more than one team

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateUsersPduFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateUsersPduFromCommunityApiMigrationTest.kt
@@ -92,6 +92,15 @@ class Cas3UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
             StaffUserTeamMembershipFactory()
               .withBorough(
                 KeyValue(
+                  code = "PDUCODENotExistInCas",
+                  description = "PDUDESCRIPTIONNotExistInCas",
+                ),
+              )
+              .withStartDate(LocalDate.parse("2024-02-05"))
+              .produce(),
+            StaffUserTeamMembershipFactory()
+              .withBorough(
+                KeyValue(
                   code = "PDUCODE1",
                   description = "PDUDESCRIPTION1",
                 ),


### PR DESCRIPTION
This PR CAS-322 is to get the last Borough that CAS3 users have been assigned in nDelius:

- We check the latest start date for the user in a team. We get the Borough code and we validate to see if this PDU exists in CAS
- We find some situations that the user is assigned multiple teams at the same time. Some of there are regional teams we need to check them to get a valid PDU in CAS 