### PR TITLE
CAS-385 Bookings have duplicated confirmation records

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1403,6 +1403,7 @@ class BookingService(
     return success(cancellationEntity)
   }
 
+  @Transactional
   fun createConfirmation(
     booking: BookingEntity,
     dateTime: OffsetDateTime,

--- a/src/main/resources/db/migration/all/20240524103521__remove_duplicated_booking_confirmation.sql
+++ b/src/main/resources/db/migration/all/20240524103521__remove_duplicated_booking_confirmation.sql
@@ -1,0 +1,1 @@
+DELETE from confirmations WHERE id='5ddb1e72-6f50-44ee-9677-bf626bb3cb7d';


### PR DESCRIPTION
This [PR CAS-385](https://dsdmoj.atlassian.net/browse/CAS-385) is to fix a bug in production when a booking have two confirmation records.
- Will add Transactional around the create confirmation to make sure that it will rollback if its failed
- Remove the duplicated record for the affected booking