### PR TITLE
Add a script to help devs directly connect to the local postgres container

### DIFF
--- a/script/local_db
+++ b/script/local_db
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Check if Docker is running
+docker info > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Docker is not running. Please start Docker and try again."
+    exit 1
+fi
+
+# Grab the container ID of the database provisioned by Docker Compose or the AP
+# tools repository
+databaseContainerId=$(docker ps -q --filter "name=approved-premises-postgres-dev")
+
+docker exec -it $databaseContainerId \
+  bash -c "psql -U localdev -d approved_premises_localdev"


### PR DESCRIPTION
We have some documentation on how to use an IDE to help with this[1] however sometimes it is useful to have a raw SQL prompt, in the same way we do on real environments via `script/remote_db`.

This script gets us straight onto the locally running container with a PSQL REPL.

[1] https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4750868858/API+database+reader+Connecting+to+Remote+DBs