### PR TITLE
APS-831 Add ability to log API Request/Response for local deploys

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SentryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SentryService.kt
@@ -2,15 +2,22 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import io.sentry.Sentry
 import io.sentry.SentryLevel
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class SentryService {
+
+  var log: Logger = LoggerFactory.getLogger(this::class.java)
+
   fun captureException(throwable: Throwable) {
+    log.debug("Will capture exception in sentry", throwable)
     Sentry.captureException(throwable)
   }
 
   fun captureErrorMessage(message: String) {
+    log.debug("Will capture error message in sentry: '$message'")
     Sentry.captureMessage(message, SentryLevel.ERROR)
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,6 +31,7 @@ domain-events:
     async-save-enabled: false
 
 log-client-credentials-jwt-info: true
+log-request-response: true
 
 seed:
   file-prefix: "./seed"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -161,6 +161,7 @@ hmpps:
     url: http://localhost:9091/auth
 
 log-client-credentials-jwt-info: false
+log-request-response: false
 
 prison-case-notes:
   lookback-days: 365


### PR DESCRIPTION
This is only enabled for local deployments.

If enabled a sentry error will be logged, meaning we’d spot this quickly if the configuration was enabled in any other environment.

Note in the sample log below that we only log application/json responses and not binary responses (in this case, a report file)

```
2024-05-23 12:35:48.729  INFO 56857 --- [nio-8080-exec-4] u.g.j.d.h.a.config.HttpLoggingFilter     : Request  | request.uri=/applications, request.user=JIMSNOWLDAP, request.method=GET, request.pathPattern=/applications, request.serviceName=approved-premises, request.id=7807a750-b333-4efe-a649-70be48dd732e 
2024-05-23 12:35:48.729  INFO 56857 --- [nio-8080-exec-4] u.g.j.d.h.a.config.HttpLoggingFilter     : Response [{"createdByUserId":"aa30f20a-84e3-4baa-bef0-3c9bd51879ad","status":"started","isWithdrawn":false,"hasRequestsForPlacement":false,"type":"CAS1","id":"97bd44ae-3e91-4b0e-ad8c-2873f0050bbc","person":{"name":"Aadland Bertrand","dateOfBirth":"1987-08-02","sex":"Male","status":"InCustody","crn":"X320741","type":"FullPerson","nomsNumber":"A1234AI","pncNumber":null,"ethnicity":"White: British/English/Welsh/Scottish/Northern Irish","nationality":"British","religionOrBelief":"Other","genderIdentity":"Prefer not to say","prisonName":"Leeds","isRestricted":false},"createdAt":"2024-05-23T10:37:17.202561Z","isWomensApplication":false,"isPipeApplication":false,"isEmergencyApplication":null,"isEsapApplication":null,"arrivalDate":"2025-12-12T00:00:00Z","risks":{"crn":"X320741","roshRisks":{"status":"retrieved","value":{"overallRisk":"High","riskToChildren":"Medium","riskToPublic":"High","riskToKnownAdult":"High","riskToStaff":"Low","lastUpdated":"2022-11-02"}},"tier":{"status":"retrieved","value":{"level":"D2","lastUpdated":"2022-09-05"}},"flags":{"status":"not_found","value":null},"mappa":{"status":"not_found","value":null}},"tier":null,"releaseType":null,"submittedAt":null}] | request.uri=/applications, request.user=JIMSNOWLDAP, request.method=GET, request.pathPattern=/applications, request.serviceName=approved-premises, request.id=7807a750-b333-4efe-a649-70be48dd732e 
2024-05-23 12:35:55.332  INFO 56857 --- [nio-8080-exec-6] u.g.j.d.h.a.c.LoggingHandlerInterceptor  : GET /reports/referrals - 200 | request.params.year=2023, request.uri=/reports/referrals, request.user=JIMSNOWLDAP, request.method=GET, request.pathPattern=/reports/referrals, request.params.month=1, request.serviceName=approved-premises, request.id=c1523478-41d4-4f62-86b0-74d8aa978c03 
2024-05-23 12:35:55.333  INFO 56857 --- [nio-8080-exec-6] u.g.j.d.h.a.config.HttpLoggingFilter     : Request  | request.params.year=2023, request.uri=/reports/referrals, request.user=JIMSNOWLDAP, request.method=GET, request.pathPattern=/reports/referrals, request.params.month=1, request.serviceName=approved-premises, request.id=c1523478-41d4-4f62-86b0-74d8aa978c03 
2024-05-23 12:35:55.333  INFO 56857 --- [nio-8080-exec-6] u.g.j.d.h.a.config.HttpLoggingFilter     : Response not logged as content type is application/vnd.openxmlformats-officedocument.spreadsheetml.sheet | request.params.year=2023, request.uri=/reports/referrals, request.user=JIMSNOWLDAP, request.method=GET, request.pathPattern=/reports/referrals, request.params.month=1, request.serviceName=approved-premises, request.id=c1523478-41d4-4f62-86b0-74d8aa978c03 
2024-05-23 12:35:59.452  INFO 56857 --- [nio-8080-exec-8] u.g.j.d.h.a.config.HttpLoggingFilter     : Request  | request.params.crn=X320741, request.uri=/people/search, request.user=JIMSNOWLDAP, request.method=GET, request.pathPattern=/people/search, request.serviceName=approved-premises, request.id=dbe843d1-f6d0-4025-b918-fac1f499412c 
2024-05-23 12:35:59.452  INFO 56857 --- [nio-8080-exec-8] u.g.j.d.h.a.config.HttpLoggingFilter     : Response not logged as content type is application/vnd.spring-boot.actuator.v3+json | request.params.crn=X320741, request.uri=/people/search, request.user=JIMSNOWLDAP, request.method=GET, request.pathPattern=/people/search, request.serviceName=approved-premises, request.id=dbe843d1-f6d0-4025-b918-fac1f499412c 
```