### PR TITLE
CAS-327 Repoint notes to assessments - part 1

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -63,6 +63,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/cas2/assessments/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/assessments/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasAnyRole("LICENCE_CA", "POM", "CAS2_ASSESSOR"))
+        authorize(HttpMethod.POST, "/cas2/assessments/*/notes", hasAnyRole("LICENCE_CA", "POM", "CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "POM"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -108,6 +108,7 @@ class SubmissionsController(
     return ResponseEntity(HttpStatus.OK)
   }
 
+  @Deprecated("Superseded by assessmentsAssessmentIdNotesPost() in AssessmentsController.")
   override fun submissionsApplicationIdNotesPost(applicationId: UUID, body: NewCas2ApplicationNote): ResponseEntity<Cas2ApplicationNote> {
     val noteResult = assessmentNoteService.createApplicationNote(applicationId, body)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/SubmissionsController.kt
@@ -23,8 +23,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ExternalUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.AssessmentNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationNotesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.SubmissionsTransformer
@@ -37,7 +37,7 @@ import javax.transaction.Transactional
 class SubmissionsController(
   private val httpAuthService: HttpAuthService,
   private val applicationService: ApplicationService,
-  private val applicationNoteService: ApplicationNoteService,
+  private val assessmentNoteService: AssessmentNoteService,
   private val submissionsTransformer: SubmissionsTransformer,
   private val applicationNotesTransformer: ApplicationNotesTransformer,
   private val offenderService: OffenderService,
@@ -109,7 +109,7 @@ class SubmissionsController(
   }
 
   override fun submissionsApplicationIdNotesPost(applicationId: UUID, body: NewCas2ApplicationNote): ResponseEntity<Cas2ApplicationNote> {
-    val noteResult = applicationNoteService.createApplicationNote(applicationId, body)
+    val noteResult = assessmentNoteService.createApplicationNote(applicationId, body)
 
     val validationResult = processAuthorisationFor(applicationId, noteResult) as ValidatableActionResult<Cas2ApplicationNote>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -11,7 +14,22 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Repository
-interface Cas2ApplicationNoteRepository : JpaRepository<Cas2ApplicationNoteEntity, UUID>
+interface Cas2ApplicationNoteRepository : JpaRepository<Cas2ApplicationNoteEntity, UUID> {
+  @Query(
+    "SELECT n FROM Cas2ApplicationNoteEntity n WHERE n.assessment IS NULL",
+  )
+  fun findAllNotesWithoutAssessment(of: PageRequest): Slice<Cas2ApplicationNoteEntity>
+
+  @Query(
+    "SELECT COUNT(*) FROM Cas2ApplicationNoteEntity n WHERE n.assessment IS NULL",
+  )
+  fun countAllNotesWithoutAssessment(): Int
+
+  @Query(
+    "SELECT COUNT(*) FROM Cas2ApplicationNoteEntity n WHERE n.assessment IS NOT NULL",
+  )
+  fun countAllNotesWithAssessment(): Int
+}
 
 @Entity
 @Table(name = "cas_2_application_notes")
@@ -32,7 +50,7 @@ data class Cas2ApplicationNoteEntity(
 
   @ManyToOne
   @JoinColumn(name = "assessment_id")
-  val assessment: Cas2AssessmentEntity? = null,
+  var assessment: Cas2AssessmentEntity? = null,
 ) {
 
   @ManyToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
@@ -29,6 +29,10 @@ data class Cas2ApplicationNoteEntity(
   val createdAt: OffsetDateTime,
 
   var body: String,
+
+  @ManyToOne
+  @JoinColumn(name = "assessment_id")
+  val assessment: Cas2AssessmentEntity? = null,
 ) {
 
   @ManyToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationNoteEntity.kt
@@ -50,7 +50,7 @@ data class Cas2ApplicationNoteEntity(
 
   @ManyToOne
   @JoinColumn(name = "assessment_id")
-  var assessment: Cas2AssessmentEntity? = null,
+  var assessment: Cas2AssessmentEntity?,
 ) {
 
   @ManyToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas2NoteMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas2NoteMigrationJob.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
+
+class Cas2NoteMigrationJob(
+  private val noteRepository: Cas2ApplicationNoteRepository,
+  private val transactionTemplate: TransactionTemplate,
+  private val pageSize: Int,
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = true
+
+  override fun process() {
+    log.info("Starting CAS2 note migration process...")
+
+    var hasNext = true
+    var slice: Slice<Cas2ApplicationNoteEntity>
+    var page = 1
+    var notesWithoutAssessment = noteRepository.countAllNotesWithoutAssessment()
+    val notesWithAssessment = noteRepository.countAllNotesWithAssessment()
+
+    while (hasNext) {
+      log.info("Getting page $page for max page size $pageSize")
+      slice = noteRepository.findAllNotesWithoutAssessment(PageRequest.of(0, pageSize))
+      slice.content.forEach { note ->
+        transactionTemplate.executeWithoutResult {
+          log.info("Adding assessment to note ${note.id}")
+          note.assessment = note.application.assessment
+          noteRepository.save(
+            note,
+          )
+        }
+      }
+      hasNext = slice.hasNext()
+      page += 1
+    }
+    log.info("Before the migration:")
+    log.info("notes without assessments: $notesWithoutAssessment")
+    log.info("notes with assessments: $notesWithAssessment")
+    log.info("After the migration:")
+    log.info("notes without assessments: ${noteRepository.countAllNotesWithoutAssessment()}")
+    log.info("notes with assessments: ${noteRepository.countAllNotesWithAssessment()}")
+    log.info("CAS2 note migration process complete!")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1BackfillUs
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1UserDetailsMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2NoteMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2StatusUpdateMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas3UpdateApplicationOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas3UpdateUsersPduFromCommunityApiJob
@@ -93,6 +95,12 @@ class MigrationJobService(
 
         MigrationJobType.cas2StatusUpdatesWithAssessments -> Cas2StatusUpdateMigrationJob(
           applicationContext.getBean(Cas2StatusUpdateRepository::class.java),
+          transactionTemplate,
+          pageSize,
+        )
+
+        MigrationJobType.cas2NotesWithAssessments -> Cas2NoteMigrationJob(
+          applicationContext.getBean(Cas2ApplicationNoteRepository::class.java),
           transactionTemplate,
           pageSize,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/AssessmentNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/AssessmentNoteService.kt
@@ -28,7 +28,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service("Cas2ApplicationNoteService")
-class ApplicationNoteService(
+class AssessmentNoteService(
   private val applicationRepository: Cas2ApplicationRepository,
   private val assessmentRepository: Cas2AssessmentRepository,
   private val applicationNoteRepository: Cas2ApplicationNoteRepository,

--- a/src/main/resources/db/migration/all/20240524130000__add_notes_to_assessments.sql
+++ b/src/main/resources/db/migration/all/20240524130000__add_notes_to_assessments.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION;
+-- add a nullable foreign key for assessments
+ALTER TABLE cas_2_application_notes
+    ADD COLUMN assessment_id UUID;
+
+ALTER TABLE cas_2_application_notes
+    ADD FOREIGN KEY (assessment_id) REFERENCES cas_2_assessments (id);
+
+-- index on the assessment id
+CREATE INDEX ON cas_2_application_notes(assessment_id);
+COMMIT;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3663,6 +3663,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas2_status_updates_with_assessments
+        - update_cas2_notes_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -258,6 +258,46 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /assessments/{assessmentId}/notes:
+    post:
+      tags:
+        - Operations on CAS2 assessments
+      summary: Add a note to an assessment
+      parameters:
+        - name: assessmentId
+          in: path
+          description: ID of the assessment
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: the note to add
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/NewCas2ApplicationNote'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas2ApplicationNote'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid assessmentId
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /submissions:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8337,6 +8337,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas2_status_updates_with_assessments
+        - update_cas2_notes_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3889,6 +3889,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas2_status_updates_with_assessments
+        - update_cas2_notes_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4268,6 +4268,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas2_status_updates_with_assessments
+        - update_cas2_notes_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -260,6 +260,46 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /assessments/{assessmentId}/notes:
+    post:
+      tags:
+        - Operations on CAS2 assessments
+      summary: Add a note to an assessment
+      parameters:
+        - name: assessmentId
+          in: path
+          description: ID of the assessment
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: the note to add
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewCas2ApplicationNote'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas2ApplicationNote'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid assessmentId
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
   /submissions:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3754,6 +3754,7 @@ components:
         - update_task_due_dates
         - update_cas2_applications_with_assessments
         - update_cas2_status_updates_with_assessments
+        - update_cas2_notes_with_assessments
         - update_cas1_user_details
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2NoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2NoteEntityFactory.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2NoteEntityFactory : Factory<Cas2ApplicationNoteEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdByUser: Yielded<Cas2User> = { NomisUserEntityFactory().produce() }
+  private var application: Yielded<Cas2ApplicationEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var body: Yielded<String> = { "Note body" }
+  private var assessment: Yielded<Cas2AssessmentEntity?> = { null }
+
+  fun withApplication(application: Cas2ApplicationEntity) = apply {
+    this.application = { application }
+  }
+
+  fun withAssessment(assessment: Cas2AssessmentEntity) = apply {
+    this.assessment = { assessment }
+  }
+
+  fun withCreatedByUser(createdByUser: NomisUserEntity) = apply {
+    this.createdByUser = { createdByUser }
+  }
+
+  override fun produce(): Cas2ApplicationNoteEntity = Cas2ApplicationNoteEntity(
+    id = this.id(),
+    createdByUser = this.createdByUser(),
+    application = this.application?.invoke() ?: error("Must provide an application."),
+    createdAt = this.createdAt(),
+    body = this.body(),
+    assessment = this.assessment(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -54,6 +54,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1ApplicationU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2NoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
@@ -121,6 +122,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
@@ -356,6 +359,9 @@ abstract class IntegrationTestBase {
   lateinit var cas2StatusUpdateRepository: Cas2StatusUpdateTestRepository
 
   @Autowired
+  lateinit var cas2NoteRepository: Cas2ApplicationNoteRepository
+
+  @Autowired
   lateinit var temporaryAccommodationApplicationRepository: TemporaryAccommodationApplicationTestRepository
 
   @Autowired
@@ -512,6 +518,7 @@ abstract class IntegrationTestBase {
   lateinit var cas2ApplicationEntityFactory: PersistedFactory<Cas2ApplicationEntity, UUID, Cas2ApplicationEntityFactory>
   lateinit var cas2AssessmentEntityFactory: PersistedFactory<Cas2AssessmentEntity, UUID, Cas2AssessmentEntityFactory>
   lateinit var cas2StatusUpdateEntityFactory: PersistedFactory<Cas2StatusUpdateEntity, UUID, Cas2StatusUpdateEntityFactory>
+  lateinit var cas2NoteEntityFactory: PersistedFactory<Cas2ApplicationNoteEntity, UUID, Cas2NoteEntityFactory>
   lateinit var temporaryAccommodationApplicationEntityFactory: PersistedFactory<TemporaryAccommodationApplicationEntity, UUID, TemporaryAccommodationApplicationEntityFactory>
   lateinit var offlineApplicationEntityFactory: PersistedFactory<OfflineApplicationEntity, UUID, OfflineApplicationEntityFactory>
   lateinit var approvedPremisesApplicationJsonSchemaEntityFactory: PersistedFactory<ApprovedPremisesApplicationJsonSchemaEntity, UUID, ApprovedPremisesApplicationJsonSchemaEntityFactory>
@@ -612,6 +619,7 @@ abstract class IntegrationTestBase {
     cas2ApplicationEntityFactory = PersistedFactory({ Cas2ApplicationEntityFactory() }, cas2ApplicationRepository)
     cas2AssessmentEntityFactory = PersistedFactory({ Cas2AssessmentEntityFactory() }, cas2AssessmentRepository)
     cas2StatusUpdateEntityFactory = PersistedFactory({ Cas2StatusUpdateEntityFactory() }, cas2StatusUpdateRepository)
+    cas2NoteEntityFactory = PersistedFactory({ Cas2NoteEntityFactory() }, cas2NoteRepository)
     temporaryAccommodationApplicationEntityFactory = PersistedFactory({ TemporaryAccommodationApplicationEntityFactory() }, temporaryAccommodationApplicationRepository)
     offlineApplicationEntityFactory = PersistedFactory({ OfflineApplicationEntityFactory() }, offlineApplicationRepository)
     approvedPremisesApplicationJsonSchemaEntityFactory = PersistedFactory({ ApprovedPremisesApplicationJsonSchemaEntityFactory() }, approvedPremisesApplicationJsonSchemaRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationNotesTest.kt
@@ -553,3 +553,542 @@ class Cas2ApplicationNotesTest(
     }
   }
 }
+
+class Cas2AssessmentNotesTest(
+  @Value("\${url-templates.frontend.cas2.application-overview}") private val applicationUrlTemplate: String,
+  @Value("\${url-templates.frontend.cas2.submitted-application-overview}") private val assessmentUrlTemplate: String,
+) : IntegrationTestBase() {
+
+  @SpykBean
+  lateinit var realNotesRepository: Cas2ApplicationNoteRepository
+
+  val schema = """
+                {
+                  "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+                  "${"\$id"}": "https://example.com/product.schema.json",
+                  "title": "Thing",
+                  "description": "A thing",
+                  "type": "object",
+                  "properties": {},
+                  "required": []
+                }
+              """
+
+  @AfterEach
+  fun afterEach() {
+    // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
+    // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
+    // Manually clearing after each test seems to fix this.
+    clearMocks(realNotesRepository)
+  }
+
+  @Nested
+  inner class MissingJwt {
+    @Test
+    fun `creating a note without JWT returns 401`() {
+      webTestClient.post()
+        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+  }
+
+  @Nested
+  inner class ControlsOnExternalUsers {
+    @Test
+    fun `creating a note is forbidden to external users who are not Assessors`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "auth",
+        roles = listOf("ROLE_CAS2_ADMIN"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `assessors create note returns 201`() {
+      val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+      `Given a CAS2 POM User` { referrer, _ ->
+        `Given a CAS2 Assessor` { _, jwt ->
+          val applicationSchema =
+            cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+              withAddedAt(OffsetDateTime.now())
+              withId(UUID.randomUUID())
+              withSchema(
+                schema,
+              )
+            }
+
+          val application = cas2ApplicationEntityFactory.produceAndPersist {
+            withId(applicationId)
+            withCreatedByUser(referrer)
+            withApplicationSchema(applicationSchema)
+            withSubmittedAt(OffsetDateTime.now())
+            withNomsNumber("123NOMS")
+          }
+
+          val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+            withApplication(application)
+            withNacroReferralId("OH123")
+            withAssessorName("Anne Assessor")
+          }
+
+          Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+          val rawResponseBody = webTestClient.post()
+            .uri("/cas2/assessments/${assessment.id}/notes")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.cas2.value)
+            .bodyValue(
+              NewCas2ApplicationNote(note = "New note content"),
+            )
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .returnResult<String>()
+            .responseBody
+            .blockFirst()
+
+          Assertions.assertThat(realNotesRepository.count()).isEqualTo(1)
+
+          val responseBody =
+            objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
+
+          Assertions.assertThat(responseBody.body).isEqualTo("New note content")
+
+          emailAsserter.assertEmailsRequestedCount(1)
+          emailAsserter.assertEmailRequested(
+            toEmailAddress = referrer.email!!,
+            templateId = "debe17a2-9f79-4d26-88a0-690dd73e2a5b",
+            personalisation = mapOf(
+              "dateNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toLocalDate().toCas2UiFormat(),
+              "timeNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toCas2UiFormattedHourOfDay(),
+              "nomsNumber" to "123NOMS",
+              "applicationType" to "Home Detention Curfew (HDC)",
+              "applicationUrl" to applicationUrlTemplate.replace("#id", application.id.toString()),
+            ),
+            replyToEmailId = "cbe00c2d-387b-4283-9b9c-13c8b7a61444",
+          )
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class PostToCreate {
+
+    @Nested
+    inner class ControlsOnInternalUsers {
+
+      @Nested
+      inner class WhenUserIsPom {
+        @Nested
+        inner class WhenApplicationCreatedByUser {
+          @Test
+          fun `referrer create note returns 201`() {
+            val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+            `Given a CAS2 POM User` { referrer, jwt ->
+              val applicationSchema =
+                cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withAddedAt(OffsetDateTime.now())
+                  withId(UUID.randomUUID())
+                  withSchema(
+                    schema,
+                  )
+                }
+
+              val application = cas2ApplicationEntityFactory.produceAndPersist {
+                withId(applicationId)
+                withCreatedByUser(referrer)
+                withApplicationSchema(applicationSchema)
+                withSubmittedAt(OffsetDateTime.now())
+              }
+
+              val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+                withApplication(application)
+                withNacroReferralId("OH123")
+                withAssessorName("Anne Assessor")
+              }
+
+              Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+              val rawResponseBody = webTestClient.post()
+                .uri("/cas2/assessments/${assessment.id}/notes")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.cas2.value)
+                .bodyValue(
+                  NewCas2ApplicationNote(note = "New note content"),
+                )
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .returnResult<String>()
+                .responseBody
+                .blockFirst()
+
+              Assertions.assertThat(realNotesRepository.count()).isEqualTo(1)
+
+              val responseBody =
+                objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
+
+              Assertions.assertThat(responseBody.body).isEqualTo("New note content")
+
+              emailAsserter.assertEmailsRequestedCount(1)
+              emailAsserter.assertEmailRequested(
+                toEmailAddress = "assessors@example.com",
+                templateId = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1",
+                personalisation = mapOf(
+                  "nacroReferenceId" to "OH123",
+                  "nacroReferenceIdInSubject" to "(OH123)",
+                  "dateNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toLocalDate().toCas2UiFormat(),
+                  "timeNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toCas2UiFormattedHourOfDay(),
+                  "assessorName" to "Anne Assessor",
+                  "applicationType" to "Home Detention Curfew (HDC)",
+                  "applicationUrl" to assessmentUrlTemplate.replace("#applicationId", application.id.toString()),
+                ),
+                replyToEmailId = "cbe00c2d-387b-4283-9b9c-13c8b7a61444",
+              )
+            }
+          }
+        }
+
+        @Nested
+        inner class WhenApplicationCreatedByDifferentUser {
+          @Nested
+          inner class WhenDifferentPrison {
+
+            @Test
+            fun `referrer cannot create note`() {
+              val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+              `Given a CAS2 POM User` { _, jwt ->
+                val applicationSchema =
+                  cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                    withAddedAt(OffsetDateTime.now())
+                    withId(UUID.randomUUID())
+                    withSchema(
+                      schema,
+                    )
+                  }
+
+                val otherUser = nomisUserEntityFactory.produceAndPersist {
+                  withActiveCaseloadId("another-prison")
+                }
+
+                val application = cas2ApplicationEntityFactory.produceAndPersist {
+                  withId(applicationId)
+                  withCreatedByUser(otherUser)
+                  withApplicationSchema(applicationSchema)
+                  withSubmittedAt(OffsetDateTime.now())
+                  withReferringPrisonCode("another-prison")
+                }
+
+                val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+                  withApplication(application)
+                }
+
+                Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+                webTestClient.post()
+                  .uri("/cas2/assessments/${assessment.id}/notes")
+                  .header("Authorization", "Bearer $jwt")
+                  .header("X-Service-Name", ServiceName.cas2.value)
+                  .bodyValue(
+                    NewCas2ApplicationNote(note = "New note content"),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isForbidden
+
+                Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+              }
+            }
+          }
+
+          @Nested
+          inner class WhenSamePrison {
+
+            @Test
+            fun `referrer can create a note for an application they did not create`() {
+              `Given a CAS2 POM User` { referrer, jwt ->
+                val applicationSchema =
+                  cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                    withAddedAt(OffsetDateTime.now())
+                    withId(UUID.randomUUID())
+                    withSchema(
+                      schema,
+                    )
+                  }
+
+                val otherUser = nomisUserEntityFactory.produceAndPersist {
+                  withActiveCaseloadId(referrer.activeCaseloadId!!)
+                }
+
+                val applicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+                  withApplicationSchema(applicationSchema)
+                  withCreatedByUser(otherUser)
+                  withSubmittedAt(OffsetDateTime.now().minusDays(1))
+                  withReferringPrisonCode(referrer.activeCaseloadId!!)
+                }
+
+                val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+                  withApplication(applicationEntity)
+                  withNacroReferralId("OH456")
+                  withAssessorName("Anne Other Assessor")
+                }
+
+                Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+                val rawResponseBody = webTestClient.post()
+                  .uri("/cas2/assessments/${assessment.id}/notes")
+                  .header("Authorization", "Bearer $jwt")
+                  .header("X-Service-Name", ServiceName.cas2.value)
+                  .bodyValue(
+                    NewCas2ApplicationNote(note = "New prison note content"),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isCreated()
+                  .returnResult<String>()
+                  .responseBody
+                  .blockFirst()
+
+                Assertions.assertThat(realNotesRepository.count()).isEqualTo(1)
+
+                val responseBody =
+                  objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
+
+                Assertions.assertThat(responseBody.body).isEqualTo("New prison note content")
+
+                emailAsserter.assertEmailsRequestedCount(1)
+                emailAsserter.assertEmailRequested(
+                  toEmailAddress = "assessors@example.com",
+                  templateId = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1",
+                  personalisation = mapOf(
+                    "nacroReferenceId" to "OH456",
+                    "nacroReferenceIdInSubject" to "(OH456)",
+                    "dateNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toLocalDate().toCas2UiFormat(),
+                    "timeNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toCas2UiFormattedHourOfDay(),
+                    "assessorName" to "Anne Other Assessor",
+                    "applicationType" to "Home Detention Curfew (HDC)",
+                    "applicationUrl" to assessmentUrlTemplate.replace("#applicationId", applicationEntity.id.toString()),
+                  ),
+                  replyToEmailId = "cbe00c2d-387b-4283-9b9c-13c8b7a61444",
+                )
+              }
+            }
+          }
+        }
+      }
+
+      @Nested
+      inner class WhenUserIsLicenceCA {
+        @Nested
+        inner class WhenApplicationCreatedByUser {
+          @Test
+          fun `referrer create note returns 201`() {
+            val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+            `Given a CAS2 Licence Case Admin User` { referrer, jwt ->
+              val applicationSchema =
+                cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                  withAddedAt(OffsetDateTime.now())
+                  withId(UUID.randomUUID())
+                  withSchema(
+                    schema,
+                  )
+                }
+
+              val application = cas2ApplicationEntityFactory.produceAndPersist {
+                withId(applicationId)
+                withCreatedByUser(referrer)
+                withApplicationSchema(applicationSchema)
+                withSubmittedAt(OffsetDateTime.now())
+              }
+
+              val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+                withApplication(application)
+                withNacroReferralId("OH123")
+                withAssessorName("Anne Assessor")
+              }
+
+              Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+              val rawResponseBody = webTestClient.post()
+                .uri("/cas2/assessments/${assessment.id}/notes")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.cas2.value)
+                .bodyValue(
+                  NewCas2ApplicationNote(note = "New note content"),
+                )
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .returnResult<String>()
+                .responseBody
+                .blockFirst()
+
+              Assertions.assertThat(realNotesRepository.count()).isEqualTo(1)
+
+              val responseBody =
+                objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
+
+              Assertions.assertThat(responseBody.body).isEqualTo("New note content")
+
+              emailAsserter.assertEmailsRequestedCount(1)
+              emailAsserter.assertEmailRequested(
+                toEmailAddress = "assessors@example.com",
+                templateId = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1",
+                personalisation = mapOf(
+                  "nacroReferenceId" to "OH123",
+                  "nacroReferenceIdInSubject" to "(OH123)",
+                  "dateNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toLocalDate().toCas2UiFormat(),
+                  "timeNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toCas2UiFormattedHourOfDay(),
+                  "assessorName" to "Anne Assessor",
+                  "applicationType" to "Home Detention Curfew (HDC)",
+                  "applicationUrl" to assessmentUrlTemplate.replace("#applicationId", application.id.toString()),
+                ),
+                replyToEmailId = "cbe00c2d-387b-4283-9b9c-13c8b7a61444",
+              )
+            }
+          }
+        }
+
+        @Nested
+        inner class WhenApplicationCreatedByDifferentUser {
+          @Nested
+          inner class WhenDifferentPrison {
+
+            @Test
+            fun `referrer cannot create note`() {
+              val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+              `Given a CAS2 Licence Case Admin User` { _, jwt ->
+                val applicationSchema =
+                  cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                    withAddedAt(OffsetDateTime.now())
+                    withId(UUID.randomUUID())
+                    withSchema(
+                      schema,
+                    )
+                  }
+
+                val otherUser = nomisUserEntityFactory.produceAndPersist {
+                  withActiveCaseloadId("another-prison")
+                }
+
+                val application = cas2ApplicationEntityFactory.produceAndPersist {
+                  withId(applicationId)
+                  withCreatedByUser(otherUser)
+                  withApplicationSchema(applicationSchema)
+                  withSubmittedAt(OffsetDateTime.now())
+                  withReferringPrisonCode("another-prison")
+                }
+
+                val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+                  withApplication(application)
+                }
+
+                Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+                webTestClient.post()
+                  .uri("/cas2/assessments/${assessment.id}/notes")
+                  .header("Authorization", "Bearer $jwt")
+                  .header("X-Service-Name", ServiceName.cas2.value)
+                  .bodyValue(
+                    NewCas2ApplicationNote(note = "New note content"),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isForbidden
+
+                Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+              }
+            }
+          }
+
+          @Nested
+          inner class WhenSamePrison {
+
+            @Test
+            fun `referrer can create a note for an application they did not create`() {
+              `Given a CAS2 POM User` { referrer, jwt ->
+                val applicationSchema =
+                  cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                    withAddedAt(OffsetDateTime.now())
+                    withId(UUID.randomUUID())
+                    withSchema(
+                      schema,
+                    )
+                  }
+
+                val otherUser = nomisUserEntityFactory.produceAndPersist {
+                  withActiveCaseloadId(referrer.activeCaseloadId!!)
+                }
+
+                val applicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+                  withApplicationSchema(applicationSchema)
+                  withCreatedByUser(otherUser)
+                  withSubmittedAt(OffsetDateTime.now().minusDays(1))
+                  withReferringPrisonCode(referrer.activeCaseloadId!!)
+                }
+
+                val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+                  withApplication(applicationEntity)
+                  withNacroReferralId("OH456")
+                  withAssessorName("Anne Other Assessor")
+                }
+
+                Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
+
+                val rawResponseBody = webTestClient.post()
+                  .uri("/cas2/assessments/${assessment.id}/notes")
+                  .header("Authorization", "Bearer $jwt")
+                  .header("X-Service-Name", ServiceName.cas2.value)
+                  .bodyValue(
+                    NewCas2ApplicationNote(note = "New prison note content"),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isCreated()
+                  .returnResult<String>()
+                  .responseBody
+                  .blockFirst()
+
+                Assertions.assertThat(realNotesRepository.count()).isEqualTo(1)
+
+                val responseBody =
+                  objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
+
+                Assertions.assertThat(responseBody.body).isEqualTo("New prison note content")
+
+                emailAsserter.assertEmailsRequestedCount(1)
+                emailAsserter.assertEmailRequested(
+                  toEmailAddress = "assessors@example.com",
+                  templateId = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1",
+                  personalisation = mapOf(
+                    "nacroReferenceId" to "OH456",
+                    "nacroReferenceIdInSubject" to "(OH456)",
+                    "dateNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toLocalDate().toCas2UiFormat(),
+                    "timeNoteAdded" to OffsetDateTime.ofInstant(responseBody.createdAt, ZoneOffset.UTC).toCas2UiFormattedHourOfDay(),
+                    "assessorName" to "Anne Other Assessor",
+                    "applicationType" to "Home Detention Curfew (HDC)",
+                    "applicationUrl" to assessmentUrlTemplate.replace("#applicationId", applicationEntity.id.toString()),
+                  ),
+                  replyToEmailId = "cbe00c2d-387b-4283-9b9c-13c8b7a61444",
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationNotesTest.kt
@@ -252,12 +252,16 @@ class Cas2ApplicationNotesTest(
                   withActiveCaseloadId("another-prison")
                 }
 
-                cas2ApplicationEntityFactory.produceAndPersist {
+                val application = cas2ApplicationEntityFactory.produceAndPersist {
                   withId(applicationId)
                   withCreatedByUser(otherUser)
                   withApplicationSchema(applicationSchema)
                   withSubmittedAt(OffsetDateTime.now())
                   withReferringPrisonCode("another-prison")
+                }
+
+                cas2AssessmentEntityFactory.produceAndPersist() {
+                  withApplication(application)
                 }
 
                 Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
@@ -449,12 +453,16 @@ class Cas2ApplicationNotesTest(
                   withActiveCaseloadId("another-prison")
                 }
 
-                cas2ApplicationEntityFactory.produceAndPersist {
+                val application = cas2ApplicationEntityFactory.produceAndPersist {
                   withId(applicationId)
                   withCreatedByUser(otherUser)
                   withApplicationSchema(applicationSchema)
                   withSubmittedAt(OffsetDateTime.now())
                   withReferringPrisonCode("another-prison")
+                }
+
+                val assessment = cas2AssessmentEntityFactory.produceAndPersist {
+                  withApplication(application)
                 }
 
                 Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2MigrateNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2MigrateNotesTest.kt
@@ -1,0 +1,116 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearMocks
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Assessor`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2MigrateNotesTest : MigrationJobTestBase() {
+
+  @SpykBean
+  lateinit var realNotesRepository: Cas2ApplicationNoteRepository
+
+  @AfterEach
+  fun afterEach() {
+    // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
+    // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
+    // Manually clearing after each test seems to fix this.
+    clearMocks(realNotesRepository)
+  }
+
+  @Test
+  fun `Should add assessments for CAS2 notes that don't have one and returns 202 response`() {
+    `Given a CAS2 POM User` { userEntity, _ ->
+      `Given a CAS2 Assessor` { assessor, _ ->
+        val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withAddedAt(OffsetDateTime.now())
+          withId(UUID.randomUUID())
+        }
+
+        val submittedApplication1 = createApplicationEntity(applicationSchema, userEntity, OffsetDateTime.now().minusDays(1))
+
+        val assessment1 = cas2AssessmentEntityFactory.produceAndPersist {
+          withApplication(submittedApplication1)
+        }
+
+        // create the notes (without assessment relationships) so there are two pages
+        val assessment1NoteIds = mutableListOf<UUID>()
+        repeat(12) {
+          assessment1NoteIds.add(
+            cas2NoteEntityFactory.produceAndPersist {
+              withApplication(submittedApplication1)
+              withCreatedByUser(userEntity)
+            }.id,
+          )
+        }
+
+        repeat(2) {
+          assessment1NoteIds.add(
+            cas2NoteEntityFactory.produceAndPersist {
+              withApplication(submittedApplication1)
+              withAssessment(assessment1)
+              withCreatedByUser(userEntity)
+            }.id,
+          )
+        }
+
+        val submittedApplication2 = createApplicationEntity(applicationSchema, userEntity, OffsetDateTime.now().minusDays(1))
+
+        val assessment2 = cas2AssessmentEntityFactory.produceAndPersist {
+          withApplication(submittedApplication2)
+        }
+
+        val assessment2NoteIds = mutableListOf<UUID>()
+        repeat(11) {
+          assessment2NoteIds.add(
+            cas2NoteEntityFactory.produceAndPersist {
+              withApplication(submittedApplication2)
+              withCreatedByUser(userEntity)
+            }.id,
+          )
+        }
+
+        repeat(3) {
+          assessment2NoteIds.add(
+            cas2NoteEntityFactory.produceAndPersist {
+              withApplication(submittedApplication2)
+              withAssessment(assessment2)
+              withCreatedByUser(userEntity)
+            }.id,
+          )
+        }
+
+        migrationJobService.runMigrationJob(MigrationJobType.cas2NotesWithAssessments, 10)
+
+        assessment1NoteIds.forEach {
+          val updatedNote = realNotesRepository.findById(it)
+          Assertions.assertThat(updatedNote.get().assessment!!.id).isEqualTo(assessment1.id)
+        }
+
+        assessment2NoteIds.forEach {
+          val updatedNote = realNotesRepository.findById(it)
+          Assertions.assertThat(updatedNote.get().assessment!!.id).isEqualTo(assessment2.id)
+        }
+      }
+    }
+  }
+
+  private fun createApplicationEntity(applicationSchema: Cas2ApplicationJsonSchemaEntity, userEntity: NomisUserEntity, submittedAt: OffsetDateTime?) =
+    cas2ApplicationEntityFactory.produceAndPersist {
+      withId(UUID.randomUUID())
+      withApplicationSchema(applicationSchema)
+      withCreatedByUser(userEntity)
+      withData("{}")
+      withSubmittedAt(submittedAt)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationNoteServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityF
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
@@ -39,6 +40,7 @@ import java.util.UUID
 
 class ApplicationNoteServiceTest {
   private val mockApplicationRepository = mockk<Cas2ApplicationRepository>()
+  private val mockAssessmentRepository = mockk<Cas2AssessmentRepository>()
   private val mockApplicationNoteRepository = mockk<Cas2ApplicationNoteRepository>()
   private val mockUserService = mockk<NomisUserService>()
   private val mockExternalUserService = mockk<ExternalUserService>()
@@ -49,6 +51,7 @@ class ApplicationNoteServiceTest {
 
   private val applicationNoteService = uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationNoteService(
     mockApplicationRepository,
+    mockAssessmentRepository,
     mockApplicationNoteRepository,
     mockUserService,
     mockExternalUserService,
@@ -427,6 +430,396 @@ class ApplicationNoteServiceTest {
 
         applicationNoteService.createApplicationNote(
           applicationId = applicationId,
+          NewCas2ApplicationNote(note = "new note"),
+        )
+
+        verify(exactly = 1) {
+          Sentry.captureException(
+            any(),
+          )
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class CreateAssessmentNote {
+
+    private val referrer = NomisUserEntityFactory().withActiveCaseloadId("my-prison").produce()
+
+    @Nested
+    inner class WhenApplicationIsNotFound {
+      @Test
+      fun `returns Not Found`() {
+        every { mockAssessmentRepository.findByIdOrNull(any()) } returns Cas2AssessmentEntityFactory().produce()
+        every { mockApplicationRepository.findByIdOrNull(any()) } returns null
+
+        Assertions.assertThat(
+          applicationNoteService.createAssessmentNote(
+            assessmentId = UUID.randomUUID(),
+            note = NewCas2ApplicationNote(note = "note for missing app"),
+          ) is AuthorisableActionResult.NotFound,
+        ).isTrue
+      }
+    }
+
+    @Nested
+    inner class WhenAssessmentIsNotFound {
+      @Test
+      fun `returns Not Found`() {
+        every { mockAssessmentRepository.findByIdOrNull(any()) } returns null
+
+        Assertions.assertThat(
+          applicationNoteService.createAssessmentNote(
+            assessmentId = UUID.randomUUID(),
+            note = NewCas2ApplicationNote(note = "note for missing app"),
+          ) is AuthorisableActionResult.NotFound,
+        ).isTrue
+      }
+    }
+
+    @Nested
+    inner class WhenApplicationIsNotSubmitted {
+      @Test
+      fun `returns Validation error when application is not submitted`() {
+        val assessment = Cas2AssessmentEntityFactory().produce()
+
+        val applicationNotSubmitted = Cas2ApplicationEntityFactory()
+          .withCreatedByUser(referrer)
+          .withCrn("CRN123")
+          .withNomsNumber("NOMSABC")
+          .withAssessment(assessment)
+          .produce()
+
+        every { mockAssessmentRepository.findByIdOrNull(any()) } returns assessment
+        every { mockApplicationRepository.findByIdOrNull(any()) } returns applicationNotSubmitted
+
+        every { mockUserService.getUserForRequest() } returns referrer
+
+        val result = applicationNoteService.createAssessmentNote(
+          assessmentId = applicationNotSubmitted.id,
+          note = NewCas2ApplicationNote(note = "note for in progress app"),
+        )
+        Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+        result as AuthorisableActionResult.Success
+
+        Assertions.assertThat(result.entity is ValidatableActionResult.GeneralValidationError).isTrue
+        val validatableActionResult = result.entity as ValidatableActionResult.GeneralValidationError
+
+        Assertions.assertThat(validatableActionResult.message).isEqualTo("This application has not been submitted")
+      }
+    }
+
+    @Nested
+    inner class AsNomisUser {
+
+      @BeforeEach
+      fun setup() {
+        val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+        every { mockHttpAuthService.getCas2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+        every { mockPrincipal.isExternalUser() } returns false
+        every { mockNotifyConfig.emailAddresses.cas2Assessors } returns "assessors@example.com"
+        every { mockNotifyConfig.templates.cas2NoteAddedForAssessor } returns "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1"
+        every { mockUserService.getUserForRequest() } returns referrer
+        every { mockApplicationNoteRepository.save(any()) } answers
+          {
+            noteEntity
+          }
+      }
+
+      private val assessment = Cas2AssessmentEntityFactory()
+        .withAssessorName("Anne Assessor")
+        .withNacroReferralId("OH123").produce()
+      private val submittedApplication = Cas2ApplicationEntityFactory()
+        .withId(assessment.application.id)
+        .withCreatedByUser(referrer)
+        .withCrn("CRN123")
+        .withNomsNumber("NOMSABC")
+        .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+        .withAssessment(assessment)
+        .produce()
+      private val applicationId = submittedApplication.id
+      private val noteEntity = Cas2ApplicationNoteEntity(
+        id = UUID.randomUUID(),
+        createdByUser = referrer,
+        application = submittedApplication,
+        body = "new note",
+        createdAt = OffsetDateTime.now().randomDateTimeBefore(1),
+      )
+
+      @Nested
+      inner class WhenApplicationCreatedByUser {
+        @Test
+        fun `returns Success result with entity from db`() {
+          every { mockAssessmentRepository.findByIdOrNull(assessment.id) } returns assessment
+          every { mockApplicationRepository.findByIdOrNull(applicationId) } returns submittedApplication
+
+          every {
+            mockEmailNotificationService.sendCas2Email(
+              recipientEmailAddress = "assessors@example.com",
+              templateId = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1",
+              personalisation = mapOf(
+                "nacroReferenceId" to "OH123",
+                "nacroReferenceIdInSubject" to "(OH123)",
+                "dateNoteAdded" to noteEntity.createdAt.toLocalDate().toCas2UiFormat(),
+                "timeNoteAdded" to noteEntity.createdAt.toCas2UiFormattedHourOfDay(),
+                "assessorName" to "Anne Assessor",
+                "applicationType" to "Home Detention Curfew (HDC)",
+                "applicationUrl" to "http://frontend/assess/applications/$applicationId/overview",
+              ),
+            )
+          } just Runs
+
+          val result = applicationNoteService.createAssessmentNote(
+            assessmentId = assessment!!.id,
+            NewCas2ApplicationNote(note = "new note"),
+          )
+
+          verify(exactly = 1) { mockApplicationNoteRepository.save(any()) }
+
+          Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+          result as AuthorisableActionResult.Success
+
+          Assertions.assertThat(result.entity is ValidatableActionResult.Success).isTrue
+          val validatableActionResult = result.entity as ValidatableActionResult.Success
+
+          val createdNote = validatableActionResult.entity
+
+          Assertions.assertThat(createdNote).isEqualTo(noteEntity)
+
+          verify(exactly = 1) { mockEmailNotificationService.sendCas2Email(any(), any(), any()) }
+        }
+
+        @Nested
+        inner class WhenThereAreNoAssessorDetails {
+          @Test
+          fun `passes placeholder copy to email template`() {
+            val assessment = Cas2AssessmentEntityFactory().produce()
+            val submittedApplicationWithoutAssessorDetails = Cas2ApplicationEntityFactory()
+              .withId(assessment.application.id)
+              .withCreatedByUser(referrer)
+              .withAssessment(assessment)
+              .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+              .produce()
+
+            every { mockAssessmentRepository.findByIdOrNull(assessment.id) } returns assessment
+            every { mockApplicationRepository.findByIdOrNull(submittedApplicationWithoutAssessorDetails.id) } returns submittedApplicationWithoutAssessorDetails
+
+            every {
+              mockEmailNotificationService.sendCas2Email(
+                recipientEmailAddress = "assessors@example.com",
+                templateId = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1",
+                personalisation = mapOf(
+                  "nacroReferenceId" to "Unknown. " +
+                    "The Nacro CAS-2 reference number has not been added to the application yet.",
+                  "nacroReferenceIdInSubject" to "",
+                  "dateNoteAdded" to noteEntity.createdAt.toLocalDate().toCas2UiFormat(),
+                  "timeNoteAdded" to noteEntity.createdAt.toCas2UiFormattedHourOfDay(),
+                  "assessorName" to "Unknown. " +
+                    "The assessor has not added their name to the application yet.",
+                  "applicationType" to "Home Detention Curfew (HDC)",
+                  "applicationUrl" to "http://frontend/assess/applications/${submittedApplicationWithoutAssessorDetails.id}/overview",
+                ),
+              )
+            } just Runs
+
+            val result = applicationNoteService.createAssessmentNote(
+              assessmentId = assessment.id,
+              NewCas2ApplicationNote(note = "new note"),
+            )
+
+            Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+            verify(exactly = 1) { mockEmailNotificationService.sendCas2Email(any(), any(), any()) }
+          }
+        }
+      }
+
+      @Nested
+      inner class WhenApplicationCreatedByOtherUser {
+        val assessment = Cas2AssessmentEntityFactory()
+          .withAssessorName("Anne Prison Assessor").withNacroReferralId("OH456").produce()
+        val applicationCreatedByOtherUser = Cas2ApplicationEntityFactory()
+          .withId(assessment.application.id)
+          .withCreatedByUser(NomisUserEntityFactory().produce())
+          .withCrn("CRN123")
+          .withNomsNumber("NOMSABC")
+          .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+          .withReferringPrisonCode("other-prison")
+          .withAssessment(assessment)
+          .produce()
+
+        @Nested
+        inner class WhenDifferentPrison {
+          @Test
+          fun `returns Not Authorised`() {
+            every { mockAssessmentRepository.findByIdOrNull(assessment.id) } returns assessment
+            every { mockApplicationRepository.findByIdOrNull(applicationCreatedByOtherUser.id) } returns applicationCreatedByOtherUser
+            every {
+              mockUserAccessService.offenderIsFromSamePrisonAsUser("other-prison", "my-prison")
+            } returns false
+
+            Assertions.assertThat(
+              applicationNoteService.createAssessmentNote(
+                assessmentId = assessment.id,
+                note = NewCas2ApplicationNote(note = "note for unauthorised app"),
+              ) is AuthorisableActionResult.Unauthorised,
+            ).isTrue
+          }
+        }
+
+        @Nested
+        inner class WhenSamePrison {
+          @Test
+          fun `returns Success result with entity from db`() {
+            every { mockAssessmentRepository.findByIdOrNull(assessment.id) } returns assessment
+            every { mockApplicationRepository.findByIdOrNull(applicationCreatedByOtherUser.id) } returns applicationCreatedByOtherUser
+            every {
+              mockUserAccessService.offenderIsFromSamePrisonAsUser("other-prison", "my-prison")
+            } returns true
+
+            every {
+              mockEmailNotificationService.sendCas2Email(
+                recipientEmailAddress = "assessors@example.com",
+                templateId = "0d646bf0-d40f-4fe7-aa74-dd28b10d04f1",
+                personalisation = mapOf(
+                  "nacroReferenceId" to "OH456",
+                  "nacroReferenceIdInSubject" to "(OH456)",
+                  "dateNoteAdded" to noteEntity.createdAt.toLocalDate().toCas2UiFormat(),
+                  "timeNoteAdded" to noteEntity.createdAt.toCas2UiFormattedHourOfDay(),
+                  "assessorName" to "Anne Prison Assessor",
+                  "applicationType" to "Home Detention Curfew (HDC)",
+                  "applicationUrl" to "http://frontend/assess/applications/${applicationCreatedByOtherUser.id}/overview",
+                ),
+              )
+            } just Runs
+
+            val result = applicationNoteService.createAssessmentNote(
+              assessmentId = assessment.id,
+              NewCas2ApplicationNote(note = "new note"),
+            )
+
+            verify(exactly = 1) { mockApplicationNoteRepository.save(any()) }
+
+            Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+            result as AuthorisableActionResult.Success
+
+            Assertions.assertThat(result.entity is ValidatableActionResult.Success).isTrue
+            val validatableActionResult = result.entity as ValidatableActionResult.Success
+
+            val createdNote = validatableActionResult.entity
+
+            Assertions.assertThat(createdNote).isEqualTo(noteEntity)
+
+            verify(exactly = 1) { mockEmailNotificationService.sendCas2Email(any(), any(), any()) }
+          }
+        }
+      }
+    }
+
+    @Nested
+    inner class AsExternalUser {
+      private val externalUser = ExternalUserEntityFactory().produce()
+
+      @BeforeEach
+      fun setup() {
+        val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+        every { mockHttpAuthService.getCas2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+        every { mockPrincipal.isExternalUser() } returns true
+        every { mockNotifyConfig.templates.cas2NoteAddedForReferrer } returns "abc123"
+        every { mockNotifyConfig.emailAddresses.cas2Assessors } returns "assessors@example.com"
+        every { mockApplicationNoteRepository.save(any()) } answers
+          {
+            noteEntity
+          }
+      }
+
+      val assessment = Cas2AssessmentEntityFactory().produce()
+      private val submittedApplication = Cas2ApplicationEntityFactory()
+        .withId(assessment.application.id)
+        .withCreatedByUser(referrer)
+        .withCrn("CRN123")
+        .withNomsNumber("NOMSABC")
+        .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+        .withAssessment(assessment)
+        .produce()
+      private val applicationId = submittedApplication.id
+      private val noteEntity = Cas2ApplicationNoteEntity(
+        id = UUID.randomUUID(),
+        createdByUser = externalUser,
+        application = submittedApplication,
+        body = "new note",
+        createdAt = OffsetDateTime.now().randomDateTimeBefore(1),
+      )
+
+      @Test
+      fun `returns Success result with entity from db`() {
+        every { mockAssessmentRepository.findByIdOrNull(assessment.id) } returns assessment
+        every { mockApplicationRepository.findByIdOrNull(applicationId) } returns submittedApplication
+        every { mockExternalUserService.getUserForRequest() } returns externalUser
+
+        every {
+          mockEmailNotificationService.sendCas2Email(
+            recipientEmailAddress = referrer.email!!,
+            templateId = "abc123",
+            personalisation = mapOf(
+              "dateNoteAdded" to noteEntity.createdAt.toLocalDate().toCas2UiFormat(),
+              "timeNoteAdded" to noteEntity.createdAt.toCas2UiFormattedHourOfDay(),
+              "nomsNumber" to "NOMSABC",
+              "applicationType" to "Home Detention Curfew (HDC)",
+              "applicationUrl" to "http://frontend/applications/$applicationId/overview",
+            ),
+          )
+        } just Runs
+
+        val result = applicationNoteService.createAssessmentNote(
+          assessmentId = assessment.id,
+          NewCas2ApplicationNote(note = "new note"),
+        )
+
+        verify(exactly = 1) { mockApplicationNoteRepository.save(any()) }
+
+        Assertions.assertThat(result is AuthorisableActionResult.Success).isTrue
+        result as AuthorisableActionResult.Success
+
+        Assertions.assertThat(result.entity is ValidatableActionResult.Success).isTrue
+        val validatableActionResult = result.entity as ValidatableActionResult.Success
+
+        val createdNote = validatableActionResult.entity
+
+        Assertions.assertThat(createdNote).isEqualTo(noteEntity)
+      }
+
+      @Test
+      fun `alerts Sentry when the Referrer does not have an email`() {
+        val submittedApplicationWithNoReferrerEmail = Cas2ApplicationEntityFactory()
+          .withId(assessment.application.id)
+          .withCreatedByUser(NomisUserEntityFactory().withEmail(null).produce())
+          .withCrn("CRN123")
+          .withNomsNumber("NOMSABC")
+          .withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(2))
+          .withAssessment(assessment)
+          .produce()
+
+        every { mockAssessmentRepository.findByIdOrNull(assessment.id) } returns assessment
+        every { mockApplicationRepository.findByIdOrNull(applicationId) } answers
+          {
+            submittedApplicationWithNoReferrerEmail
+          }
+        every { mockExternalUserService.getUserForRequest() } returns externalUser
+        mockkStatic(Sentry::class)
+
+        every {
+          Sentry.captureException(
+            RuntimeException(
+              "Email not found for User ${submittedApplicationWithNoReferrerEmail.createdByUser.id}. " +
+                "Unable to send email for Note ${noteEntity.id} on Application ${submittedApplicationWithNoReferrerEmail.id}",
+              NotFoundException("Email not found for User ${submittedApplicationWithNoReferrerEmail.createdByUser.id}"),
+            ),
+          )
+        } returns SentryId.EMPTY_ID
+
+        applicationNoteService.createAssessmentNote(
+          assessmentId = assessment.id,
           NewCas2ApplicationNote(note = "new note"),
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/AssessmentNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/AssessmentNoteServiceTest.kt
@@ -38,7 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormattedHo
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class ApplicationNoteServiceTest {
+class AssessmentNoteServiceTest {
   private val mockApplicationRepository = mockk<Cas2ApplicationRepository>()
   private val mockAssessmentRepository = mockk<Cas2AssessmentRepository>()
   private val mockApplicationNoteRepository = mockk<Cas2ApplicationNoteRepository>()
@@ -49,7 +49,7 @@ class ApplicationNoteServiceTest {
   private val mockUserAccessService = mockk<UserAccessService>()
   private val mockNotifyConfig = mockk<NotifyConfig>()
 
-  private val applicationNoteService = uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.ApplicationNoteService(
+  private val assessmentNoteService = uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.AssessmentNoteService(
     mockApplicationRepository,
     mockAssessmentRepository,
     mockApplicationNoteRepository,
@@ -78,7 +78,7 @@ class ApplicationNoteServiceTest {
           }
 
         Assertions.assertThat(
-          applicationNoteService.createApplicationNote(
+          assessmentNoteService.createApplicationNote(
             applicationId = UUID.randomUUID(),
             note = NewCas2ApplicationNote(note = "note for missing app"),
           ) is AuthorisableActionResult.NotFound,
@@ -103,7 +103,7 @@ class ApplicationNoteServiceTest {
 
         every { mockUserService.getUserForRequest() } returns referrer
 
-        val result = applicationNoteService.createApplicationNote(
+        val result = assessmentNoteService.createApplicationNote(
           applicationId = applicationNotSubmitted.id,
           note = NewCas2ApplicationNote(note = "note for in progress app"),
         )
@@ -178,7 +178,7 @@ class ApplicationNoteServiceTest {
             )
           } just Runs
 
-          val result = applicationNoteService.createApplicationNote(
+          val result = assessmentNoteService.createApplicationNote(
             applicationId = applicationId,
             NewCas2ApplicationNote(note = "new note"),
           )
@@ -231,7 +231,7 @@ class ApplicationNoteServiceTest {
               )
             } just Runs
 
-            val result = applicationNoteService.createApplicationNote(
+            val result = assessmentNoteService.createApplicationNote(
               applicationId = applicationId,
               NewCas2ApplicationNote(note = "new note"),
             )
@@ -270,7 +270,7 @@ class ApplicationNoteServiceTest {
             } returns false
 
             Assertions.assertThat(
-              applicationNoteService.createApplicationNote(
+              assessmentNoteService.createApplicationNote(
                 applicationId = applicationCreatedByOtherUser.id,
                 note = NewCas2ApplicationNote(note = "note for unauthorised app"),
               ) is AuthorisableActionResult.Unauthorised,
@@ -307,7 +307,7 @@ class ApplicationNoteServiceTest {
               )
             } just Runs
 
-            val result = applicationNoteService.createApplicationNote(
+            val result = assessmentNoteService.createApplicationNote(
               applicationId = applicationCreatedByOtherUser.id,
               NewCas2ApplicationNote(note = "new note"),
             )
@@ -384,7 +384,7 @@ class ApplicationNoteServiceTest {
           )
         } just Runs
 
-        val result = applicationNoteService.createApplicationNote(
+        val result = assessmentNoteService.createApplicationNote(
           applicationId = applicationId,
           NewCas2ApplicationNote(note = "new note"),
         )
@@ -428,7 +428,7 @@ class ApplicationNoteServiceTest {
           )
         } returns SentryId.EMPTY_ID
 
-        applicationNoteService.createApplicationNote(
+        assessmentNoteService.createApplicationNote(
           applicationId = applicationId,
           NewCas2ApplicationNote(note = "new note"),
         )
@@ -455,7 +455,7 @@ class ApplicationNoteServiceTest {
         every { mockApplicationRepository.findByIdOrNull(any()) } returns null
 
         Assertions.assertThat(
-          applicationNoteService.createAssessmentNote(
+          assessmentNoteService.createAssessmentNote(
             assessmentId = UUID.randomUUID(),
             note = NewCas2ApplicationNote(note = "note for missing app"),
           ) is AuthorisableActionResult.NotFound,
@@ -470,7 +470,7 @@ class ApplicationNoteServiceTest {
         every { mockAssessmentRepository.findByIdOrNull(any()) } returns null
 
         Assertions.assertThat(
-          applicationNoteService.createAssessmentNote(
+          assessmentNoteService.createAssessmentNote(
             assessmentId = UUID.randomUUID(),
             note = NewCas2ApplicationNote(note = "note for missing app"),
           ) is AuthorisableActionResult.NotFound,
@@ -496,7 +496,7 @@ class ApplicationNoteServiceTest {
 
         every { mockUserService.getUserForRequest() } returns referrer
 
-        val result = applicationNoteService.createAssessmentNote(
+        val result = assessmentNoteService.createAssessmentNote(
           assessmentId = applicationNotSubmitted.id,
           note = NewCas2ApplicationNote(note = "note for in progress app"),
         )
@@ -570,7 +570,7 @@ class ApplicationNoteServiceTest {
             )
           } just Runs
 
-          val result = applicationNoteService.createAssessmentNote(
+          val result = assessmentNoteService.createAssessmentNote(
             assessmentId = assessment!!.id,
             NewCas2ApplicationNote(note = "new note"),
           )
@@ -623,7 +623,7 @@ class ApplicationNoteServiceTest {
               )
             } just Runs
 
-            val result = applicationNoteService.createAssessmentNote(
+            val result = assessmentNoteService.createAssessmentNote(
               assessmentId = assessment.id,
               NewCas2ApplicationNote(note = "new note"),
             )
@@ -659,7 +659,7 @@ class ApplicationNoteServiceTest {
             } returns false
 
             Assertions.assertThat(
-              applicationNoteService.createAssessmentNote(
+              assessmentNoteService.createAssessmentNote(
                 assessmentId = assessment.id,
                 note = NewCas2ApplicationNote(note = "note for unauthorised app"),
               ) is AuthorisableActionResult.Unauthorised,
@@ -693,7 +693,7 @@ class ApplicationNoteServiceTest {
               )
             } just Runs
 
-            val result = applicationNoteService.createAssessmentNote(
+            val result = assessmentNoteService.createAssessmentNote(
               assessmentId = assessment.id,
               NewCas2ApplicationNote(note = "new note"),
             )
@@ -771,7 +771,7 @@ class ApplicationNoteServiceTest {
           )
         } just Runs
 
-        val result = applicationNoteService.createAssessmentNote(
+        val result = assessmentNoteService.createAssessmentNote(
           assessmentId = assessment.id,
           NewCas2ApplicationNote(note = "new note"),
         )
@@ -818,7 +818,7 @@ class ApplicationNoteServiceTest {
           )
         } returns SentryId.EMPTY_ID
 
-        applicationNoteService.createAssessmentNote(
+        assessmentNoteService.createAssessmentNote(
           assessmentId = assessment.id,
           NewCas2ApplicationNote(note = "new note"),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationNoteTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationNoteTransformerTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
@@ -34,6 +35,7 @@ class ApplicationNoteTransformerTest {
         application = submittedApplication,
         body = "new note",
         createdAt = createdAt,
+        assessment = Cas2AssessmentEntityFactory().produce(),
       )
 
       val expectedRepresentation = Cas2ApplicationNote(
@@ -62,6 +64,7 @@ class ApplicationNoteTransformerTest {
         application = submittedApplication,
         body = "new note",
         createdAt = createdAt,
+        assessment = Cas2AssessmentEntityFactory().produce(),
       )
 
       val expectedRepresentation = Cas2ApplicationNote(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/TimelineEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/TimelineEventsTransformerTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
@@ -77,6 +78,7 @@ class TimelineEventsTransformerTest {
         createdByUser = nomisUser,
         application = submittedCas2ApplicationFactory.produce(),
         body = "a comment",
+        assessment = Cas2AssessmentEntityFactory().produce(),
       )
 
       val submittedAt = OffsetDateTime.now().minusDays(4)


### PR DESCRIPTION
This PR is the work required to carry out the first part of the task to repoint notes to assessments as described in:
https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4897341539/Associate+Application+Notes+with+Assessments+CAS2-327

**Database**

Since we cannot achieve our desired status in one step since we need to ensure that we don’t break the front end, we need to introduce an interim database schema which we can use to ensure continuity across both the front and back ends.  The interim schema will be:

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/acb8b837-6005-4295-89f8-ae5788c69bf4)

This means temporarily having both the existing `application_id` field and the new `assessment_id` field in the database until the front end is changed to use a new endpoint.  Swapping the front end functionality so that the `cas_2_assessments.id` to `cas_2_application_notes.assessment_id` relationship can be created for new applications and then removing the `cas_2_applications` to cas_2_application_notes relationship.

_Tasks_

The specific database related tasks required to achieve this interim schema are:

- Create a nullable assessment_id UUID field in cas_2_application_notes table.
- Create PK-FK relationship and between cas_2_assessments.id and cas_2_application_notes.assessment_id.
- Create an index on cas_2_application_notes.assessment_id.

**Data Model**

There is a requirement for an interim model where the `Cas2ApplicationNoteEntity` will both `application` and `assessment` fields.  Once the front end has been updated, the application field can be removed from this data class.  The interim `Cas2ApplicationNoteEntity` that will contain both fields is:

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/44abe4ff-bc34-4e09-b34d-a3f43f78b640)

The assessment field will be of type `Cas2AssessmentEntity`.

_Tasks_

Specific tasks related to the data model are:

- Add a new nullable field assessment to `Cas2ApplicationNoteEntity` of type `Cas2AssessmentEntity`; join the column to `assessment_id` and annotate `@ManyToOne`.

**Endpoints**

Similarly to the database and data model, we will temporarily need an interim solution where both endpoints will be specified in the OpenAPI specification:

`/submissions/{applicationId}/notes `- existing endpoint

`/assessments/{assessmentId}/notes` - new endpoint

OAuth roles that can access this endpoint are defined in `OAuth2ResourceServerSecurityConfiguration`, the interim solution will require that roles have access to both endpoints:

`authorize(HttpMethod.POST, "/cas2/submissions/*/notes", hasAnyRole("LICENCE_CA", "POM", "CAS2_ASSESSOR"))`

`authorize(HttpMethod.POST, "/cas2/assessments/*/notes", hasAnyRole("LICENCE_CA", "POM", "CAS2_ASSESSOR"))
`

_Tasks_

- Edit `OAuth2ResourceServerSecurityConfiguration` to give new permissions to `/cas2/assessments/*/notes` endpoints, permissions should be as per the existing endpoint.
- Create new `/assessments/{assessmentId}/notes` POST endpoint in `cas2-api.yml`.  The parameters, request body and response will be as per the existing POST endpoint (`/submissions/{applicationId}/notes`).

**Controllers**

As per other aspects of this work the will be an ‘interim’ controller state which is required.  A new `AssessmentsController.assessmentsAssessmentIdNotesPost()` method will be required, this method will override the method auto generated in the delegate interface `AssessmentsCas2Delegate`.  There will be a controller method to post notes in the `SubmissionsController` (existing) and a new controller method in the `AssessmentsController`, and a new method in the `ApplicationsNoteService`.  Later the legacy methods can be deleted once the front end has been migrated to use the assessments endpoint.

The `assessmentsAssessmentIdNotesPost` method will call a new `createAssessmentNote()` method in the `ApplicationNoteService`.  The method `createAssessmentNote()` is essentially as per the existing `createApplicationNote()`, with the difference being it is passed an `assessment_id` rather than an `application_id`. 

This new controller and service method will essentially exist at the same time as the `submissionsApplicationIdNotesPost()` and `createApplicationNote()` until the front end can be updated to use the new endpoints.  These methods will be annotated `@Deprecated`.

New integration tests will need to be created to test the new controller method based on the existing coverage for of `submissionsApplicationIdNotesPost()` and the new service method will require unit tests.

This work will enable us to check that the `cas_2_application_notes.assessment_id` is being populated correctly and ensure that the `AssessmentsController` and `Cas2ApplicationNoteEntity` are working as expected, and will then allow us to do the data migration before changing the front end.

This new controller functionality state will be therefore be as follows:

![image](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/159027876/c1e9bc1e-d5c2-4774-ad53-7baa1dd8c866)

_Tasks_

The specific tasks related to this work are:

- Create new service method `createAssessmentNote()` which is as per `createApplicationNote()` but will take the `assessment_id` as a method argument.  This method will look up the application based on the `assessment_id` supplied.
- Mark `createApplicationNote()` as deprecated.
- Write unit tests for new `createAssessmentNote()` coverage based on existing coverage.  New inner test class will be `CreateAssessmentNote` and test methods will be as per `CreateApplicationNote` methods.
- Create `createAssessmentNote()` unit tests to test when assessment is `AuthorisableActionResult.NotFound()`.
- Rename (refactor) `ApplicationNoteService` class to `AssessmentNoteService`.
- Create body of `AssessmentsController.assessmentsAssessmentIdNotesPost()` which is as per `SubmissionsController.submissionsApplicationIdNotesPost()` but will call `createAssessmentNote()`.
- Mark now legacy controller method `submissionsApplicationIdNotesPost()`  as deprecated.
- Create new integration tests to test new controller assessment notes functionality.  Create new class `Cas2AssessmentNotesTest` which will be as per existing tests in `Cas2ApplicationNotesTest` but calling the new assessments endpoint.
- Refactor `Cas2ApplicationsNoteTest.kt `as `Cas2AssessmentsNoteTest.kt`.
- Pass `assessment` to `saveNote()` for both `createApplicationNote()` and `createAssessmentNote()` and update associated tests.

**Data Migration**

_Tasks_

- Add new migration job `Cas2NoteMigrationJob.kt` which will be similar to `Cas2StatusUpdateMigrationJob` and will populate assessment ids for status notes that only have application ids.  A join will be required via the `cas_2_applications` table to determine the `assessment_id` for each particular `application_id`.  At this point all historical status updates will all have a populated `assessment_id`. 
- Add the new job to `MigrationJobService.kt`.
- Add `Cas2NoteEntityFactory` to `produce()` example `Cas2NoteEntity` objects which are required for the migration integration test.  Also needs to be added to `IntegrationTestBase`.
- Add integration test` Cas2MigrateNotesTest.kt` to test migration job functionality.
- Add additional checks to test that the right number of records has been affected.

