### PR TITLE
Improve CAS2 Status Update Test Stability

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EmailNotificationService.kt
@@ -100,6 +100,11 @@ interface EmailNotifier {
   fun sendCas2Email(recipientEmailAddress: String, templateId: String, personalisation: Map<String, *>)
 }
 
-data class EmailRequest(val email: String, val templateId: String, val personalisation: Map<String, *>, val replyToEmailId: String? = null)
+data class EmailRequest(
+  val email: String,
+  val templateId: String,
+  val personalisation: Map<String, *>,
+  val replyToEmailId: String? = null,
+)
 
 data class SendEmailRequestedEvent(val request: EmailRequest)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/EmailNotificationAsserter.kt
@@ -36,18 +36,21 @@ class EmailNotificationAsserter {
     templateId: String,
     personalisation: Map<String, Any> = emptyMap(),
     replyToEmailId: String? = null,
-  ) {
-    val anyMatch = requestedEmails.any {
+  ): EmailRequest {
+    val match = requestedEmails.firstOrNull {
       toEmailAddress == it.email &&
         templateId == it.templateId &&
         it.personalisation.entries.containsAll(personalisation.entries) &&
         (replyToEmailId == null || it.replyToEmailId == replyToEmailId)
     }
 
-    assertThat(anyMatch)
+    assertThat(match)
       .withFailMessage {
         "Could not find email request for template $templateId to $toEmailAddress with personalisation $personalisation. Provided email requests are ${formatRequestedEmails()}"
-      }.isTrue
+      }
+      .isNotNull
+
+    return match!!
   }
 
   fun formatRequestedEmails() = "\n" + requestedEmails.map { "\n $it" }


### PR DESCRIPTION
Prior to this commit we were checking for a specific time value in email personalisation, but if the test started and finished in different minutes of the hour this test could fail.

A better solution would be to manage a mutable/fixed clock during integration tests so we can ensure the system clock used in code reports a known date-time, but that is a non-trivial change