### PR TITLE
APS-835 Add Seed Job to Update a CAS1 Application Event Number

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -242,6 +242,18 @@ WHERE taa.probation_region_id = :probationRegionId AND a.submitted_at IS NOT NUL
     type: Class<T>,
     pageable: Pageable?,
   ): Slice<TemporaryAccommodationApplicationEntity>
+
+  @Modifying
+  @Query(
+    """
+    UPDATE ApprovedPremisesApplicationEntity ap set 
+    ap.eventNumber = :eventNumber,
+    ap.offenceId = :offenceId,
+    ap.convictionId = :convictionId
+    where ap.id = :applicationId
+    """,
+  )
+  fun updateEventNumber(applicationId: UUID, eventNumber: String, offenceId: String, convictionId: Long)
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
@@ -74,6 +75,18 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
     nativeQuery = true,
   )
   fun findAllCreatedInMonth(month: Int, year: Int): List<DomainEventEntity>
+
+  fun findByApplicationId(applicationId: UUID): List<DomainEventEntity>
+
+  @Modifying
+  @Query(
+    """
+    UPDATE DomainEventEntity d set 
+    d.data = :updatedData
+    where d.id = :id
+    """,
+  )
+  fun updateData(id: UUID, updatedData: String)
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UpdateEventNumberSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UpdateEventNumberSeedJob.kt
@@ -1,0 +1,134 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import java.util.UUID
+
+/**
+ * This seed job can be used to update the event number and associated offence id/conviction id for a given
+ * application. It will also update the event number in any Application Assessed, Application Submitted or
+ * Booking Made domain events (these are the only domain events for which probation-integration needs a valid
+ * deliusEventNumber value)
+ *
+ * This job has been created to allow us to recover from situations where the event number associated with
+ * an application do not exist in delius (i.e. they have been deleted in delius). In this case domain event
+ * processing in probation-integration will fail. Once the event number has been updated for an application
+ * and its associated domain event's, those domain events can be replayed using the Cas1DomainEventReplaySeedJob,
+ * and they should then be processed by probation-integration without issue.
+ *
+ * Because the seed job reads the complete domain event json into objects, updates the event number and then
+ * rewrites the json from these objects, care needs to be taken to ensure that there is no data loss caused by
+ * changes to the Domain Event's schema since the JSON was originally written to the Database (although historically,
+ * the Domain Event JSON Schema is very stable)
+ */
+class Cas1UpdateEventNumberSeedJob(
+  fileName: String,
+  private val applicationService: ApplicationService,
+  private val applicationRepository: ApplicationRepository,
+  private val domainEventRepository: DomainEventRepository,
+  private val objectMapper: ObjectMapper,
+) : SeedJob<Cas1UpdateEventNumberSeedJobCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "application_id",
+    "event_number",
+    "offence_id",
+    "conviction_id",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = Cas1UpdateEventNumberSeedJobCsvRow(
+    applicationId = UUID.fromString(columns["application_id"]!!.trim()),
+    eventNumber = columns["event_number"]!!.toInt(),
+    offenceId = columns["offence_id"]!!,
+    convictionId = columns["conviction_id"]!!.toLong(),
+  )
+
+  override fun processRow(row: Cas1UpdateEventNumberSeedJobCsvRow) {
+    val applicationId = row.applicationId
+    val updatedEventNumber = row.eventNumber
+    val updatedOffenceId = row.offenceId
+    val updatedConvictionId = row.convictionId
+
+    log.info("Updating event number for $applicationId to $updatedEventNumber with offence $updatedOffenceId and conviction $updatedConvictionId")
+
+    val application = applicationRepository.findByIdOrNull(applicationId)
+      ?: error("Application with identifier '$applicationId' does not exist")
+
+    if (application !is ApprovedPremisesApplicationEntity) {
+      error("Application should be of type ApprovedPremisesApplicationEntity")
+    }
+
+    val previousEventNumber = application.eventNumber
+    val previousOffenceId = application.offenceId
+    val previousConvictionId = application.convictionId
+
+    log.info("Application previously used event number $previousEventNumber, offence $previousOffenceId and conviction $previousConvictionId")
+
+    applicationRepository.updateEventNumber(applicationId, updatedEventNumber.toString(), updatedOffenceId, updatedConvictionId)
+
+    updateDomainEvents(applicationId, updatedEventNumber)
+
+    applicationService.addNoteToApplication(
+      applicationId = row.applicationId,
+      note = "Application Support have updated application to use event number '$updatedEventNumber'. Previous event number was '$previousEventNumber'",
+      user = null,
+    )
+  }
+
+  private fun updateDomainEvents(applicationId: UUID, updatedEventNumber: Int) {
+    val domainEvents = domainEventRepository.findByApplicationId(applicationId)
+
+    domainEvents.filter {
+      it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED
+    }.forEach {
+      log.info("Updating domain event ${it.id} of type ${it.type}")
+      val envelope = objectMapper.readValue(it.data, ApplicationSubmittedEnvelope::class.java)
+      val updatedEnvelope = envelope.copy(
+        eventDetails = envelope.eventDetails.copy(deliusEventNumber = updatedEventNumber.toString()),
+      )
+      domainEventRepository.updateData(it.id, objectMapper.writeValueAsString(updatedEnvelope))
+    }
+
+    domainEvents.filter {
+      it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED
+    }.forEach {
+      log.info("Updating domain event ${it.id} of type ${it.type}")
+      val envelope = objectMapper.readValue(it.data, ApplicationAssessedEnvelope::class.java)
+      val updatedEnvelope = envelope.copy(
+        eventDetails = envelope.eventDetails.copy(deliusEventNumber = updatedEventNumber.toString()),
+      )
+      domainEventRepository.updateData(it.id, objectMapper.writeValueAsString(updatedEnvelope))
+    }
+
+    domainEvents.filter {
+      it.type == DomainEventType.APPROVED_PREMISES_BOOKING_MADE
+    }.forEach {
+      log.info("Updating domain event ${it.id} of type ${it.type}")
+      val envelope = objectMapper.readValue(it.data, BookingMadeEnvelope::class.java)
+      val updatedEnvelope = envelope.copy(
+        eventDetails = envelope.eventDetails.copy(deliusEventNumber = updatedEventNumber.toString()),
+      )
+      domainEventRepository.updateData(it.id, objectMapper.writeValueAsString(updatedEnvelope))
+    }
+  }
+}
+
+data class Cas1UpdateEventNumberSeedJobCsvRow(
+  val applicationId: UUID,
+  val eventNumber: Int,
+  val offenceId: String,
+  val convictionId: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpd
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
@@ -54,6 +56,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DomainEven
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DuplicateApplicationSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateEventNumberSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1WithdrawPlacementRequestSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2ApplicationsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
@@ -281,6 +284,14 @@ class SeedService(
           filename,
           applicationContext.getBean(ApplicationService::class.java),
           applicationContext.getBean(OffenderService::class.java),
+        )
+
+        SeedFileType.approvedPremisesUpdateEventNumber -> Cas1UpdateEventNumberSeedJob(
+          filename,
+          applicationContext.getBean(ApplicationService::class.java),
+          applicationContext.getBean(ApplicationRepository::class.java),
+          applicationContext.getBean(DomainEventRepository::class.java),
+          applicationContext.getBean(ObjectMapper::class.java),
         )
       }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3648,6 +3648,7 @@ components:
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
         - approved_premises_duplicate_application
+        - approved_premises_update_event_number
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8322,6 +8322,7 @@ components:
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
         - approved_premises_duplicate_application
+        - approved_premises_update_event_number
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3874,6 +3874,7 @@ components:
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
         - approved_premises_duplicate_application
+        - approved_premises_update_event_number
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4279,6 +4279,7 @@ components:
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
         - approved_premises_duplicate_application
+        - approved_premises_update_event_number
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3739,6 +3739,7 @@ components:
         - approved_premises_withdraw_placement_request
         - approved_premises_replay_domain_events
         - approved_premises_duplicate_application
+        - approved_premises_update_event_number
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/SeedCasUpdateEventNumberTest.kt
@@ -1,0 +1,325 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedAssessedBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmitted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedSubmittedBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeBookedBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Ldu
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Region
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Team
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.SeedCasUpdateEventNumberTest.CONSTANTS.NEW_CONVICTION_ID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.SeedCasUpdateEventNumberTest.CONSTANTS.NEW_EVENT_NUMBER
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.SeedCasUpdateEventNumberTest.CONSTANTS.NEW_OFFENCE_ID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.SeedCasUpdateEventNumberTest.CONSTANTS.OLD_CONVICTION_ID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.SeedCasUpdateEventNumberTest.CONSTANTS.OLD_EVENT_NUMBER
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.SeedCasUpdateEventNumberTest.CONSTANTS.OLD_OFFENCE_ID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateEventNumberSeedJobCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.Period
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedCasUpdateEventNumberTest : SeedTestBase() {
+
+  @Autowired
+  lateinit var domainEventService: DomainEventService
+
+  private object CONSTANTS {
+    const val OLD_EVENT_NUMBER = "1010101"
+    const val OLD_OFFENCE_ID = "2020202"
+    const val OLD_CONVICTION_ID: Long = 3030303
+    const val NEW_EVENT_NUMBER = "999990000"
+    const val NEW_OFFENCE_ID = "888880000"
+    const val NEW_CONVICTION_ID: Long = 777770000
+  }
+
+  @Test
+  fun `Update Application event number and add note`() {
+    val (application, _) = createApplication()
+
+    callSeedJob(application = application)
+
+    val updatedApplication = approvedPremisesApplicationRepository.findById(application.id).get()
+    assertThat(updatedApplication.eventNumber).isEqualTo(NEW_EVENT_NUMBER)
+    assertThat(updatedApplication.offenceId).isEqualTo(NEW_OFFENCE_ID)
+    assertThat(updatedApplication.convictionId).isEqualTo(NEW_CONVICTION_ID)
+
+    val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(application.id)
+    assertThat(notes).hasSize(1)
+    assertThat(notes)
+      .extracting("body")
+      .contains(
+        "Application Support have updated application to use event number '999990000'. Previous event number was '1010101'",
+      )
+  }
+
+  @Test
+  fun `Update Application Assessed Domain Event`() {
+    val (application, offenderDetails) = createApplication()
+
+    val staffUserDetails = StaffUserDetailsFactory().produce()
+
+    domainEventService.saveApplicationAssessedDomainEvent(
+      DomainEvent(
+        id = UUID.randomUUID(),
+        applicationId = application.id,
+        assessmentId = UUID.randomUUID(),
+        crn = application.crn,
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
+        occurredAt = Instant.now(),
+        data = ApplicationAssessedEnvelope(
+          id = UUID.randomUUID(),
+          timestamp = Instant.now(),
+          eventType = EventType.applicationAssessed,
+          eventDetails = ApplicationAssessed(
+            applicationId = application.id,
+            applicationUrl = "theUrl",
+            personReference = PersonReference(
+              crn = offenderDetails.otherIds.crn,
+              noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
+            ),
+            deliusEventNumber = application.eventNumber,
+            assessedAt = Instant.now(),
+            assessedBy = ApplicationAssessedAssessedBy(
+              staffMember = staffUserDetails.toStaffMember(),
+              probationArea = ProbationArea(
+                code = staffUserDetails.probationArea.code,
+                name = staffUserDetails.probationArea.description,
+              ),
+              cru = Cru(
+                name = "the CRU name",
+              ),
+            ),
+            decision = "theDecision",
+            decisionRationale = "theDecisionRationale",
+            arrivalDate = Instant.now(),
+          ),
+        ),
+      ),
+    )
+
+    val domainEventBeforeUpdate = domainEventRepository.findByApplicationId(application.id)[0]
+
+    callSeedJob(application = application)
+
+    val domainEventAfterUpdate = domainEventRepository.findByApplicationId(application.id)[0]
+
+    val unmarshalledData = objectMapper.readValue(domainEventAfterUpdate.data, ApplicationAssessedEnvelope::class.java)
+    assertThat(unmarshalledData.eventDetails.deliusEventNumber).isEqualTo(NEW_EVENT_NUMBER)
+
+    assertThat(domainEventBeforeUpdate.data.replace(OLD_EVENT_NUMBER, NEW_EVENT_NUMBER)).isEqualTo(domainEventAfterUpdate.data)
+  }
+
+  @Test
+  fun `Update Application Submitted Domain Event`() {
+    val (application, offenderDetails) = createApplication()
+
+    val staffUserDetails = StaffUserDetailsFactory().produce()
+
+    domainEventService.saveApplicationSubmittedDomainEvent(
+      DomainEvent(
+        id = UUID.randomUUID(),
+        applicationId = application.id,
+        crn = application.crn,
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
+        occurredAt = Instant.now(),
+        data = ApplicationSubmittedEnvelope(
+          id = UUID.randomUUID(),
+          timestamp = Instant.now(),
+          eventType = EventType.applicationSubmitted,
+          eventDetails = ApplicationSubmitted(
+            applicationId = application.id,
+            applicationUrl = "theUrl",
+            personReference = PersonReference(
+              crn = application.crn,
+              noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
+            ),
+            deliusEventNumber = application.eventNumber,
+            mappa = "mappa1",
+            offenceId = application.offenceId,
+            releaseType = "releaseTpye",
+            age = Period.between(offenderDetails.dateOfBirth, LocalDate.now()).years,
+            gender = ApplicationSubmitted.Gender.male,
+            targetLocation = "target location",
+            submittedAt = Instant.now(),
+            submittedBy = ApplicationSubmittedSubmittedBy(
+              staffMember = staffUserDetails.toStaffMember(),
+              probationArea = ProbationArea("theCode", "theName"),
+              team = Team("theCode", "theName"),
+              ldu = Ldu("theCode", "theName"),
+              region = Region("theCode", "theName"),
+            ),
+            sentenceLengthInMonths = null,
+          ),
+        ),
+        metadata = mapOf(),
+      ),
+    )
+
+    val domainEventBeforeUpdate = domainEventRepository.findByApplicationId(application.id)[0]
+
+    callSeedJob(application = application)
+
+    val domainEventAfterUpdate = domainEventRepository.findByApplicationId(application.id)[0]
+
+    val unmarshalledData = objectMapper.readValue(domainEventAfterUpdate.data, ApplicationSubmittedEnvelope::class.java)
+    assertThat(unmarshalledData.eventDetails.deliusEventNumber).isEqualTo(NEW_EVENT_NUMBER)
+
+    assertThat(domainEventBeforeUpdate.data.replace(OLD_EVENT_NUMBER, NEW_EVENT_NUMBER)).isEqualTo(domainEventAfterUpdate.data)
+  }
+
+  @Test
+  fun `Update Booking Made Domain Event`() {
+    val (application, offenderDetails) = createApplication()
+
+    val staffUserDetails = StaffUserDetailsFactory().produce()
+
+    domainEventService.saveBookingMadeDomainEvent(
+      DomainEvent(
+        id = UUID.randomUUID(),
+        applicationId = application.id,
+        crn = application.crn,
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
+        occurredAt = Instant.now(),
+        bookingId = UUID.randomUUID(),
+        data = BookingMadeEnvelope(
+          id = UUID.randomUUID(),
+          timestamp = Instant.now(),
+          eventType = EventType.bookingMade,
+          eventDetails = BookingMade(
+            applicationId = application.id,
+            applicationUrl = "theUrl",
+            bookingId = UUID.randomUUID(),
+            personReference = PersonReference(
+              crn = application.crn,
+              noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
+            ),
+            deliusEventNumber = application.eventNumber,
+            createdAt = Instant.now(),
+            bookedBy = BookingMadeBookedBy(
+              staffMember = staffUserDetails.toStaffMember(),
+              cru = Cru(
+                name = "theCruName",
+              ),
+            ),
+            premises = Premises(
+              id = UUID.randomUUID(),
+              name = "premisesName",
+              apCode = "premisesApCode",
+              legacyApCode = "premisesQCode",
+              localAuthorityAreaName = "laAreaName",
+            ),
+            arrivalOn = LocalDate.now(),
+            departureOn = LocalDate.now(),
+            applicationSubmittedOn = Instant.now(),
+            releaseType = "releaseType",
+            sentenceType = "sentenceType",
+            situation = "situation",
+          ),
+        ),
+      ),
+    )
+
+    val domainEventBeforeUpdate = domainEventRepository.findByApplicationId(application.id)[0]
+
+    callSeedJob(application = application)
+
+    val domainEventAfterUpdate = domainEventRepository.findByApplicationId(application.id)[0]
+
+    val unmarshalledData = objectMapper.readValue(domainEventAfterUpdate.data, BookingMadeEnvelope::class.java)
+    assertThat(unmarshalledData.eventDetails.deliusEventNumber).isEqualTo(NEW_EVENT_NUMBER)
+
+    assertThat(domainEventBeforeUpdate.data.replace(OLD_EVENT_NUMBER, NEW_EVENT_NUMBER)).isEqualTo(domainEventAfterUpdate.data)
+  }
+
+  private fun callSeedJob(application: ApprovedPremisesApplicationEntity) {
+    withCsv(
+      "valid-csv",
+      rowsToCsv(
+        listOf(
+          Cas1UpdateEventNumberSeedJobCsvRow(
+            application.id,
+            NEW_EVENT_NUMBER.toInt(),
+            NEW_OFFENCE_ID,
+            NEW_CONVICTION_ID,
+          ),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesUpdateEventNumber, "valid-csv")
+  }
+
+  private fun createApplication(): Pair<ApprovedPremisesApplicationEntity, OffenderDetailSummary> {
+    val (applicant, _) = `Given a User`()
+    val (offenderDetails, _) = `Given an Offender`()
+
+    return Pair(
+      approvedPremisesApplicationEntityFactory.produceAndPersist {
+        withCrn(offenderDetails.otherIds.crn)
+        withCreatedByUser(applicant)
+        withApplicationSchema(
+          approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+            withPermissiveSchema()
+          },
+        )
+        withSubmittedAt(OffsetDateTime.now())
+        withApArea(apAreaEntityFactory.produceAndPersist())
+        withReleaseType("licence")
+        withEventNumber(OLD_EVENT_NUMBER)
+        withOffenceId(OLD_OFFENCE_ID)
+        withConvictionId(OLD_CONVICTION_ID)
+      },
+      offenderDetails,
+    )
+  }
+
+  private fun rowsToCsv(rows: List<Cas1UpdateEventNumberSeedJobCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "application_id",
+        "event_number",
+        "offence_id",
+        "conviction_id",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.applicationId.toString())
+        .withQuotedField(it.eventNumber.toString())
+        .withQuotedField(it.offenceId)
+        .withQuotedField(it.convictionId.toString())
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
@@ -8,4 +8,5 @@ import java.util.UUID
 @Repository
 interface DomainEventTestRepository : JpaRepository<DomainEventEntity, UUID> {
   fun findFirstByOrderByCreatedAtDesc(): DomainEventEntity?
+  fun findByApplicationId(applicationId: UUID): List<DomainEventEntity>
 }


### PR DESCRIPTION
This commit adds a seed job that can be used to update the event number and associated offence id/conviction id for a given application.

It will also update the event number in any Application Assessed, Application Submitted or Booking Made domain events (these are the only domain events for which probation-integration needs a valid deliusEventNumber value)

This job has been created to allow us to recover from situations where the event number associated with an application do not exist in delius (i.e. they have been deleted in delius). In this case domain event processing in probation-integration will fail. Once the event number has been updated for an application and its associated domain event's, those domain events can be replayed using the Cas1DomainEventReplaySeedJob, and they should then be processed by probation-integration without issue.

Because the seed job reads the complete domain event json into objects, updates the event number and then rewrites the json from these objects, care needs to be taken to ensure that there is no data loss caused by changes to the Domain Event's schema since the JSON was originally written to the Database (although historically, the Domain Event JSON Schema is very stable)

Test evidence:

Given the seed CSV:

```
application_id,event_number,offence_id,conviction_id
"0f771648-bf12-4e4d-8111-14e03085849b","5454","2323","4545"
```

After applying seed job:

![Screenshot 2024-05-29 at 15 46 43](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/8f05a1c9-c682-4fae-aaa0-036612dcb896)

```
approved_premises_localdev=# select event_number, offence_id, conviction_id from approved_premises_applications where id = '0f771648-bf12-4e4d-8111-14e03085849b';
 event_number | offence_id | conviction_id 
--------------+------------+---------------
 5454         | 2323       |          4545
```
