### PR TITLE
APS-825 - Use jsonb for domain_events.data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationStatusUpdatesReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationStatusUpdatesReport.kt
@@ -23,7 +23,7 @@ interface Cas2ApplicationStatusUpdatesReportRepository : JpaRepository<DomainEve
          ) AS updatedAt
 
       FROM domain_events events
-      LEFT JOIN LATERAL json_array_elements(events.data -> 'eventDetails' -> 'newStatus' -> 'statusDetails') as details ON true
+      LEFT JOIN LATERAL jsonb_array_elements(events.data -> 'eventDetails' -> 'newStatus' -> 'statusDetails') as details ON true
       WHERE events.type = 'CAS2_APPLICATION_STATUS_UPDATED'
         AND events.occurred_at  > CURRENT_DATE - 365
       GROUP BY events.id  

--- a/src/main/resources/db/migration/all/20240614123435__use_jsonb_for_domain_events_data.sql
+++ b/src/main/resources/db/migration/all/20240614123435__use_jsonb_for_domain_events_data.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domain_events ALTER COLUMN "data" SET DATA TYPE jsonb USING "data"::jsonb;


### PR DESCRIPTION
The domain_events.data column stores JSON data. We use data stored in this column in a lot of reports, and it has been noted that these reads are causing notable performance hits (e.g. it can add seconds to query execution times).

This commit updates domain_events.data to use the ‘jsonb’ type instead of the ‘json’ type. This should significantly improve read speed, in exchange for a slight performance penalty on inserts. As we typically only insert a handful of domain events per thread of execution, if any at all, this is an acceptable trade off.

See https://dsdmoj.atlassian.net/browse/APS-825 for test evidence. I've ensured that domain events are still processed by probation-integration, and timelines can still be rendered