### PR TITLE
Cas2-216: Abandon an in-progress application

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -65,6 +65,7 @@ data class Cas2ApplicationEntity(
   var schemaVersion: JsonSchemaEntity,
   val createdAt: OffsetDateTime,
   var submittedAt: OffsetDateTime?,
+  var abandonedAt: OffsetDateTime? = null,
 
   @OneToMany(mappedBy = "application")
   @OrderBy(clause = "createdAt DESC")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationSummaryEntity.kt
@@ -45,6 +45,8 @@ data class Cas2ApplicationSummaryEntity(
   val createdAt: OffsetDateTime,
   @Column(name = "submitted_at")
   var submittedAt: OffsetDateTime?,
+  @Column(name = "abandoned_at")
+  var abandonedAt: OffsetDateTime? = null,
   @Column(name = "hdc_eligibility_date")
   var hdcEligibilityDate: LocalDate? = null,
   @Column(name = "label")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -204,6 +204,12 @@ class ApplicationService(
       return AuthorisableActionResult.Unauthorised()
     }
 
+    if (application.abandonedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("This application has already been abandoned"),
+      )
+    }
+
     if (application.submittedAt != null) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.GeneralValidationError("This application has already been submitted"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -100,6 +100,10 @@ class ApplicationService(
     val applicationEntity = applicationRepository.findByIdOrNull(applicationId)
       ?: return AuthorisableActionResult.NotFound()
 
+    if (applicationEntity.abandonedAt != null) {
+      return AuthorisableActionResult.NotFound()
+    }
+
     val canAccess = userAccessService.userCanViewApplication(user, applicationEntity)
 
     return if (canAccess) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -155,12 +155,6 @@ class ApplicationService(
     val application = applicationRepository.findByIdOrNull(applicationId)?.let(jsonSchemaService::checkSchemaOutdated)
       ?: return AuthorisableActionResult.NotFound()
 
-    if (application !is Cas2ApplicationEntity) {
-      return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("onlyCas2Supported"),
-      )
-    }
-
     if (application.createdByUser != user) {
       return AuthorisableActionResult.Unauthorised()
     }
@@ -202,12 +196,6 @@ class ApplicationService(
 
     if (application.createdByUser != user) {
       return AuthorisableActionResult.Unauthorised()
-    }
-
-    if (application !is Cas2ApplicationEntity) {
-      return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("onlyCas2Supported"),
-      )
     }
 
     if (application.submittedAt != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -159,15 +159,21 @@ class ApplicationService(
       return AuthorisableActionResult.Unauthorised()
     }
 
-    if (!application.schemaUpToDate) {
-      return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("The schema version is outdated"),
-      )
-    }
-
     if (application.submittedAt != null) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.GeneralValidationError("This application has already been submitted"),
+      )
+    }
+
+    if (application.abandonedAt != null) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("This application has been abandoned"),
+      )
+    }
+
+    if (!application.schemaUpToDate) {
+      return AuthorisableActionResult.Success(
+        ValidatableActionResult.GeneralValidationError("The schema version is outdated"),
       )
     }
 

--- a/src/main/resources/db/migration/all/20240528090000__add_abandoned_at_to_cas2_applications.sql
+++ b/src/main/resources/db/migration/all/20240528090000__add_abandoned_at_to_cas2_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas_2_applications ADD COLUMN abandoned_at TIMESTAMP WITH TIME ZONE NULL;

--- a/src/main/resources/db/migration/all/20240528100000__create_cas_2_summary_views_add_abandoned.sql
+++ b/src/main/resources/db/migration/all/20240528100000__create_cas_2_summary_views_add_abandoned.sql
@@ -1,0 +1,47 @@
+-- replace application summary views with new abandoned_at column
+CREATE OR REPLACE VIEW cas_2_application_summary AS SELECT
+    CAST(a.id AS TEXT),
+    a.crn,
+    a.noms_number,
+    CAST(a.created_by_user_id AS TEXT),
+    nu.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    asu.label,
+    CAST(asu.status_id AS TEXT),
+    a.referring_prison_code,
+    a.conditional_release_date,
+    asu.created_at AS status_created_at,
+    a.abandoned_at
+FROM cas_2_applications a
+LEFT JOIN (SELECT DISTINCT ON (application_id) su.application_id, su.label, su.status_id, su.created_at
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+    ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id;
+
+-- filter applications that do not have abandoned_at
+CREATE OR REPLACE VIEW cas_2_application_live_summary AS SELECT
+    a.id,
+    a.crn,
+    a.noms_number,
+    a.created_by_user_id,
+    a.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    a.label,
+    a.status_id,
+    a.referring_prison_code,
+    a.abandoned_at
+FROM cas_2_application_summary a
+WHERE (a.conditional_release_date IS NULL OR a.conditional_release_date >= current_date)
+AND a.abandoned_at IS NULL
+AND a.status_id IS NULL
+   OR (a.status_id = '004e2419-9614-4c1e-a207-a8418009f23d' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Referral withdrawn
+    OR (a.status_id = 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Referral cancelled
+    OR (a.status_id = '89458555-3219-44a2-9584-c4f715d6b565' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Awaiting arrival
+    OR (a.status_id NOT IN ('004e2419-9614-4c1e-a207-a8418009f23d',
+           'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9',
+           '89458555-3219-44a2-9584-c4f715d6b565'));

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -153,6 +153,32 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /applications/{applicationId}/abandon:
+    put:
+      tags:
+        - Operations on CAS2 applications
+      summary: Abandons an in progress CAS2 application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        409:
+          description: The application has been submitted
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /assessments/{assessmentId}:
     put:
       tags:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -155,6 +155,32 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /applications/{applicationId}/abandon:
+    put:
+      tags:
+        - Operations on CAS2 applications
+      summary: Abandons an in progress CAS2 application
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+        401:
+          $ref: '#/components/responses/401Response'
+        409:
+          description: The application has been submitted
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /assessments/{assessmentId}:
     put:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -28,6 +28,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var submittedAt: Yielded<OffsetDateTime?> = { null }
+  private var abandonedAt: Yielded<OffsetDateTime?> = { null }
   private var statusUpdates: Yielded<MutableList<Cas2StatusUpdateEntity>> = { mutableListOf() }
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
   private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
@@ -82,6 +83,10 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.submittedAt = { submittedAt }
   }
 
+  fun withAbandonedAt(abandonedAt: OffsetDateTime?) = apply {
+    this.abandonedAt = { abandonedAt }
+  }
+
   fun withStatusUpdates(statusUpdates: MutableList<Cas2StatusUpdateEntity>) = apply {
     this.statusUpdates = { statusUpdates }
   }
@@ -119,6 +124,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     schemaVersion = this.applicationSchema(),
     createdAt = this.createdAt(),
     submittedAt = this.submittedAt(),
+    abandonedAt = this.abandonedAt(),
     statusUpdates = this.statusUpdates(),
     schemaUpToDate = false,
     nomsNumber = this.nomsNumber(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationAbandonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationAbandonTest.kt
@@ -1,0 +1,156 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.clearMocks
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 Licence Case Admin User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS2 POM User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import java.time.OffsetDateTime
+
+class Cas2ApplicationAbandonTest : IntegrationTestBase() {
+  @SpykBean
+  lateinit var realApplicationRepository: Cas2ApplicationRepository
+
+  val schema = """
+        {
+          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
+          "${"\$id"}": "https://example.com/product.schema.json",
+          "title": "Thing",
+          "description": "A thing",
+          "type": "object",
+          "properties": {
+            "thingId": {
+              "description": "The unique identifier for a thing",
+              "type": "integer"
+            }
+          },
+          "required": [ "thingId" ]
+        }
+        """
+
+  val data = """
+          {
+             "thingId": 123
+          }
+          """
+
+  @AfterEach
+  fun afterEach() {
+    // SpringMockK does not correctly clear mocks for @SpyKBeans that are also a @Repository, causing mocked behaviour
+    // in one test to show up in another (see https://github.com/Ninja-Squad/springmockk/issues/85)
+    // Manually clearing after each test seems to fix this.
+    clearMocks(realApplicationRepository)
+  }
+
+  @Nested
+  inner class ControlsOnExternalUsers {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["ROLE_CAS2_ASSESSOR", "ROLE_CAS2_MI"])
+    fun `abandoning an application is forbidden to external users based on role`(role: String) {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf(role),
+      )
+
+      webTestClient.put()
+        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd/abandon")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Nested
+  inner class MissingJwt {
+    @Test
+    fun `Abandon application without JWT returns 401`() {
+      webTestClient.put()
+        .uri("/cas2/applications/9b785e59-b85c-4be0-b271-d9ac287684b6/abandon")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+  }
+
+  @Nested
+  inner class PutToAbandon {
+
+    @Nested
+    inner class PomUsers {
+      @Test
+      fun `Abandon existing CAS2 application returns 200 with correct body`() {
+        `Given a CAS2 POM User` { submittingUser, jwt ->
+          `Given an Offender` { offenderDetails, _ ->
+            val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, submittingUser)
+
+            webTestClient.put()
+              .uri("/cas2/applications/${application.id}/abandon")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+
+            Assertions.assertNotNull(realApplicationRepository.findById(application.id).get().abandonedAt)
+          }
+        }
+      }
+    }
+
+    @Nested
+    inner class LicenceCaseAdminUsers {
+      @Test
+      fun `Abandon existing CAS2 application returns 200 with correct body`() {
+        `Given a CAS2 Licence Case Admin User` { submittingUser, jwt ->
+          `Given an Offender` { offenderDetails, _ ->
+            val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, submittingUser)
+
+            webTestClient.put()
+              .uri("/cas2/applications/${application.id}/abandon")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+
+            Assertions.assertNotNull(realApplicationRepository.findById(application.id).get().abandonedAt)
+          }
+        }
+      }
+    }
+  }
+
+  private fun produceAndPersistBasicApplication(
+    crn: String,
+    userEntity: NomisUserEntity,
+  ): Cas2ApplicationEntity {
+    val jsonSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))
+      withSchema(
+        schema,
+      )
+    }
+
+    val application = cas2ApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(jsonSchema)
+      withCrn(crn)
+      withCreatedByUser(userEntity)
+      withData(
+        data,
+      )
+    }
+
+    return application
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -301,6 +301,16 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withId(UUID.randomUUID())
             }
 
+            // abandoned application
+            val abandonedApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(applicationSchema)
+              withCreatedByUser(userEntity)
+              withCrn(offenderDetails.otherIds.crn)
+              withData("{}")
+              withCreatedAt(OffsetDateTime.parse("2024-01-03T16:10:00+01:00"))
+              withAbandonedAt(OffsetDateTime.now())
+            }
+
             // unsubmitted application
             val firstApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
               withApplicationSchema(applicationSchema)
@@ -379,6 +389,10 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
             Assertions.assertThat(responseBody).noneMatch {
               otherCas2ApplicationEntity.id == it.id
+            }
+
+            Assertions.assertThat(responseBody).noneMatch {
+              abandonedApplicationEntity.id == it.id
             }
 
             Assertions.assertThat(responseBody[0].createdAt)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -283,6 +283,23 @@ class ApplicationServiceTest {
     }
 
     @Test
+    fun `where application is abandoned returns NotFound result`() {
+      val user = NomisUserEntityFactory().produce()
+      val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
+
+      every { mockApplicationRepository.findByIdOrNull(any()) } returns
+        Cas2ApplicationEntityFactory()
+          .withCreatedByUser(
+            NomisUserEntityFactory()
+              .produce(),
+          )
+          .withAbandonedAt(OffsetDateTime.now())
+          .produce()
+
+      assertThat(applicationService.getApplicationForUser(applicationId, user) is AuthorisableActionResult.NotFound).isTrue
+    }
+
+    @Test
     fun `where user cannot access the application returns Unauthorised result`() {
       val user = NomisUserEntityFactory()
         .produce()


### PR DESCRIPTION
Given the referrer has an in progress application
When they withdraw the application
Then it will no longer appear on their in progress dashboard

When they try to request, submit or update an abandoned application
Then the service will not permit it

## Changes in this PR
https://dsdmoj.atlassian.net/browse/CAS2-216 

UI PR here: https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/727

We want to allow users to flag in progress applications as abandoned. In order to do this we will add an `abandonedAt` value to CAS2 Applications - similar to the `submitted_at` value, this timestamp will determine whether an application has been abandoned or not.

We chose to use the terminology of 'abandoned' because 'withdrawal' or 'cancel' could apply to applications post-submission rather than in progress applications. 

Once it has an abandoned timestamp, users should not be able to submit, update or view the application.

