### PR TITLE
[APS-801] Introduce `/cas1/` namespace for lost beds endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/LostBedsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/LostBedsController.kt
@@ -1,0 +1,192 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.LostBedsCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBedCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LostBedService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedCancellationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class LostBedsController(
+  private val usersService: UserService,
+  private val userAccessService: UserAccessService,
+  private val premisesService: PremisesService,
+  private val bookingService: BookingService,
+  private val lostBedsService: LostBedService,
+  private val lostBedsTransformer: LostBedsTransformer,
+  private val lostBedCancellationTransformer: LostBedCancellationTransformer,
+) : LostBedsCas1Delegate {
+
+  override fun premisesPremisesIdLostBedsPost(premisesId: UUID, body: NewLostBed): ResponseEntity<LostBed> {
+    val premises = premisesService.getPremises(premisesId)
+      ?: throw NotFoundProblem(premisesId, "Premises")
+
+    if (!userAccessService.currentUserCanManagePremisesLostBeds(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    throwIfLostBedDatesConflict(body.startDate, body.endDate, null, body.bedId)
+
+    val result = premisesService.createLostBeds(
+      premises = premises,
+      startDate = body.startDate,
+      endDate = body.endDate,
+      reasonId = body.reason,
+      referenceNumber = body.referenceNumber,
+      notes = body.notes,
+      bedId = body.bedId,
+    )
+
+    val lostBeds = extractResultEntityOrThrow(result)
+
+    return ResponseEntity.ok(lostBedsTransformer.transformJpaToApi(lostBeds))
+  }
+
+  override fun premisesPremisesIdLostBedsGet(premisesId: UUID): ResponseEntity<List<LostBed>> {
+    val premises = premisesService.getPremises(premisesId)
+      ?: throw NotFoundProblem(premisesId, "Premises")
+
+    val lostBeds = lostBedsService.getActiveLostBedsForPremisesId(premisesId)
+
+    if (!userAccessService.currentUserCanManagePremisesLostBeds(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    return ResponseEntity.ok(lostBeds.map(lostBedsTransformer::transformJpaToApi))
+  }
+
+  override fun premisesPremisesIdLostBedsLostBedIdGet(premisesId: UUID, lostBedId: UUID): ResponseEntity<LostBed> {
+    val premises = premisesService.getPremises(premisesId)
+      ?: throw NotFoundProblem(premisesId, "Premises")
+
+    if (!userAccessService.currentUserCanManagePremisesLostBeds(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    val lostBed = premises.lostBeds.firstOrNull { it.id == lostBedId }
+      ?: throw NotFoundProblem(lostBedId, "LostBed")
+
+    val user = usersService.getUserForRequest()
+
+    if (!user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)) {
+      throw ForbiddenProblem()
+    }
+
+    return ResponseEntity.ok(lostBedsTransformer.transformJpaToApi(lostBed))
+  }
+
+  override fun premisesPremisesIdLostBedsLostBedIdPut(
+    premisesId: UUID,
+    lostBedId: UUID,
+    body: UpdateLostBed,
+  ): ResponseEntity<LostBed> {
+    val premises = premisesService.getPremises(premisesId) ?: throw NotFoundProblem(premisesId, "Premises")
+    val lostBed = premises.lostBeds.firstOrNull { it.id == lostBedId } ?: throw NotFoundProblem(lostBedId, "LostBed")
+
+    if (!userAccessService.currentUserCanManagePremisesLostBeds(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    throwIfBookingDatesConflict(body.startDate, body.endDate, lostBed.bed.id)
+    throwIfLostBedDatesConflict(body.startDate, body.endDate, lostBedId, lostBed.bed.id)
+
+    val updateLostBedResult = premisesService
+      .updateLostBeds(
+        lostBedId,
+        body.startDate,
+        body.endDate,
+        body.reason,
+        body.referenceNumber,
+        body.notes,
+      )
+
+    val validationResult = when (updateLostBedResult) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(lostBedId, "LostBed")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> updateLostBedResult.entity
+    }
+
+    val updatedLostBed = when (validationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+      is ValidatableActionResult.Success -> validationResult.entity
+    }
+
+    return ResponseEntity.ok(lostBedsTransformer.transformJpaToApi(updatedLostBed))
+  }
+
+  override fun premisesPremisesIdLostBedsLostBedIdCancellationsPost(
+    premisesId: UUID,
+    lostBedId: UUID,
+    body: NewLostBedCancellation,
+  ): ResponseEntity<LostBedCancellation> {
+    val premises = premisesService.getPremises(premisesId) ?: throw NotFoundProblem(premisesId, "Premises")
+    val lostBed = premises.lostBeds.firstOrNull { it.id == lostBedId } ?: throw NotFoundProblem(lostBedId, "LostBed")
+
+    if (!userAccessService.currentUserCanManagePremisesLostBeds(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    val cancelLostBedResult = premisesService.cancelLostBed(
+      lostBed = lostBed,
+      notes = body.notes,
+    )
+
+    val cancellation = when (cancelLostBedResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = cancelLostBedResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = cancelLostBedResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = cancelLostBedResult.conflictingEntityId, conflictReason = cancelLostBedResult.message)
+      is ValidatableActionResult.Success -> cancelLostBedResult.entity
+    }
+
+    return ResponseEntity.ok(lostBedCancellationTransformer.transformJpaToApi(cancellation))
+  }
+
+  private fun <EntityType> extractResultEntityOrThrow(result: ValidatableActionResult<EntityType>) = when (result) {
+    is ValidatableActionResult.Success -> result.entity
+    is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = result.message)
+    is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = result.validationMessages)
+    is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = result.conflictingEntityId, conflictReason = result.message)
+  }
+
+  private fun throwIfBookingDatesConflict(
+    arrivalDate: LocalDate,
+    departureDate: LocalDate,
+    bedId: UUID,
+  ) {
+    bookingService.getBookingWithConflictingDates(arrivalDate, departureDate, null, bedId)?.let {
+      throw ConflictProblem(it.id, "A Booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates")
+    }
+  }
+
+  private fun throwIfLostBedDatesConflict(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    thisEntityId: UUID?,
+    bedId: UUID,
+  ) {
+    bookingService.getLostBedWithConflictingDates(startDate, endDate, thisEntityId, bedId)?.let {
+      throw ConflictProblem(it.id, "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates")
+    }
+  }
+}

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -1,0 +1,224 @@
+openapi: 3.0.1
+info:
+  title: 'Community Accommodation Services: Approved Premises (CAS1)'
+  version: 1.0.0
+servers:
+  - url: /cas1
+paths:
+  /premises/{premisesId}/lost-beds:
+    post:
+      tags:
+        - lost beds
+      summary: Posts a lost bed to a specified approved premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the lost bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the lost bed
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/NewLostBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/LostBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
+    get:
+      tags:
+        - lost beds
+      summary: Lists all Lost Beds entries for the Premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to show lost beds for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/LostBed'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+  /premises/{premisesId}/lost-beds/{lostBedId}:
+    get:
+      tags:
+        - lost beds
+      summary: Returns a specific lost bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the lost bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: lostBedId
+          in: path
+          description: ID of the lost bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/LostBed'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises or lost bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+    put:
+      tags:
+        - lost beds
+      summary: Updates a lost bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the lost bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: lostBedId
+          in: path
+          description: ID of the lost bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the lost bed
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/UpdateLostBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/LostBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
+  /premises/{premisesId}/lost-beds/{lostBedId}/cancellations:
+    post:
+      tags:
+        - lost beds
+      summary: Posts a cancellation to a specified lost bed
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the cancellation is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: lostBedId
+          in: path
+          description: ID of the lost bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the cancellation
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/NewLostBedCancellation'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/LostBedCancellation'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises ID or lost bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1,0 +1,4954 @@
+# DO NOT EDIT.
+# This is a build artefact for use in code generation.
+openapi: 3.0.1
+info:
+  title: 'Community Accommodation Services: Approved Premises (CAS1)'
+  version: 1.0.0
+servers:
+  - url: /cas1
+paths:
+  /premises/{premisesId}/lost-beds:
+    post:
+      tags:
+        - lost beds
+      summary: Posts a lost bed to a specified approved premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the lost bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the lost bed
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewLostBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LostBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
+    get:
+      tags:
+        - lost beds
+      summary: Lists all Lost Beds entries for the Premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to show lost beds for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LostBed'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /premises/{premisesId}/lost-beds/{lostBedId}:
+    get:
+      tags:
+        - lost beds
+      summary: Returns a specific lost bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the lost bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: lostBedId
+          in: path
+          description: ID of the lost bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LostBed'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises or lost bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+    put:
+      tags:
+        - lost beds
+      summary: Updates a lost bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the lost bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: lostBedId
+          in: path
+          description: ID of the lost bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the lost bed
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdateLostBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LostBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
+  /premises/{premisesId}/lost-beds/{lostBedId}/cancellations:
+    post:
+      tags:
+        - lost beds
+      summary: Posts a cancellation to a specified lost bed
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the cancellation is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: lostBedId
+          in: path
+          description: ID of the lost bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the cancellation
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewLostBedCancellation'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LostBedCancellation'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or lost bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
+components:
+  responses:
+    401Response:
+      description: not authenticated
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Problem'
+    403Response:
+      description: unauthorised
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Problem'
+    500Response:
+      description: unexpected error
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Problem'
+  headers:
+    X-Pagination-CurrentPage:
+      schema:
+        type: integer
+      description: The current page number
+    X-Pagination-TotalPages:
+      schema:
+        type: integer
+      description: The total number of pages
+    X-Pagination-TotalResults:
+      schema:
+        type: integer
+      description: The total number of results
+    X-Pagination-PageSize:
+      schema:
+        type: integer
+      description: The size of each page
+  schemas:
+    Premises:
+      type: object
+      properties:
+        service:
+          type: string
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        addressLine1:
+          type: string
+          example: one something street
+        addressLine2:
+          type: string
+          example: Blackmore End
+        town:
+          type: string
+          example: Braintree
+        postcode:
+          type: string
+          example: LS1 3AD
+        bedCount:
+          type: integer
+          example: 22
+        availableBedsForToday:
+          type: integer
+          example: 20
+        notes:
+          type: string
+          example: some notes about this property
+        probationRegion:
+          $ref: '#/components/schemas/ProbationRegion'
+        apArea:
+          $ref: '#/components/schemas/ApArea'
+        localAuthorityArea:
+          $ref: '#/components/schemas/LocalAuthorityArea'
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Characteristic'
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremises'
+          CAS3: '#/components/schemas/TemporaryAccommodationPremises'
+      required:
+        - service
+        - id
+        - name
+        - addressLine1
+        - postcode
+        - bedCount
+        - availableBedsForToday
+        - probationRegion
+        - apArea
+        - status
+    PremisesSummary:
+      type: object
+      properties:
+        service:
+          type: string
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        addressLine1:
+          type: string
+          example: one something street
+        addressLine2:
+          type: string
+          example: Blackmore End
+        postcode:
+          type: string
+          example: LS1 3AD
+        bedCount:
+          type: integer
+          example: 22
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesSummary'
+          CAS3: '#/components/schemas/TemporaryAccommodationPremisesSummary'
+      required:
+        - service
+        - id
+        - name
+        - addressLine1
+        - postcode
+        - bedCount
+        - status
+    ApprovedPremises:
+      allOf:
+        - $ref: '#/components/schemas/Premises'
+        - type: object
+          properties:
+            apCode:
+              type: string
+              example: NEHOPE1
+      required:
+        - apCode
+        - localAuthorityArea
+    TemporaryAccommodationPremises:
+      allOf:
+        - $ref: '#/components/schemas/Premises'
+        - type: object
+          properties:
+            pdu:
+              type: string
+            probationDeliveryUnit:
+              $ref: '#/components/schemas/ProbationDeliveryUnit'
+            turnaroundWorkingDayCount:
+              type: integer
+              example: 2
+      required:
+        - pdu
+    ApprovedPremisesSummary:
+      allOf:
+        - $ref: '#/components/schemas/PremisesSummary'
+        - type: object
+          properties:
+            apCode:
+              type: string
+              example: NEHOPE1
+            probationRegion:
+              type: string
+            apArea:
+              type: string
+      required:
+        - apCode
+        - probationRegion
+        - apArea
+    TemporaryAccommodationPremisesSummary:
+      allOf:
+        - $ref: '#/components/schemas/PremisesSummary'
+        - type: object
+          properties:
+            pdu:
+              type: string
+            localAuthorityAreaName:
+              type: string
+      required:
+        - pdu
+    NewPremises:
+      type: object
+      properties:
+        name:
+          type: string
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+        notes:
+          type: string
+          example: some notes about this property
+        localAuthorityAreaId:
+          type: string
+          format: uuid
+        probationRegionId:
+          type: string
+          format: uuid
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+        pdu:
+          type: string
+        probationDeliveryUnitId:
+          type: string
+          format: uuid
+        turnaroundWorkingDayCount:
+          type: integer
+      required:
+        - name
+        - addressLine1
+        - postcode
+        - probationRegionId
+        - characteristicIds
+        - status
+    TaskWrapper:
+      type: object
+      properties:
+        task:
+          $ref: '#/components/schemas/Task'
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserWithWorkload'
+      required:
+        - task
+        - users
+    Task:
+      type: object
+      properties:
+        taskType:
+          $ref: '#/components/schemas/TaskType'
+        id:
+          type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
+        applicationId:
+          type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
+        personName:
+          type: string
+        crn:
+          type: string
+        dueDate:
+          type: string
+          format: date
+          deprecated: true
+          description: The Due date of the task - this is deprecated in favour of the `dueAt` field
+        dueAt:
+          type: string
+          format: date-time
+        allocatedToStaffMember:
+          $ref: '#/components/schemas/ApprovedPremisesUser'
+        status:
+          $ref: '#/components/schemas/TaskStatus'
+        apArea:
+          $ref: '#/components/schemas/ApArea'
+        outcomeRecordedAt:
+          type: string
+          format: date-time
+      discriminator:
+        propertyName: taskType
+        mapping:
+          Assessment: '#/components/schemas/AssessmentTask'
+          PlacementRequest: '#/components/schemas/PlacementRequestTask'
+          PlacementApplication: '#/components/schemas/PlacementApplicationTask'
+          BookingAppeal: '#/components/schemas/BookingAppealTask'
+      required:
+        - id
+        - taskType
+        - applicationId
+        - personName
+        - dueDate
+        - status
+        - crn
+        - dueAt
+    TaskStatus:
+      type: string
+      enum:
+        - not_started
+        - in_progress
+        - complete
+        - info_requested
+    TaskSortField:
+      type: string
+      enum:
+        - createdAt
+        - dueAt
+        - person
+        - allocatedTo
+        - completedAt
+        - taskType
+        - decision
+    AssessmentTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            createdFromAppeal:
+              type: boolean
+            outcome:
+              $ref: '#/components/schemas/AssessmentDecision'
+          required:
+            - createdFromAppeal
+    PlacementRequestTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+        - $ref: '#/components/schemas/PlacementDates'
+        - type: object
+          properties:
+            tier:
+              $ref: '#/components/schemas/RiskTierEnvelope'
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            placementRequestStatus:
+              $ref: '#/components/schemas/PlacementRequestStatus'
+            outcome:
+              $ref: '#/components/schemas/PlacementRequestTaskOutcome'
+          required:
+            - tier
+            - releaseType
+            - placementRequestStatus
+    PlacementApplicationTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            tier:
+              $ref: '#/components/schemas/RiskTierEnvelope'
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            placementType:
+              $ref: '#/components/schemas/PlacementType'
+            placementDates:
+              type: array
+              items:
+                $ref: '#/components/schemas/PlacementDates'
+            outcome:
+              $ref: '#/components/schemas/PlacementApplicationDecision'
+          required:
+            - id
+            - tier
+            - releaseType
+            - placementType
+    PlacementRequestTaskOutcome:
+      type: string
+      enum:
+        - matched
+        - unable_to_match
+    BookingAppealTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+    TaskType:
+      type: string
+      enum:
+        - Assessment
+        - PlacementRequest
+        - PlacementApplication
+        - BookingAppeal
+    LocalAuthorityArea:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
+        identifier:
+          type: string
+          example: LEEDS
+        name:
+          type: string
+          example: Leeds City Council
+      required:
+        - id
+        - identifier
+        - name
+    ApArea:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: cd1c2d43-0b0b-4438-b0e3-d4424e61fb6a
+        identifier:
+          type: string
+          example: LON
+        name:
+          type: string
+          example: Yorkshire & The Humber
+      required:
+        - id
+        - identifier
+        - name
+    ProbationRegion:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        name:
+          type: string
+          example: NPS North East Central Referrals
+      required:
+        - id
+        - name
+    Characteristic:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        name:
+          type: string
+          example: Is this premises catered (rather than self-catered)?
+        propertyName:
+          type: string
+          example: isCatered
+        serviceScope:
+          type: string
+          enum:
+            - approved-premises
+            - temporary-accommodation
+            - "*"
+        modelScope:
+          type: string
+          enum:
+            - premises
+            - room
+            - "*"
+      required:
+        - id
+        - name
+        - serviceScope
+        - modelScope
+    BookingBody:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        arrivalDate:
+          type: string
+          format: date
+        originalArrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        originalDepartureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        keyWorker:
+          $ref: '#/components/schemas/StaffMember'
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
+        bed:
+          $ref: '#/components/schemas/Bed'
+      required:
+        - id
+        - person
+        - arrivalDate
+        - originalArrivalDate
+        - departureDate
+        - originalDepartureDate
+        - createdAt
+        - serviceName
+    NewBooking:
+      type: object
+      properties:
+        crn:
+          type: string
+          example: A123456
+        arrivalDate:
+          type: string
+          format: date
+          example: 2022-07-28
+        departureDate:
+          type: string
+          format: date
+          example: 2022-09-30
+        bedId:
+          type: string
+          format: uuid
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
+        enableTurnarounds:
+          type: boolean
+        assessmentId:
+          type: string
+          format: uuid
+        eventNumber:
+          type: string
+      required:
+        - crn
+        - arrivalDate
+        - departureDate
+        - serviceName
+    NewPlacementRequestBooking:
+      type: object
+      properties:
+        arrivalDate:
+          type: string
+          format: date
+          example: 2022-07-28
+        departureDate:
+          type: string
+          format: date
+          example: 2022-09-30
+        bedId:
+          type: string
+          format: uuid
+        premisesId:
+          type: string
+          format: uuid
+      required:
+        - arrivalDate
+        - departureDate
+    WithdrawPlacementRequest:
+      type: object
+      properties:
+        reason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+      required:
+        - reason
+    WithdrawPlacementRequestReason:
+        type: string
+        enum:
+          - DuplicatePlacementRequest
+          - AlternativeProvisionIdentified
+          - ChangeInCircumstances
+          - ChangeInReleaseDecision
+          - NoCapacityDueToLostBed
+          - NoCapacityDueToPlacementPrioritisation
+          - NoCapacity
+          - ErrorInPlacementRequest
+          - WithdrawnByPP
+          - RelatedApplicationWithdrawn
+          - RelatedPlacementRequestWithdrawn
+          - RelatedPlacementApplicationWithdrawn
+    PlacementApplicationType:
+      type: string
+      description: |
+        'Initial' means that the request for placement was created for the arrival date included on the original application. 
+        'Additional' means the request for placement was created after the application had been assessed as suitable.
+        A given application should only have, at most, one request for placement of type 'Initial'.
+      enum:
+        - Initial
+        - Additional
+    Booking:
+      allOf:
+        - $ref: '#/components/schemas/BookingBody'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/BookingStatus'
+            extensions:
+              type: array
+              items:
+                $ref: '#/components/schemas/Extension'
+            arrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Arrival'
+            departure:
+              description: The latest version of the departure, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Departure'
+            departures:
+              description: The full history of the departure
+              type: array
+              items:
+                $ref: '#/components/schemas/Departure'
+            nonArrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Nonarrival'
+            cancellation:
+              description: The latest version of the cancellation, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cancellation'
+            cancellations:
+              description: The full history of the cancellation
+              type: array
+              items:
+                $ref: '#/components/schemas/Cancellation'
+            confirmation:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Confirmation'
+            turnaround:
+              description: The latest version of the turnaround, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Turnaround'
+            turnarounds:
+              description: The full history of turnarounds
+              type: array
+              items:
+                $ref: '#/components/schemas/Turnaround'
+            turnaroundStartDate:
+              type: string
+              format: date
+            effectiveEndDate:
+              type: string
+              format: date
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
+            premises:
+              $ref: '#/components/schemas/BookingPremisesSummary'
+          required:
+            - status
+            - extensions
+            - departures
+            - cancellations
+            - premises
+    BookingPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    ExtendedPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        apCode:
+          type: string
+        postcode:
+          type: string
+        bedCount:
+          type: integer
+        availableBedsForToday:
+          type: integer
+        bookings:
+          type: array
+          items:
+            $ref: '#/components/schemas/PremisesBooking'
+        dateCapacities:
+          type: array
+          items:
+            $ref: '#/components/schemas/DateCapacity'
+    PremisesBooking:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        arrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        person:
+          $ref: '#/components/schemas/Person'
+        bed:
+          $ref: '#/components/schemas/Bed'
+        status:
+          $ref: '#/components/schemas/BookingStatus'
+    BookingSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        premisesId:
+          type: string
+          format: uuid
+        premisesName:
+          type: string
+        arrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - premisesId
+        - premisesName
+        - arrivalDate
+        - departureDate
+        - createdAt
+    Person:
+      type: object
+      properties:
+        crn:
+          type: string
+        type:
+          $ref: '#/components/schemas/PersonType'
+      discriminator:
+        propertyName: type
+        mapping:
+          FullPerson: '#/components/schemas/FullPerson'
+          RestrictedPerson: '#/components/schemas/RestrictedPerson'
+          UnknownPerson: '#/components/schemas/UnknownPerson'
+      required:
+        - crn
+        - type
+    UnknownPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+    RestrictedPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+    FullPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+        - type: object
+          properties:
+            name:
+              type: string
+            dateOfBirth:
+              type: string
+              format: date
+            nomsNumber:
+              type: string
+            pncNumber:
+              type: string
+            ethnicity:
+              type: string
+            nationality:
+              type: string
+            religionOrBelief:
+              type: string
+            sex:
+              type: string
+            genderIdentity:
+              type: string
+            status:
+              $ref: '#/components/schemas/PersonStatus'
+            prisonName:
+              type: string
+            isRestricted:
+              type: boolean
+          required:
+            - name
+            - dateOfBirth
+            - sex
+            - status
+    PersonStatus:
+      type: string
+      enum:
+        - InCustody
+        - InCommunity
+        - Unknown
+    NewArrival:
+      type: object
+      properties:
+        type:
+          type: string
+        expectedDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        keyWorkerStaffCode:
+          type: string
+      required:
+        - type
+        - expectedDepartureDate
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/NewCas1Arrival'
+          CAS2: '#/components/schemas/NewCas2Arrival'
+          CAS3: '#/components/schemas/NewCas3Arrival'
+    NewCas1Arrival:
+      allOf:
+        - $ref: '#/components/schemas/NewArrival'
+        - type: object
+          properties:
+            arrivalDateTime:
+              type: string
+              format: date-time
+          required:
+            - arrivalDateTime
+    NewCas2Arrival:
+      allOf:
+        - $ref: '#/components/schemas/NewArrival'
+        - type: object
+          properties:
+            arrivalDate:
+              type: string
+              format: date
+          required:
+            - arrivalDate
+    NewCas3Arrival:
+      allOf:
+        - $ref: '#/components/schemas/NewArrival'
+        - type: object
+          properties:
+            arrivalDate:
+              type: string
+              format: date
+          required:
+            - arrivalDate
+    Arrival:
+      type: object
+      properties:
+        expectedDepartureDate:
+          type: string
+          format: date
+        arrivalDate:
+          type: string
+          format: date
+        arrivalTime:
+          type: string
+          format: time
+        notes:
+          type: string
+        keyWorkerStaffCode:
+          type: string
+        bookingId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - type
+        - bookingId
+        - expectedDepartureDate
+        - createdAt
+        - arrivalDate
+        - arrivalTime
+    Nonarrival:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/NonArrivalReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - date
+        - reason
+        - createdAt
+    NewNonarrival:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        notes:
+          type: string
+      required:
+        - date
+        - reason
+    NewCancellation:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        notes:
+          type: string
+        otherReason:
+          type: string
+      required:
+        - bookingId
+        - date
+        - reason
+    NewWithdrawal:
+      type: object
+      properties:
+        reason:
+          $ref: '#/components/schemas/WithdrawalReason'
+        otherReason:
+          type: string
+      required:
+        - reason
+    Cancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/CancellationReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        premisesName:
+          type: string
+      required:
+        - bookingId
+        - date
+        - reason
+        - createdAt
+        - premisesName
+    Extension:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        previousDepartureDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - previousDepartureDate
+        - newDepartureDate
+        - createdAt
+    NewExtension:
+      type: object
+      properties:
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+      required:
+        - newDepartureDate
+    DateChange:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        previousArrivalDate:
+          type: string
+          format: date
+        newArrivalDate:
+          type: string
+          format: date
+        previousDepartureDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - previousArrivalDate
+        - newArrivalDate
+        - previousDepartureDate
+        - newDepartureDate
+        - createdAt
+    NewDateChange:
+      type: object
+      properties:
+        newArrivalDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+    NewDeparture:
+      type: object
+      properties:
+        dateTime:
+          type: string
+          format: date-time
+        reasonId:
+          type: string
+          format: uuid
+        notes:
+          type: string
+        moveOnCategoryId:
+          type: string
+          format: uuid
+        destinationProviderId:
+          type: string
+          format: uuid
+      required:
+        - dateTime
+        - reasonId
+        - moveOnCategoryId
+    Departure:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        reason:
+          $ref: '#/components/schemas/DepartureReason'
+        notes:
+          type: string
+        moveOnCategory:
+          $ref: '#/components/schemas/MoveOnCategory'
+        destinationProvider:
+          $ref: '#/components/schemas/DestinationProvider'
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - dateTime
+        - reason
+        - moveOnCategory
+        - createdAt
+    Confirmation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - dateTime
+        - createdAt
+    NewConfirmation:
+      type: object
+      properties:
+        notes:
+          type: string
+    Turnaround:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        workingDays:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - workingDays
+        - createdAt
+    NewTurnaround:
+      type: object
+      properties:
+        workingDays:
+          type: integer
+      required:
+        - workingDays
+    Problem:
+      type: object
+      properties:
+        type:
+          type: string
+          example: https://example.net/validation-error
+        title:
+          type: string
+          example: Invalid request parameters
+        status:
+          type: integer
+          example: 400
+        detail:
+          type: string
+          example: You provided invalid request parameters
+        instance:
+          type: string
+          example: f7493e12-546d-42c3-b838-06c12671ab5b
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/Problem'
+        - type: object
+          properties:
+            invalid-params:
+              type: array
+              items:
+                $ref: '#/components/schemas/InvalidParam'
+    InvalidParam:
+      type: object
+      properties:
+        propertyName:
+          type: string
+          example: arrivalDate
+        errorType:
+          type: string
+    LostBed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        bedId:
+          type: string
+          format: uuid
+        bedName:
+          type: string
+        roomName:
+          type: string
+        reason:
+          $ref: '#/components/schemas/LostBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        status:
+          $ref: '#/components/schemas/LostBedStatus'
+        cancellation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/LostBedCancellation'
+      required:
+        - id
+        - startDate
+        - endDate
+        - bedId
+        - bedName
+        - roomName
+        - reason
+        - status
+    NewLostBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        bedId:
+          type: string
+          format: uuid
+      required:
+        - startDate
+        - endDate
+        - reason
+        - bedId
+    UpdateLostBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - startDate
+        - endDate
+        - reason
+    LostBedCancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - createdAt
+    NewLostBedCancellation:
+      type: object
+      properties:
+        notes:
+          type: string
+    LostBedStatus:
+      type: string
+      enum:
+        - active
+        - cancelled
+    DepartureReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Admitted to Hospital
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
+    MoveOnCategory:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Housing Association - Rented
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
+    DestinationProvider:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Ext - North East Region
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive
+    SupervisingProvider:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: North East Region
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive
+    SupervisingTeam:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: CP - Sheffield
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive
+    SupervisingOfficer:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Smith, John (PS - PO)
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive
+    StaffMember:
+      type: object
+      properties:
+        code:
+          type: string
+        keyWorker:
+          type: boolean
+        name:
+          type: string
+          example: Brown, James (PS - PSO)
+      required:
+        - code
+        - keyWorker
+        - name
+    LostBedReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Double Room with Single Occupancy - Other (Non-FM)
+        isActive:
+          type: boolean
+        serviceScope:
+          type: string
+      required:
+        - id
+        - name
+        - isActive
+        - serviceScope
+    CancellationReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Recall
+        isActive:
+          type: boolean
+        serviceScope:
+          type: string
+      required:
+        - id
+        - name
+        - isActive
+        - serviceScope
+    NonArrivalReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Recall
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive
+    DateCapacity:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        availableBeds:
+          type: integer
+          example: 10
+      required:
+        - date
+        - availableBeds
+    PersonRisks:
+      type: object
+      properties:
+        crn:
+          type: string
+        roshRisks:
+          $ref: '#/components/schemas/RoshRisksEnvelope'
+        mappa:
+          $ref: '#/components/schemas/MappaEnvelope'
+        tier:
+          $ref: '#/components/schemas/RiskTierEnvelope'
+        flags:
+          $ref: '#/components/schemas/FlagsEnvelope'
+      required:
+        - crn
+        - roshRisks
+        - tier
+        - flags
+    RoshRisksEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/RoshRisks'
+      required:
+        - status
+    RoshRisks:
+      type: object
+      properties:
+        overallRisk:
+          type: string
+        riskToChildren:
+          type: string
+        riskToPublic:
+          type: string
+        riskToKnownAdult:
+          type: string
+        riskToStaff:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - overallRisk
+        - riskToChildren
+        - riskToPublic
+        - riskToKnownAdult
+        - riskToStaff
+    MappaEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/Mappa'
+      required:
+        - status
+    Mappa:
+      type: object
+      properties:
+        level:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - level
+        - lastUpdated
+    RiskTierEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/RiskTier'
+      required:
+        - status
+    RiskTier:
+      type: object
+      properties:
+        level:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - level
+        - lastUpdated
+    FlagsEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          type: array
+          items:
+            type: string
+      required:
+        - status
+    RiskEnvelopeStatus:
+      type: string
+      enum:
+        - retrieved
+        - not_found
+        - error
+    PersonAcctAlert:
+      type: object
+      properties:
+        alertId:
+          type: integer
+          format: int64
+        comment:
+          type: string
+        dateCreated:
+          type: string
+          format: date
+        dateExpires:
+          type: string
+          format: date
+        expired:
+          type: boolean
+        active:
+          type: boolean
+      required:
+        - alertId
+        - dateCreated
+        - expired
+        - active
+    Application:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+      discriminator:
+        propertyName: type
+        mapping:
+          Offline: '#/components/schemas/OfflineApplication'
+          CAS1: '#/components/schemas/ApprovedPremisesApplication'
+          CAS2: '#/components/schemas/Cas2Application'
+          CAS3: '#/components/schemas/TemporaryAccommodationApplication'
+      required:
+        - type
+        - id
+        - person
+        - createdAt
+    OfflineApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+    ApprovedPremisesApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties:
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              type: boolean
+            isEmergencyApplication:
+              type: boolean
+            isEsapApplication:
+              type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
+            arrivalDate:
+              type: string
+              format: date-time
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/AnyValue'
+            document:
+              $ref: '#/components/schemas/AnyValue'
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+            assessmentId:
+              type: string
+              format: uuid
+            assessmentDecision:
+              $ref: '#/components/schemas/AssessmentDecision'
+            assessmentDecisionDate:
+              type: string
+              format: date
+            submittedAt:
+              type: string
+              format: date-time
+            personStatusOnSubmission:
+              $ref: '#/components/schemas/PersonStatus'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
+            applicantUserDetails:
+              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            caseManagerIsNotApplicant:
+              description: "If true, caseManagerUserDetails will provide case manager details. Otherwise, applicantUserDetails can be used for case manager details"
+              type: boolean
+            caseManagerUserDetails:
+              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+          required:
+            - createdByUserId
+            - schemaVersion
+            - outdatedSchema
+            - status
+    Cas2Application:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties:
+            createdBy:
+              $ref: '#/components/schemas/NomisUser'
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/AnyValue'
+            document:
+              $ref: '#/components/schemas/AnyValue'
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+            submittedAt:
+              type: string
+              format: date-time
+            telephoneNumber:
+              type: string
+            assessment:
+              $ref: '#/components/schemas/Cas2Assessment'
+            timelineEvents:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas2TimelineEvent'
+          required:
+            - createdBy
+            - schemaVersion
+            - outdatedSchema
+            - status
+    Cas2SubmittedApplication:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        submittedBy:
+          $ref: '#/components/schemas/NomisUser'
+        schemaVersion:
+          type: string
+          format: uuid
+        outdatedSchema:
+          type: boolean
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        submittedAt:
+          type: string
+          format: date-time
+        telephoneNumber:
+          type: string
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2TimelineEvent'
+        assessment:
+          type: object
+          $ref: '#/components/schemas/Cas2Assessment'
+      required:
+        - id
+        - person
+        - createdAt
+        - createdBy
+        - schemaVersion
+        - outdatedSchema
+        - status
+        - timelineEvents
+        - assessment
+    TemporaryAccommodationApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties:
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/AnyValue'
+            document:
+              $ref: '#/components/schemas/AnyValue'
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            submittedAt:
+              type: string
+              format: date-time
+            arrivalDate:
+              type: string
+              format: date-time
+            offenceId:
+              type: string
+          required:
+            - createdByUserId
+            - schemaVersion
+            - outdatedSchema
+            - status
+            - offenceId
+    ApplicationSummary:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+      discriminator:
+        propertyName: type
+        mapping:
+          Offline: '#/components/schemas/OfflineApplicationSummary'
+          CAS1: '#/components/schemas/ApprovedPremisesApplicationSummary'
+          CAS2: '#/components/schemas/Cas2ApplicationSummary'
+          CAS3: '#/components/schemas/TemporaryAccommodationApplicationSummary'
+      required:
+        - type
+        - id
+        - person
+        - createdAt
+    OfflineApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+    ApprovedPremisesApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties:
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              type: boolean
+            isEmergencyApplication:
+              type: boolean
+            isEsapApplication:
+              type: boolean
+            arrivalDate:
+              type: string
+              format: date-time
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            createdByUserId:
+              type: string
+              format: uuid
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+            tier:
+              type: string
+            isWithdrawn:
+              type: boolean
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            hasRequestsForPlacement:
+              type: boolean
+          required:
+            - createdByUserId
+            - status
+            - isWithdrawn
+            - hasRequestsForPlacement
+    TemporaryAccommodationApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties:
+            createdByUserId:
+              type: string
+              format: uuid
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+          required:
+            - createdByUserId
+            - status
+    Cas2ApplicationSummary:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        createdByUserName:
+          type: string
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        latestStatusUpdate:
+          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        hdcEligibilityDate:
+          type: string
+          format: date
+        personName:
+          type: string
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+      required:
+        - type
+        - id
+        - createdAt
+        - createdByUserId
+        - status
+        - personName
+        - crn
+        - nomsNumber
+    NewCas2ApplicationNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
+    Cas2ApplicationNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          example: 'roger@example.com'
+        name:
+          type: string
+          example: 'Roger Smith'
+        body:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - username
+        - email
+        - name
+        - body
+        - createdAt
+      description: Notes added to an application
+    Cas2ApplicationStatus:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        statusDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2ApplicationStatusDetail'
+      required:
+        - id
+        - name
+        - label
+        - description
+        - statusDetails
+    Cas2ApplicationStatusDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'changeOfCircumstances'
+        label:
+          type: string
+          example: 'Change of Circumstances'
+      required:
+        - id
+        - name
+        - label
+    Cas2AssessmentStatusUpdate:
+      type: object
+      properties:
+        newStatus:
+          type: string
+          example: 'moreInfoRequired'
+          description: 'The "name" of the new status to be applied'
+        newStatusDetails:
+          type: array
+          items:
+            type: string
+            example: 'changeOfCircumstances'
+            description: 'The "name" of the new detail belonging to the new status'
+      required:
+        - newStatus
+    Cas2SubmittedApplicationSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        crn:
+          type: string
+        nomsNumber:
+          type: string
+        personName:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - status
+        - id
+        - person
+        - createdAt
+        - personName
+        - crn
+        - nomsNumber
+    Cas2StatusUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        updatedBy:
+          $ref: '#/components/schemas/ExternalUser'
+        updatedAt:
+          type: string
+          format: date-time
+        statusUpdateDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdateDetail'
+      required:
+        - id
+        - name
+        - label
+        - description
+    Cas2StatusUpdateDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - id
+        - name
+        - label
+    LatestCas2StatusUpdate:
+      type: object
+      properties:
+        statusId:
+          type: string
+          format: uuid
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - statusId
+        - label
+    ApplicationStatus:
+      type: string
+      enum:
+        - inProgress
+        - submitted
+        - requestedFurtherInformation
+        - pending
+        - rejected
+        - awaitingPlacement
+        - placed
+        - inapplicable
+        - withdrawn
+    ApprovedPremisesApplicationStatus:
+      type: string
+      enum:
+        - started
+        - submitted
+        - rejected
+        - awaitingAssesment
+        - unallocatedAssesment
+        - assesmentInProgress
+        - awaitingPlacement
+        - placementAllocated
+        - inapplicable
+        - withdrawn
+        - requestedFurtherInformation
+        - pendingPlacementRequest
+    AnyValue:
+      description: Any object that conforms to the current JSON schema for an application
+    ApplicationTimelineNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
+        note:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - note
+      description: Notes added to an application
+    NewApplicationTimelineNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
+    NewApplication:
+      type: object
+      properties:
+        crn:
+          type: string
+        convictionId:
+          type: integer
+          format: int64
+          example: 1502724704
+        deliusEventNumber:
+          type: string
+          example: "7"
+        offenceId:
+          type: string
+          example: "M1502750438"
+      required:
+        - crn
+    UpdateApplicationType:
+      type: string
+      enum:
+        - CAS1
+        - CAS2
+        - CAS3
+      x-enum-varnames:
+        - CAS1
+        - CAS2
+        - CAS3
+    UpdateApplication:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/UpdateApplicationType'
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/AnyValue'
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/UpdateApprovedPremisesApplication'
+          CAS2: '#/components/schemas/UpdateCas2Application'
+          CAS3: '#/components/schemas/UpdateTemporaryAccommodationApplication'
+      required:
+        - type
+        - data
+    UpdateCas2Application:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
+    UpdateApprovedPremisesApplication:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
+        - type: object
+          properties:
+            isInapplicable:
+              type: boolean
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              type: boolean
+            isEmergencyApplication:
+              type: boolean
+            isEsapApplication:
+              type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
+            targetLocation:
+              type: string
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            arrivalDate:
+              type: string
+              format: date
+            noticeType:
+              $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
+    UpdateTemporaryAccommodationApplication:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
+    SubmitApplication:
+      type: object
+      properties:
+        type:
+          type: string
+        translatedDocument:
+          $ref: '#/components/schemas/AnyValue'
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/SubmitApprovedPremisesApplication'
+          CAS3: '#/components/schemas/SubmitTemporaryAccommodationApplication'
+          CAS2: '#/components/schemas/SubmitCas2Application'
+      required:
+        - type
+        - translatedDocument
+    SubmitApprovedPremisesApplication:
+      allOf:
+        - $ref: '#/components/schemas/SubmitApplication'
+        - type: object
+          properties:
+            isPipeApplication:
+              type: boolean
+            isWomensApplication:
+              type: boolean
+            isEmergencyApplication:
+              type: boolean
+            isEsapApplication:
+              type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
+            targetLocation:
+              type: string
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            sentenceType:
+              $ref: '#/components/schemas/SentenceTypeOption'
+            situation:
+              $ref: '#/components/schemas/SituationOption'
+            arrivalDate:
+              type: string
+              format: date
+            apAreaId:
+              type: string
+              format: uuid
+            applicantUserDetails:
+              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            caseManagerIsNotApplicant:
+              type: boolean
+            caseManagerUserDetails:
+              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            noticeType:
+              $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
+            reasonForShortNotice:
+              type: string
+            reasonForShortNoticeOther:
+              type: string
+          required:
+            - targetLocation
+            - releaseType
+            - sentenceType
+    SubmitCas2Application:
+      type: object
+      properties:
+        translatedDocument:
+          $ref: '#/components/schemas/AnyValue'
+        applicationId:
+          type: string
+          format: uuid
+          description: Id of the application being submitted
+        preferredAreas:
+          type: string
+          description: First and second preferences for where the accommodation should be located, pipe-separated
+          example: 'Leeds | Bradford'
+        hdcEligibilityDate:
+          type: string
+          example: '2023-03-30'
+          format: date
+        conditionalReleaseDate:
+          type: string
+          example: '2023-04-30'
+          format: date
+        telephoneNumber:
+          type: string
+      required:
+        - translatedDocument
+        - applicationId
+        - telephoneNumber
+    SubmitTemporaryAccommodationApplication:
+      allOf:
+        - $ref: '#/components/schemas/SubmitApplication'
+        - type: object
+          properties:
+            arrivalDate:
+              type: string
+              format: date
+            isRegisteredSexOffender:
+              type: boolean
+            needsAccessibleProperty:
+              type: boolean
+            hasHistoryOfArson:
+              type: boolean
+            isDutyToReferSubmitted:
+              type: boolean
+            dutyToReferSubmissionDate:
+              type: string
+              format: date
+            dutyToReferOutcome:
+              type: string
+              example: 'Pending'
+            isApplicationEligible:
+              type: boolean
+            eligibilityReason:
+              type: string
+            dutyToReferLocalAuthorityAreaName:
+              type: string
+            personReleaseDate:
+              type: string
+              format: date
+              example: '2024-02-21'
+            pdu:
+              type: string
+            isHistoryOfSexualOffence:
+              type: boolean
+            isConcerningSexualBehaviour:
+              type: boolean
+            isConcerningArsonBehaviour:
+              type: boolean
+            prisonReleaseTypes:
+              type: array
+              items:
+                type: string
+                example: 'PSS'
+            summaryData:
+              $ref: '#/components/schemas/AnyValue'
+          required:
+            - arrivalDate
+            - summaryData
+    ReleaseTypeOption:
+      type: string
+      enum:
+        - licence
+        - rotl
+        - hdc
+        - pss
+        - in_community
+        - not_applicable
+        - extendedDeterminateLicence
+        - paroleDirectedLicence
+    SentenceTypeOption:
+      type: string
+      enum:
+        - standardDeterminate
+        - life
+        - ipp
+        - extendedDeterminate
+        - communityOrder
+        - bailPlacement
+        - nonStatutory
+    SituationOption:
+      type: string
+      enum:
+        - riskManagement
+        - residencyManagement
+        - bailAssessment
+        - bailSentence
+        - awaitingSentence
+    Cas1ApplicationTimelinessCategory:
+      type: string
+      enum:
+        - standard
+        - emergency
+        - shortNotice
+    PrisonCaseNote:
+      type: object
+      properties:
+        id:
+          type: string
+        sensitive:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        occurredAt:
+          type: string
+          format: date-time
+        authorName:
+          type: string
+        type:
+          type: string
+        subType:
+          type: string
+        note:
+          type: string
+      required:
+        - id
+        - sensitive
+        - createdAt
+        - occurredAt
+        - authorName
+        - type
+        - subType
+        - note
+    Adjudication:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        reportedAt:
+          type: string
+          format: date-time
+        establishment:
+          type: string
+        offenceDescription:
+          type: string
+          example: "Wounding or inflicting grievous bodily harm (inflicting bodily injury with or without weapon) (S20) - 00801"
+        hearingHeld:
+          type: boolean
+        finding:
+          type: string
+      required:
+        - id
+        - reportedAt
+        - establishment
+        - offenceDescription
+        - hearingHeld
+    Assessment:
+      type: object
+      properties:
+        service:
+          type: string
+        id:
+          type: string
+          format: uuid
+        schemaVersion:
+          type: string
+          format: uuid
+        outdatedSchema:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        allocatedAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        decision:
+          $ref: '#/components/schemas/AssessmentDecision'
+        rejectionRationale:
+          type: string
+        data:
+          $ref: '#/components/schemas/AnyValue'
+        clarificationNotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClarificationNote'
+        referralHistoryNotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferralHistoryNote'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesAssessment'
+          CAS3: '#/components/schemas/TemporaryAccommodationAssessment'
+      required:
+        - service
+        - id
+        - allocatedToUser
+        - schemaVersion
+        - outdatedSchema
+        - createdAt
+        - clarificationNotes
+    AssessmentStatus:
+      type: string
+      enum:
+        - awaiting_response
+        - completed
+        - reallocated
+        - in_progress
+        - not_started
+        - unallocated
+        - in_review
+        - ready_to_place
+        - closed
+        - rejected
+      x-enum-varnames:
+        - cas1AwaitingResponse
+        - cas1Completed
+        - cas1Reallocated
+        - cas1InProgress
+        - cas1NotStarted
+        - cas3Unallocated
+        - cas3InReview
+        - cas3ReadyToPlace
+        - cas3Closed
+        - cas3Rejected
+    ApprovedPremisesAssessmentStatus:
+      type: string
+      enum:
+        - awaiting_response
+        - completed
+        - reallocated
+        - in_progress
+        - not_started
+    TemporaryAccommodationAssessmentStatus:
+      type: string
+      enum:
+        - unallocated
+        - in_review
+        - ready_to_place
+        - closed
+        - rejected
+    ApprovedPremisesAssessment:
+      allOf:
+        - $ref: '#/components/schemas/Assessment'
+        - type: object
+          properties:
+            application:
+              $ref: '#/components/schemas/ApprovedPremisesApplication'
+            allocatedToStaffMember:
+              $ref: '#/components/schemas/ApprovedPremisesUser'
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            createdFromAppeal:
+              type: boolean
+          required:
+            - application
+            - createdFromAppeal
+    TemporaryAccommodationAssessment:
+      allOf:
+        - $ref: '#/components/schemas/Assessment'
+        - type: object
+          properties:
+            application:
+              $ref: '#/components/schemas/TemporaryAccommodationApplication'
+            allocatedToStaffMember:
+              $ref: '#/components/schemas/TemporaryAccommodationUser'
+            status:
+              $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            summaryData:
+              $ref: '#/components/schemas/AnyValue'
+          required:
+            - application
+            - summaryData
+    Cas2Assessment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
+        statusUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2StatusUpdate'
+      required:
+        - id
+    UpdateCas2Assessment:
+      type: object
+      properties:
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
+    AssessmentSummary:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        applicationId:
+          type: string
+          format: uuid
+        arrivalDate:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        dateOfInfoRequest:
+          type: string
+          format: date-time
+        decision:
+          $ref: '#/components/schemas/AssessmentDecision'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        person:
+          $ref: '#/components/schemas/Person'
+      required:
+        - type
+        - id
+        - applicationId
+        - createdAt
+        - person
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesAssessmentSummary'
+          CAS3: '#/components/schemas/TemporaryAccommodationAssessmentSummary'
+    ApprovedPremisesAssessmentSummary:
+      allOf:
+        - $ref: '#/components/schemas/AssessmentSummary'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            dueAt:
+              type: string
+              format: date-time
+          required:
+            - status
+            - dueAt
+    TemporaryAccommodationAssessmentSummary:
+      allOf:
+        - $ref: '#/components/schemas/AssessmentSummary'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+          required:
+            - status
+    AssessmentSortField:
+      type: string
+      enum:
+        - name
+        - crn
+        - arrivalDate
+        - status
+        - createdAt
+        - dueAt
+      x-enum-varnames:
+        - personName
+        - personCrn
+        - assessmentArrivalDate
+        - assessmentStatus
+        - assessmentCreatedAt
+        - assessmentDueAt
+    AssessmentDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected
+    UpdatePremises:
+      type: object
+      properties:
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+        notes:
+          type: string
+        localAuthorityAreaId:
+          type: string
+          format: uuid
+        probationRegionId:
+          type: string
+          format: uuid
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+        pdu:
+          type: string
+        probationDeliveryUnitId:
+          type: string
+          format: uuid
+        turnaroundWorkingDayCount:
+          type: integer
+        name:
+          type: string
+      required:
+        - addressLine1
+        - postcode
+        - probationRegionId
+        - characteristicIds
+        - status
+    UpdateAssessment:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/AnyValue'
+      required:
+        - data
+    AssessmentAcceptance:
+      type: object
+      properties:
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        requirements:
+          $ref: '#/components/schemas/PlacementRequirements'
+        placementDates:
+          $ref: '#/components/schemas/PlacementDates'
+        notes:
+          type: string
+      required:
+        - document
+    AssessmentRejection:
+      type: object
+      properties:
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        rejectionRationale:
+          type: string
+        referralRejectionReasonId:
+          type: string
+          format: uuid
+        referralRejectionReasonDetail:
+          type: string
+        isWithdrawn:
+          type: boolean
+      required:
+        - document
+        - rejectionRationale
+    ClarificationNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        responseReceivedOn:
+          type: string
+          format: date
+        createdByStaffMemberId:
+          type: string
+          format: uuid
+        query:
+          type: string
+        response:
+          type: string
+      required:
+        - id
+        - createdAt
+        - createdByStaffMemberId
+        - query
+    UpdatedClarificationNote:
+      type: object
+      properties:
+        response:
+          type: string
+        responseReceivedOn:
+          type: string
+          format: date
+          example: 2022-07-28
+      required:
+        - response
+        - responseReceivedOn
+    NewClarificationNote:
+      type: object
+      properties:
+        query:
+          type: string
+      required:
+        - query
+    ReferralHistoryNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        message:
+          type: string
+        createdByUserName:
+          type: string
+        type:
+          type: string
+      required:
+        - id
+        - createdAt
+        - message
+        - createdByUserName
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          user: '#/components/schemas/ReferralHistoryUserNote'
+          system: '#/components/schemas/ReferralHistorySystemNote'
+    ReferralHistoryUserNote:
+      allOf:
+        - $ref: '#/components/schemas/ReferralHistoryNote'
+    ReferralHistorySystemNote:
+      allOf:
+        - $ref: '#/components/schemas/ReferralHistoryNote'
+        - type: object
+          properties:
+            category:
+              type: string
+              enum:
+                - submitted
+                - unallocated
+                - in_review
+                - ready_to_place
+                - rejected
+                - completed
+          required:
+            - category
+    NewReferralHistoryUserNote:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
+    NewReallocation:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+    Reallocation:
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/ApprovedPremisesUser'
+        taskType:
+          $ref: '#/components/schemas/TaskType'
+      required:
+        - user
+        - taskType
+    ExternalUser:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+          example: 'CAS2_ASSESSOR_USER'
+        name:
+          type: string
+          example: 'Roger Smith'
+        email:
+          type: string
+          example: 'roger@external.example.com'
+        origin:
+          type: string
+          example: 'NACRO'
+      required:
+        - id
+        - username
+        - name
+        - email
+    NomisUser:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        nomisUsername:
+          type: string
+          example: 'SMITHR_GEN'
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - nomisUsername
+        - isActive
+    User:
+      type: object
+      properties:
+        service:
+          type: string
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        deliusUsername:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
+        isActive:
+          type: boolean
+        region:
+          $ref: '#/components/schemas/ProbationRegion'
+        probationDeliveryUnit:
+          $ref: '#/components/schemas/ProbationDeliveryUnit'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesUser'
+          CAS3: '#/components/schemas/TemporaryAccommodationUser'
+      required:
+        - service
+        - id
+        - name
+        - deliusUsername
+        - region
+    UserWithWorkload:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            numTasksPending:
+              type: integer
+            numTasksCompleted7Days:
+              type: integer
+            numTasksCompleted30Days:
+              type: integer
+            qualifications:
+              type: array
+              items:
+                $ref: '#/components/schemas/UserQualification'
+            roles:
+              type: array
+              items:
+                $ref: '#/components/schemas/ApprovedPremisesUserRole'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
+    ApprovedPremisesUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            qualifications:
+              type: array
+              items:
+                $ref: '#/components/schemas/UserQualification'
+            roles:
+              type: array
+              items:
+                $ref: '#/components/schemas/ApprovedPremisesUserRole'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
+          required:
+            - qualifications
+            - roles
+            - apArea
+    UserRolesAndQualifications:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovedPremisesUserRole'
+        qualifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserQualification'
+      required:
+        - roles
+        - qualifications
+    TemporaryAccommodationUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            roles:
+              type: array
+              items:
+                $ref: '#/components/schemas/TemporaryAccommodationUserRole'
+          required:
+            - roles
+    ApprovedPremisesUserRole:
+      type: string
+      enum:
+        - assessor
+        - matcher
+        - manager
+        - workflow_manager
+        - applicant
+        - role_admin
+        - report_viewer
+        - excluded_from_assess_allocation
+        - excluded_from_match_allocation
+        - excluded_from_placement_application_allocation
+        - appeals_manager
+    TemporaryAccommodationUserRole:
+      type: string
+      enum:
+        - assessor
+        - referrer
+        - reporter
+    UserQualification:
+      type: string
+      enum:
+        - womens
+        - pipe
+        - lao
+        - emergency
+        - esap
+        - recovery_focused
+        - mental_health_specialist
+    ServiceName:
+      type: string
+      enum:
+        - approved-premises
+        - cas2
+        - temporary-accommodation
+      x-enum-varnames:
+        - approvedPremises
+        - cas2
+        - temporaryAccommodation
+    NewRoom:
+      type: object
+      properties:
+        name:
+          type: string
+        notes:
+          type: string
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified.
+      required:
+        - name
+        - characteristicIds
+    UpdateRoom:
+      type: object
+      properties:
+        notes:
+          type: string
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        name:
+          type: string
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified
+      required:
+        - characteristicIds
+    Room:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        code:
+          type: string
+          example: NEABC-4
+        notes:
+          type: string
+        beds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bed'
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Characteristic'
+      required:
+        - id
+        - name
+        - characteristics
+    Bed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        code:
+          type: string
+          example: NEABC04
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified
+      required:
+        - id
+        - name
+    BedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        roomName:
+          type: string
+        status:
+          $ref: '#/components/schemas/BedStatus'
+      required:
+        - id
+        - name
+        - roomName
+        - status
+    BedDetail:
+      allOf:
+        - $ref: '#/components/schemas/BedSummary'
+        - type: object
+          properties:
+            characteristics:
+              type: array
+              items:
+                type: object
+                $ref: '#/components/schemas/CharacteristicPair'
+          required:
+            - characteristics
+    BedStatus:
+      type: string
+      enum:
+        - occupied
+        - available
+        - out_of_service
+    PropertyStatus:
+      type: string
+      enum:
+        - pending
+        - active
+        - archived
+    OASysAssessmentId:
+      description: The ID of assessment being used. This should always be the latest Layer 3 assessment, regardless of state.
+      type: integer
+      format: int64
+      example: 138985987
+    OASysSupportingInformationQuestion:
+      type: object
+      properties:
+        label:
+          type: string
+        sectionNumber:
+          type: integer
+        questionNumber:
+          type: string
+        linkedToHarm:
+          type: boolean
+        linkedToReOffending:
+          type: boolean
+        answer:
+          type: string
+      required:
+        - label
+        - questionNumber
+    OASysQuestion:
+      type: object
+      properties:
+        label:
+          type: string
+        questionNumber:
+          type: string
+        answer:
+          type: string
+      required:
+        - label
+        - questionNumber
+    ArrayOfOASysOffenceDetailsQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysQuestion'
+        example:
+          - label: "Offence analysis"
+            questionNumber: "2.1"
+            answer: "Mr Smith admits he went to Mr Jones's address on 23rd March 2010..."
+          - label: "Victim - perpetrator relationship"
+            questionNumber: "2.4.1"
+            answer: "Mr Smith told me that he did not know the victim, prior to the incident..."
+    ArrayOfOASysRiskContributorsQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysQuestion'
+        example:
+          - label: "Accommodation issues contributing to risks of offending and harm"
+            questionNumber: "3.9"
+            answer: "Mr Smith told me that he was renting a room in a shared house, prior to his current remand..."
+          - label: "Education, training and employability issues contributing to risks of offending and harm"
+            questionNumber: "4.9"
+            answer: "Mr Smith told me that his formal school education was regularly interrupted as he and his family travelled a lot whilst he was growing up..."
+    ArrayOfOASysRiskManagementQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysQuestion'
+        example:
+          - label: "Current situation"
+            questionNumber: "RM28.1"
+            answer: "Currently on remand at HMP Wandsworth - Management of case under MAPPA - level not yet set."
+          - label: "Supervision"
+            questionNumber: "RM30"
+            answer: "Probation Officer, Education training and employment Officer, Prison Offender Supervisor"
+          - label: "Monitoring and control"
+            questionNumber: "RM31"
+            answer: "State they will have secure accommodation for Mr Smith and partner on release, although ..."
+    ArrayOfOASysRiskOfSeriousHarmSummaryQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysQuestion'
+        example:
+          - label: "Who is at risk?"
+            questionNumber: "R10.1"
+            answer: "Males whom Mr Smith believes have wronged him, or strangers with whom he gets...."
+          - label: "What is the nature of the risk?"
+            questionNumber: "R10.2"
+            answer: "Violence, Threats, Physical harm"
+          - label: "When is the risk likely to be greatest?"
+            questionNumber: "R10.3"
+            answer: "Not imminent ? lengthy gap between convictions for violent offences..."
+          - label: "What circumstances are likely to increase the risk?"
+            questionNumber: "R10.4"
+            answer: "As above ? drug use, need to obtain money for drugs at all costs..."
+          - label: "What factors are likely to reduce the risk?"
+            questionNumber: "R10.5"
+            answer: "Mr Smith thinking about consequences of his actions and not acting impulsively..."
+    ArrayOfOASysRisksToTheIndividualQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysQuestion'
+        example:
+          - label: "Current concerns about self-harm or suicide"
+            questionNumber: "R8.1.1"
+            answers: "There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody..."
+          - label: "Previous concerns about self-harm or suicide"
+            questionNumber: "R8.1.4"
+            answer: "During Mr Smith's psr report, he denied having any history of self-harm, however... "
+          - label: "Current concerns about Coping in Custody or Hostel."
+            questionNumber: "R8.2.1"
+            answer: "Has told prison staff that he swallowed batteries on one occasion due to wanting..."
+          - label: "Previous concerns about Coping in Custody or Hostel."
+            questionNumber: "R8.2.2"
+            answer: "Reported in 2021 that he will keep himself to himself because he gets discomfiture..."
+    ArrayOfOASysRisksToOthersQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysQuestion'
+        example:
+          - label: "Current offence details"
+            questionNumber: "R6.1 FA1"
+            answer: "Mr Smith was released on licence from custody on 12/7/2018.  Between then and 1/8/2018 Mr Smith approached..."
+          - label: "Current where and when"
+            questionNumber: "R6.1 FA2"
+            answer: "Between 12/7/2018 - 31/7/2018, initially victim in the street putting bins out... "
+          - label: "Previous offence details"
+            questionNumber: "R6.2 FA8"
+            answer: "Mr Smith is assessed to have committed a number of offences that are considered to have crossed the Threshold of serious harm..."
+          - label: "Previous where and when"
+            questionNumber: "R6.2 FA9"
+            answer: "Bolton and Bury Districts."
+    ArrayOfOASysSupportingInformationQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysSupportingInformationQuestion'
+        example:
+          - label: "Accommodation issues contributing to risks of offending and harm?"
+            questionNumber: "3.9"
+            sectionNumber: 3
+            linkedToHarm: false
+            linkedToReOffending: true
+            answer: "Mr Smith told me that he was renting a room in a shared house, prior to his current remand. He said that this accomodation..."
+          - label: "Education, training and employability issues contributing to risks of offending and harm"
+            questionNumber: "4.9"
+            sectionNumber: 4
+            linkedToHarm: false
+            linkedToReOffending: true
+            answer: "He said that he has since learnt to read and write during periods of custody and..."
+    ArrayOfOASysRiskToSelfQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysQuestion'
+        example:
+          - label: "Current concerns about self-harm or suicide"
+            questionNumber: "R8.1.1"
+            answer: "There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody....."
+          - label: "Current concerns about Coping in Custody or Hostel."
+            questionNumber: "R8.2.1"
+            answer: "Has told prison staff that he swallowed batteries on one occasion due to wanting..."
+    ArrayOfOASysRiskManagementPlanQuestions:
+      type: array
+      items:
+        type: object
+        $ref: '#/components/schemas/OASysQuestion'
+        example:
+          - label: "Key information about current situation"
+            questionNumber: "RM28.1"
+            answer: "Currently on remand - Management of case under MAPPA - level not yet set......"
+          - label: "Further considerations about current situation"
+            questionNumber: "RM28"
+            answer: "Mr Manette is currently on remand awaiting sentence"
+    OASysSections:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/OASysAssessmentId'
+        assessmentState:
+          $ref: '#/components/schemas/OASysAssessmentState'
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+        offenceDetails:
+          $ref: '#/components/schemas/ArrayOfOASysOffenceDetailsQuestions'
+        roshSummary:
+          $ref: '#/components/schemas/ArrayOfOASysRiskOfSeriousHarmSummaryQuestions'
+        supportingInformation:
+          $ref: '#/components/schemas/ArrayOfOASysSupportingInformationQuestions'
+        riskToSelf:
+          $ref: '#/components/schemas/ArrayOfOASysRiskToSelfQuestions'
+        riskManagementPlan:
+          $ref: '#/components/schemas/ArrayOfOASysRiskManagementPlanQuestions'
+      required:
+        - assessmentId
+        - assessmentState
+        - dateStarted
+        - offenceDetails
+        - roshSummary
+        - supportingInformation
+        - riskToSelf
+        - riskManagementPlan
+    OASysRiskToSelf:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/OASysAssessmentId'
+        assessmentState:
+          $ref: '#/components/schemas/OASysAssessmentState'
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+        riskToSelf:
+          $ref: '#/components/schemas/ArrayOfOASysRiskToSelfQuestions'
+      required:
+        - assessmentId
+        - assessmentState
+        - dateStarted
+        - riskToSelf
+    OASysRiskOfSeriousHarm:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/OASysAssessmentId'
+        assessmentState:
+          $ref: '#/components/schemas/OASysAssessmentState'
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+        rosh:
+          $ref: '#/components/schemas/ArrayOfOASysRiskOfSeriousHarmSummaryQuestions'
+      required:
+        - assessmentId
+        - assessmentState
+        - dateStarted
+        - rosh
+    OASysSection:
+      type: object
+      properties:
+        section:
+          type: integer
+          example: 10
+        name:
+          type: string
+          example: Emotional wellbeing
+        linkedToHarm:
+          type: boolean
+        linkedToReOffending:
+          type: boolean
+      required:
+        - section
+        - name
+    OASysAssessmentState:
+      type: string
+      enum:
+        - Completed
+        - Incomplete
+    ActiveOffence:
+      type: object
+      properties:
+        deliusEventNumber:
+          type: string
+          example: "7"
+        offenceDescription:
+          type: string
+        offenceId:
+          type: string
+          example: "M1502750438"
+        convictionId:
+          type: integer
+          format: int64
+          example: 1502724704
+        offenceDate:
+          type: string
+          format: date
+      required:
+        - deliusEventNumber
+        - offenceDescription
+        - offenceId
+        - convictionId
+    DocumentLevel:
+      type: string
+      description: The level at which a Document is associated - i.e. to the Offender or to a specific Conviction
+      enum:
+        - Offender
+        - Conviction
+    Document:
+      type: object
+      description: Meta Info about a file relating to an Offender
+      properties:
+        id:
+          type: string
+        level:
+          $ref: '#/components/schemas/DocumentLevel'
+        fileName:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        typeCode:
+          type: string
+        typeDescription:
+          type: string
+        description:
+          type: string
+      required:
+        - id
+        - level
+        - fileName
+        - createdAt
+        - typeCode
+        - typeDescription
+    PersonalTimeline:
+      type: object
+      properties:
+        person:
+          $ref: '#/components/schemas/Person'
+        applications:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationTimeline'
+      required:
+        - person
+        - applications
+    ApplicationTimeline:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        isOfflineApplication:
+          type: boolean
+        status:
+          $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+        createdBy:
+          $ref: '#/components/schemas/User'
+        timelineEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEvent'
+      required:
+        - id
+        - createdAt
+        - isOfflineApplication
+        - timelineEvents
+    TimelineEvent:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventType'
+        id:
+          type: string
+        occurredAt:
+          type: string
+          format: date-time
+        content:
+          type: string
+        createdBy:
+          $ref: '#/components/schemas/User'
+        associatedUrls:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimelineEventAssociatedUrl'
+        triggerSource:
+          type: string
+          $ref: '#/components/schemas/TriggerSourceType'
+    TimelineEventAssociatedUrl:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventUrlType'
+        url:
+          type: string
+      required:
+        - type
+        - url
+    TimelineEventType:
+      type: string
+      enum:
+        - approved_premises_application_submitted
+        - approved_premises_application_assessed
+        - approved_premises_booking_made
+        - approved_premises_person_arrived
+        - approved_premises_person_not_arrived
+        - approved_premises_person_departed
+        - approved_premises_booking_not_made
+        - approved_premises_booking_cancelled
+        - approved_premises_booking_changed
+        - approved_premises_application_withdrawn
+        - approved_premises_information_request
+        - approved_premises_assessment_appealed
+        - approved_premises_assessment_allocated
+        - approved_premises_placement_application_withdrawn
+        - approved_premises_placement_application_allocated
+        - approved_premises_match_request_withdrawn
+        - approved_premises_request_for_placement_created
+        - cas3_person_arrived
+        - cas3_person_departed
+        - application_timeline_note
+        - cas2_application_submitted
+        - cas2_note
+        - cas2_status_update
+    TriggerSourceType:
+      type: string
+      enum:
+        - user
+        - system
+    TimelineEventUrlType:
+      type: string
+      enum:
+        - application
+        - booking
+        - assessment
+        - assessmentAppeal
+    Cas2TimelineEvent:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventType'
+        occurredAt:
+          type: string
+          format: date-time
+        label:
+          type: string
+        body:
+          type: string
+        createdByName:
+          type: string
+      required:
+        - type
+        - occurredAt
+        - label
+        - createdByName
+    SeedRequest:
+      type: object
+      properties:
+        seedType:
+          $ref: '#/components/schemas/SeedFileType'
+        fileName:
+          type: string
+      required:
+        - seedType
+        - fileName
+    SeedFileType:
+      type: string
+      enum:
+        - approved_premises
+        - approved_premises_rooms
+        - temporary_accommodation_premises
+        - temporary_accommodation_bedspace
+        - user
+        - nomis_users
+        - external_users
+        - cas2_applications
+        - temporary_accommodation_users
+        - approved_premises_users
+        - characteristics
+        - approved_premises_ap_staff_users
+        - approved_premises_offline_applications
+        - approved_premises_bookings
+        - approved_premises_cancel_bookings
+        - approved_premises_ap_area_email_addresses
+        - approved_premises_booking_adhoc_property
+        - approved_premises_assessment_more_info_bug_fix
+        - approved_premises_redact_assessment_details
+        - approved_premises_withdraw_placement_request
+        - approved_premises_replay_domain_events
+        - approved_premises_duplicate_application
+    MigrationJobRequest:
+      type: object
+      properties:
+        jobType:
+          $ref: '#/components/schemas/MigrationJobType'
+      required:
+        - jobType
+    MigrationJobType:
+      type: string
+      enum:
+        - update_all_users_from_community_api
+        - update_sentence_type_and_situation
+        - update_booking_status
+        - update_application_ap_areas
+        - update_task_due_dates
+        - update_cas2_applications_with_assessments
+        - update_cas2_status_updates_with_assessments
+        - update_cas1_user_details
+        - update_cas1_fix_placement_app_links
+        - update_cas1_notice_types
+        - update_cas1_backfill_user_ap_area
+        - update_cas3_application_offender_name
+        - update_cas3_users_pdu_from_community_api
+    PlacementDates:
+      type: object
+      properties:
+        expectedArrival:
+          type: string
+          format: date
+        duration:
+          type: integer
+      required:
+        - expectedArrival
+        - duration
+    PlacementRequirements:
+      type: object
+      properties:
+        gender:
+          $ref: '#/components/schemas/Gender'
+        type:
+          $ref: '#/components/schemas/ApType'
+        location:
+          type: string
+          example: B74
+        radius:
+          type: integer
+        essentialCriteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementCriteria'
+        desirableCriteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementCriteria'
+      required:
+        - gender
+        - type
+        - location
+        - radius
+        - essentialCriteria
+        - desirableCriteria
+    PlacementApplication:
+      allOf:
+        - $ref: '#/components/schemas/NewPlacementApplication'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field provides a PlacementRequest ID.
+              format: uuid
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            createdAt:
+              type: string
+              format: date-time
+            submittedAt:
+              type: string
+              format: date-time
+            assessmentId:
+              type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field shouldn't be used.
+              format: uuid
+            assessmentCompletedAt:
+              type: string
+              format: date-time
+            applicationCompletedAt:
+              type: string
+              format: date-time
+            data:
+              $ref: '#/components/schemas/AnyValue'
+            document:
+              $ref: '#/components/schemas/AnyValue'
+            canBeWithdrawn:
+              type: boolean
+            isWithdrawn:
+              type: boolean
+            withdrawalReason:
+              $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+            type:
+              $ref: '#/components/schemas/PlacementApplicationType'
+            placementDates:
+              type: array
+              items:
+                $ref: '#/components/schemas/PlacementDates'
+          required:
+            - id
+            - createdByUserId
+            - schemaVersion
+            - outdatedScheme
+            - createdAt
+            - assessmentId
+            - assessmentCompletedAt
+            - applicationCompletedAt
+            - canBeWithdrawn
+            - isWithdrawn
+            - type
+            - placementDates
+    NewPlacementApplication:
+      type: object
+      properties:
+        applicationId:
+          type: string
+          format: uuid
+      required:
+        - applicationId
+    UpdatePlacementApplication:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/AnyValue'
+      required:
+        - data
+    SubmitPlacementApplication:
+      type: object
+      properties:
+        translatedDocument:
+          $ref: '#/components/schemas/AnyValue'
+        placementType:
+          $ref: '#/components/schemas/PlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
+      required:
+        - translatedDocument
+        - placementType
+        - placementDates
+    PlacementApplicationDecisionEnvelope:
+      type: object
+      properties:
+        decision:
+          $ref: '#/components/schemas/PlacementApplicationDecision'
+        summaryOfChanges:
+          type: string
+        decisionSummary:
+          type: string
+      required:
+        - decision
+        - summaryOfChanges
+        - decisionSummary
+    PlacementApplicationDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected
+        - withdraw
+        - withdrawn_by_pp
+    PlacementType:
+      type: string
+      enum:
+        - rotl
+        - release_following_decision
+        - additional_placement
+    WithdrawPlacementApplication:
+      type: object
+      properties:
+        reason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+      required:
+        - reason
+    RequestForPlacement:
+      type: object
+      properties:
+        id:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the `PlacementApplication` ID.
+            If `type` is `"automatic"` this field provides a `PlacementRequest` ID.
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        requestReviewedAt:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the value of `PlacementApplication.decisionMadeAt`.
+            If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
+          format: date-time
+        document:
+          $ref: '#/components/schemas/AnyValue'
+        canBeDirectlyWithdrawn:
+          description: |
+            If true, the user making this request can withdraw this request for placement. 
+            If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application.
+          type: boolean
+        isWithdrawn:
+          type: boolean
+        withdrawalReason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+        type:
+          $ref: '#/components/schemas/RequestForPlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
+        status:
+          $ref: '#/components/schemas/RequestForPlacementStatus'
+      required:
+        - id
+        - createdByUserId
+        - createdAt
+        - canBeDirectlyWithdrawn
+        - isWithdrawn
+        - type
+        - placementDates
+        - status
+    RequestForPlacementType:
+      type: string
+      enum:
+        - manual
+        - automatic
+    RequestForPlacementStatus:
+      type: string
+      enum:
+        - request_unsubmitted
+        - request_rejected
+        - request_submitted
+        - awaiting_match
+        - request_withdrawn
+        - placement_booked
+        - person_arrived
+        - person_not_arrived
+        - person_departed
+    PlacementRequest:
+      allOf:
+        - $ref: '#/components/schemas/PlacementRequirements'
+        - $ref: '#/components/schemas/PlacementDates'
+        - type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            person:
+              $ref: '#/components/schemas/Person'
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            status:
+              $ref: '#/components/schemas/PlacementRequestStatus'
+            assessmentDecision:
+              $ref: '#/components/schemas/AssessmentDecision'
+            assessmentDate:
+              type: string
+              format: date-time
+            applicationDate:
+              type: string
+              format: date-time
+            assessor:
+              $ref: '#/components/schemas/ApprovedPremisesUser'
+            isParole:
+              type: boolean
+            notes:
+              type: string
+            booking:
+              $ref: '#/components/schemas/BookingSummary'
+            requestType:
+              $ref: '#/components/schemas/PlacementRequestRequestType'
+            isWithdrawn:
+              type: boolean
+            withdrawalReason:
+              $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+          required:
+            - person
+            - risks
+            - id
+            - applicationId
+            - assessmentId
+            - releaseType
+            - status
+            - assessmentDecision
+            - assessmentDate
+            - applicationDate
+            - assessor
+            - isParole
+            - isWithdrawn
+    PlacementRequestRequestType:
+      type: string
+      enum:
+        - parole
+        - standardRelease
+    PlacementRequestDetail:
+      allOf:
+        - $ref: '#/components/schemas/PlacementRequest'
+        - type: object
+          properties:
+            cancellations:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cancellation'
+            application:
+              $ref: '#/components/schemas/Application'
+          required:
+            - cancellations
+            - application
+    PlacementRequestStatus:
+      type: string
+      enum:
+        - notMatched
+        - unableToMatch
+        - matched
+    PlacementCriteria:
+      type: string
+      enum:
+        - isPIPE
+        - isESAP
+        - isMHAPStJosephs
+        - isMHAPElliottHouse
+        - isSemiSpecialistMentalHealth
+        - isRecoveryFocussed
+        - hasBrailleSignage
+        - hasTactileFlooring
+        - hasHearingLoop
+        - isStepFreeDesignated
+        - isArsonDesignated
+        - isWheelchairDesignated
+        - isSingle
+        - isCatered
+        - isSuitedForSexOffenders
+        - isSuitableForVulnerable
+        - acceptsSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsChildSexOffenders
+        - acceptsNonSexualChildOffenders
+        - isArsonSuitable
+        - isGroundFloor
+        - hasEnSuite
+    Gender:
+      type: string
+      enum:
+        - male
+        - female
+    ApType:
+      type: string
+      enum:
+        - normal
+        - pipe
+        - esap
+        - rfap
+        - mhapStJosephs
+        - mhapElliottHouse
+    BedSearchParameters:
+      type: object
+      properties:
+        serviceName:
+          type: string
+        startDate:
+          type: string
+          format: date
+          description: The date the Bed will need to be free from
+        durationDays:
+          type: integer
+          description: The number of days the Bed will need to be free from the start_date until
+      required:
+        - serviceName
+        - startDate
+        - durationDays
+      discriminator:
+        propertyName: serviceName
+        mapping:
+          approved-premises: '#/components/schemas/ApprovedPremisesBedSearchParameters'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchParameters'
+    ApprovedPremisesBedSearchParameters:
+      allOf:
+        - $ref: '#/components/schemas/BedSearchParameters'
+        - type: object
+          properties:
+            postcodeDistrict:
+              type: string
+              description: The postcode district to search outwards from
+            maxDistanceMiles:
+              type: integer
+              description: Maximum number of miles from the postcode district to search, only required if more than 50 miles which is the default
+            requiredCharacteristics:
+              type: array
+              items:
+                $ref: '#/components/schemas/PlacementCriteria'
+          required:
+            - postcodeDistrict
+            - maxDistanceMiles
+            - requiredCharacteristics
+    TemporaryAccommodationBedSearchParameters:
+      allOf:
+        - $ref: '#/components/schemas/BedSearchParameters'
+        - type: object
+          properties:
+            probationDeliveryUnit:
+              type: string
+              description: The pdu to search within
+          required:
+            - probationDeliveryUnit
+    BedSearchResults:
+      type: object
+      properties:
+        resultsRoomCount:
+          type: integer
+          description: How many distinct Rooms the Beds in the results belong to
+        resultsPremisesCount:
+          type: integer
+          description: How many distinct Premises the Beds in the results belong to
+        resultsBedCount:
+          type: integer
+          description: How many Beds are in the results
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BedSearchResult'
+      required:
+        - resultsRoomCount
+        - resultsPremisesCount
+        - resultsBedCount
+        - results
+    BedSearchResult:
+      type: object
+      properties:
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
+        premises:
+          $ref: '#/components/schemas/BedSearchResultPremisesSummary'
+        room:
+          $ref: '#/components/schemas/BedSearchResultRoomSummary'
+        bed:
+          $ref: '#/components/schemas/BedSearchResultBedSummary'
+      required:
+        - serviceName
+        - premises
+        - room
+        - bed
+      discriminator:
+        propertyName: serviceName
+        mapping:
+          approved-premises: '#/components/schemas/ApprovedPremisesBedSearchResult'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchResult'
+    ApprovedPremisesBedSearchResult:
+      allOf:
+        - $ref: '#/components/schemas/BedSearchResult'
+        - type: object
+          properties:
+            distanceMiles:
+              type: number
+              description: how many miles away from the postcode district the Premises this Bed belongs to is
+          required:
+            - distanceMiles
+    TemporaryAccommodationBedSearchResult:
+      allOf:
+        - $ref: '#/components/schemas/BedSearchResult'
+        - type: object
+          properties:
+            overlaps:
+              type: array
+              items:
+                $ref: '#/components/schemas/TemporaryAccommodationBedSearchResultOverlap'
+          required:
+            - overlaps
+    TemporaryAccommodationBedSearchResultOverlap:
+      type: object
+      properties:
+        crn:
+          type: string
+        days:
+          type: integer
+        bookingId:
+          type: string
+          format: uuid
+        roomId:
+          type: string
+          format: uuid
+      required:
+        - crn
+        - days
+        - bookingId
+        - roomId
+    BedSearchResultPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacteristicPair'
+        bedCount:
+          type: integer
+          description: the total number of Beds in the Premises
+      required:
+        - id
+        - name
+        - addressLine1
+        - postcode
+        - characteristics
+        - bedCount
+    BedSearchResultRoomSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacteristicPair'
+      required:
+        - id
+        - name
+        - characteristics
+    BedSearchResultBedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    CharacteristicPair:
+      type: object
+      properties:
+        propertyName:
+          type: string
+        name:
+          type: string
+      required:
+        - name
+    SortOrder:
+      type: string
+      enum:
+        - ascending
+        - descending
+    BookingStatus:
+      type: string
+      enum:
+        - arrived
+        - awaiting-arrival
+        - not-arrived
+        - departed
+        - cancelled
+        - provisional
+        - confirmed
+        - closed
+    BookingSearchSortField:
+      type: string
+      enum:
+        - name
+        - crn
+        - startDate
+        - endDate
+        - createdAt
+      x-enum-varnames:
+        - personName
+        - personCrn
+        - bookingStartDate
+        - bookingEndDate
+        - bookingCreatedAt
+    BookingSearchResults:
+      type: object
+      properties:
+        resultsCount:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/BookingSearchResult"
+      required:
+        - resultsCount
+        - results
+    BookingSearchResult:
+      type: object
+      properties:
+        person:
+          $ref: "#/components/schemas/BookingSearchResultPersonSummary"
+        booking:
+          $ref: "#/components/schemas/BookingSearchResultBookingSummary"
+        premises:
+          $ref: "#/components/schemas/BookingSearchResultPremisesSummary"
+        room:
+          $ref: "#/components/schemas/BookingSearchResultRoomSummary"
+        bed:
+          $ref: "#/components/schemas/BookingSearchResultBedSummary"
+      required:
+        - person
+        - booking
+        - premises
+        - room
+        - bed
+    BookingSearchResultPersonSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        crn:
+          type: string
+      required:
+        - crn
+    BookingSearchResultBookingSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: "#/components/schemas/BookingStatus"
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - status
+        - startDate
+        - endDate
+        - createdAt
+    BookingSearchResultPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+      required:
+        - id
+        - name
+        - addressLine1
+        - postcode
+    BookingSearchResultRoomSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    BookingSearchResultBedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    NewPlacementRequestBookingConfirmation:
+      type: object
+      properties:
+        premisesName:
+          type: string
+        arrivalDate:
+          type: string
+          format: date
+          example: 2022-07-28
+        departureDate:
+          type: string
+          format: date
+          example: 2022-09-30
+      required:
+        - premisesName
+        - arrivalDate
+        - departureDate
+    NewBedMove:
+      type: object
+      properties:
+        bedId:
+          type: string
+          format: uuid
+        notes:
+          type: string
+      required:
+        - bedId
+    NewBookingNotMade:
+      type: object
+      properties:
+        notes:
+          type: string
+    BookingNotMade:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        placementRequestId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - placementRequestId
+        - createdAt
+    ProbationDeliveryUnit:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    ReferralRejectionReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: There was not enough time to place them
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
+    CacheType:
+      type: string
+      enum:
+        - qCodeStaffMembers
+        - userAccess
+        - staffDetails
+        - teamsManagingCase
+        - ukBankHolidays
+        - offenderDetails
+        - inmateDetails
+    BedOccupancyRange:
+      type: object
+      properties:
+        bedId:
+          type: string
+          format: uuid
+        bedName:
+          type: string
+        schedule:
+          type: array
+          items:
+            $ref: '#/components/schemas/BedOccupancyEntry'
+      required:
+        - bedId
+        - bedName
+        - schedule
+    BedOccupancyEntryType:
+      type: string
+      enum:
+        - booking
+        - lost_bed
+        - open
+    BedOccupancyEntry:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/BedOccupancyEntryType'
+        length:
+          type: integer
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+      required:
+        - type
+        - length
+        - startDate
+        - endDate
+      discriminator:
+        propertyName: type
+        mapping:
+          booking: '#/components/schemas/BedOccupancyBookingEntry'
+          lost_bed: '#/components/schemas/BedOccupancyLostBedEntry'
+          open: '#/components/schemas/BedOccupancyOpenEntry'
+    BedOccupancyBookingEntry:
+      allOf:
+        - $ref: '#/components/schemas/BedOccupancyEntry'
+        - type: object
+          properties:
+            bookingId:
+              type: string
+              format: uuid
+            personName:
+              type: string
+          required:
+            - bookingId
+            - personName
+    BedOccupancyLostBedEntry:
+      allOf:
+        - $ref: '#/components/schemas/BedOccupancyEntry'
+        - type: object
+          properties:
+            lostBedId:
+              type: string
+              format: uuid
+          required:
+            - lostBedId
+    BedOccupancyOpenEntry:
+      allOf:
+        - $ref: '#/components/schemas/BedOccupancyEntry'
+    PersonType:
+      type: string
+      enum:
+        - FullPerson
+        - RestrictedPerson
+        - UnknownPerson
+        - FullPersonInfo
+        - RestrictedPersonInfo
+    Withdrawables:
+      type: object
+      properties:
+        notes:
+          type: array
+          items:
+            type: string
+        withdrawables:
+          type: array
+          items:
+            $ref: '#/components/schemas/Withdrawable'
+      required:
+        - notes
+        - withdrawables
+    Withdrawable:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          $ref: '#/components/schemas/WithdrawableType'
+        dates:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatePeriod'
+          description: 0, 1 or more dates can be specified depending upon the WithdrawableType
+      required:
+        - id
+        - type
+        - dates
+    DatePeriod:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+      required:
+        - startDate
+        - endDate
+    WithdrawableType:
+      type: string
+      enum:
+        - application
+        - booking
+        - placement_application
+        - placement_request
+    WithdrawalReason:
+      type: string
+      enum:
+        - change_in_circumstances_new_application_to_be_submitted
+        - error_in_application
+        - duplicate_application
+        - death
+        - other_accommodation_identified
+        - other
+    PlacementRequestSortField:
+      type: string
+      enum:
+        - duration
+        - expected_arrival
+        - created_at
+        - application_date
+        - request_type
+        - person_name
+        - person_risks_tier
+      x-enum-varnames:
+        - duration
+        - expectedArrival
+        - createdAt
+        - applicationSubmittedAt
+    UserSortField:
+      type: string
+      enum:
+        - name
+      x-enum-varnames:
+        - personName
+    SortDirection:
+      type: string
+      enum:
+        - asc
+        - desc
+    AllocatedFilter:
+      type: string
+      enum:
+        - allocated
+        - unallocated
+    ApplicationSortField:
+      type: string
+      enum:
+        - tier
+        - createdAt
+        - arrivalDate
+        - releaseType
+    RiskTierLevel:
+      type: string
+      enum:
+        - D0
+        - D1
+        - D2
+        - D3
+        - C0
+        - C1
+        - C2
+        - C3
+        - B0
+        - B1
+        - B2
+        - B3
+        - A0
+        - A1
+        - A2
+        - A3
+    NewAppeal:
+      type: object
+      properties:
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+      required:
+        - appealDate
+        - appealDetail
+        - decision
+        - decisionDetail
+    Appeal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        applicationId:
+          type: string
+          format: uuid
+        assessmentId:
+          type: string
+          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
+      required:
+        - id
+        - appealDate
+        - appealDetail
+        - decision
+        - decisionDetail
+        - createdAt
+        - applicationId
+        - createdByUser
+    AppealDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected
+    Cas1ApplicationUserDetails:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
+      required:
+        - name
+    Cas3ReportType:
+      type: string
+      enum:
+        - referral
+        - booking
+        - bedUsage
+        - bedOccupancy
+    Cas2ReportName:
+      type: string
+      enum:
+        - submitted-applications
+        - application-status-updates
+        - unsubmitted-applications

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/LostBedsTest.kt
@@ -1,0 +1,1165 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBedCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateLostBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+class LostBedsTest : InitialiseDatabasePerClassTestBase() {
+  @Autowired
+  lateinit var lostBedsTransformer: LostBedsTransformer
+
+  @Nested
+  inner class GetAllLostBeds {
+    @Test
+    fun `Get All Lost Beds without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/lost-beds")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Get All Lost Beds on non existent Premises returns 404`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.get()
+        .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/lost-beds")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Get All Lost Beds returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        val lostBed = lostBedsEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          withBed(bed)
+          withPremises(premises)
+        }
+
+        val cancelledLostBed = lostBedsEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          withBed(bed)
+          withPremises(premises)
+        }
+
+        lostBedCancellationEntityFactory.produceAndPersist {
+          withLostBed(cancelledLostBed)
+        }
+
+        val expectedJson = objectMapper.writeValueAsString(listOf(lostBedsTransformer.transformJpaToApi(lostBed)))
+
+        webTestClient.get()
+          .uri("/cas1/premises/${premises.id}/lost-beds")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(expectedJson)
+      }
+    }
+  }
+
+  @Nested
+  inner class GetLostBed {
+    @Test
+    fun `Get Lost Bed without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val lostBeds = lostBedsEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          },
+        )
+        withPremises(premises)
+      }
+
+      webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Get Lost Bed for non-existent premises returns 404`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.get()
+        .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/lost-beds")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Get Lost Bed for non-existent lost bed returns 404`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        webTestClient.get()
+          .uri("/cas1/premises/${premises.id}/lost-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Get Lost Bed returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        val lostBeds = lostBedsEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
+              }
+            },
+          )
+          withPremises(premises)
+        }
+
+        val expectedJson = objectMapper.writeValueAsString(lostBedsTransformer.transformJpaToApi(lostBeds))
+
+        webTestClient.get()
+          .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(expectedJson)
+      }
+    }
+  }
+
+  @Nested
+  inner class CreateLostBed {
+    @Test
+    fun `Create Lost Beds without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+      }
+
+      webTestClient.post()
+        .uri("/cas1/premises/${premises.id}/lost-beds")
+        .bodyValue(
+          NewLostBed(
+            startDate = LocalDate.parse("2022-08-15"),
+            endDate = LocalDate.parse("2022-08-18"),
+            bedId = bed.id,
+            reason = UUID.randomUUID(),
+            referenceNumber = "REF-123",
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Create Lost Beds returns 400 Bad Request if the bed ID does not reference a bed on the premises`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist {
+              withYieldedApArea {
+                apAreaEntityFactory.produceAndPersist()
+              }
+            }
+          }
+        }
+
+        val reason = lostBedReasonEntityFactory.produceAndPersist {
+          withServiceScope(ServiceName.approvedPremises.value)
+        }
+
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/lost-beds")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewLostBed(
+              startDate = LocalDate.parse("2022-08-17"),
+              endDate = LocalDate.parse("2022-08-18"),
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+              bedId = UUID.randomUUID(),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBody()
+          .jsonPath("invalid-params[0].propertyName").isEqualTo("$.bedId")
+          .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Create Lost Beds returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(3) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        val reason = lostBedReasonEntityFactory.produceAndPersist {
+          withServiceScope(ServiceName.approvedPremises.value)
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/lost-beds")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewLostBed(
+              startDate = LocalDate.parse("2022-08-17"),
+              endDate = LocalDate.parse("2022-08-18"),
+              bedId = bed.id,
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath(".startDate").isEqualTo("2022-08-17")
+          .jsonPath(".endDate").isEqualTo("2022-08-18")
+          .jsonPath(".bedId").isEqualTo(bed.id.toString())
+          .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+          .jsonPath(".reason.name").isEqualTo(reason.name)
+          .jsonPath(".reason.isActive").isEqualTo(true)
+          .jsonPath(".referenceNumber").isEqualTo("REF-123")
+          .jsonPath(".notes").isEqualTo("notes")
+          .jsonPath(".status").isEqualTo("active")
+          .jsonPath(".cancellation").isEqualTo(null)
+      }
+    }
+
+    @Test
+    fun `Create Lost Bed succeeds even if overlapping with Booking`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(2) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        val reason = lostBedReasonEntityFactory.produceAndPersist {
+          withServiceScope(ServiceName.approvedPremises.value)
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        BookingEntityFactory()
+          .withBed(bed)
+          .withPremises(premises)
+          .withArrivalDate(LocalDate.parse("2022-08-15"))
+          .withDepartureDate(LocalDate.parse("2022-08-18"))
+          .produce()
+
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/lost-beds")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewLostBed(
+              startDate = LocalDate.parse("2022-08-17"),
+              endDate = LocalDate.parse("2022-08-18"),
+              bedId = bed.id,
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath(".startDate").isEqualTo("2022-08-17")
+          .jsonPath(".endDate").isEqualTo("2022-08-18")
+          .jsonPath(".bedId").isEqualTo(bed.id.toString())
+          .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+          .jsonPath(".reason.name").isEqualTo(reason.name)
+          .jsonPath(".reason.isActive").isEqualTo(true)
+          .jsonPath(".referenceNumber").isEqualTo("REF-123")
+          .jsonPath(".notes").isEqualTo("notes")
+          .jsonPath(".status").isEqualTo("active")
+          .jsonPath(".cancellation").isEqualTo(null)
+      }
+    }
+
+    @Test
+    fun `Create Lost Beds for current day does not break GET all Premises endpoint`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(2) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        lostBedsEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
+              }
+            },
+          )
+          withStartDate(LocalDate.now().minusDays(2))
+          withEndDate(LocalDate.now().plusDays(2))
+          withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+        }
+
+        bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withOriginalArrivalDate(LocalDate.now().minusDays(4))
+          withArrivalDate(LocalDate.now().minusDays(4))
+          withOriginalDepartureDate(LocalDate.now().plusDays(6))
+          withDepartureDate(LocalDate.now().plusDays(6))
+        }
+
+        webTestClient.get()
+          .uri("/premises")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+      }
+    }
+
+    @Test
+    fun `Create Lost Bed returns 409 Conflict when a lost bed for the same bed overlaps`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val reason = lostBedReasonEntityFactory.produceAndPersist {
+            withServiceScope(ServiceName.approvedPremises.value)
+          }
+
+          val existingLostBed = lostBedsEntityFactory.produceAndPersist {
+            withBed(bed)
+            withPremises(premises)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          }
+
+          webTestClient.post()
+            .uri("/cas1/premises/${premises.id}/lost-beds")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewLostBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+                bedId = bed.id,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+            .expectBody()
+            .jsonPath("title").isEqualTo("Conflict")
+            .jsonPath("status").isEqualTo(409)
+            .jsonPath("detail").isEqualTo("A Lost Bed already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingLostBed.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `Create Lost Bed returns OK with correct body when only cancelled lost beds for the same bed overlap`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val reason = lostBedReasonEntityFactory.produceAndPersist {
+            withServiceScope(ServiceName.approvedPremises.value)
+          }
+
+          val existingLostBed = lostBedsEntityFactory.produceAndPersist {
+            withBed(bed)
+            withPremises(premises)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withYieldedReason {
+              lostBedReasonEntityFactory.produceAndPersist()
+            }
+          }
+
+          existingLostBed.cancellation = lostBedCancellationEntityFactory.produceAndPersist {
+            withLostBed(existingLostBed)
+            withCreatedAt(OffsetDateTime.parse("2022-07-01T12:34:56.789Z"))
+          }
+
+          webTestClient.post()
+            .uri("/cas1/premises/${premises.id}/lost-beds")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewLostBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+                bedId = bed.id,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath(".startDate").isEqualTo("2022-08-01")
+            .jsonPath(".endDate").isEqualTo("2022-08-30")
+            .jsonPath(".bedId").isEqualTo(bed.id.toString())
+            .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+            .jsonPath(".reason.name").isEqualTo(reason.name)
+            .jsonPath(".reason.isActive").isEqualTo(true)
+            .jsonPath(".referenceNumber").isEqualTo("REF-123")
+            .jsonPath(".notes").isEqualTo("notes")
+            .jsonPath(".status").isEqualTo("active")
+            .jsonPath(".cancellation").isEqualTo(null)
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class UpdateLostBed {
+    @Test
+    fun `Update Lost Bed without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val lostBeds = lostBedsEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          },
+        )
+        withPremises(premises)
+      }
+
+      bedEntityFactory.produceAndPersist {
+        withYieldedRoom {
+          roomEntityFactory.produceAndPersist {
+            withYieldedPremises { premises }
+          }
+        }
+      }
+
+      webTestClient.put()
+        .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}")
+        .bodyValue(
+          UpdateLostBed(
+            startDate = LocalDate.parse("2022-08-15"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = UUID.randomUUID(),
+            referenceNumber = "REF-123",
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Update Lost Bed for non-existent premises returns 404`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.put()
+        .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/lost-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateLostBed(
+            startDate = LocalDate.parse("2022-08-15"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = UUID.randomUUID(),
+            referenceNumber = "REF-123",
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `Update Lost Bed for non-existent lost bed returns 404`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.put()
+        .uri("/cas1/premises/${premises.id}/lost-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateLostBed(
+            startDate = LocalDate.parse("2022-08-15"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = UUID.randomUUID(),
+            referenceNumber = "REF-123",
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Update Lost Beds returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(2) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        val lostBeds = lostBedsEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          withBed(bed)
+          withPremises(premises)
+        }
+
+        val reason = lostBedReasonEntityFactory.produceAndPersist {
+          withServiceScope(ServiceName.approvedPremises.value)
+        }
+
+        webTestClient.put()
+          .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            UpdateLostBed(
+              startDate = LocalDate.parse("2022-08-17"),
+              endDate = LocalDate.parse("2022-08-18"),
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath(".startDate").isEqualTo("2022-08-17")
+          .jsonPath(".endDate").isEqualTo("2022-08-18")
+          .jsonPath(".bedId").isEqualTo(bed.id.toString())
+          .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+          .jsonPath(".reason.name").isEqualTo(reason.name)
+          .jsonPath(".reason.isActive").isEqualTo(true)
+          .jsonPath(".referenceNumber").isEqualTo("REF-123")
+          .jsonPath(".notes").isEqualTo("notes")
+          .jsonPath(".status").isEqualTo("active")
+          .jsonPath(".cancellation").isEqualTo(null)
+      }
+    }
+
+    @Test
+    fun `Update Lost Beds returns 409 Conflict when a booking for the same bed overlaps`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist {
+              withYieldedApArea {
+                apAreaEntityFactory.produceAndPersist()
+              }
+            }
+          }
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        val lostBeds = lostBedsEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.parse("2022-08-16"))
+          withEndDate(LocalDate.parse("2022-08-30"))
+          withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          withYieldedBed { bed }
+          withPremises(premises)
+        }
+
+        val reason = lostBedReasonEntityFactory.produceAndPersist {
+          withServiceScope(ServiceName.approvedPremises.value)
+        }
+
+        val existingBooking = bookingEntityFactory.produceAndPersist {
+          withServiceName(ServiceName.approvedPremises)
+          withCrn("CRN123")
+          withYieldedPremises { premises }
+          withYieldedBed { bed }
+          withArrivalDate(LocalDate.parse("2022-07-15"))
+          withDepartureDate(LocalDate.parse("2022-08-15"))
+        }
+
+        GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+        webTestClient.put()
+          .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            UpdateLostBed(
+              startDate = LocalDate.parse("2022-08-01"),
+              endDate = LocalDate.parse("2022-08-30"),
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .is4xxClientError
+          .expectBody()
+          .jsonPath("title").isEqualTo("Conflict")
+          .jsonPath("status").isEqualTo(409)
+          .jsonPath("detail").isEqualTo("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingBooking.id}")
+      }
+    }
+
+    @Test
+    fun `Update Lost Beds returns OK with correct body when only cancelled bookings for the same bed overlap`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { offenderDetails, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist {
+                withYieldedApArea {
+                  apAreaEntityFactory.produceAndPersist()
+                }
+              }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val lostBeds = lostBedsEntityFactory.produceAndPersist {
+            withStartDate(LocalDate.parse("2022-08-16"))
+            withEndDate(LocalDate.parse("2022-08-30"))
+            withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+            withYieldedBed { bed }
+            withPremises(premises)
+          }
+
+          val reason = lostBedReasonEntityFactory.produceAndPersist {
+            withServiceScope(ServiceName.approvedPremises.value)
+          }
+
+          val existingBooking = bookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.approvedPremises)
+            withCrn(offenderDetails.otherIds.crn)
+            withYieldedPremises { premises }
+            withYieldedBed { bed }
+            withArrivalDate(LocalDate.parse("2022-07-15"))
+            withDepartureDate(LocalDate.parse("2022-08-15"))
+          }
+
+          existingBooking.cancellations = cancellationEntityFactory.produceAndPersistMultiple(1) {
+            withYieldedBooking { existingBooking }
+            withDate(LocalDate.parse("2022-07-01"))
+            withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+          }.toMutableList()
+
+          webTestClient.put()
+            .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              UpdateLostBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath(".startDate").isEqualTo("2022-08-01")
+            .jsonPath(".endDate").isEqualTo("2022-08-30")
+            .jsonPath(".bedId").isEqualTo(bed.id.toString())
+            .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+            .jsonPath(".reason.name").isEqualTo(reason.name)
+            .jsonPath(".reason.isActive").isEqualTo(true)
+            .jsonPath(".referenceNumber").isEqualTo("REF-123")
+            .jsonPath(".notes").isEqualTo("notes")
+            .jsonPath(".status").isEqualTo("active")
+            .jsonPath(".cancellation").isEqualTo(null)
+        }
+      }
+    }
+
+    @Test
+    fun `Update Lost Beds returns 409 Conflict when a lost bed for the same bed overlaps`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val reason = lostBedReasonEntityFactory.produceAndPersist {
+            withServiceScope(ServiceName.approvedPremises.value)
+          }
+
+          val lostBeds = lostBedsEntityFactory.produceAndPersist {
+            withStartDate(LocalDate.parse("2022-08-16"))
+            withEndDate(LocalDate.parse("2022-08-30"))
+            withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+            withYieldedBed { bed }
+            withPremises(premises)
+          }
+
+          val existingLostBed = lostBedsEntityFactory.produceAndPersist {
+            withBed(bed)
+            withPremises(premises)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          }
+
+          webTestClient.put()
+            .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              UpdateLostBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+            .expectBody()
+            .jsonPath("title").isEqualTo("Conflict")
+            .jsonPath("status").isEqualTo(409)
+            .jsonPath("detail").isEqualTo("A Lost Bed already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingLostBed.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `Update Lost Beds returns OK with correct body when only cancelled lost beds for the same bed overlap`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val reason = lostBedReasonEntityFactory.produceAndPersist {
+            withServiceScope(ServiceName.approvedPremises.value)
+          }
+
+          val lostBeds = lostBedsEntityFactory.produceAndPersist {
+            withStartDate(LocalDate.parse("2022-08-16"))
+            withEndDate(LocalDate.parse("2022-08-30"))
+            withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+            withYieldedBed { bed }
+            withPremises(premises)
+          }
+
+          val existingLostBed = lostBedsEntityFactory.produceAndPersist {
+            withBed(bed)
+            withPremises(premises)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withYieldedReason {
+              lostBedReasonEntityFactory.produceAndPersist()
+            }
+          }
+
+          existingLostBed.cancellation = lostBedCancellationEntityFactory.produceAndPersist {
+            withLostBed(existingLostBed)
+            withCreatedAt(OffsetDateTime.parse("2022-07-01T12:34:56.789Z"))
+          }
+
+          webTestClient.put()
+            .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              UpdateLostBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath(".startDate").isEqualTo("2022-08-01")
+            .jsonPath(".endDate").isEqualTo("2022-08-30")
+            .jsonPath(".bedId").isEqualTo(bed.id.toString())
+            .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+            .jsonPath(".reason.name").isEqualTo(reason.name)
+            .jsonPath(".reason.isActive").isEqualTo(true)
+            .jsonPath(".referenceNumber").isEqualTo("REF-123")
+            .jsonPath(".notes").isEqualTo("notes")
+            .jsonPath(".status").isEqualTo("active")
+            .jsonPath(".cancellation").isEqualTo(null)
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class CancelLostBed {
+    @Test
+    fun `Cancel Lost Bed without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val lostBeds = lostBedsEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          },
+        )
+        withPremises(premises)
+      }
+
+      webTestClient.post()
+        .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}/cancellations")
+        .bodyValue(
+          NewLostBedCancellation(
+            notes = "Unauthorized",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Cancel Lost Bed for non-existent premises returns 404`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.post()
+        .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/lost-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488/cancellations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewLostBedCancellation(
+            notes = "Non-existent premises",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `Cancel Lost Bed for non-existent lost bed returns 404`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.post()
+        .uri("/cas1/premises/${premises.id}/lost-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488/cancellations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewLostBedCancellation(
+            notes = "Non-existent lost bed",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Cancel Lost Bed returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(2) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        val lostBeds = lostBedsEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
+              }
+            },
+          )
+          withPremises(premises)
+        }
+
+        lostBedReasonEntityFactory.produceAndPersist {
+          withServiceScope(ServiceName.approvedPremises.value)
+        }
+
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/lost-beds/${lostBeds.id}/cancellations")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewLostBedCancellation(
+              notes = "Some cancellation notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath("$.notes").isEqualTo("Some cancellation notes")
+          .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+      }
+    }
+  }
+}


### PR DESCRIPTION
> See [APS-801 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-801).

This PR introduces the CAS1-specific API specification (cas1-api.yml), starting with the 'lost beds' API endpoints. These new endpoints replicate the behaviour of the existing lost beds endpoints in the `PremisesController` as applied specifically to CAS1.

The configuration for the CAS1-specific spec has the `useTags` property set to `true` to allow for controllers to be decomposed more easily (for example, by default all endpoints starting with `/premises/` would be put into the `PremisesController`).

This PR is the first of a two-stage process to implement APS-801, as removing the CAS1-specific logic from the existing endpoints requires the frontend to make the switch in all environments first. The second PR can be found here: #1911