### PR TITLE
APS-823 capture application requiredPremisesType on application and assessment submission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -162,6 +162,7 @@ class AssessmentController(
       document = serializedData,
       placementRequirements = assessmentAcceptance.requirements,
       placementDates = assessmentAcceptance.placementDates,
+      apType = assessmentAcceptance.apType,
       notes = assessmentAcceptance.notes,
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -173,6 +173,7 @@ enum class MetaDataName {
   CAS1_APP_REASON_FOR_SHORT_NOTICE,
   CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER,
   CAS1_PLACEMENT_APPLICATION_ID,
+  CAS1_REQUESTED_AP_TYPE,
 }
 
 enum class DomainEventType(val typeName: String, val typeDescription: String, val timelineEventType: TimelineEventType?) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
@@ -326,6 +327,7 @@ class AssessmentService(
     document: String?,
     placementRequirements: PlacementRequirements?,
     placementDates: PlacementDates?,
+    apType: ApType?,
     notes: String?,
   ): AuthorisableActionResult<ValidatableActionResult<AssessmentEntity>> {
     val acceptedAt = OffsetDateTime.now()
@@ -429,7 +431,7 @@ class AssessmentService(
     }
 
     if (application is ApprovedPremisesApplicationEntity) {
-      cas1AssessmentDomainEventService.assessmentAccepted(application, assessment, offenderDetails, staffDetails, placementDates)
+      cas1AssessmentDomainEventService.assessmentAccepted(application, assessment, offenderDetails, staffDetails, placementDates, apType)
       cas1AssessmentEmailService.assessmentAccepted(application)
 
       if (createPlacementRequest) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -44,8 +44,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -56,7 +54,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -432,8 +429,7 @@ class AssessmentService(
     }
 
     if (application is ApprovedPremisesApplicationEntity) {
-      saveCas1ApplicationAssessedDomainEvent(application, assessment, offenderDetails, staffDetails, placementDates)
-
+      cas1AssessmentDomainEventService.assessmentAccepted(application, assessment, offenderDetails, staffDetails, placementDates)
       cas1AssessmentEmailService.assessmentAccepted(application)
 
       if (createPlacementRequest) {
@@ -443,57 +439,6 @@ class AssessmentService(
 
     return AuthorisableActionResult.Success(
       ValidatableActionResult.Success(savedAssessment),
-    )
-  }
-
-  private fun saveCas1ApplicationAssessedDomainEvent(
-    application: ApprovedPremisesApplicationEntity,
-    assessment: AssessmentEntity,
-    offenderDetails: OffenderDetailSummary,
-    staffDetails: StaffUserDetails,
-    placementDates: PlacementDates?,
-  ) {
-    val domainEventId = UUID.randomUUID()
-    val acceptedAt = assessment.submittedAt!!
-
-    domainEventService.saveApplicationAssessedDomainEvent(
-      DomainEvent(
-        id = domainEventId,
-        applicationId = application.id,
-        assessmentId = assessment.id,
-        crn = application.crn,
-        nomsNumber = offenderDetails.otherIds.nomsNumber,
-        occurredAt = acceptedAt.toInstant(),
-        data = ApplicationAssessedEnvelope(
-          id = domainEventId,
-          timestamp = acceptedAt.toInstant(),
-          eventType = EventType.applicationAssessed,
-          eventDetails = ApplicationAssessed(
-            applicationId = application.id,
-            applicationUrl = applicationUrlTemplate
-              .resolve("id", application.id.toString()),
-            personReference = PersonReference(
-              crn = offenderDetails.otherIds.crn,
-              noms = offenderDetails.otherIds.nomsNumber ?: "Unknown NOMS Number",
-            ),
-            deliusEventNumber = application.eventNumber,
-            assessedAt = acceptedAt.toInstant(),
-            assessedBy = ApplicationAssessedAssessedBy(
-              staffMember = staffDetails.toStaffMember(),
-              probationArea = ProbationArea(
-                code = staffDetails.probationArea.code,
-                name = staffDetails.probationArea.description,
-              ),
-              cru = Cru(
-                name = cruService.cruNameFromProbationAreaCode(staffDetails.probationArea.code),
-              ),
-            ),
-            decision = assessment.decision.toString(),
-            decisionRationale = assessment.rejectionRationale,
-            arrivalDate = placementDates?.expectedArrival?.toLocalDateTime()?.toInstant(),
-          ),
-        ),
-      ),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1880,6 +1880,7 @@ class BookingService(
           applicationEntity.document,
           null,
           null,
+          null,
           "Automatically moved to ready-to-place after booking is cancelled",
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -114,6 +114,7 @@ class Cas1ApplicationDomainEventService(
         metadata = mapOf(
           MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE to submitApplication.reasonForShortNotice,
           MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER to submitApplication.reasonForShortNoticeOther,
+          MetaDataName.CAS1_REQUESTED_AP_TYPE to application.apType.name,
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -13,12 +13,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Further
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.FurtherInformationRequestedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
@@ -148,6 +150,7 @@ class Cas1AssessmentDomainEventService(
     offenderDetails: OffenderDetailSummary,
     staffDetails: StaffUserDetails,
     placementDates: PlacementDates?,
+    apType: ApType?,
   ) {
     val domainEventId = UUID.randomUUID()
     val acceptedAt = assessment.submittedAt!!
@@ -188,6 +191,9 @@ class Cas1AssessmentDomainEventService(
             decisionRationale = assessment.rejectionRationale,
             arrivalDate = placementDates?.expectedArrival?.toLocalDateTime()?.toInstant(),
           ),
+        ),
+        metadata = mapOf(
+          MetaDataName.CAS1_REQUESTED_AP_TYPE to apType?.name,
         ),
       ),
     )

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2726,6 +2726,8 @@ components:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
           $ref: '#/components/schemas/PlacementDates'
+        apType:
+          $ref: '#/components/schemas/ApType'
         notes:
           type: string
       required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7400,6 +7400,8 @@ components:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
           $ref: '#/components/schemas/PlacementDates'
+        apType:
+          $ref: '#/components/schemas/ApType'
         notes:
           type: string
       required:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3169,6 +3169,8 @@ components:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
           $ref: '#/components/schemas/PlacementDates'
+        apType:
+          $ref: '#/components/schemas/ApType'
         notes:
           type: string
       required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3317,6 +3317,8 @@ components:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
           $ref: '#/components/schemas/PlacementDates'
+        apType:
+          $ref: '#/components/schemas/ApType'
         notes:
           type: string
       required:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2817,6 +2817,8 @@ components:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
           $ref: '#/components/schemas/PlacementDates'
+        apType:
+          $ref: '#/components/schemas/ApType'
         notes:
           type: string
       required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -3234,7 +3234,7 @@ class BookingServiceTest {
       every { mockCancellationRepository.save(any()) } answers { it.invocation.args[0] as CancellationEntity }
       every { mockCas3DomainEventService.saveBookingCancelledEvent(any(), any()) } just Runs
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
-      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any()) } returns AuthorisableActionResult.Success(ValidatableActionResult.Success(assessmentEntity!!))
+      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any(), any()) } returns AuthorisableActionResult.Success(ValidatableActionResult.Success(assessmentEntity!!))
       mockkStatic(Sentry::class)
 
       val result = bookingService.createCas3Cancellation(
@@ -3266,7 +3266,7 @@ class BookingServiceTest {
         mockBookingRepository.save(bookingEntity)
       }
       verify(exactly = 1) {
-        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, any())
+        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, null, any())
       }
       verify(exactly = 0) {
         Sentry.captureException(any())
@@ -3284,7 +3284,7 @@ class BookingServiceTest {
       every { mockCancellationRepository.save(any()) } answers { it.invocation.args[0] as CancellationEntity }
       every { mockCas3DomainEventService.saveBookingCancelledEvent(any(), any()) } just Runs
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
-      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any()) } returns AuthorisableActionResult.Unauthorised()
+      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any(), any()) } returns AuthorisableActionResult.Unauthorised()
       mockkStatic(Sentry::class)
       every { Sentry.captureException(any()) } returns SentryId.EMPTY_ID
 
@@ -3317,7 +3317,7 @@ class BookingServiceTest {
         mockBookingRepository.save(bookingEntity)
       }
       verify(exactly = 1) {
-        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, any())
+        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, null, any())
       }
       verify(exactly = 1) {
         Sentry.captureException(any())
@@ -3335,7 +3335,7 @@ class BookingServiceTest {
       every { mockCancellationRepository.save(any()) } answers { it.invocation.args[0] as CancellationEntity }
       every { mockCas3DomainEventService.saveBookingCancelledEvent(any(), any()) } just Runs
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
-      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any()) } throws RuntimeException("some-exception")
+      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any(), any()) } throws RuntimeException("some-exception")
       mockkStatic(Sentry::class)
 
       val result = bookingService.createCas3Cancellation(
@@ -3367,7 +3367,7 @@ class BookingServiceTest {
         mockBookingRepository.save(bookingEntity)
       }
       verify(exactly = 1) {
-        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, any())
+        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, null, any())
       }
       verify(exactly = 1) {
         Sentry.captureException(any())
@@ -3385,7 +3385,7 @@ class BookingServiceTest {
       every { mockCancellationRepository.save(any()) } answers { it.invocation.args[0] as CancellationEntity }
       every { mockCas3DomainEventService.saveBookingCancelledEvent(any(), any()) } just Runs
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
-      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any()) } throws Throwable("some-exception")
+      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any(), any()) } throws Throwable("some-exception")
       mockkStatic(Sentry::class)
 
       assertThatExceptionOfType(Throwable::class.java)
@@ -3412,7 +3412,7 @@ class BookingServiceTest {
         mockBookingRepository.save(bookingEntity)
       }
       verify(exactly = 1) {
-        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, any())
+        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, null, any())
       }
       verify(exactly = 0) {
         Sentry.captureException(any())
@@ -3454,7 +3454,7 @@ class BookingServiceTest {
         mockBookingRepository.save(bookingEntity)
       }
       verify(exactly = 0) {
-        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, any())
+        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, null, any())
       }
       verify(exactly = 0) {
         Sentry.captureException(any())
@@ -3472,7 +3472,7 @@ class BookingServiceTest {
       every { mockCancellationRepository.save(any()) } answers { it.invocation.args[0] as CancellationEntity }
       every { mockCas3DomainEventService.saveBookingCancelledEvent(any(), any()) } just Runs
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
-      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any()) } returns AuthorisableActionResult.Success(ValidatableActionResult.GeneralValidationError("Error"))
+      every { mockAssessmentService.acceptAssessment(user, any(), any(), any(), any(), any(), any()) } returns AuthorisableActionResult.Success(ValidatableActionResult.GeneralValidationError("Error"))
       mockkStatic(Sentry::class)
       every { Sentry.captureException(any()) } returns SentryId.EMPTY_ID
 
@@ -3502,7 +3502,7 @@ class BookingServiceTest {
         mockBookingRepository.save(bookingEntity)
       }
       verify(exactly = 1) {
-        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, any())
+        mockAssessmentService.acceptAssessment(user, assessmentEntity.id, assessmentEntity.document, null, null, null, any())
       }
       verify(exactly = 1) {
         Sentry.captureException(any())
@@ -3546,7 +3546,7 @@ class BookingServiceTest {
         mockBookingRepository.save(bookingEntity)
       }
       verify(exactly = 0) {
-        mockAssessmentService.acceptAssessment(user, any(), any(), null, null, any())
+        mockAssessmentService.acceptAssessment(user, any(), any(), null, null, null, any())
       }
       verify(exactly = 0) {
         Sentry.captureException(any())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -180,7 +180,7 @@ class AcceptAssessmentTest {
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesApplicationJsonSchemaEntityFactory().produce()
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
   }
@@ -199,7 +199,7 @@ class AcceptAssessmentTest {
       OffenderDetailsSummaryFactory().produce(),
     )
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
 
@@ -227,7 +227,7 @@ class AcceptAssessmentTest {
       OffenderDetailsSummaryFactory().produce(),
     )
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
 
@@ -254,7 +254,7 @@ class AcceptAssessmentTest {
       OffenderDetailsSummaryFactory().produce(),
     )
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
 
@@ -285,7 +285,7 @@ class AcceptAssessmentTest {
       OffenderDetailsSummaryFactory().produce(),
     )
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
 
@@ -314,7 +314,7 @@ class AcceptAssessmentTest {
 
     every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) } returns AuthorisableActionResult.Unauthorised()
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
   }
@@ -353,11 +353,11 @@ class AcceptAssessmentTest {
 
     every { placementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements) } returns ValidatableActionResult.Success(placementRequirementEntity)
 
-    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any()) } just Runs
+    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any(), any()) } just Runs
 
     every { cas1AssessmentEmailServiceMock.assessmentAccepted(any()) } just Runs
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
 
@@ -374,7 +374,7 @@ class AcceptAssessmentTest {
     }
 
     verify(exactly = 1) {
-      cas1AssessmentDomainEventServiceMock.assessmentAccepted(application, any(), any(), any(), any())
+      cas1AssessmentDomainEventServiceMock.assessmentAccepted(application, any(), any(), any(), any(), any())
     }
     verify(exactly = 1) {
       cas1AssessmentEmailServiceMock.assessmentAccepted(application)
@@ -438,11 +438,11 @@ class AcceptAssessmentTest {
 
     every { cas1AssessmentEmailServiceMock.assessmentAccepted(any()) } just Runs
 
-    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any()) } just Runs
+    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any(), any()) } just Runs
 
     every { cas1PlacementRequestEmailServiceMock.placementRequestSubmitted(any()) } just Runs
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, placementDates, notes)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, placementDates, null, notes)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
 
@@ -470,7 +470,7 @@ class AcceptAssessmentTest {
     }
 
     verify(exactly = 1) {
-      cas1AssessmentDomainEventServiceMock.assessmentAccepted(application, any(), any(), any(), any())
+      cas1AssessmentDomainEventServiceMock.assessmentAccepted(application, any(), any(), any(), any(), any())
     }
 
     verify(exactly = 1) {
@@ -498,7 +498,7 @@ class AcceptAssessmentTest {
       OffenderDetailsSummaryFactory().produce(),
     )
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -562,14 +562,14 @@ class AcceptAssessmentTest {
 
     every { communityApiClientMock.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
 
-    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any()) } just Runs
+    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any(), any()) } just Runs
 
     every { emailNotificationServiceMock.sendEmail(any(), any(), any()) } just Runs
 
     every { userServiceMock.getUserForRequest() } returns user
     every { assessmentReferralHistoryNoteRepositoryMock.save(any()) } returnsArgument 0
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", null, null, null)
+    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", null, null, null, null)
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -13,11 +13,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.allocations.UserAllocator
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedAssessedBy
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
@@ -49,8 +44,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejec
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
@@ -94,7 +87,7 @@ class AcceptAssessmentTest {
   private val taskDeadlineServiceMock = mockk<TaskDeadlineService>()
   private val cas1AssessmentEmailServiceMock = mockk<Cas1AssessmentEmailService>()
   private val cas1PlacementRequestEmailServiceMock = mockk<Cas1PlacementRequestEmailService>()
-  private val cas1AssessmentDomainEventService = mockk<Cas1AssessmentDomainEventService>()
+  private val cas1AssessmentDomainEventServiceMock = mockk<Cas1AssessmentDomainEventService>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -115,7 +108,7 @@ class AcceptAssessmentTest {
     UrlTemplate("http://frontend/applications/#id"),
     taskDeadlineServiceMock,
     cas1AssessmentEmailServiceMock,
-    cas1AssessmentDomainEventService,
+    cas1AssessmentDomainEventServiceMock,
     cas1PlacementRequestEmailServiceMock,
   )
 
@@ -358,9 +351,9 @@ class AcceptAssessmentTest {
 
     every { communityApiClientMock.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
 
-    every { domainEventServiceMock.saveApplicationAssessedDomainEvent(any()) } just Runs
-
     every { placementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements) } returns ValidatableActionResult.Success(placementRequirementEntity)
+
+    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any()) } just Runs
 
     every { cas1AssessmentEmailServiceMock.assessmentAccepted(any()) } just Runs
 
@@ -376,12 +369,13 @@ class AcceptAssessmentTest {
     assertThat(updatedAssessment.submittedAt).isNotNull()
     assertThat(updatedAssessment.document).isEqualTo("{\"test\": \"data\"}")
 
-    verifyDomainEventSent(offenderDetails, staffUserDetails, assessment)
-
     verify(exactly = 0) {
       placementRequestServiceMock.createPlacementRequest(any(), any(), any(), any(), false, null)
     }
 
+    verify(exactly = 1) {
+      cas1AssessmentDomainEventServiceMock.assessmentAccepted(application, any(), any(), any(), any())
+    }
     verify(exactly = 1) {
       cas1AssessmentEmailServiceMock.assessmentAccepted(application)
     }
@@ -444,6 +438,8 @@ class AcceptAssessmentTest {
 
     every { cas1AssessmentEmailServiceMock.assessmentAccepted(any()) } just Runs
 
+    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any()) } just Runs
+
     every { cas1PlacementRequestEmailServiceMock.placementRequestSubmitted(any()) } just Runs
 
     val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, placementDates, notes)
@@ -458,8 +454,6 @@ class AcceptAssessmentTest {
     assertThat(updatedAssessment.submittedAt).isNotNull()
     assertThat(updatedAssessment.document).isEqualTo("{\"test\": \"data\"}")
 
-    verifyDomainEventSent(offenderDetails, staffUserDetails, assessment)
-
     verify(exactly = 1) {
       placementRequestServiceMock.createPlacementRequest(
         source = PlacementRequestSource.ASSESSMENT_OF_APPLICATION,
@@ -473,6 +467,10 @@ class AcceptAssessmentTest {
 
     verify(exactly = 1) {
       cas1AssessmentEmailServiceMock.assessmentAccepted(application)
+    }
+
+    verify(exactly = 1) {
+      cas1AssessmentDomainEventServiceMock.assessmentAccepted(application, any(), any(), any(), any())
     }
 
     verify(exactly = 1) {
@@ -564,7 +562,7 @@ class AcceptAssessmentTest {
 
     every { communityApiClientMock.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
 
-    every { domainEventServiceMock.saveApplicationAssessedDomainEvent(any()) } just Runs
+    every { cas1AssessmentDomainEventServiceMock.assessmentAccepted(any(), any(), any(), any(), any()) } just Runs
 
     every { emailNotificationServiceMock.sendEmail(any(), any(), any()) } just Runs
 
@@ -584,45 +582,5 @@ class AcceptAssessmentTest {
     assertThat(updatedAssessment.document).isEqualTo("{\"test\": \"data\"}")
     assertThat(updatedAssessment.completedAt).isNull()
     assertAssessmentHasSystemNote(assessment, user, ReferralHistorySystemNoteType.READY_TO_PLACE)
-  }
-
-  private fun verifyDomainEventSent(offenderDetails: OffenderDetailSummary, staffUserDetails: StaffUserDetails, assessment: AssessmentEntity) {
-    verify(exactly = 1) {
-      domainEventServiceMock.saveApplicationAssessedDomainEvent(
-        match {
-          val data = it.data.eventDetails
-          val expectedPersonReference = PersonReference(
-            crn = offenderDetails.otherIds.crn,
-            noms = offenderDetails.otherIds.nomsNumber!!,
-          )
-          val expectedAssessor = ApplicationAssessedAssessedBy(
-            staffMember = StaffMember(
-              staffCode = staffUserDetails.staffCode,
-              staffIdentifier = staffUserDetails.staffIdentifier,
-              forenames = staffUserDetails.staff.forenames,
-              surname = staffUserDetails.staff.surname,
-              username = staffUserDetails.username,
-            ),
-            probationArea = ProbationArea(
-              code = staffUserDetails.probationArea.code,
-              name = staffUserDetails.probationArea.description,
-            ),
-            cru = Cru(
-              name = "South West & South Central",
-            ),
-          )
-
-          it.applicationId == assessment.application.id &&
-            it.crn == assessment.application.crn &&
-            data.applicationId == assessment.application.id &&
-            data.applicationUrl == "http://frontend/applications/${assessment.application.id}" &&
-            data.personReference == expectedPersonReference &&
-            data.deliusEventNumber == (assessment.application as ApprovedPremisesApplicationEntity).eventNumber &&
-            data.assessedBy == expectedAssessor &&
-            data.decision == "ACCEPTED" &&
-            data.decisionRationale == null
-        },
-      )
-    }
   }
 }


### PR DESCRIPTION
Capture the AP Type at the point of initial submission and again, if provided as part of the assessment submission.

assessmentAccepted domain event creation moved from AssessmentService to the Cas1AssessmentDomainEventService.

A new DomainEventEntity MetaDataName added to capture requested AP Type - CAS1_REQUESTED_AP_TYPE
On application submission, the requested AP Type is recorded in the meta data. 
ApType added to AssessmentAcceptance and recorded as part of a APPROVED_PREMISES_APPLIATION_ASSESSED domain event. 

[Link](https://dsdmoj.atlassian.net/browse/APS-823) to ticket