### PR TITLE
Change how tests allocate wiremock ports

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WiremockManager.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WiremockManager.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.nio.channels.FileChannel
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
+
+object WiremockPortHolder {
+  private val possiblePorts = (57830..57880).shuffled()
+
+  private var port: Int? = null
+  private var channel: FileChannel? = null
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun getPort(): Int {
+    synchronized(this) {
+      if (port != null) {
+        return port!!
+      }
+
+      possiblePorts.forEach { portToTry ->
+        log.info("Trying Wiremock port: $portToTry")
+        val lockFilePath = Paths.get("${System.getProperty("java.io.tmpdir")}${System.getProperty("file.separator")}ap-int-port-lock-$portToTry.lock")
+
+        try {
+          channel = FileChannel.open(lockFilePath, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+          channel!!.position(0)
+
+          if (channel!!.tryLock() == null) {
+            log.info("Port $portToTry is in use")
+            channel!!.close()
+            channel = null
+            return@forEach
+          }
+
+          log.info("Using Wiremock port: $portToTry")
+          port = portToTry
+
+          return portToTry
+        } catch (_: Exception) {
+        }
+      }
+
+      error("Could not lock any potential Wiremock ports")
+    }
+  }
+
+  fun releasePort() = channel?.close()
+}
+
+@Component
+class WiremockManager {
+
+  lateinit var wiremockServer: WireMockServer
+
+  @Value("\${wiremock.port}")
+  lateinit var wiremockPort: Number
+
+  fun setupTests() {
+    wiremockServer = WireMockServer(wiremockPort.toInt())
+    wiremockServer.start()
+  }
+
+  fun teardownTests() {
+    wiremockServer.stop()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WiremockManager.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WiremockManager.kt
@@ -4,25 +4,28 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.net.ServerSocket
 import java.nio.channels.FileChannel
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 
-object WiremockPortHolder {
-  private val possiblePorts = (57830..57880).shuffled()
+object WiremockPortManager {
 
-  private var port: Int? = null
   private var channel: FileChannel? = null
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun getPort(): Int {
+  fun reserveFreePort(): Int {
     synchronized(this) {
-      if (port != null) {
-        return port!!
-      }
+      var port: Int? = null
+      var attempts = 0
+      while (port == null) {
+        if (attempts > 100) {
+          error("After 100 attempts, i can't find a free port for wiremock")
+        }
 
-      possiblePorts.forEach { portToTry ->
+        val portToTry = ServerSocket(0).localPort
+
         log.info("Trying Wiremock port: $portToTry")
         val lockFilePath = Paths.get("${System.getProperty("java.io.tmpdir")}${System.getProperty("file.separator")}ap-int-port-lock-$portToTry.lock")
 
@@ -34,18 +37,17 @@ object WiremockPortHolder {
             log.info("Port $portToTry is in use")
             channel!!.close()
             channel = null
-            return@forEach
+            attempts += 1
+            continue
           }
 
           log.info("Using Wiremock port: $portToTry")
           port = portToTry
-
-          return portToTry
         } catch (_: Exception) {
         }
       }
 
-      error("Could not lock any potential Wiremock ports")
+      return port
     }
   }
 
@@ -55,17 +57,22 @@ object WiremockPortHolder {
 @Component
 class WiremockManager {
 
+  private val log = LoggerFactory.getLogger(this::class.java)
+
   lateinit var wiremockServer: WireMockServer
 
   @Value("\${wiremock.port}")
   lateinit var wiremockPort: Number
 
   fun setupTests() {
-    wiremockServer = WireMockServer(wiremockPort.toInt())
-    wiremockServer.start()
+    if (!this::wiremockServer.isInitialized || !wiremockServer.isRunning) {
+      log.info("Starting wiremock on port $wiremockPort")
+      wiremockServer = WireMockServer(wiremockPort.toInt())
+      wiremockServer.start()
+    }
   }
 
   fun teardownTests() {
-    wiremockServer.stop()
+    wiremockServer.resetAll()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TestPropertiesInitializer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TestPropertiesInitializer.kt
@@ -8,14 +8,14 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.datasource.DriverManagerDataSource
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.WiremockPortHolder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.WiremockPortManager
 import javax.annotation.PreDestroy
 
 class TestPropertiesInitializer : ApplicationContextInitializer<ConfigurableApplicationContext?> {
   private var postgresPort = System.getenv("POSTGRES_PORT") ?: "5433"
 
   override fun initialize(applicationContext: ConfigurableApplicationContext?) {
-    val wiremockPort = WiremockPortHolder.getPort()
+    val wiremockPort = WiremockPortManager.reserveFreePort()
 
     val databaseName = setupDatabase()
 
@@ -69,5 +69,5 @@ class TestPropertiesInitializer : ApplicationContextInitializer<ConfigurableAppl
 @Component
 class TestPropertiesDestructor {
   @PreDestroy
-  fun destroy() = WiremockPortHolder.releasePort()
+  fun destroy() = WiremockPortManager.releasePort()
 }


### PR DESCRIPTION
This PR changes how we assign the port to wiremock to resolve port-clashes we’re seeing when running tests concurrently in the pipeline

1. The port range is no longer limited. Instead we use ServerSocket(0) to offer up any available open port
2. We don’t ‘lock’ the port to the java process once determined (by capturing it in the WiremockPortHolder as an object variable). This avoids issues when there are multiple spring boot contexts within one java process, something which is possible when running multiple spring boot integration tests with differing spring configuration
3. Instead of stopping wiremock after each test, we instead leave it running and instead reset it’s state. Whilst not strictly required because the port is ‘locked’ by the shared file, this ensures the port is also always in use so can’t be taken/considered. Leave wiremock running may also have a minor performance improvement