### PR TITLE
Fix/aps 326 user name in timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -54,6 +54,7 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
         d.applicationId as applicationId,
         d.assessmentId as assessmentId,
         d.bookingId as bookingId,
+        d.triggerSource as triggerSource,
         b.premises.id as premisesId,
         a.id as appealId,
         u as triggeredByUser

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -91,6 +91,8 @@ data class DomainEventEntity(
   @Type(type = "com.vladmihalcea.hibernate.type.json.JsonType")
   val data: String,
   val service: String,
+  @Enumerated(value = EnumType.STRING)
+  val triggerSource: TriggerSourceType? = null,
   val triggeredByUserId: UUID?,
   val nomsNumber: String?,
   @ElementCollection
@@ -151,6 +153,7 @@ data class DomainEventEntity(
     )
   }
 }
+enum class TriggerSourceType { USER, SYSTEM }
 
 enum class MetaDataName {
   CAS1_APP_REASON_FOR_SHORT_NOTICE,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -14,5 +15,6 @@ interface DomainEventSummary {
   val bookingId: UUID?
   val premisesId: UUID?
   val appealId: UUID?
+  val triggerSource: TriggerSourceType?
   val triggeredByUser: UserEntity?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlCon
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
@@ -183,10 +184,11 @@ class DomainEventService(
     )
 
   @Transactional
-  fun saveAssessmentAllocatedEvent(domainEvent: DomainEvent<AssessmentAllocatedEnvelope>) =
+  fun saveAssessmentAllocatedEvent(domainEvent: DomainEvent<AssessmentAllocatedEnvelope>, triggerSource: TriggerSourceType) =
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
+      triggerSource = triggerSource,
     )
 
   @Transactional
@@ -205,6 +207,7 @@ class DomainEventService(
     domainEvent: DomainEvent<*>,
     eventType: DomainEventType,
     emit: Boolean = true,
+    triggerSource: TriggerSourceType? = null,
   ) {
     val domainEventEntity = domainEventRepository.save(
       DomainEventEntity(
@@ -218,6 +221,7 @@ class DomainEventService(
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS1",
+        triggerSource = triggerSource,
         triggeredByUserId = userService.getUserForRequestOrNull()?.id,
         nomsNumber = domainEvent.nomsNumber,
         metadata = domainEvent.metadata,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
@@ -38,6 +39,12 @@ class Cas1AssessmentDomainEventService(
         is ClientResult.Success -> result.body
         is ClientResult.Failure -> result.throwException()
       }
+    }
+
+    val triggerSource = if (allocatingUser == null) {
+      TriggerSourceType.SYSTEM
+    } else {
+      TriggerSourceType.USER
     }
 
     val id = UUID.randomUUID()
@@ -72,6 +79,7 @@ class Cas1AssessmentDomainEventService(
           ),
         ),
       ),
+      triggerSource,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
@@ -104,6 +104,7 @@ class DomainEventService(
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS2",
+        triggerSource = null,
         triggeredByUserId = null,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
@@ -204,6 +204,7 @@ class DomainEventService(
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS3",
+        triggerSource = null,
         triggeredByUserId = null,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineNoteTransformer.kt
@@ -26,5 +26,6 @@ class ApplicationTimelineNoteTransformer(
     content = jpa.body,
     createdBy = jpa.createdBy?.let { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) },
     associatedUrls = emptyList(),
+    triggerSource = null,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventAssociatedUrl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventUrlType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.domainevents.DomainEventDescriber
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
@@ -31,6 +32,11 @@ class ApplicationTimelineTransformer(
       associatedUrls = associatedUrls,
       content = domainEventDescriber.getDescription(domainEventSummary),
       createdBy = domainEventSummary.triggeredByUser?.let { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) },
+      triggerSource = when (domainEventSummary.triggerSource) {
+        uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType.USER -> TriggerSourceType.user
+        uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType.SYSTEM -> TriggerSourceType.system
+        null -> null
+      },
     )
   }
 

--- a/src/main/resources/db/migration/all/20240515162205__add_trigger_source_column_to_domain_event.sql
+++ b/src/main/resources/db/migration/all/20240515162205__add_trigger_source_column_to_domain_event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domain_events ADD trigger_source TEXT null;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3540,6 +3540,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TimelineEventAssociatedUrl'
+        triggerSource:
+          type: string
+          $ref: '#/components/schemas/TriggerSourceType'
     TimelineEventAssociatedUrl:
       type: object
       properties:
@@ -3576,6 +3579,11 @@ components:
         - cas2_application_submitted
         - cas2_note
         - cas2_status_update
+    TriggerSourceType:
+      type: string
+      enum:
+        - user
+        - system
     TimelineEventUrlType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8214,6 +8214,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TimelineEventAssociatedUrl'
+        triggerSource:
+          type: string
+          $ref: '#/components/schemas/TriggerSourceType'
     TimelineEventAssociatedUrl:
       type: object
       properties:
@@ -8250,6 +8253,11 @@ components:
         - cas2_application_submitted
         - cas2_note
         - cas2_status_update
+    TriggerSourceType:
+      type: string
+      enum:
+        - user
+        - system
     TimelineEventUrlType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4105,6 +4105,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TimelineEventAssociatedUrl'
+        triggerSource:
+          type: string
+          $ref: '#/components/schemas/TriggerSourceType'
     TimelineEventAssociatedUrl:
       type: object
       properties:
@@ -4141,6 +4144,11 @@ components:
         - cas2_application_submitted
         - cas2_note
         - cas2_status_update
+    TriggerSourceType:
+      type: string
+      enum:
+        - user
+        - system
     TimelineEventUrlType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3631,6 +3631,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TimelineEventAssociatedUrl'
+        triggerSource:
+          type: string
+          $ref: '#/components/schemas/TriggerSourceType'
     TimelineEventAssociatedUrl:
       type: object
       properties:
@@ -3667,6 +3670,11 @@ components:
         - cas2_application_submitted
         - cas2_note
         - cas2_status_update
+    TriggerSourceType:
+      type: string
+      enum:
+        - user
+        - system
     TimelineEventUrlType:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -6,6 +6,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -23,6 +24,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var data: Yielded<String> = { "{}" }
   private var service: Yielded<String> = { randomOf(listOf("CAS1", "CAS2", "CAS3")) }
+  private var triggerSource: Yielded<TriggerSourceType?> = { null }
   private var triggeredByUserId: Yielded<UUID?> = { null }
   private var nomsNumber: Yielded<String?> = { randomStringMultiCaseWithNumbers(8) }
 
@@ -80,6 +82,10 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     this.triggeredByUserId = { userId }
   }
 
+  fun withTriggerSourceSystem() = apply {
+    this.triggerSource = { TriggerSourceType.SYSTEM }
+  }
+
   fun withNomsNumber(nomsNumber: String?) = apply {
     this.nomsNumber = { nomsNumber }
   }
@@ -95,6 +101,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     createdAt = this.createdAt(),
     data = this.data(),
     service = this.service(),
+    triggerSource = null,
     triggeredByUserId = this.triggeredByUserId(),
     nomsNumber = this.nomsNumber(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -136,6 +136,7 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
               null,
               null,
               null,
+              it.triggerSource,
               user,
             ),
           )
@@ -169,6 +170,7 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
       withApplicationId(applicationEntity.id)
       withData(data)
       withTriggeredByUserId(userEntity.id)
+      withTriggerSourceSystem()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -52,6 +52,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
@@ -615,6 +616,7 @@ data class DomainEventSummaryImpl(
   override val bookingId: UUID?,
   override val premisesId: UUID?,
   override val appealId: UUID?,
+  override val triggerSource: TriggerSourceType?,
   override val triggeredByUser: UserEntity?,
 ) : DomainEventSummary {
   companion object {
@@ -627,6 +629,7 @@ data class DomainEventSummaryImpl(
       bookingId = null,
       premisesId = null,
       appealId = null,
+      triggerSource = null,
       triggeredByUser = null,
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -58,6 +58,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestFo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
@@ -840,14 +841,15 @@ class DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
 
-      domainEventServiceSpy.saveAssessmentAllocatedEvent(domainEvent)
+      domainEventServiceSpy.saveAssessmentAllocatedEvent(domainEvent, TriggerSourceType.USER)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
+          triggerSource = TriggerSourceType.USER,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -58,8 +58,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestFo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -143,7 +143,7 @@ class Cas1AssessmentDomainEventServiceTest {
     }
 
     @Test
-    fun `assessmentAllocated allocating user is optional`() {
+    fun `assessmentAllocated allocating user is system`() {
       val assigneeUserStaffDetails = StaffUserDetailsFactory().produce()
       every { communityApiClient.getStaffUserDetails(assigneeUser.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
@@ -159,7 +159,7 @@ class Cas1AssessmentDomainEventServiceTest {
           withArg {
             Assertions.assertThat(it.data.eventDetails.allocatedBy).isNull()
           },
-          any(),
+          TriggerSourceType.SYSTEM,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -98,7 +99,7 @@ class Cas1AssessmentDomainEventServiceTest {
         allocatingUserStaffDetails,
       )
 
-      every { domainEventService.saveAssessmentAllocatedEvent(any()) } just Runs
+      every { domainEventService.saveAssessmentAllocatedEvent(any(), any()) } just Runs
 
       service.assessmentAllocated(assessment, assigneeUser, allocatingUser)
 
@@ -133,6 +134,10 @@ class Cas1AssessmentDomainEventServiceTest {
 
             rootDomainEventDataMatches && envelopeMatches && eventDetailsMatch
           },
+          match {
+            val triggerSource = it
+            triggerSource == TriggerSourceType.USER
+          },
         )
       }
     }
@@ -145,7 +150,7 @@ class Cas1AssessmentDomainEventServiceTest {
         assigneeUserStaffDetails,
       )
 
-      every { domainEventService.saveAssessmentAllocatedEvent(any()) } just Runs
+      every { domainEventService.saveAssessmentAllocatedEvent(any(), any()) } just Runs
 
       service.assessmentAllocated(assessment, assigneeUser, allocatingUser = null)
 
@@ -154,6 +159,7 @@ class Cas1AssessmentDomainEventServiceTest {
           withArg {
             Assertions.assertThat(it.data.eventDetails.allocatedBy).isNull()
           },
+          any(),
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.domainevents.DomainEventDescriber
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
@@ -47,6 +48,7 @@ class ApplicationTimelineTransformerTest {
     override val bookingId: UUID?,
     override val premisesId: UUID?,
     override val appealId: UUID?,
+    override val triggerSource: TriggerSourceType?,
     override val triggeredByUser: UserEntity?,
   ) : DomainEventSummary
 
@@ -64,6 +66,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
       appealId = null,
+      triggerSource = null,
       triggeredByUser = userJpa,
     )
 
@@ -93,6 +96,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
       appealId = null,
+      triggerSource = null,
       triggeredByUser = userJpa,
     )
 
@@ -114,6 +118,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
       appealId = null,
+      triggerSource = null,
       triggeredByUser = null,
     )
 
@@ -146,6 +151,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
       appealId = appealId,
+      triggerSource = null,
       triggeredByUser = null,
     )
 
@@ -183,6 +189,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = premisesId,
       appealId = null,
+      triggerSource = null,
       triggeredByUser = null,
     )
 
@@ -213,6 +220,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = null,
       appealId = null,
+      triggerSource = null,
       triggeredByUser = null,
     )
 
@@ -245,6 +253,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = null,
       appealId = null,
+      triggerSource = null,
       triggeredByUser = null,
     )
 
@@ -277,6 +286,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = null,
       appealId = null,
+      triggerSource = null,
       triggeredByUser = null,
     )
 
@@ -316,6 +326,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = premisesId,
       appealId = appealId,
+      triggerSource = null,
       triggeredByUser = null,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -82,6 +82,7 @@ class ApplicationTimelineTransformerTest {
     assertThat(result.associatedUrls).isEmpty()
     assertThat(result.content).isEqualTo("Some event")
     assertThat(result.createdBy).isEqualTo(userApi)
+    assertThat(result.triggerSource).isEqualTo(null)
   }
 
   @Test
@@ -344,6 +345,31 @@ class ApplicationTimelineTransformerTest {
         ),
         content = "Some event",
       ),
+    )
+  }
+
+  @ParameterizedTest
+  @EnumSource(TriggerSourceType::class)
+  fun `transformDomainEventSummaryToTimelineEvent correctly maps triggerSource`(triggerSource: TriggerSourceType) {
+    val assessmentId = UUID.randomUUID()
+    val domainEvent = DomainEventSummaryImpl(
+      id = UUID.randomUUID().toString(),
+      type = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
+      occurredAt = OffsetDateTime.now(),
+      bookingId = null,
+      applicationId = null,
+      assessmentId = assessmentId,
+      premisesId = null,
+      appealId = null,
+      triggerSource = triggerSource,
+      triggeredByUser = null,
+    )
+
+    every { mockDomainEventDescriber.getDescription(domainEvent) } returns "Some event"
+
+    Assertions.assertThat(
+      applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)
+        .triggerSource?.name.equals(triggerSource.name, true),
     )
   }
 }


### PR DESCRIPTION
Resolves a bug in CAS1 where automatic, system generated actions are attributed to the user who was logged in and triggered them, in the timeline.

A new, nullable column, triggerSource on domainEvent will provide the ability to record whether the event was triggered by 'USER' or 'SYSTEM'.

When saving an AssessmentAllocated event, CAS1 will record the triggerSource as 'USER' if allocatingUser has a value otherwise a triggerSource of 'SYSTEM' will be recorded.

A corresponding change to the UI has been made so that the timeline will better reflect when an event was triggered by the system.