### PR TITLE
APS-827:  Add roles for "legacy" and "future" MANAGE sections

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -716,7 +716,7 @@ class PremisesController(
 
     val user = usersService.getUserForRequest()
 
-    if (premises is ApprovedPremisesEntity && !user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)) {
+    if (premises is ApprovedPremisesEntity && !user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -147,6 +147,8 @@ class UsersController(
     ApprovedPremisesUserRole.applicant -> JpaUserRole.CAS1_APPLICANT
     ApprovedPremisesUserRole.assessor -> JpaUserRole.CAS1_ASSESSOR
     ApprovedPremisesUserRole.manager -> JpaUserRole.CAS1_MANAGER
+    ApprovedPremisesUserRole.legacyManager -> JpaUserRole.CAS1_LEGACY_MANAGER
+    ApprovedPremisesUserRole.futureManager -> JpaUserRole.CAS1_FUTURE_MANAGER
     ApprovedPremisesUserRole.matcher -> JpaUserRole.CAS1_MATCHER
     ApprovedPremisesUserRole.workflowManager -> JpaUserRole.CAS1_WORKFLOW_MANAGER
     ApprovedPremisesUserRole.reportViewer -> JpaUserRole.CAS1_REPORT_VIEWER

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/LostBedsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/LostBedsController.kt
@@ -87,7 +87,7 @@ class LostBedsController(
 
     val user = usersService.getUserForRequest()
 
-    if (!user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)) {
+    if (!user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/LostBedsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/LostBedsController.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedCancell
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBedCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateLostBed
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
@@ -19,7 +18,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LostBedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedCancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
 import java.time.LocalDate
@@ -27,7 +25,6 @@ import java.util.UUID
 
 @Service
 class LostBedsController(
-  private val usersService: UserService,
   private val userAccessService: UserAccessService,
   private val premisesService: PremisesService,
   private val bookingService: BookingService,
@@ -84,12 +81,6 @@ class LostBedsController(
 
     val lostBed = premises.lostBeds.firstOrNull { it.id == lostBedId }
       ?: throw NotFoundProblem(lostBedId, "LostBed")
-
-    val user = usersService.getUserForRequest()
-
-    if (!user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)) {
-      throw ForbiddenProblem()
-    }
 
     return ResponseEntity.ok(lostBedsTransformer.transformJpaToApi(lostBed))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -305,6 +305,8 @@ enum class UserRole(val service: ServiceName) {
   CAS1_ASSESSOR(ServiceName.approvedPremises),
   CAS1_MATCHER(ServiceName.approvedPremises),
   CAS1_MANAGER(ServiceName.approvedPremises),
+  CAS1_LEGACY_MANAGER(ServiceName.approvedPremises),
+  CAS1_FUTURE_MANAGER(ServiceName.approvedPremises),
   CAS1_WORKFLOW_MANAGER(ServiceName.approvedPremises),
   CAS1_APPLICANT(ServiceName.approvedPremises),
   CAS1_ADMIN(ServiceName.approvedPremises),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -124,14 +124,6 @@ class UserAccessService(
       else -> false
     }
 
-  fun getApprovedPremisesApplicationAccessLevelForCurrentUser(): ApprovedPremisesApplicationAccessLevel =
-    getApprovedPremisesApplicationAccessLevelForUser(userService.getUserForRequest())
-
-  fun getApprovedPremisesApplicationAccessLevelForUser(user: UserEntity): ApprovedPremisesApplicationAccessLevel = when {
-    user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER, UserRole.CAS1_MANAGER) -> ApprovedPremisesApplicationAccessLevel.ALL
-    else -> ApprovedPremisesApplicationAccessLevel.TEAM
-  }
-
   fun getTemporaryAccommodationApplicationAccessLevelForCurrentUser(): TemporaryAccommodationApplicationAccessLevel =
     getTemporaryAccommodationApplicationAccessLevelForUser(userService.getUserForRequest())
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -71,7 +71,7 @@ class UserAccessService(
   }
 
   fun userCanManagePremisesBookings(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_WORKFLOW_MANAGER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_WORKFLOW_MANAGER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -91,7 +91,7 @@ class UserAccessService(
     userCanManagePremisesLostBeds(userService.getUserForRequest(), premises)
 
   fun userCanManagePremisesLostBeds(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -100,7 +100,7 @@ class UserAccessService(
     userCanViewPremisesCapacity(userService.getUserForRequest(), premises)
 
   fun userCanViewPremisesCapacity(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -109,7 +109,7 @@ class UserAccessService(
     userCanViewPremisesStaff(userService.getUserForRequest(), premises)
 
   fun userCanViewPremisesStaff(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -71,7 +71,7 @@ class UserAccessService(
   }
 
   fun userCanManagePremisesBookings(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_WORKFLOW_MANAGER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_WORKFLOW_MANAGER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -91,7 +91,7 @@ class UserAccessService(
     userCanManagePremisesLostBeds(userService.getUserForRequest(), premises)
 
   fun userCanManagePremisesLostBeds(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -100,7 +100,7 @@ class UserAccessService(
     userCanViewPremisesCapacity(userService.getUserForRequest(), premises)
 
   fun userCanViewPremisesCapacity(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -109,7 +109,7 @@ class UserAccessService(
     userCanViewPremisesStaff(userService.getUserForRequest(), premises)
 
   fun userCanViewPremisesStaff(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -76,6 +76,8 @@ class UserTransformer(
     UserRole.CAS1_ASSESSOR -> ApprovedPremisesUserRole.assessor
     UserRole.CAS1_MATCHER -> ApprovedPremisesUserRole.matcher
     UserRole.CAS1_MANAGER -> ApprovedPremisesUserRole.manager
+    UserRole.CAS1_LEGACY_MANAGER -> ApprovedPremisesUserRole.legacyManager
+    UserRole.CAS1_FUTURE_MANAGER -> ApprovedPremisesUserRole.futureManager
     UserRole.CAS1_WORKFLOW_MANAGER -> ApprovedPremisesUserRole.workflowManager
     UserRole.CAS1_APPLICANT -> ApprovedPremisesUserRole.applicant
     UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION -> ApprovedPremisesUserRole.excludedFromMatchAllocation

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserServiceUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserServiceUtils.kt
@@ -19,6 +19,8 @@ fun transformUserRoles(approvedPremisesUserRole: ApprovedPremisesUserRole): User
   ApprovedPremisesUserRole.assessor -> UserRole.CAS1_ASSESSOR
   ApprovedPremisesUserRole.matcher -> UserRole.CAS1_MATCHER
   ApprovedPremisesUserRole.manager -> UserRole.CAS1_MANAGER
+  ApprovedPremisesUserRole.legacyManager -> UserRole.CAS1_LEGACY_MANAGER
+  ApprovedPremisesUserRole.futureManager -> UserRole.CAS1_FUTURE_MANAGER
   ApprovedPremisesUserRole.workflowManager -> UserRole.CAS1_WORKFLOW_MANAGER
   ApprovedPremisesUserRole.applicant -> UserRole.CAS1_APPLICANT
   ApprovedPremisesUserRole.roleAdmin -> UserRole.CAS1_ADMIN

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3008,6 +3008,8 @@ components:
         - assessor
         - matcher
         - manager
+        - legacy_manager
+        - future_manager
         - workflow_manager
         - applicant
         - role_admin

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7682,6 +7682,8 @@ components:
         - assessor
         - matcher
         - manager
+        - legacy_manager
+        - future_manager
         - workflow_manager
         - applicant
         - role_admin

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3234,6 +3234,8 @@ components:
         - assessor
         - matcher
         - manager
+        - legacy_manager
+        - future_manager
         - workflow_manager
         - applicant
         - role_admin

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3639,6 +3639,8 @@ components:
         - assessor
         - matcher
         - manager
+        - legacy_manager
+        - future_manager
         - workflow_manager
         - applicant
         - role_admin

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3099,6 +3099,8 @@ components:
         - assessor
         - matcher
         - manager
+        - legacy_manager
+        - future_manager
         - workflow_manager
         - applicant
         - role_admin

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -72,7 +72,7 @@ class BookingTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER"])
     fun `Get a booking returns OK with the correct body when user has one of roles MANAGER, MATCHER`(
       role: UserRole,
     ) {
@@ -161,8 +161,8 @@ class BookingTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
-    fun `Get a booking for an Approved Premises returns OK with the correct body when user has one of roles MANAGER, MATCHER`(
+    @EnumSource(value = UserRole::class, names = ["CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER"])
+    fun `Get a booking for an Approved Premises returns OK with the correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(
       role: UserRole,
     ) {
       `Given a User`(roles = listOf(role)) { userEntity, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
@@ -43,8 +43,8 @@ class CapacityTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `Get Capacity with no bookings or lost beds on Approved Premises returns OK with empty list body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+  fun `Get Capacity with no bookings or lost beds on Approved Premises returns OK with empty list body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -71,8 +71,8 @@ class CapacityTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `Get Capacity for Approved Premises with booking in past returns OK with empty list body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+  fun `Get Capacity for Approved Premises with booking in past returns OK with empty list body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -52,8 +52,8 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `List Lost Beds on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+  fun `List Lost Beds on Approved Premises returns OK with correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -226,7 +226,7 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `Get Lost Bed for non-existent lost bed returns 404`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -246,8 +246,8 @@ class LostBedsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `Get Lost Bed on Approved Premises returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+  fun `Get Lost Bed on Approved Premises returns OK with correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -302,7 +302,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER"])
     fun `GET to users with a role other than ROLE_ADMIN or WORKFLOW_MANAGER is forbidden`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/LostBedsTest.kt
@@ -57,8 +57,8 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Get All Lost Beds returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Get All Lost Beds returns OK with correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -156,7 +156,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
     fun `Get Lost Bed for non-existent lost bed returns 404`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -176,8 +176,8 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Get Lost Bed returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Get Lost Bed returns OK with correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -289,8 +289,8 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Create Lost Beds returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Create Lost Beds returns OK with correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -681,8 +681,8 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Update Lost Beds returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Update Lost Beds returns OK with correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1111,8 +1111,8 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Cancel Lost Bed returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Cancel Lost Bed returns OK with correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -2445,7 +2445,7 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `Get all offline applications where Probation Officer exists returns empty list for user without any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER`() {
+  fun `Get all offline applications where Probation Officer exists returns empty list for user without any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, LEGACY_MANAGER, MANAGER`() {
     val userId = UUID.fromString("8a0624b8-8e92-47ce-b645-b65ea5a197d0")
     val distinguishedName = "SOMEPERSON"
     val userEntity = UserEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -79,7 +79,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService.Cas1ApplicationUpdateFields
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApprovedPremisesApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
@@ -193,7 +192,6 @@ class ApplicationServiceTest {
     )
 
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
-    every { mockUserAccessService.getApprovedPremisesApplicationAccessLevelForUser(userEntity) } returns ApprovedPremisesApplicationAccessLevel.TEAM
     every { mockApplicationRepository.findNonWithdrawnApprovedPremisesSummariesForUser(userId) } returns applicationSummaries
     every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1FutureManagerUserAccessTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1FutureManagerUserAccessTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
+import java.util.UUID
+
+class Cas1FutureManagerUserAccessTest {
+  private val userService = mockk<UserService>()
+  private val offenderService = mockk<OffenderService>()
+  private val requestContextService = mockk<RequestContextService>()
+
+  private val userAccessService = UserAccessService(
+    userService,
+    offenderService,
+    requestContextService,
+  )
+
+  private val probationRegionId = UUID.randomUUID()
+  private val probationRegion = ProbationRegionEntityFactory()
+    .withId(probationRegionId)
+    .withApArea(
+      ApAreaEntityFactory()
+        .produce(),
+    )
+    .produce()
+
+  private val futureManager = UserEntityFactory()
+    .withProbationRegion(probationRegion)
+    .produce()
+
+  val approvedPremises = ApprovedPremisesEntityFactory()
+    .withProbationRegion(probationRegion)
+    .withLocalAuthorityArea(
+      LocalAuthorityEntityFactory()
+        .produce(),
+    )
+    .produce()
+
+  @BeforeEach
+  fun setup() {
+    futureManager.addRoleForUnitTest(UserRole.CAS1_FUTURE_MANAGER)
+    every { userService.getUserForRequest() } returns futureManager
+    every { requestContextService.getServiceForRequest() } returns ServiceName.approvedPremises
+  }
+
+  @Nested
+  inner class Cas1FutureManager {
+
+    @Test
+    fun `may view premises`() {
+      assertThat(userAccessService.userCanViewPremises(futureManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may manage premises`() {
+      assertThat(userAccessService.userCanManagePremises(futureManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may view booking`() {
+      val booking = BookingEntityFactory()
+        .withPremises(approvedPremises)
+        .produce()
+
+      assertThat(userAccessService.userCanViewBooking(futureManager, booking)).isTrue
+    }
+
+    @Test
+    fun `may manage premises booking`() {
+      assertThat(userAccessService.userCanManagePremisesBookings(futureManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may manage premises out-of-service (aka lost) beds`() {
+      assertThat(userAccessService.userCanManagePremisesLostBeds(futureManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may view premises capacity`() {
+      assertThat(userAccessService.userCanViewPremisesCapacity(futureManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may view premises staff`() {
+      assertThat(userAccessService.userCanViewPremisesStaff(futureManager, approvedPremises)).isTrue
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1LegacyManagerUserAccessTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1LegacyManagerUserAccessTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
+import java.util.UUID
+
+class Cas1LegacyManagerUserAccessTest {
+  private val userService = mockk<UserService>()
+  private val offenderService = mockk<OffenderService>()
+  private val requestContextService = mockk<RequestContextService>()
+
+  private val userAccessService = UserAccessService(
+    userService,
+    offenderService,
+    requestContextService,
+  )
+
+  private val probationRegionId = UUID.randomUUID()
+  private val probationRegion = ProbationRegionEntityFactory()
+    .withId(probationRegionId)
+    .withApArea(
+      ApAreaEntityFactory()
+        .produce(),
+    )
+    .produce()
+
+  private val legacyManager = UserEntityFactory()
+    .withProbationRegion(probationRegion)
+    .produce()
+
+  val approvedPremises = ApprovedPremisesEntityFactory()
+    .withProbationRegion(probationRegion)
+    .withLocalAuthorityArea(
+      LocalAuthorityEntityFactory()
+        .produce(),
+    )
+    .produce()
+
+  @BeforeEach
+  fun setup() {
+    legacyManager.addRoleForUnitTest(UserRole.CAS1_LEGACY_MANAGER)
+    every { userService.getUserForRequest() } returns legacyManager
+    every { requestContextService.getServiceForRequest() } returns ServiceName.approvedPremises
+  }
+
+  @Nested
+  inner class Cas1LegacyManager {
+
+    @Test
+    fun `may view premises`() {
+      assertThat(userAccessService.userCanViewPremises(legacyManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may manage premises`() {
+      assertThat(userAccessService.userCanManagePremises(legacyManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may view booking`() {
+      val booking = BookingEntityFactory()
+        .withPremises(approvedPremises)
+        .produce()
+
+      assertThat(userAccessService.userCanViewBooking(legacyManager, booking)).isTrue
+    }
+
+    @Test
+    fun `may manage premises booking`() {
+      assertThat(userAccessService.userCanManagePremisesBookings(legacyManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may manage premises out-of-service (aka lost) beds`() {
+      assertThat(userAccessService.userCanManagePremisesLostBeds(legacyManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may view premises capacity`() {
+      assertThat(userAccessService.userCanViewPremisesCapacity(legacyManager, approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `may view premises staff`() {
+      assertThat(userAccessService.userCanViewPremisesStaff(legacyManager, approvedPremises)).isTrue
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REFERRER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApprovedPremisesApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TemporaryAccommodationApplicationAccessLevel
@@ -818,32 +817,6 @@ class UserAccessServiceTest {
 
     assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesInUserRegion)).isFalse
     assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesNotInUserRegion)).isFalse
-  }
-
-  @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])
-  fun `getApprovedPremisesApplicationAccessLevelForUser returns ALL if the user has one of the CAS1_WORKFLOW_MANAGER, CAS1_ASSESSOR, CAS1_MATCHER, or CAS1_MANAGER roles`(role: UserRole) {
-    user.addRoleForUnitTest(role)
-
-    assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForUser(user)).isEqualTo(ApprovedPremisesApplicationAccessLevel.ALL)
-  }
-
-  @Test
-  fun `getApprovedPremisesApplicationAccessLevelForUser returns TEAM if the user has no suitable role`() {
-    assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForUser(user)).isEqualTo(ApprovedPremisesApplicationAccessLevel.TEAM)
-  }
-
-  @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"])
-  fun `getApprovedPremisesApplicationAccessLevelForCurrentUser returns ALL if the user has one of the CAS1_WORKFLOW_MANAGER, CAS1_ASSESSOR, CAS1_MATCHER, or CAS1_MANAGER roles`(role: UserRole) {
-    user.addRoleForUnitTest(role)
-
-    assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForCurrentUser()).isEqualTo(ApprovedPremisesApplicationAccessLevel.ALL)
-  }
-
-  @Test
-  fun `getApprovedPremisesApplicationAccessLevelForCurrentUser returns TEAM if the user has no suitable role`() {
-    assertThat(userAccessService.getApprovedPremisesApplicationAccessLevelForCurrentUser()).isEqualTo(ApprovedPremisesApplicationAccessLevel.TEAM)
   }
 
   @Test


### PR DESCRIPTION
Jira: [APS-827: Reduce scope of interim "Manage" section](https://dsdmoj.atlassian.net/browse/APS-827)

We are developing some improved and extended features in the 'manage' section
of CAS1. Our needs are to:

1. continue to offer (a subset of) the existing 'manage' features to users in the
   North East

2. develop new and improved features in a hidden / feature flagged space to be rolled
   out first to the existing manage users in the North East and then nationally.

To support this we introduce two new roles:

### i) LEGACY_MANAGER

This role will have access to a sub-set of the existing manage features:

- ✅ view list of premises (`/premises`)

- view information for particular premises (`/premises/{premisesId}`)
    - ✅ view arriving today
    - ✅ view departing today
    - ✅ view upcoming arrivals
    - ✅ view upcoming departures
    - ✅ view current residents
    - ✅ manage beds (`/premises/{premisesId}/beds`)
    - ❌ create manual placement
    - ❌ view calendar

- view out of service beds (`/premises/{premisesId}/lost-beds`)
    - ✅ create new out of service bed (`/premises/{premisesId}/lost-beds/new`)

- view placement (`/premises/{premisesId}/bookings/{bookingId}`)
    - ✅ move person to new bed
    - ❌ mark as arrived
    - ❌ mark as not arrived
    - ❌ log departure
    - ✅ update departure date
    - ✅ withdraw placement
    - ✅ change placement dates

### ii) FUTURE_MANAGER

This role will have access to new features, including to:

- manage out of service beds
- manage premises and room characteristics
- transfer a resident to another AP
- appeal a placement
- access an improved calendar of placements and out of service beds

## API: reproducing the MANAGER permissions 

Initially we give these 2 new roles the same API permissions as the existing MANAGER role. Access to the particular actions listed above will be controlled on the UI.

We:

- Verify that `{LEGACY,FUTURE}_MANAGER` can view premises
- Verify that `{LEGACY,FUTURE}_MANAGER` can manage premises
- Verify that `{LEGACY,FUTURE}_MANAGER` can view booking
- Allow `{LEGACY,FUTURE}_MANAGER` to manage premises bookings
- Allow `{LEGACY,FUTURE}_MANAGER` to manage premises out-of-service (lost) beds
- Allow `{LEGACY,FUTURE}_MANAGER` to view premises capacity
- Allow `{LEGACY,FUTURE}_MANAGER` to view premises staff

## How we'll use these new roles:

### 1. Copy existing lost-beds to CAS1 namespace

We've reproduced our existing "lost bed" functionality in a new CAS1 namespace:

```
/cas1/premises/{premisesId}/lost-beds
```

which is handled by a new `LostBedsControllers` within the `approvedpremisesapi.controller.cas1` namespace.

The UI will switch to using these relocated endpoints

### 2. Provide reduced lost-bed features to LEGACY_MANAGER

We'll use the new LEGACY_MANAGER role to offer (on the UI) a sub-set of the original lost-bed features to AP staff in the North East

### 3. Build new out-of-service-beds features in OutOfServiceBeds* classes

We'll build the new out-of-service-bed features separately and restrict them to the new FUTURE_MANAGER role which will be granted to internal development users only initially:

`/cas1/premises/{premisesId}/out-of-service-beds`

handled by CAS1 `OutOfServiceBedsController` and `OutOfServiceBedsService` classes and a new `OutOfServiceBedEntity`

### 4. Switch new out-of-service-beds on for North East 

We'll give the North East AP staff the `FUTURE_MANAGER` role and remove their `LEGACY_MANAGER` role. We'll also migrate all legacy `LostBed` data to the new `OutOfServiceBed` data.