### PR TITLE
[APS-805] Introduce database model for CAS1 out-of-service beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntity, UUID>
+
+@Entity
+@Table(name = "cas1_out_of_service_beds")
+data class Cas1OutOfServiceBedEntity(
+  @Id
+  val id: UUID,
+  @ManyToOne
+  @JoinColumn(name = "premises_id")
+  val premises: ApprovedPremisesEntity,
+  @ManyToOne
+  @JoinColumn(name = "out_of_service_bed_reason_id")
+  val reason: Cas1OutOfServiceBedReasonEntity,
+  @ManyToOne
+  @JoinColumn(name = "bed_id")
+  val bed: BedEntity,
+  val createdAt: OffsetDateTime,
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+  val referenceNumber: String?,
+  val notes: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedReasonEntity.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface Cas1OutOfServiceBedReasonRepository : JpaRepository<Cas1OutOfServiceBedReasonEntity, UUID>
+
+@Entity
+@Table(name = "cas1_out_of_service_bed_reasons")
+data class Cas1OutOfServiceBedReasonEntity(
+  @Id
+  val id: UUID,
+  val createdAt: OffsetDateTime,
+  val name: String,
+  val isActive: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1OutOfServiceBedReasonMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas1OutOfServiceBedReasonMigrationJob.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
+import java.time.OffsetDateTime
+
+class Cas1OutOfServiceBedReasonMigrationJob(
+  private val lostBedReasonRepository: LostBedReasonRepository,
+  private val cas1OutOfServiceBedReasonRepository: Cas1OutOfServiceBedReasonRepository,
+) : MigrationJob() {
+  override val shouldRunInTransaction = false
+
+  override fun process() {
+    lostBedReasonRepository
+      .findAllByServiceScope(ServiceName.approvedPremises.value)
+      .map {
+        Cas1OutOfServiceBedReasonEntity(
+          id = it.id,
+          createdAt = OffsetDateTime.now(),
+          name = it.name,
+          isActive = it.isActive,
+        )
+      }
+      .apply(cas1OutOfServiceBedReasonRepository::saveAll)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -13,10 +13,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
@@ -25,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigratio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.BookingStatusMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1BackfillUserApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1OutOfServiceBedReasonMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1UserDetailsMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2NoteMigrationJob
@@ -132,6 +135,11 @@ class MigrationJobService(
           applicationContext.getBean(UserService::class.java),
           applicationContext.getBean(CommunityApiClient::class.java),
           transactionTemplate,
+        )
+
+        MigrationJobType.cas1OutOfServiceBedReasons -> Cas1OutOfServiceBedReasonMigrationJob(
+          applicationContext.getBean(LostBedReasonRepository::class.java),
+          applicationContext.getBean(Cas1OutOfServiceBedReasonRepository::class.java),
         )
 
         MigrationJobType.cas3ApplicationOffenderName -> Cas3UpdateApplicationOffenderNameJob(

--- a/src/main/resources/db/migration/all/20240524115141__create_cas1_out_of_service_beds_table.sql
+++ b/src/main/resources/db/migration/all/20240524115141__create_cas1_out_of_service_beds_table.sql
@@ -1,0 +1,24 @@
+CREATE TABLE cas1_out_of_service_bed_reasons (
+    id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    name TEXT NOT NULL,
+    is_active BOOL NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (name)
+);
+
+CREATE TABLE cas1_out_of_service_beds (
+    id UUID NOT NULL,
+    premises_id UUID NOT NULL,
+    out_of_service_bed_reason_id UUID NOT NULL,
+    bed_id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    reference_number TEXT NULL,
+    notes TEXT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (premises_id) REFERENCES approved_premises(premises_id),
+    FOREIGN KEY (out_of_service_bed_reason_id) REFERENCES cas1_out_of_service_bed_reasons(id),
+    FOREIGN KEY (bed_id) REFERENCES beds(id)
+);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3668,6 +3668,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
     PlacementDates:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8342,6 +8342,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
     PlacementDates:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3894,6 +3894,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
     PlacementDates:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4299,6 +4299,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
     PlacementDates:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3759,6 +3759,7 @@ components:
         - update_cas1_fix_placement_app_links
         - update_cas1_notice_types
         - update_cas1_backfill_user_ap_area
+        - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
     PlacementDates:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedEntityFactory.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas1OutOfServiceBedEntityFactory : Factory<Cas1OutOfServiceBedEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var reason: Yielded<Cas1OutOfServiceBedReasonEntity> = { Cas1OutOfServiceBedReasonEntityFactory().produce() }
+  private var bed: Yielded<BedEntity> = { BedEntityFactory().produce() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
+  private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
+  private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }
+  private var referenceNumber: Yielded<String?> = { UUID.randomUUID().toString() }
+  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withReason(reason: Cas1OutOfServiceBedReasonEntity) = apply {
+    this.reason = { reason }
+  }
+
+  fun withReason(configuration: Cas1OutOfServiceBedReasonEntityFactory.() -> Unit) = apply {
+    this.reason = { Cas1OutOfServiceBedReasonEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withBed(bed: BedEntity) = apply {
+    this.bed = { bed }
+  }
+
+  fun withBed(configuration: BedEntityFactory.() -> Unit) = apply {
+    this.bed = { BedEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withStartDate(startDate: LocalDate) = apply {
+    this.startDate = { startDate }
+  }
+
+  fun withEndDate(endDate: LocalDate) = apply {
+    this.endDate = { endDate }
+  }
+
+  fun withReferenceNumber(referenceNumber: String?) = apply {
+    this.referenceNumber = { referenceNumber }
+  }
+
+  fun withNotes(notes: String?) = apply {
+    this.notes = { notes }
+  }
+
+  override fun produce(): Cas1OutOfServiceBedEntity {
+    val bed = this.bed()
+
+    return Cas1OutOfServiceBedEntity(
+      id = this.id(),
+      premises = bed.room.premises as ApprovedPremisesEntity,
+      reason = this.reason(),
+      bed = bed,
+      createdAt = this.createdAt(),
+      startDate = this.startDate(),
+      endDate = this.endDate(),
+      referenceNumber = this.referenceNumber(),
+      notes = this.notes(),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedReasonEntityFactory.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas1OutOfServiceBedReasonEntityFactory : Factory<Cas1OutOfServiceBedReasonEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var isActive: Yielded<Boolean> = { true }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withIsActive(isActive: Boolean) = apply {
+    this.isActive = { isActive }
+  }
+
+  override fun produce(): Cas1OutOfServiceBedReasonEntity = Cas1OutOfServiceBedReasonEntity(
+    id = this.id(),
+    createdAt = this.createdAt(),
+    name = this.name(),
+    isActive = this.isActive(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -51,6 +51,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingNotMadeEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1ApplicationUserDetailsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
@@ -120,6 +122,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
@@ -197,6 +201,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingNotMad
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedReasonTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2StatusUpdateTestRepository
@@ -482,6 +488,12 @@ abstract class IntegrationTestBase {
   lateinit var referralRejectionReasonRepository: ReferralRejectionReasonRepository
 
   @Autowired
+  lateinit var cas1OutOfServiceBedTestRepository: Cas1OutOfServiceBedTestRepository
+
+  @Autowired
+  lateinit var cas1OutOfServiceBedReasonTestRepository: Cas1OutOfServiceBedReasonTestRepository
+
+  @Autowired
   lateinit var emailAsserter: EmailNotificationAsserter
 
   @Autowired
@@ -555,6 +567,8 @@ abstract class IntegrationTestBase {
   lateinit var appealEntityFactory: PersistedFactory<AppealEntity, UUID, AppealEntityFactory>
   lateinit var cas1ApplicationUserDetailsEntityFactory: PersistedFactory<Cas1ApplicationUserDetailsEntity, UUID, Cas1ApplicationUserDetailsEntityFactory>
   lateinit var referralRejectionReasonEntityFactory: PersistedFactory<ReferralRejectionReasonEntity, UUID, ReferralRejectionReasonEntityFactory>
+  lateinit var cas1OutOfServiceBedEntityFactory: PersistedFactory<Cas1OutOfServiceBedEntity, UUID, Cas1OutOfServiceBedEntityFactory>
+  lateinit var cas1OutOfServiceBedReasonEntityFactory: PersistedFactory<Cas1OutOfServiceBedReasonEntity, UUID, Cas1OutOfServiceBedReasonEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -656,6 +670,8 @@ abstract class IntegrationTestBase {
     appealEntityFactory = PersistedFactory({ AppealEntityFactory() }, appealTestRepository)
     cas1ApplicationUserDetailsEntityFactory = PersistedFactory({ Cas1ApplicationUserDetailsEntityFactory() }, cas1ApplicationUserDetailsRepository)
     referralRejectionReasonEntityFactory = PersistedFactory({ ReferralRejectionReasonEntityFactory() }, referralRejectionReasonRepository)
+    cas1OutOfServiceBedEntityFactory = PersistedFactory({ Cas1OutOfServiceBedEntityFactory() }, cas1OutOfServiceBedTestRepository)
+    cas1OutOfServiceBedReasonEntityFactory = PersistedFactory({ Cas1OutOfServiceBedReasonEntityFactory() }, cas1OutOfServiceBedReasonTestRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrateCas1OutOfServiceBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrateCas1OutOfServiceBedsTest.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+
+class MigrateCas1OutOfServiceBedsTest : MigrationJobTestBase() {
+  @Test
+  fun `Job migrates expected set of lost bed reasons`() {
+    val approvedPremisesLostBedReasons = lostBedReasonRepository
+      .findAll()
+      .filter { listOf("*", ServiceName.approvedPremises.value).contains(it.serviceScope) }
+
+    assertThat(approvedPremisesLostBedReasons).isNotEmpty
+    assertThat(cas1OutOfServiceBedReasonTestRepository.findAll()).isEmpty()
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1OutOfServiceBedReasons)
+
+    assertThat(cas1OutOfServiceBedReasonTestRepository.findAll()).hasSize(approvedPremisesLostBedReasons.size)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas1OutOfServiceBedReasonTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas1OutOfServiceBedReasonTestRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import java.util.UUID
+
+interface Cas1OutOfServiceBedReasonTestRepository : JpaRepository<Cas1OutOfServiceBedReasonEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas1OutOfServiceBedTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas1OutOfServiceBedTestRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import java.util.UUID
+
+interface Cas1OutOfServiceBedTestRepository : JpaRepository<Cas1OutOfServiceBedEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1OutOfServiceBedReasonMigrationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1OutOfServiceBedReasonMigrationJobTest.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.migration
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1OutOfServiceBedReasonMigrationJob
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas1OutOfServiceBedReasonMigrationJobTest {
+  private val lostBedReasonRepository = mockk<LostBedReasonRepository>()
+  private val cas1OutOfServiceBedReasonRepository = mockk<Cas1OutOfServiceBedReasonRepository>()
+
+  private val job = Cas1OutOfServiceBedReasonMigrationJob(
+    lostBedReasonRepository,
+    cas1OutOfServiceBedReasonRepository,
+  )
+
+  @Test
+  fun `The job migrates all Approved Premises lost beds reasons to the out of service beds table`() {
+    val lostBedReasons = listOf(
+      LostBedReasonEntityFactory()
+        .withId(UUID(1L, 1L))
+        .withName("Active Reason")
+        .withIsActive(true)
+        .withServiceScope(ServiceName.approvedPremises.value)
+        .produce(),
+      LostBedReasonEntityFactory()
+        .withId(UUID(2L, 2L))
+        .withName("Inactive Reason")
+        .withIsActive(false)
+        .withServiceScope(ServiceName.approvedPremises.value)
+        .produce(),
+    )
+
+    val now = OffsetDateTime.now()
+
+    val outOfServiceBedReasons = listOf(
+      Cas1OutOfServiceBedReasonEntityFactory()
+        .withId(UUID(1L, 1L))
+        .withCreatedAt(now)
+        .withName("Active Reason")
+        .withIsActive(true)
+        .produce(),
+      Cas1OutOfServiceBedReasonEntityFactory()
+        .withId(UUID(2L, 2L))
+        .withCreatedAt(now)
+        .withName("Inactive Reason")
+        .withIsActive(false)
+        .produce(),
+    )
+
+    mockkStatic(OffsetDateTime::class)
+    every { OffsetDateTime.now() } returns now
+
+    every { lostBedReasonRepository.findAllByServiceScope(ServiceName.approvedPremises.value) } returns lostBedReasons
+    every { cas1OutOfServiceBedReasonRepository.saveAll<Cas1OutOfServiceBedReasonEntity>(any()) } returnsArgument 0
+
+    job.process()
+
+    unmockkStatic(OffsetDateTime::class)
+
+    verify { cas1OutOfServiceBedReasonRepository.saveAll(outOfServiceBedReasons) }
+  }
+}


### PR DESCRIPTION
> See [APS-805 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-805).

This PR introduces the `cas1_out_of_service_beds` and `cas1_out_of_service_bed_reasons` tables and associated JPA entities as an intended future replacement for the concept of lost beds within CAS1.

Currently, the data models for these are very close to the existing lost beds model, although we expect these that they will diverge significantly as we implement Match and Manage functionality.

A migration job is provided that copies all CAS1-appropriate `lost_bed_reasons` to the `cas1_out_of_service_bed_reasons` table, which will simplify the process of migrating the existing lost beds when it becomes necessary.