### PR TITLE
Chore/remote db script defaults to read-only in all environments

### DIFF
--- a/doc/how-to/access_database_remotely.md
+++ b/doc/how-to/access_database_remotely.md
@@ -31,6 +31,21 @@ Where $ENVIRONMENT is the environment you want to connect to.
 
 When you're finished, type the `.quit` command to end the session.
 
+By default this will set the session to be **read-only**. You can check this by
+running:
+
+```sql
+SELECT setting FROM pg_settings WHERE name =
+'default_transaction_read_only';`
+```
+
+Should you need write access in an
+exceptional situation, you can set this back to false from within the session:
+
+```sql
+SET default_transaction_read_only = FALSE;
+```
+
 ## The hard(er) way
 
 This is more suitable if you need access to the bash shell, as well as

--- a/doc/how-to/access_database_remotely.md
+++ b/doc/how-to/access_database_remotely.md
@@ -6,9 +6,12 @@ mutating any live data is STRONGLY discouraged. When data needs to be modified
 create a tested [data migration job](/doc/how-to/run_migration_job_remotely.md).
 
 Both methods detailed below use [Jaqy](https://teradata.github.io/jaqy/), which
-is a Java-native universal database client. As well as carrying out simple 
-queries, you can also do exports of data (enabling, for example, one off reporting), 
-and other useful bits and pieces. For full details, check the [documentation](https://teradata.github.io/jaqy/).
+is a Java-native universal database client. As well as carrying out simple
+queries, you can also do exports of data (enabling, for example, one off reporting),
+and other useful bits and pieces. For full details, check the
+[documentation](https://teradata.github.io/jaqy/).
+The Jaqy library is managed by a third party so we validate the checksum to
+ensure the contents aren't unexpectedly modified.
 
 There are two ways to do this:
 

--- a/doc/how-to/access_database_remotely.md
+++ b/doc/how-to/access_database_remotely.md
@@ -2,7 +2,8 @@
 
 **Important** - Accessing a live console is very risky and should only be
 done as a last resort. This should ideally only be done in pairs, and
-mutating any live data is STRONGLY discouraged.
+mutating any live data is STRONGLY discouraged. When data needs to be modified
+create a tested [data migration job](/doc/how-to/run_migration_job_remotely.md).
 
 Both methods detailed below use [Jaqy](https://teradata.github.io/jaqy/), which
 is a Java-native universal database client. As well as carrying out simple 

--- a/script/remote_db
+++ b/script/remote_db
@@ -23,7 +23,10 @@ if [ \$? -ne 0 ]; then
 fi
 
 curl -L https://jdbc.postgresql.org/download/postgresql-42.5.1.jar --output postgresql-42.5.1.jar
-java -jar jaqy-1.2.0.jar -- .classpath postgresql postgresql-42.5.1.jar \; .open -u \${SPRING_DATASOURCE_USERNAME} -p \${SPRING_DATASOURCE_PASSWORD} postgresql://\${DB_HOST}/\${DB_NAME}
+
+java -jar jaqy-1.2.0.jar -- \
+  .classpath postgresql postgresql-42.5.1.jar \; \
+  .open -u \${SPRING_DATASOURCE_USERNAME} -p \${SPRING_DATASOURCE_PASSWORD} postgresql://\${DB_HOST}/\${DB_NAME} \; \
 """
 
 kubectl -n "$namespace" exec -it "$pod" -- sh -c "$script"

--- a/script/remote_db
+++ b/script/remote_db
@@ -27,6 +27,7 @@ curl -L https://jdbc.postgresql.org/download/postgresql-42.5.1.jar --output post
 java -jar jaqy-1.2.0.jar -- \
   .classpath postgresql postgresql-42.5.1.jar \; \
   .open -u \${SPRING_DATASOURCE_USERNAME} -p \${SPRING_DATASOURCE_PASSWORD} postgresql://\${DB_HOST}/\${DB_NAME} \; \
+  \"SET default_transaction_read_only = TRUE;\"
 """
 
 kubectl -n "$namespace" exec -it "$pod" -- sh -c "$script"


### PR DESCRIPTION
We've known since private beta that a direct connection to the production database is risky. [Recently there was a problem with pre-production data and we wanted to increase friction should anyone be performing writes](https://mojdt.slack.com/archives/C03K0HB0LBE/p1715848495094489).

We update some documentation before making this script put the user into a read-only session by default, rather than read/write.

![Screenshot 2024-05-22 at 17 55 49](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/5ad3f100-eb67-4670-a943-f0e7d6d86484)

We give instructions on how to turn it back to write, if that's really needed.

Should the user try a write action by default, on any environment, they'll get the following error:

![Screenshot 2024-05-22 at 17 51 30](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/912473/86ed4b82-d221-499c-9bae-1c089012d8ae)
