### PR TITLE
[APS-802][APS-803] Introduce API endpoints for CAS1 out-of-service beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/OutOfServiceBedsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/OutOfServiceBedsController.kt
@@ -1,0 +1,196 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.OutOfServiceBedsCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1OutOfServiceBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1OutOfServiceBedCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas1OutOfServiceBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedCancellationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedTransformer
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class OutOfServiceBedsController(
+  private val userAccessService: UserAccessService,
+  private val premisesService: PremisesService,
+  private val bookingService: BookingService,
+  private val outOfServiceBedService: Cas1OutOfServiceBedService,
+  private val outOfServiceBedTransformer: Cas1OutOfServiceBedTransformer,
+  private val outOfServiceBedCancellationTransformer: Cas1OutOfServiceBedCancellationTransformer,
+) : OutOfServiceBedsCas1Delegate {
+  override fun premisesPremisesIdOutOfServiceBedsGet(premisesId: UUID): ResponseEntity<List<Cas1OutOfServiceBed>> {
+    val premises = tryGetApprovedPremises(premisesId)
+
+    val outOfServiceBeds = outOfServiceBedService.getActiveOutOfServiceBedsForPremisesId(premisesId)
+
+    if (!userAccessService.currentUserCanManagePremisesOutOfServiceBed(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    return ResponseEntity.ok(outOfServiceBeds.map(outOfServiceBedTransformer::transformJpaToApi))
+  }
+
+  override fun premisesPremisesIdOutOfServiceBedsOutOfServiceBedIdCancellationsPost(
+    premisesId: UUID,
+    outOfServiceBedId: UUID,
+    body: NewCas1OutOfServiceBedCancellation,
+  ): ResponseEntity<Cas1OutOfServiceBedCancellation> {
+    val premises = tryGetApprovedPremises(premisesId)
+
+    val outOfServiceBed = premises
+      .outOfServiceBeds
+      .firstOrNull { it.id == outOfServiceBedId }
+      ?: throw NotFoundProblem(outOfServiceBedId, "OutOfServiceBed")
+
+    if (!userAccessService.currentUserCanManagePremisesOutOfServiceBed(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    val cancelOutOfServiceBedResult = outOfServiceBedService.cancelOutOfServiceBed(
+      outOfServiceBed = outOfServiceBed,
+      notes = body.notes,
+    )
+
+    val cancellation = when (cancelOutOfServiceBedResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = cancelOutOfServiceBedResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = cancelOutOfServiceBedResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = cancelOutOfServiceBedResult.conflictingEntityId, conflictReason = cancelOutOfServiceBedResult.message)
+      is ValidatableActionResult.Success -> cancelOutOfServiceBedResult.entity
+    }
+
+    return ResponseEntity.ok(outOfServiceBedCancellationTransformer.transformJpaToApi(cancellation))
+  }
+
+  override fun premisesPremisesIdOutOfServiceBedsOutOfServiceBedIdGet(
+    premisesId: UUID,
+    outOfServiceBedId: UUID,
+  ): ResponseEntity<Cas1OutOfServiceBed> {
+    val premises = tryGetApprovedPremises(premisesId)
+
+    if (!userAccessService.currentUserCanManagePremisesOutOfServiceBed(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    val outOfServiceBed = premises.outOfServiceBeds.firstOrNull { it.id == outOfServiceBedId }
+      ?: throw NotFoundProblem(outOfServiceBedId, "OutOfServiceBed")
+
+    return ResponseEntity.ok(outOfServiceBedTransformer.transformJpaToApi(outOfServiceBed))
+  }
+
+  override fun premisesPremisesIdOutOfServiceBedsOutOfServiceBedIdPut(
+    premisesId: UUID,
+    outOfServiceBedId: UUID,
+    body: UpdateCas1OutOfServiceBed,
+  ): ResponseEntity<Cas1OutOfServiceBed> {
+    val premises = tryGetApprovedPremises(premisesId)
+    val outOfServiceBed = premises.outOfServiceBeds.firstOrNull { it.id == outOfServiceBedId } ?: throw NotFoundProblem(outOfServiceBedId, "OutOfServiceBed")
+
+    if (!userAccessService.currentUserCanManagePremisesOutOfServiceBed(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    throwIfBookingDatesConflict(body.startDate, body.endDate, outOfServiceBed.bed.id)
+    throwIfOutOfServiceBedDatesConflict(body.startDate, body.endDate, outOfServiceBedId, outOfServiceBed.bed.id)
+
+    val updateOutOfServiceBedResult = outOfServiceBedService.updateOutOfServiceBed(
+      outOfServiceBedId,
+      body.startDate,
+      body.endDate,
+      body.reason,
+      body.referenceNumber,
+      body.notes,
+    )
+
+    val validationResult = when (updateOutOfServiceBedResult) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(outOfServiceBedId, "OutOfServiceBed")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> updateOutOfServiceBedResult.entity
+    }
+
+    val updatedOutOfServiceBed = when (validationResult) {
+      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
+      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
+      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+      is ValidatableActionResult.Success -> validationResult.entity
+    }
+
+    return ResponseEntity.ok(outOfServiceBedTransformer.transformJpaToApi(updatedOutOfServiceBed))
+  }
+
+  override fun premisesPremisesIdOutOfServiceBedsPost(
+    premisesId: UUID,
+    body: NewCas1OutOfServiceBed,
+  ): ResponseEntity<Cas1OutOfServiceBed> {
+    val premises = tryGetApprovedPremises(premisesId)
+
+    if (!userAccessService.currentUserCanManagePremisesOutOfServiceBed(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    throwIfOutOfServiceBedDatesConflict(body.startDate, body.endDate, null, body.bedId)
+
+    val result = outOfServiceBedService.createOutOfServiceBed(
+      premises = premises,
+      startDate = body.startDate,
+      endDate = body.endDate,
+      reasonId = body.reason,
+      referenceNumber = body.referenceNumber,
+      notes = body.notes,
+      bedId = body.bedId,
+    )
+
+    val outOfServiceBed = extractResultEntityOrThrow(result)
+
+    return ResponseEntity.ok(outOfServiceBedTransformer.transformJpaToApi(outOfServiceBed))
+  }
+
+  private fun tryGetApprovedPremises(premisesId: UUID): ApprovedPremisesEntity =
+    premisesService.getPremises(premisesId) as? ApprovedPremisesEntity ?: throw NotFoundProblem(premisesId, "Premises")
+
+  private val ApprovedPremisesEntity.outOfServiceBeds: List<Cas1OutOfServiceBedEntity>
+    get() = outOfServiceBedService.getActiveOutOfServiceBedsForPremisesId(this.id)
+
+  private fun <EntityType> extractResultEntityOrThrow(result: ValidatableActionResult<EntityType>) = when (result) {
+    is ValidatableActionResult.Success -> result.entity
+    is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = result.message)
+    is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = result.validationMessages)
+    is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = result.conflictingEntityId, conflictReason = result.message)
+  }
+
+  private fun throwIfBookingDatesConflict(
+    arrivalDate: LocalDate,
+    departureDate: LocalDate,
+    bedId: UUID,
+  ) {
+    bookingService.getBookingWithConflictingDates(arrivalDate, departureDate, null, bedId)?.let {
+      throw ConflictProblem(it.id, "A booking already exists for dates from ${it.arrivalDate} to ${it.departureDate} which overlaps with the desired dates")
+    }
+  }
+
+  private fun throwIfOutOfServiceBedDatesConflict(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    thisEntityId: UUID?,
+    bedId: UUID,
+  ) {
+    outOfServiceBedService.getOutOfServiceBedWithConflictingDates(startDate, endDate, thisEntityId, bedId)?.let {
+      throw ConflictProblem(it.id, "An out-of-service bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedCancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedCancellationEntity.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToOne
+import javax.persistence.Table
+
+@Repository
+interface Cas1OutOfServiceBedCancellationRepository : JpaRepository<Cas1OutOfServiceBedCancellationEntity, UUID>
+
+@Entity
+@Table(name = "cas1_out_of_service_bed_cancellations")
+class Cas1OutOfServiceBedCancellationEntity(
+  @Id
+  val id: UUID,
+  val createdAt: OffsetDateTime,
+  val notes: String?,
+  @OneToOne
+  @JoinColumn(name = "out_of_service_bed_id")
+  val outOfServiceBed: Cas1OutOfServiceBedEntity,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -13,7 +14,24 @@ import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Repository
-interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntity, UUID>
+interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntity, UUID> {
+  @Query("SELECT oosb FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE oosb.premises.id = :premisesId AND c is NULL")
+  fun findAllActiveForPremisesId(premisesId: UUID): List<Cas1OutOfServiceBedEntity>
+
+  @Query(
+    """
+    SELECT oosb 
+    FROM Cas1OutOfServiceBedEntity oosb 
+    LEFT JOIN oosb.cancellation c 
+    WHERE oosb.bed.id = :bedId AND 
+          oosb.startDate <= :endDate AND 
+          oosb.endDate >= :startDate AND 
+          (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR oosb.id != :thisEntityId) AND 
+          c is NULL
+    """,
+  )
+  fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<Cas1OutOfServiceBedEntity>
+}
 
 @Entity
 @Table(name = "cas1_out_of_service_beds")
@@ -25,15 +43,15 @@ data class Cas1OutOfServiceBedEntity(
   val premises: ApprovedPremisesEntity,
   @ManyToOne
   @JoinColumn(name = "out_of_service_bed_reason_id")
-  val reason: Cas1OutOfServiceBedReasonEntity,
+  var reason: Cas1OutOfServiceBedReasonEntity,
   @ManyToOne
   @JoinColumn(name = "bed_id")
   val bed: BedEntity,
   val createdAt: OffsetDateTime,
-  val startDate: LocalDate,
-  val endDate: LocalDate,
-  val referenceNumber: String?,
-  val notes: String?,
+  var startDate: LocalDate,
+  var endDate: LocalDate,
+  var referenceNumber: String?,
+  var notes: String?,
   @OneToOne(mappedBy = "outOfServiceBed")
   var cancellation: Cas1OutOfServiceBedCancellationEntity?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -9,6 +9,7 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Repository
@@ -33,4 +34,6 @@ data class Cas1OutOfServiceBedEntity(
   val endDate: LocalDate,
   val referenceNumber: String?,
   val notes: String?,
+  @OneToOne(mappedBy = "outOfServiceBed")
+  var cancellation: Cas1OutOfServiceBedCancellationEntity?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -87,6 +87,18 @@ class UserAccessService(
     else -> false
   }
 
+  /**
+   * Currently delegates to the lost bed logic. May depend on different roles in the future.
+   */
+  fun currentUserCanManagePremisesOutOfServiceBed(premises: PremisesEntity) =
+    userCanManagePremisesOutOfServiceBed(userService.getUserForRequest(), premises)
+
+  /**
+   * Currently delegates to the lost bed logic. May depend on different roles in the future.
+   */
+  fun userCanManagePremisesOutOfServiceBed(user: UserEntity, premises: PremisesEntity) =
+    userCanManagePremisesLostBeds(user, premises)
+
   fun currentUserCanManagePremisesLostBeds(premises: PremisesEntity) =
     userCanManagePremisesLostBeds(userService.getUserForRequest(), premises)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
@@ -1,0 +1,144 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service
+class Cas1OutOfServiceBedService(
+  private val outOfServiceBedRepository: Cas1OutOfServiceBedRepository,
+  private val outOfServiceBedReasonRepository: Cas1OutOfServiceBedReasonRepository,
+  private val outOfServiceBedCancellationRepository: Cas1OutOfServiceBedCancellationRepository,
+) {
+  fun createOutOfServiceBed(
+    premises: ApprovedPremisesEntity,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    reasonId: UUID,
+    referenceNumber: String?,
+    notes: String?,
+    bedId: UUID,
+  ): ValidatableActionResult<Cas1OutOfServiceBedEntity> =
+    validated {
+      if (endDate.isBefore(startDate)) {
+        "$.endDate" hasValidationError "beforeStartDate"
+      }
+
+      val bed = premises.rooms.flatMap { it.beds }.firstOrNull { it.id == bedId }
+      if (bed == null) {
+        "$.bedId" hasValidationError "doesNotExist"
+      }
+
+      val reason = outOfServiceBedReasonRepository.findByIdOrNull(reasonId)
+      if (reason == null) {
+        "$.reason" hasValidationError "doesNotExist"
+      }
+
+      if (validationErrors.any()) {
+        return fieldValidationError
+      }
+
+      val cas1outOfServiceBedsEntity = outOfServiceBedRepository.save(
+        Cas1OutOfServiceBedEntity(
+          id = UUID.randomUUID(),
+          premises = premises,
+          reason = reason!!,
+          bed = bed!!,
+          createdAt = OffsetDateTime.now(),
+          startDate = startDate,
+          endDate = endDate,
+          referenceNumber = referenceNumber,
+          notes = notes,
+          cancellation = null,
+        ),
+      )
+
+      return success(cas1outOfServiceBedsEntity)
+    }
+
+  fun updateOutOfServiceBed(
+    outOfServiceBedId: UUID,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    reasonId: UUID,
+    referenceNumber: String?,
+    notes: String?,
+  ): AuthorisableActionResult<ValidatableActionResult<Cas1OutOfServiceBedEntity>> {
+    val outOfServiceBed = outOfServiceBedRepository.findByIdOrNull(outOfServiceBedId)
+      ?: return AuthorisableActionResult.NotFound()
+
+    return AuthorisableActionResult.Success(
+      validated {
+        if (endDate.isBefore(startDate)) {
+          "$.endDate" hasValidationError "beforeStartDate"
+        }
+
+        val reason = outOfServiceBedReasonRepository.findByIdOrNull(reasonId)
+        if (reason == null) {
+          "$.reason" hasValidationError "doesNotExist"
+        }
+
+        if (validationErrors.any()) {
+          return@validated fieldValidationError
+        }
+
+        val updatedCas1OutOfServiceBedsEntity = outOfServiceBedRepository.save(
+          outOfServiceBed.apply {
+            this.startDate = startDate
+            this.endDate = endDate
+            this.reason = reason!!
+            this.referenceNumber = referenceNumber
+            this.notes = notes
+          },
+        )
+
+        success(updatedCas1OutOfServiceBedsEntity)
+      },
+    )
+  }
+
+  fun cancelOutOfServiceBed(
+    outOfServiceBed: Cas1OutOfServiceBedEntity,
+    notes: String?,
+  ) = validated<Cas1OutOfServiceBedCancellationEntity> {
+    if (outOfServiceBed.cancellation != null) {
+      return generalError("This out-of-service bed has already been cancelled.")
+    }
+
+    val cancellationEntity = outOfServiceBedCancellationRepository.save(
+      Cas1OutOfServiceBedCancellationEntity(
+        id = UUID.randomUUID(),
+        outOfServiceBed = outOfServiceBed,
+        notes = notes,
+        createdAt = OffsetDateTime.now(),
+      ),
+    )
+
+    return success(cancellationEntity)
+  }
+
+  fun getActiveOutOfServiceBedsForPremisesId(premisesId: UUID) = outOfServiceBedRepository.findAllActiveForPremisesId(premisesId)
+
+  fun getOutOfServiceBedWithConflictingDates(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    thisEntityId: UUID?,
+    bedId: UUID,
+  ) = outOfServiceBedRepository.findByBedIdAndOverlappingDate(
+    bedId,
+    startDate,
+    endDate,
+    thisEntityId,
+  ).firstOrNull()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedCancellationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedCancellationTransformer.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationEntity
+
+@Component
+class Cas1OutOfServiceBedCancellationTransformer {
+  fun transformJpaToApi(jpa: Cas1OutOfServiceBedCancellationEntity) = Cas1OutOfServiceBedCancellation(
+    id = jpa.id,
+    createdAt = jpa.createdAt.toInstant(),
+    notes = jpa.notes,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedReasonTransformer.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+
+@Component
+class Cas1OutOfServiceBedReasonTransformer {
+  fun transformJpaToApi(jpa: Cas1OutOfServiceBedReasonEntity) = Cas1OutOfServiceBedReason(
+    id = jpa.id,
+    name = jpa.name,
+    isActive = jpa.isActive,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedTransformer.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+
+@Component
+class Cas1OutOfServiceBedTransformer(
+  private val cas1OutOfServiceBedReasonTransformer: Cas1OutOfServiceBedReasonTransformer,
+  private val cas1OutOfServiceBedCancellationTransformer: Cas1OutOfServiceBedCancellationTransformer,
+) {
+  fun transformJpaToApi(jpa: Cas1OutOfServiceBedEntity) = Cas1OutOfServiceBed(
+    id = jpa.id,
+    createdAt = jpa.createdAt.toInstant(),
+    startDate = jpa.startDate,
+    endDate = jpa.endDate,
+    bedId = jpa.bed.id,
+    bedName = jpa.bed.name,
+    roomName = jpa.bed.room.name,
+    reason = cas1OutOfServiceBedReasonTransformer.transformJpaToApi(jpa.reason),
+    status = jpa.deriveStatus(),
+    referenceNumber = jpa.referenceNumber,
+    notes = jpa.notes,
+    cancellation = jpa.cancellation?.let { cas1OutOfServiceBedCancellationTransformer.transformJpaToApi(it) },
+  )
+
+  private fun Cas1OutOfServiceBedEntity.deriveStatus() = when (this.cancellation) {
+    null -> Cas1OutOfServiceBedStatus.active
+    else -> Cas1OutOfServiceBedStatus.cancelled
+  }
+}

--- a/src/main/resources/db/migration/all/20240529143616__create_cas1_out_of_service_bed_cancellations_table.sql
+++ b/src/main/resources/db/migration/all/20240529143616__create_cas1_out_of_service_bed_cancellations_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE cas1_out_of_service_bed_cancellations (
+    id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    notes TEXT NULL,
+    out_of_service_bed_id UUID NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (out_of_service_bed_id) REFERENCES cas1_out_of_service_beds(id)
+);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4731,3 +4731,130 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+    Cas1OutOfServiceBed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        bedId:
+          type: string
+          format: uuid
+        bedName:
+          type: string
+        roomName:
+          type: string
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        status:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedStatus'
+        cancellation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+      required:
+        - id
+        - createdAt
+        - startDate
+        - endDate
+        - bedId
+        - bedName
+        - roomName
+        - reason
+        - status
+    NewCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        bedId:
+          type: string
+          format: uuid
+      required:
+        - startDate
+        - endDate
+        - reason
+        - bedId
+    UpdateCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - startDate
+        - endDate
+        - reason
+    Cas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - createdAt
+    NewCas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        notes:
+          type: string
+    Cas1OutOfServiceBedStatus:
+      type: string
+      enum:
+        - active
+        - cancelled
+    Cas1OutOfServiceBedReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Double Room with Single Occupancy - Other (Non-FM)
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -222,3 +222,220 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /premises/{premisesId}/out-of-service-beds:
+    post:
+      tags:
+        - out-of-service beds
+      summary: Posts an out-of-service bed to a specified approved premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the out-of-service bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the out-of-service bed
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/NewCas1OutOfServiceBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas1OutOfServiceBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
+    get:
+      tags:
+        - out-of-service beds
+      summary: Lists all Out-Of-Service Beds entries for the Premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to show out-of-service beds for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/Cas1OutOfServiceBed'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+  /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}:
+    get:
+      tags:
+        - out-of-service beds
+      summary: Returns a specific out-of-service bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the out-of-service bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: outOfServiceBedId
+          in: path
+          description: ID of the out-of-service bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas1OutOfServiceBed'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises or out-of-service bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+    put:
+      tags:
+        - out-of-service beds
+      summary: Updates an out-of-service bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the out-of-service bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: outOfServiceBedId
+          in: path
+          description: ID of the out-of-service bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the out-of-service bed
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/UpdateCas1OutOfServiceBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas1OutOfServiceBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
+  /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}/cancellations:
+    post:
+      tags:
+        - out-of-service beds
+      summary: Posts a cancellation to a specified out-of-service bed
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the cancellation is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: outOfServiceBedId
+          in: path
+          description: ID of the out-of-service bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the cancellation
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/NewCas1OutOfServiceBedCancellation'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas1OutOfServiceBedCancellation'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises ID or out-of-service bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9405,3 +9405,130 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+    Cas1OutOfServiceBed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        bedId:
+          type: string
+          format: uuid
+        bedName:
+          type: string
+        roomName:
+          type: string
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        status:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedStatus'
+        cancellation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+      required:
+        - id
+        - createdAt
+        - startDate
+        - endDate
+        - bedId
+        - bedName
+        - roomName
+        - reason
+        - status
+    NewCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        bedId:
+          type: string
+          format: uuid
+      required:
+        - startDate
+        - endDate
+        - reason
+        - bedId
+    UpdateCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - startDate
+        - endDate
+        - reason
+    Cas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - createdAt
+    NewCas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        notes:
+          type: string
+    Cas1OutOfServiceBedStatus:
+      type: string
+      enum:
+        - active
+        - cancelled
+    Cas1OutOfServiceBedReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Double Room with Single Occupancy - Other (Non-FM)
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -224,6 +224,223 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /premises/{premisesId}/out-of-service-beds:
+    post:
+      tags:
+        - out-of-service beds
+      summary: Posts an out-of-service bed to a specified approved premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the out-of-service bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the out-of-service bed
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewCas1OutOfServiceBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas1OutOfServiceBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
+    get:
+      tags:
+        - out-of-service beds
+      summary: Lists all Out-Of-Service Beds entries for the Premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to show out-of-service beds for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas1OutOfServiceBed'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}:
+    get:
+      tags:
+        - out-of-service beds
+      summary: Returns a specific out-of-service bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the out-of-service bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: outOfServiceBedId
+          in: path
+          description: ID of the out-of-service bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas1OutOfServiceBed'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises or out-of-service bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+    put:
+      tags:
+        - out-of-service beds
+      summary: Updates an out-of-service bed for a premises
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the out-of-service bed is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: outOfServiceBedId
+          in: path
+          description: ID of the out-of-service bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the out-of-service bed
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdateCas1OutOfServiceBed'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas1OutOfServiceBed'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
+  /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}/cancellations:
+    post:
+      tags:
+        - out-of-service beds
+      summary: Posts a cancellation to a specified out-of-service bed
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the cancellation is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: outOfServiceBedId
+          in: path
+          description: ID of the out-of-service bed
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the cancellation
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NewCas1OutOfServiceBedCancellation'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or out-of-service bed ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
 components:
   responses:
     401Response:
@@ -4957,3 +5174,130 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+    Cas1OutOfServiceBed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        bedId:
+          type: string
+          format: uuid
+        bedName:
+          type: string
+        roomName:
+          type: string
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        status:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedStatus'
+        cancellation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+      required:
+        - id
+        - createdAt
+        - startDate
+        - endDate
+        - bedId
+        - bedName
+        - roomName
+        - reason
+        - status
+    NewCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        bedId:
+          type: string
+          format: uuid
+      required:
+        - startDate
+        - endDate
+        - reason
+        - bedId
+    UpdateCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - startDate
+        - endDate
+        - reason
+    Cas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - createdAt
+    NewCas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        notes:
+          type: string
+    Cas1OutOfServiceBedStatus:
+      type: string
+      enum:
+        - active
+        - cancelled
+    Cas1OutOfServiceBedReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Double Room with Single Occupancy - Other (Non-FM)
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5322,3 +5322,130 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+    Cas1OutOfServiceBed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        bedId:
+          type: string
+          format: uuid
+        bedName:
+          type: string
+        roomName:
+          type: string
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        status:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedStatus'
+        cancellation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+      required:
+        - id
+        - createdAt
+        - startDate
+        - endDate
+        - bedId
+        - bedName
+        - roomName
+        - reason
+        - status
+    NewCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        bedId:
+          type: string
+          format: uuid
+      required:
+        - startDate
+        - endDate
+        - reason
+        - bedId
+    UpdateCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - startDate
+        - endDate
+        - reason
+    Cas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - createdAt
+    NewCas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        notes:
+          type: string
+    Cas1OutOfServiceBedStatus:
+      type: string
+      enum:
+        - active
+        - cancelled
+    Cas1OutOfServiceBedReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Double Room with Single Occupancy - Other (Non-FM)
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4822,3 +4822,130 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+    Cas1OutOfServiceBed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        bedId:
+          type: string
+          format: uuid
+        bedName:
+          type: string
+        roomName:
+          type: string
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        status:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedStatus'
+        cancellation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+      required:
+        - id
+        - createdAt
+        - startDate
+        - endDate
+        - bedId
+        - bedName
+        - roomName
+        - reason
+        - status
+    NewCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        bedId:
+          type: string
+          format: uuid
+      required:
+        - startDate
+        - endDate
+        - reason
+        - bedId
+    UpdateCas1OutOfServiceBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - startDate
+        - endDate
+        - reason
+    Cas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - createdAt
+    NewCas1OutOfServiceBedCancellation:
+      type: object
+      properties:
+        notes:
+          type: string
+    Cas1OutOfServiceBedStatus:
+      type: string
+      enum:
+        - active
+        - cancelled
+    Cas1OutOfServiceBedReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Double Room with Single Occupancy - Other (Non-FM)
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedCancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedCancellationEntityFactory.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas1OutOfServiceBedCancellationEntityFactory : Factory<Cas1OutOfServiceBedCancellationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
+  private var notes: Yielded<String?> = { null }
+  private var outOfServiceBed: Yielded<Cas1OutOfServiceBedEntity> = { Cas1OutOfServiceBedEntityFactory().produce() }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withNotes(notes: String?) = apply {
+    this.notes = { notes }
+  }
+
+  fun withOutOfServiceBed(outOfServiceBed: Cas1OutOfServiceBedEntity) = apply {
+    this.outOfServiceBed = { outOfServiceBed }
+  }
+
+  fun withOutOfServiceBed(configuration: Cas1OutOfServiceBedEntityFactory.() -> Unit) = apply {
+    this.outOfServiceBed = { Cas1OutOfServiceBedEntityFactory().apply(configuration).produce() }
+  }
+
+  override fun produce() = Cas1OutOfServiceBedCancellationEntity(
+    id = this.id(),
+    createdAt = this.createdAt(),
+    notes = this.notes(),
+    outOfServiceBed = this.outOfServiceBed(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedEntityFactory.kt
@@ -76,6 +76,7 @@ class Cas1OutOfServiceBedEntityFactory : Factory<Cas1OutOfServiceBedEntity> {
       endDate = this.endDate(),
       referenceNumber = this.referenceNumber(),
       notes = this.notes(),
+      cancellation = null,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
@@ -84,6 +84,10 @@ class BedEntityFactory : Factory<BedEntity> {
     this.room = { room }
   }
 
+  fun withRoom(configuration: RoomEntityFactory.() -> Unit) = apply {
+    this.room = { RoomEntityFactory().apply(configuration).produce() }
+  }
+
   fun withYieldedRoom(room: Yielded<RoomEntity>) = apply {
     this.room = room
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -51,6 +51,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingNotMadeEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1ApplicationUserDetailsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
@@ -122,6 +123,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
@@ -201,6 +203,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingNotMad
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
@@ -494,6 +497,9 @@ abstract class IntegrationTestBase {
   lateinit var cas1OutOfServiceBedReasonTestRepository: Cas1OutOfServiceBedReasonTestRepository
 
   @Autowired
+  lateinit var cas1OutOfServiceBedCancellationTestRepository: Cas1OutOfServiceBedCancellationTestRepository
+
+  @Autowired
   lateinit var emailAsserter: EmailNotificationAsserter
 
   @Autowired
@@ -569,6 +575,7 @@ abstract class IntegrationTestBase {
   lateinit var referralRejectionReasonEntityFactory: PersistedFactory<ReferralRejectionReasonEntity, UUID, ReferralRejectionReasonEntityFactory>
   lateinit var cas1OutOfServiceBedEntityFactory: PersistedFactory<Cas1OutOfServiceBedEntity, UUID, Cas1OutOfServiceBedEntityFactory>
   lateinit var cas1OutOfServiceBedReasonEntityFactory: PersistedFactory<Cas1OutOfServiceBedReasonEntity, UUID, Cas1OutOfServiceBedReasonEntityFactory>
+  lateinit var cas1OutOfServiceBedCancellationEntityFactory: PersistedFactory<Cas1OutOfServiceBedCancellationEntity, UUID, Cas1OutOfServiceBedCancellationEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -672,6 +679,7 @@ abstract class IntegrationTestBase {
     referralRejectionReasonEntityFactory = PersistedFactory({ ReferralRejectionReasonEntityFactory() }, referralRejectionReasonRepository)
     cas1OutOfServiceBedEntityFactory = PersistedFactory({ Cas1OutOfServiceBedEntityFactory() }, cas1OutOfServiceBedTestRepository)
     cas1OutOfServiceBedReasonEntityFactory = PersistedFactory({ Cas1OutOfServiceBedReasonEntityFactory() }, cas1OutOfServiceBedReasonTestRepository)
+    cas1OutOfServiceBedCancellationEntityFactory = PersistedFactory({ Cas1OutOfServiceBedCancellationEntityFactory() }, cas1OutOfServiceBedCancellationTestRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
@@ -1,0 +1,1129 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1OutOfServiceBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1OutOfServiceBedCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas1OutOfServiceBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
+  @Autowired
+  lateinit var outOfServiceBedTransformer: Cas1OutOfServiceBedTransformer
+
+  @Nested
+  inner class GetAllOutOfServiceBeds {
+    @Test
+    fun `Get All Out-Of-Service Beds without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/out-of-service-beds")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Get All Out-Of-Service Beds on non existent Premises returns 404`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.get()
+        .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/out-of-service-beds")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Get All Out-Of-Service Beds returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          withBed(bed)
+        }
+
+        val cancelledOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          withBed(bed)
+        }
+
+        cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
+          withOutOfServiceBed(cancelledOutOfServiceBed)
+        }
+
+        val expectedJson = objectMapper.writeValueAsString(listOf(outOfServiceBedTransformer.transformJpaToApi(outOfServiceBed)))
+
+        webTestClient.get()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(expectedJson)
+      }
+    }
+  }
+
+  @Nested
+  inner class GetOutOfServiceBed {
+    @Test
+    fun `Get Out-Of-Service Bed without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          },
+        )
+      }
+
+      webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Get Out-Of-Service Bed for non-existent premises returns 404`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.get()
+        .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/out-of-service-beds")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Get Out-Of-Service Bed for non-existent out-of-service bed returns 404`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        webTestClient.get()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Get Out-Of-Service Bed returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
+              }
+            },
+          )
+        }
+
+        val expectedJson = objectMapper.writeValueAsString(outOfServiceBedTransformer.transformJpaToApi(outOfServiceBed))
+
+        webTestClient.get()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(expectedJson)
+      }
+    }
+  }
+
+  @Nested
+  inner class CreateOutOfServiceBed {
+    @Test
+    fun `Create Out-Of-Service Beds without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+      }
+
+      webTestClient.post()
+        .uri("/cas1/premises/${premises.id}/out-of-service-beds")
+        .bodyValue(
+          NewCas1OutOfServiceBed(
+            startDate = LocalDate.parse("2022-08-15"),
+            endDate = LocalDate.parse("2022-08-18"),
+            bedId = bed.id,
+            reason = UUID.randomUUID(),
+            referenceNumber = "REF-123",
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Create Out-Of-Service Beds returns 400 Bad Request if the bed ID does not reference a bed on the premises`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist {
+              withYieldedApArea {
+                apAreaEntityFactory.produceAndPersist()
+              }
+            }
+          }
+        }
+
+        val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewCas1OutOfServiceBed(
+              startDate = LocalDate.parse("2022-08-17"),
+              endDate = LocalDate.parse("2022-08-18"),
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+              bedId = UUID.randomUUID(),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBody()
+          .jsonPath("invalid-params[0].propertyName").isEqualTo("$.bedId")
+          .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Create Out-Of-Service Beds returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(3) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewCas1OutOfServiceBed(
+              startDate = LocalDate.parse("2022-08-17"),
+              endDate = LocalDate.parse("2022-08-18"),
+              bedId = bed.id,
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath(".startDate").isEqualTo("2022-08-17")
+          .jsonPath(".endDate").isEqualTo("2022-08-18")
+          .jsonPath(".bedId").isEqualTo(bed.id.toString())
+          .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+          .jsonPath(".reason.name").isEqualTo(reason.name)
+          .jsonPath(".reason.isActive").isEqualTo(true)
+          .jsonPath(".referenceNumber").isEqualTo("REF-123")
+          .jsonPath(".notes").isEqualTo("notes")
+          .jsonPath(".status").isEqualTo("active")
+          .jsonPath(".cancellation").isEqualTo(null)
+      }
+    }
+
+    @Test
+    fun `Create Out-Of-Service Bed succeeds even if overlapping with Booking`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(2) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        BookingEntityFactory()
+          .withBed(bed)
+          .withPremises(premises)
+          .withArrivalDate(LocalDate.parse("2022-08-15"))
+          .withDepartureDate(LocalDate.parse("2022-08-18"))
+          .produce()
+
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewCas1OutOfServiceBed(
+              startDate = LocalDate.parse("2022-08-17"),
+              endDate = LocalDate.parse("2022-08-18"),
+              bedId = bed.id,
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath(".startDate").isEqualTo("2022-08-17")
+          .jsonPath(".endDate").isEqualTo("2022-08-18")
+          .jsonPath(".bedId").isEqualTo(bed.id.toString())
+          .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+          .jsonPath(".reason.name").isEqualTo(reason.name)
+          .jsonPath(".reason.isActive").isEqualTo(true)
+          .jsonPath(".referenceNumber").isEqualTo("REF-123")
+          .jsonPath(".notes").isEqualTo("notes")
+          .jsonPath(".status").isEqualTo("active")
+          .jsonPath(".cancellation").isEqualTo(null)
+      }
+    }
+
+    @Test
+    fun `Create Out-Of-Service Beds for current day does not break GET all Premises endpoint`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(2) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
+              }
+            },
+          )
+          withStartDate(LocalDate.now().minusDays(2))
+          withEndDate(LocalDate.now().plusDays(2))
+          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+        }
+
+        bookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withOriginalArrivalDate(LocalDate.now().minusDays(4))
+          withArrivalDate(LocalDate.now().minusDays(4))
+          withOriginalDepartureDate(LocalDate.now().plusDays(6))
+          withDepartureDate(LocalDate.now().plusDays(6))
+        }
+
+        webTestClient.get()
+          .uri("/premises")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+      }
+    }
+
+    @Test
+    fun `Create Out-Of-Service Bed returns 409 Conflict when An out-of-service bed for the same bed overlaps`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+          val existingOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withBed(bed)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
+
+          webTestClient.post()
+            .uri("/cas1/premises/${premises.id}/out-of-service-beds")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewCas1OutOfServiceBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+                bedId = bed.id,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+            .expectBody()
+            .jsonPath("title").isEqualTo("Conflict")
+            .jsonPath("status").isEqualTo(409)
+            .jsonPath("detail").isEqualTo("An out-of-service bed already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingOutOfServiceBed.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `Create Out-Of-Service Bed returns OK with correct body when only cancelled out-of-service beds for the same bed overlap`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+          val existingOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withBed(bed)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withReason(
+              cas1OutOfServiceBedReasonEntityFactory.produceAndPersist(),
+            )
+          }
+
+          existingOutOfServiceBed.cancellation = cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
+            withOutOfServiceBed(existingOutOfServiceBed)
+            withCreatedAt(OffsetDateTime.parse("2022-07-01T12:34:56.789Z"))
+          }
+
+          webTestClient.post()
+            .uri("/cas1/premises/${premises.id}/out-of-service-beds")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              NewCas1OutOfServiceBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+                bedId = bed.id,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath(".startDate").isEqualTo("2022-08-01")
+            .jsonPath(".endDate").isEqualTo("2022-08-30")
+            .jsonPath(".bedId").isEqualTo(bed.id.toString())
+            .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+            .jsonPath(".reason.name").isEqualTo(reason.name)
+            .jsonPath(".reason.isActive").isEqualTo(true)
+            .jsonPath(".referenceNumber").isEqualTo("REF-123")
+            .jsonPath(".notes").isEqualTo("notes")
+            .jsonPath(".status").isEqualTo("active")
+            .jsonPath(".cancellation").isEqualTo(null)
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class UpdateOutOfServiceBed {
+    @Test
+    fun `Update Out-Of-Service Bed without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          },
+        )
+      }
+
+      bedEntityFactory.produceAndPersist {
+        withYieldedRoom {
+          roomEntityFactory.produceAndPersist {
+            withYieldedPremises { premises }
+          }
+        }
+      }
+
+      webTestClient.put()
+        .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+        .bodyValue(
+          UpdateCas1OutOfServiceBed(
+            startDate = LocalDate.parse("2022-08-15"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = UUID.randomUUID(),
+            referenceNumber = "REF-123",
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Update Out-Of-Service Bed for non-existent premises returns 404`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.put()
+        .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/out-of-service-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateCas1OutOfServiceBed(
+            startDate = LocalDate.parse("2022-08-15"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = UUID.randomUUID(),
+            referenceNumber = "REF-123",
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `Update Out-Of-Service Bed for non-existent out-of-service bed returns 404`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.put()
+        .uri("/cas1/premises/${premises.id}/out-of-service-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          UpdateCas1OutOfServiceBed(
+            startDate = LocalDate.parse("2022-08-15"),
+            endDate = LocalDate.parse("2022-08-18"),
+            reason = UUID.randomUUID(),
+            referenceNumber = "REF-123",
+            notes = null,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Update Out-Of-Service Beds returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(2) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          withBed(bed)
+        }
+
+        val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+        webTestClient.put()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            UpdateCas1OutOfServiceBed(
+              startDate = LocalDate.parse("2022-08-17"),
+              endDate = LocalDate.parse("2022-08-18"),
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath(".startDate").isEqualTo("2022-08-17")
+          .jsonPath(".endDate").isEqualTo("2022-08-18")
+          .jsonPath(".bedId").isEqualTo(bed.id.toString())
+          .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+          .jsonPath(".reason.name").isEqualTo(reason.name)
+          .jsonPath(".reason.isActive").isEqualTo(true)
+          .jsonPath(".referenceNumber").isEqualTo("REF-123")
+          .jsonPath(".notes").isEqualTo("notes")
+          .jsonPath(".status").isEqualTo("active")
+          .jsonPath(".cancellation").isEqualTo(null)
+      }
+    }
+
+    @Test
+    fun `Update Out-Of-Service Beds returns 409 Conflict when a booking for the same bed overlaps`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist {
+              withYieldedApArea {
+                apAreaEntityFactory.produceAndPersist()
+              }
+            }
+          }
+        }
+
+        val bed = bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.parse("2022-08-16"))
+          withEndDate(LocalDate.parse("2022-08-30"))
+          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          withBed(bed)
+        }
+
+        val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+        val existingBooking = bookingEntityFactory.produceAndPersist {
+          withServiceName(ServiceName.approvedPremises)
+          withCrn("CRN123")
+          withYieldedPremises { premises }
+          withBed(bed)
+          withArrivalDate(LocalDate.parse("2022-07-15"))
+          withDepartureDate(LocalDate.parse("2022-08-15"))
+        }
+
+        GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+        webTestClient.put()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            UpdateCas1OutOfServiceBed(
+              startDate = LocalDate.parse("2022-08-01"),
+              endDate = LocalDate.parse("2022-08-30"),
+              reason = reason.id,
+              referenceNumber = "REF-123",
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .is4xxClientError
+          .expectBody()
+          .jsonPath("title").isEqualTo("Conflict")
+          .jsonPath("status").isEqualTo(409)
+          .jsonPath("detail").isEqualTo("A booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingBooking.id}")
+      }
+    }
+
+    @Test
+    fun `Update Out-Of-Service Beds returns OK with correct body when only cancelled bookings for the same bed overlap`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { offenderDetails, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist {
+                withYieldedApArea {
+                  apAreaEntityFactory.produceAndPersist()
+                }
+              }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withStartDate(LocalDate.parse("2022-08-16"))
+            withEndDate(LocalDate.parse("2022-08-30"))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+            withBed(bed)
+          }
+
+          val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+          val existingBooking = bookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.approvedPremises)
+            withCrn(offenderDetails.otherIds.crn)
+            withYieldedPremises { premises }
+            withBed(bed)
+            withArrivalDate(LocalDate.parse("2022-07-15"))
+            withDepartureDate(LocalDate.parse("2022-08-15"))
+          }
+
+          existingBooking.cancellations = cancellationEntityFactory.produceAndPersistMultiple(1) {
+            withYieldedBooking { existingBooking }
+            withDate(LocalDate.parse("2022-07-01"))
+            withReason(cancellationReasonEntityFactory.produceAndPersist())
+          }.toMutableList()
+
+          webTestClient.put()
+            .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              UpdateCas1OutOfServiceBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath(".startDate").isEqualTo("2022-08-01")
+            .jsonPath(".endDate").isEqualTo("2022-08-30")
+            .jsonPath(".bedId").isEqualTo(bed.id.toString())
+            .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+            .jsonPath(".reason.name").isEqualTo(reason.name)
+            .jsonPath(".reason.isActive").isEqualTo(true)
+            .jsonPath(".referenceNumber").isEqualTo("REF-123")
+            .jsonPath(".notes").isEqualTo("notes")
+            .jsonPath(".status").isEqualTo("active")
+            .jsonPath(".cancellation").isEqualTo(null)
+        }
+      }
+    }
+
+    @Test
+    fun `Update Out-Of-Service Beds returns 409 Conflict when An out-of-service bed for the same bed overlaps`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+          val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withStartDate(LocalDate.parse("2022-08-16"))
+            withEndDate(LocalDate.parse("2022-08-30"))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+            withBed(bed)
+          }
+
+          val existingOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withBed(bed)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
+
+          webTestClient.put()
+            .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              UpdateCas1OutOfServiceBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+            .expectBody()
+            .jsonPath("title").isEqualTo("Conflict")
+            .jsonPath("status").isEqualTo(409)
+            .jsonPath("detail").isEqualTo("An out-of-service bed already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingOutOfServiceBed.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `Update Out-Of-Service Beds returns OK with correct body when only cancelled out-of-service beds for the same bed overlap`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withYieldedProbationRegion {
+              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            }
+          }
+
+          val bed = bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          }
+
+          val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+          val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withStartDate(LocalDate.parse("2022-08-16"))
+            withEndDate(LocalDate.parse("2022-08-30"))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+            withBed(bed)
+          }
+
+          val existingOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withBed(bed)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withReason(
+              cas1OutOfServiceBedReasonEntityFactory.produceAndPersist(),
+            )
+          }
+
+          existingOutOfServiceBed.cancellation = cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
+            withOutOfServiceBed(existingOutOfServiceBed)
+            withCreatedAt(OffsetDateTime.parse("2022-07-01T12:34:56.789Z"))
+          }
+
+          webTestClient.put()
+            .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              UpdateCas1OutOfServiceBed(
+                startDate = LocalDate.parse("2022-08-01"),
+                endDate = LocalDate.parse("2022-08-30"),
+                reason = reason.id,
+                referenceNumber = "REF-123",
+                notes = "notes",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath(".startDate").isEqualTo("2022-08-01")
+            .jsonPath(".endDate").isEqualTo("2022-08-30")
+            .jsonPath(".bedId").isEqualTo(bed.id.toString())
+            .jsonPath(".reason.id").isEqualTo(reason.id.toString())
+            .jsonPath(".reason.name").isEqualTo(reason.name)
+            .jsonPath(".reason.isActive").isEqualTo(true)
+            .jsonPath(".referenceNumber").isEqualTo("REF-123")
+            .jsonPath(".notes").isEqualTo("notes")
+            .jsonPath(".status").isEqualTo("active")
+            .jsonPath(".cancellation").isEqualTo(null)
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class CancelOutOfServiceBed {
+    @Test
+    fun `Cancel Out-Of-Service Bed without JWT returns 401`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withYieldedRoom {
+              roomEntityFactory.produceAndPersist {
+                withYieldedPremises { premises }
+              }
+            }
+          },
+        )
+      }
+
+      webTestClient.post()
+        .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}/cancellations")
+        .bodyValue(
+          NewCas1OutOfServiceBedCancellation(
+            notes = "Unauthorized",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Cancel Out-Of-Service Bed for non-existent premises returns 404`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.post()
+        .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/out-of-service-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488/cancellations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewCas1OutOfServiceBedCancellation(
+            notes = "Non-existent premises",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `Cancel Out-Of-Service Bed for non-existent out-of-service bed returns 404`() {
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        }
+      }
+
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.post()
+        .uri("/cas1/premises/${premises.id}/out-of-service-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488/cancellations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewCas1OutOfServiceBedCancellation(
+            notes = "Non-existent out-of-service bed",
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    fun `Cancel Out-Of-Service Bed returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        }
+
+        bedEntityFactory.produceAndPersistMultiple(2) {
+          withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
+        }
+
+        val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withStartDate(LocalDate.now().plusDays(2))
+          withEndDate(LocalDate.now().plusDays(4))
+          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
+              }
+            },
+          )
+        }
+
+        cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}/cancellations")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewCas1OutOfServiceBedCancellation(
+              notes = "Some cancellation notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath("$.notes").isEqualTo("Some cancellation notes")
+          .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas1OutOfServiceBedCancellationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas1OutOfServiceBedCancellationTestRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationEntity
+import java.util.UUID
+
+interface Cas1OutOfServiceBedCancellationTestRepository : JpaRepository<Cas1OutOfServiceBedCancellationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -648,6 +648,92 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+  fun `userCanManagePremisesOutOfServiceBed returns true if the given premises is an Approved Premises and the user has one of the FUTURE_MANAGER, MANAGER or MATCHER user roles`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.userCanManagePremisesOutOfServiceBed(user, approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `userCanManagePremisesOutOfServiceBed returns false if the given premises is an Approved Premises and the user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanManagePremisesOutOfServiceBed(user, approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `userCanManagePremisesOutOfServiceBed returns true if the given premises is a Temporary Accommodation premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.userCanManagePremisesOutOfServiceBed(user, temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `userCanManagePremisesOutOfServiceBed returns false if the given premises is a Temporary Accommodation premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.userCanManagePremisesOutOfServiceBed(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @Test
+  fun `userCanManagePremisesOutOfServiceBed returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.userCanManagePremisesOutOfServiceBed(user, temporaryAccommodationPremisesInUserRegion)).isFalse
+    assertThat(userAccessService.userCanManagePremisesOutOfServiceBed(user, temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+  fun `currentUserCanManagePremisesOutOfServiceBed returns true if the given premises is an Approved Premises and the current user has one of the FUTURE_MANAGER, MANAGER or MATCHER user roles`(role: UserRole) {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(role)
+
+    assertThat(userAccessService.currentUserCanManagePremisesOutOfServiceBed(approvedPremises)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesOutOfServiceBed returns false if the given premises is an Approved Premises and the current user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanManagePremisesOutOfServiceBed(approvedPremises)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesOutOfServiceBed returns true if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.currentUserCanManagePremisesOutOfServiceBed(temporaryAccommodationPremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesOutOfServiceBed returns false if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.currentUserCanManagePremisesOutOfServiceBed(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanManagePremisesOutOfServiceBed returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanManagePremisesOutOfServiceBed(temporaryAccommodationPremisesInUserRegion)).isFalse
+    assertThat(userAccessService.currentUserCanManagePremisesOutOfServiceBed(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @ParameterizedTest
   @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
   fun `userCanViewPremisesCapacity returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
@@ -1,0 +1,323 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas1OutOfServiceBedServiceTest {
+  private val outOfServiceBedRepository = mockk<Cas1OutOfServiceBedRepository>()
+  private val outOfServiceBedReasonRepository = mockk<Cas1OutOfServiceBedReasonRepository>()
+  private val outOfServiceBedCancellationRepository = mockk<Cas1OutOfServiceBedCancellationRepository>()
+
+  private val approvedPremisesFactory = ApprovedPremisesEntityFactory()
+    .withDefaults()
+
+  private val outOfServiceBedService = Cas1OutOfServiceBedService(
+    outOfServiceBedRepository,
+    outOfServiceBedReasonRepository,
+    outOfServiceBedCancellationRepository,
+  )
+
+  @Nested
+  inner class CreateOutOfServiceBeds {
+
+    @Test
+    fun `Returns FieldValidationError with correct param to message map when invalid parameters supplied`() {
+      val premisesEntity = approvedPremisesFactory.produce()
+
+      val reasonId = UUID.randomUUID()
+
+      every { outOfServiceBedReasonRepository.findByIdOrNull(reasonId) } returns null
+
+      val result = outOfServiceBedService.createOutOfServiceBed(
+        premises = premisesEntity,
+        startDate = LocalDate.parse("2022-08-28"),
+        endDate = LocalDate.parse("2022-08-25"),
+        reasonId = reasonId,
+        referenceNumber = "12345",
+        notes = "notes",
+        bedId = UUID.randomUUID(),
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
+        entry("$.endDate", "beforeStartDate"),
+        entry("$.reason", "doesNotExist"),
+      )
+    }
+
+    @Test
+    fun `Returns Success with correct result when validation passed`() {
+      val premisesEntity = approvedPremisesFactory.produce()
+
+      val room = RoomEntityFactory()
+        .withPremises(premisesEntity)
+        .produce()
+
+      val bed = BedEntityFactory()
+        .withYieldedRoom { room }
+        .produce()
+
+      premisesEntity.rooms += room
+      room.beds += bed
+
+      val outOfServiceBedReason = Cas1OutOfServiceBedReasonEntityFactory()
+        .produce()
+
+      every { outOfServiceBedReasonRepository.findByIdOrNull(outOfServiceBedReason.id) } returns outOfServiceBedReason
+
+      every { outOfServiceBedRepository.save(any()) } returnsArgument 0
+
+      val result = outOfServiceBedService.createOutOfServiceBed(
+        premises = premisesEntity,
+        startDate = LocalDate.parse("2022-08-25"),
+        endDate = LocalDate.parse("2022-08-28"),
+        reasonId = outOfServiceBedReason.id,
+        referenceNumber = "12345",
+        notes = "notes",
+        bedId = bed.id,
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
+      result as ValidatableActionResult.Success
+      assertThat(result.entity.premises).isEqualTo(premisesEntity)
+      assertThat(result.entity.reason).isEqualTo(outOfServiceBedReason)
+      assertThat(result.entity.startDate).isEqualTo(LocalDate.parse("2022-08-25"))
+      assertThat(result.entity.endDate).isEqualTo(LocalDate.parse("2022-08-28"))
+      assertThat(result.entity.referenceNumber).isEqualTo("12345")
+      assertThat(result.entity.notes).isEqualTo("notes")
+    }
+  }
+
+  @Nested
+  inner class UpdateOutOfServiceBeds {
+    @Test
+    fun `Returns FieldValidationError with correct param to message map when invalid parameters supplied`() {
+      val premisesEntity = approvedPremisesFactory.produce()
+
+      val reasonId = UUID.randomUUID()
+
+      val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+        .withBed {
+          withRoom {
+            withPremises(premisesEntity)
+          }
+        }
+        .produce()
+
+      every { outOfServiceBedRepository.findByIdOrNull(outOfServiceBed.id) } returns outOfServiceBed
+      every { outOfServiceBedReasonRepository.findByIdOrNull(reasonId) } returns null
+
+      val result = outOfServiceBedService.updateOutOfServiceBed(
+        outOfServiceBedId = outOfServiceBed.id,
+        startDate = LocalDate.parse("2022-08-28"),
+        endDate = LocalDate.parse("2022-08-25"),
+        reasonId = reasonId,
+        referenceNumber = "12345",
+        notes = "notes",
+      )
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      val resultEntity = (result as AuthorisableActionResult.Success).entity
+      assertThat(resultEntity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      assertThat((resultEntity as ValidatableActionResult.FieldValidationError).validationMessages).contains(
+        entry("$.endDate", "beforeStartDate"),
+        entry("$.reason", "doesNotExist"),
+      )
+    }
+
+    @Test
+    fun `Returns Success with correct result when validation passed`() {
+      val premisesEntity = approvedPremisesFactory.produce()
+
+      val outOfServiceBedReason = Cas1OutOfServiceBedReasonEntityFactory()
+        .produce()
+
+      val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+        .withBed {
+          withRoom {
+            withPremises(premisesEntity)
+          }
+        }
+        .produce()
+
+      every { outOfServiceBedRepository.findByIdOrNull(outOfServiceBed.id) } returns outOfServiceBed
+      every { outOfServiceBedReasonRepository.findByIdOrNull(outOfServiceBedReason.id) } returns outOfServiceBedReason
+
+      every { outOfServiceBedRepository.save(any()) } returnsArgument 0
+
+      val result = outOfServiceBedService.updateOutOfServiceBed(
+        outOfServiceBedId = outOfServiceBed.id,
+        startDate = LocalDate.parse("2022-08-25"),
+        endDate = LocalDate.parse("2022-08-28"),
+        reasonId = outOfServiceBedReason.id,
+        referenceNumber = "12345",
+        notes = "notes",
+      )
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      val resultEntity = (result as AuthorisableActionResult.Success).entity
+      assertThat(resultEntity).isInstanceOf(ValidatableActionResult.Success::class.java)
+      resultEntity as ValidatableActionResult.Success
+      assertThat(resultEntity.entity.premises).isEqualTo(premisesEntity)
+      assertThat(resultEntity.entity.reason).isEqualTo(outOfServiceBedReason)
+      assertThat(resultEntity.entity.startDate).isEqualTo(LocalDate.parse("2022-08-25"))
+      assertThat(resultEntity.entity.endDate).isEqualTo(LocalDate.parse("2022-08-28"))
+      assertThat(resultEntity.entity.referenceNumber).isEqualTo("12345")
+      assertThat(resultEntity.entity.notes).isEqualTo("notes")
+    }
+  }
+
+  @Nested
+  inner class CancelOutOfServiceBed {
+    @Test
+    fun `Returns GeneralValidationError when the out-of-service bed already has a cancellation`() {
+      val premisesEntity = approvedPremisesFactory.produce()
+
+      val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+        .withBed {
+          withRoom {
+            withPremises(premisesEntity)
+          }
+        }
+        .produce()
+        .apply {
+          cancellation = Cas1OutOfServiceBedCancellationEntityFactory()
+            .withOutOfServiceBed(this)
+            .produce()
+        }
+
+      val result = outOfServiceBedService.cancelOutOfServiceBed(outOfServiceBed, notes = null)
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
+      result as ValidatableActionResult.GeneralValidationError
+      assertThat(result.message).isEqualTo("This out-of-service bed has already been cancelled.")
+    }
+
+    @Test
+    fun `Returns Success with correct result when validation passed`() {
+      val premisesEntity = approvedPremisesFactory.produce()
+
+      val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+        .withBed {
+          withRoom {
+            withPremises(premisesEntity)
+          }
+        }
+        .produce()
+
+      val notes = "Some notes"
+
+      every { outOfServiceBedCancellationRepository.save(any()) } returnsArgument 0
+
+      val result = outOfServiceBedService.cancelOutOfServiceBed(outOfServiceBed, notes)
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
+      result as ValidatableActionResult.Success
+      assertThat(result.entity.outOfServiceBed).isEqualTo(outOfServiceBed)
+      assertThat(result.entity.notes).isEqualTo(notes)
+    }
+  }
+
+  @Nested
+  inner class GetActiveOutOfServiceBedsForPremisesId {
+    @Test
+    fun `Delegates to repository method`() {
+      val expectedList = mockk<List<Cas1OutOfServiceBedEntity>>()
+      every { outOfServiceBedRepository.findAllActiveForPremisesId(any()) } returns expectedList
+
+      val premisesId = UUID.randomUUID()
+
+      val result = outOfServiceBedService.getActiveOutOfServiceBedsForPremisesId(premisesId)
+
+      assertThat(result).isEqualTo(expectedList)
+      verify(exactly = 1) { outOfServiceBedRepository.findAllActiveForPremisesId(premisesId) }
+    }
+  }
+
+  @Nested
+  inner class GetOutOfServiceBedWithConflictingDates {
+    @Test
+    fun `Returns null when no overlapping out-of-service beds exist`() {
+      val expectedList = listOf<Cas1OutOfServiceBedEntity>()
+      every { outOfServiceBedRepository.findByBedIdAndOverlappingDate(any(), any(), any(), any()) } returns expectedList
+
+      val id = UUID.randomUUID()
+      val bedId = UUID.randomUUID()
+
+      val result = outOfServiceBedService.getOutOfServiceBedWithConflictingDates(
+        LocalDate.parse("2024-01-01"),
+        LocalDate.parse("2024-02-01"),
+        id,
+        bedId,
+      )
+
+      assertThat(result).isEqualTo(null)
+      verify(exactly = 1) {
+        outOfServiceBedRepository.findByBedIdAndOverlappingDate(
+          bedId,
+          LocalDate.parse("2024-01-01"),
+          LocalDate.parse("2024-02-01"),
+          id,
+        )
+      }
+    }
+
+    @Test
+    fun `Returns the first result when one or more out-of-service beds exist`() {
+      val expectedList = listOf(
+        Cas1OutOfServiceBedEntityFactory()
+          .withBed {
+            withRoom {
+              withPremises(
+                ApprovedPremisesEntityFactory()
+                  .withDefaults()
+                  .produce(),
+              )
+            }
+          }
+          .produce(),
+      )
+      every { outOfServiceBedRepository.findByBedIdAndOverlappingDate(any(), any(), any(), any()) } returns expectedList
+
+      val id = UUID.randomUUID()
+      val bedId = UUID.randomUUID()
+
+      val result = outOfServiceBedService.getOutOfServiceBedWithConflictingDates(
+        LocalDate.parse("2024-01-01"),
+        LocalDate.parse("2024-02-01"),
+        id,
+        bedId,
+      )
+
+      assertThat(result).isEqualTo(expectedList[0])
+      verify(exactly = 1) {
+        outOfServiceBedRepository.findByBedIdAndOverlappingDate(
+          bedId,
+          LocalDate.parse("2024-01-01"),
+          LocalDate.parse("2024-02-01"),
+          id,
+        )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedCancellationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedCancellationTransformerTest.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedCancellationTransformer
+
+class Cas1OutOfServiceBedCancellationTransformerTest {
+  private val transformer = Cas1OutOfServiceBedCancellationTransformer()
+
+  @Test
+  fun `transformJpaToApi transforms correctly`() {
+    val cancellation = Cas1OutOfServiceBedCancellationEntityFactory()
+      .withNotes("Some notes")
+      .withOutOfServiceBed {
+        withBed {
+          withRoom {
+            withPremises(
+              ApprovedPremisesEntityFactory()
+                .withDefaults()
+                .produce(),
+            )
+          }
+        }
+      }
+      .produce()
+
+    val result = transformer.transformJpaToApi(cancellation)
+
+    assertThat(result.id).isEqualTo(cancellation.id)
+    assertThat(result.createdAt).isEqualTo(cancellation.createdAt.toInstant())
+    assertThat(result.notes).isEqualTo(cancellation.notes)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedReasonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedReasonTransformerTest.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
+
+class Cas1OutOfServiceBedReasonTransformerTest {
+  private val transformer = Cas1OutOfServiceBedReasonTransformer()
+
+  @Test
+  fun `transformJpaToApi transforms correctly`() {
+    val reason = Cas1OutOfServiceBedReasonEntityFactory()
+      .produce()
+
+    val result = transformer.transformJpaToApi(reason)
+
+    assertThat(result.id).isEqualTo(reason.id)
+    assertThat(result.name).isEqualTo(reason.name)
+    assertThat(result.isActive).isEqualTo(reason.isActive)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
@@ -1,0 +1,123 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedCancellationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
+import java.util.UUID
+
+class Cas1OutOfServiceBedTransformerTest {
+  private val cas1OutOfServiceBedReasonTransformer = mockk<Cas1OutOfServiceBedReasonTransformer>()
+  private val cas1OutOfServiceBedCancellationTransformer = mockk<Cas1OutOfServiceBedCancellationTransformer>()
+  private val transformer = Cas1OutOfServiceBedTransformer(
+    cas1OutOfServiceBedReasonTransformer,
+    cas1OutOfServiceBedCancellationTransformer,
+  )
+
+  @Test
+  fun `transformJpaToApi transforms correctly when active`() {
+    val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+      .withBed {
+        withRoom {
+          withPremises(
+            ApprovedPremisesEntityFactory()
+              .withDefaults()
+              .produce(),
+          )
+        }
+      }
+      .withNotes("Some notes")
+      .produce()
+
+    val reason = Cas1OutOfServiceBedReason(
+      id = UUID.randomUUID(),
+      name = randomStringLowerCase(12),
+      isActive = true,
+    )
+
+    every { cas1OutOfServiceBedReasonTransformer.transformJpaToApi(outOfServiceBed.reason) } returns reason
+
+    val result = transformer.transformJpaToApi(outOfServiceBed)
+
+    assertThat(result.id).isEqualTo(outOfServiceBed.id)
+    assertThat(result.createdAt).isEqualTo(outOfServiceBed.createdAt.toInstant())
+    assertThat(result.startDate).isEqualTo(outOfServiceBed.startDate)
+    assertThat(result.endDate).isEqualTo(outOfServiceBed.endDate)
+    assertThat(result.bedId).isEqualTo(outOfServiceBed.bed.id)
+    assertThat(result.bedName).isEqualTo(outOfServiceBed.bed.name)
+    assertThat(result.roomName).isEqualTo(outOfServiceBed.bed.room.name)
+    assertThat(result.reason).isEqualTo(reason)
+    assertThat(result.status).isEqualTo(Cas1OutOfServiceBedStatus.active)
+    assertThat(result.referenceNumber).isEqualTo(outOfServiceBed.referenceNumber)
+    assertThat(result.notes).isEqualTo(outOfServiceBed.notes)
+    assertThat(result.cancellation).isNull()
+
+    verify { cas1OutOfServiceBedCancellationTransformer.transformJpaToApi(any()) wasNot Called }
+  }
+
+  @Test
+  fun `transformJpaToApi transforms correctly when cancelled`() {
+    val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+      .withBed {
+        withRoom {
+          withPremises(
+            ApprovedPremisesEntityFactory()
+              .withDefaults()
+              .produce(),
+          )
+        }
+      }
+      .withNotes("Some notes")
+      .produce()
+
+    val cancellationEntity = Cas1OutOfServiceBedCancellationEntityFactory()
+      .withOutOfServiceBed(outOfServiceBed)
+      .produce()
+
+    outOfServiceBed.cancellation = cancellationEntity
+
+    val reason = Cas1OutOfServiceBedReason(
+      id = UUID.randomUUID(),
+      name = randomStringLowerCase(12),
+      isActive = true,
+    )
+
+    val cancellation = Cas1OutOfServiceBedCancellation(
+      id = UUID.randomUUID(),
+      createdAt = Instant.now(),
+      notes = randomStringMultiCaseWithNumbers(20),
+    )
+
+    every { cas1OutOfServiceBedReasonTransformer.transformJpaToApi(outOfServiceBed.reason) } returns reason
+    every { cas1OutOfServiceBedCancellationTransformer.transformJpaToApi(cancellationEntity) } returns cancellation
+
+    val result = transformer.transformJpaToApi(outOfServiceBed)
+
+    assertThat(result.id).isEqualTo(outOfServiceBed.id)
+    assertThat(result.createdAt).isEqualTo(outOfServiceBed.createdAt.toInstant())
+    assertThat(result.startDate).isEqualTo(outOfServiceBed.startDate)
+    assertThat(result.endDate).isEqualTo(outOfServiceBed.endDate)
+    assertThat(result.bedId).isEqualTo(outOfServiceBed.bed.id)
+    assertThat(result.bedName).isEqualTo(outOfServiceBed.bed.name)
+    assertThat(result.roomName).isEqualTo(outOfServiceBed.bed.room.name)
+    assertThat(result.reason).isEqualTo(reason)
+    assertThat(result.status).isEqualTo(Cas1OutOfServiceBedStatus.cancelled)
+    assertThat(result.referenceNumber).isEqualTo(outOfServiceBed.referenceNumber)
+    assertThat(result.notes).isEqualTo(outOfServiceBed.notes)
+    assertThat(result.cancellation).isEqualTo(cancellation)
+  }
+}


### PR DESCRIPTION
> See [APS-802](https://dsdmoj.atlassian.net/browse/APS-802) and [APS-803](https://dsdmoj.atlassian.net/browse/APS-803) on the Approved Premises Jira board.

This PR introduces API endpoints to view and manipulate out-of-service beds in CAS1. Out-of-service beds are the intended replacement for the current lost beds model and were introduced in #1920.

Currently these endpoints are functionally almost identical to the existing lost beds endpoints, except that logic spread across multiple classes in the service layer have been coalesced into a single `Cas1OutOfServiceBedService`. This provides a way for out-of-service beds to diverge from the existing lost beds model without breaking backwards compatibility.

[APS-802]: https://dsdmoj.atlassian.net/browse/APS-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APS-803]: https://dsdmoj.atlassian.net/browse/APS-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ