### PR TITLE
APS-854 - Revise CAS1 Application Raw Data Report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
     exclude("org.apache.httpcomponents", "httpclient")
   }
 
+  implementation("com.opencsv:opencsv:5.9")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.13.9")
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ClockConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ClockConfig.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class ClockConfig {
+
+  @Bean
+  fun clock(): Clock = Clock.systemDefaultZone()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ControllerUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ControllerUtils.kt
@@ -30,5 +30,6 @@ fun generateStreamingResponse(
   )
 
 enum class ContentType(val mimeType: String, val extension: String) {
+  CSV("text/csv", "csv"),
   XLSX("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
@@ -62,6 +62,21 @@ class Cas1ReportsController(
           outputStream,
         )
       }
+      Cas1ReportName.applicationsV2 -> generateStreamingResponse(
+        contentType = ContentType.CSV,
+        fileName = createCas1ReportName("applications", year, month, ContentType.CSV),
+      ) { outputStream ->
+        cas1ReportService.createApplicationReportV2(
+          ApplicationReportProperties(
+            serviceName = xServiceName,
+            year = year,
+            month = month,
+            deliusUsername = userService.getUserForRequest().deliusUsername,
+            includePii = includePii,
+          ),
+          outputStream,
+        )
+      }
       Cas1ReportName.dailyMetrics -> generateStreamingResponse(
         contentType = ContentType.XLSX,
         fileName = createCas1ReportName("daily-metrics", year, month, ContentType.XLSX),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationReportRepository.kt
@@ -1,0 +1,163 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1
+
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.JdbcResultSetConsumer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.ReportJdbcTemplate
+import java.time.LocalDateTime
+
+@Repository
+class Cas1ApplicationReportRepository(
+  val reportJdbcTemplate: ReportJdbcTemplate,
+) {
+
+  companion object {
+
+    const val COMPLETE_DATASET_QUERY = """
+    SELECT DISTINCT on (application.submitted_at, application.id)
+application.id as application_id,
+submission_event.data -> 'eventDetails' -> 'personReference' ->> 'crn' as crn,
+submission_event.data -> 'eventDetails' -> 'personReference' ->> 'noms' as noms,
+submission_event.data -> 'eventDetails' ->> 'age' as age_in_years,
+submission_event.data -> 'eventDetails' ->> 'gender' as gender,
+'not yet provided' as ethnicity,
+'not yet provided' as nationality,
+'not yet provided' as religion,
+'not yet provided' as has_physical_disability,
+'not yet provided' as has_learning_social_communication_difficulty,
+'not yet provided' as has_mental_health_condition,
+apa.risk_ratings -> 'tier' -> 'value' ->> 'level' as tier,
+submission_event.data -> 'eventDetails' ->> 'mappa' as mappa,
+submission_event.data -> 'eventDetails' ->> 'offenceId' as offence_id,
+submission_ap_type_metadata.value as premises_type,
+apa.sentence_type as sentence_type,
+submission_event.data -> 'eventDetails' ->> 'releaseType' as release_type,
+ap_area.name as application_origin_cru,
+submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'ldu' ->> 'name' as referral_ldu,
+submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'region' ->> 'name' as referral_region,
+submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'team' ->> 'name' as referral_team,
+submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'staffMember' ->> 'username' as referrer_username,
+concat(
+  submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'staffMember' ->> 'forenames', 
+  ' ',
+  submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'staffMember' ->> 'surname'
+) as referrer_name,
+submission_event.data -> 'eventDetails' ->> 'targetLocation' as target_location,
+to_char(cast(submission_event.data -> 'eventDetails' ->> 'submittedAt' as timestamp), 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as application_submission_date,
+apa.notice_type as application_timeliness_status,
+reason_for_short_notice_metadata.value as applicant_reason_for_late_application,
+reason_for_short_notice_other_metadata.value as applicant_reason_for_late_application_detail,
+initial_assessment.data -> 'suitability-assessment' -> 'application-timeliness' ->> 'agreeWithShortNoticeReason' as initial_assessor_agree_with_short_notice_reason,
+initial_assessment.data -> 'suitability-assessment' -> 'application-timeliness' ->> 'agreeWithShortNoticeReasonComments' as initial_assessor_reason_for_late_application,
+initial_assessment.data -> 'suitability-assessment' -> 'application-timeliness' ->> 'reasonForLateApplication' as initial_assessor_reason_for_late_application_detail,
+initial_assessment_ap_type_metadata.value as initial_assessor_premises_type,
+to_char(initial_assessment.allocated_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as last_allocated_to_initial_assessor_date,
+initial_assessment_event.data -> 'eventDetails' -> 'assessedBy' -> 'cru' ->> 'name' as initial_assessor_cru,
+initial_assessment_event.data -> 'eventDetails' -> 'assessedBy' -> 'staffMember' ->> 'username' as initial_assessor_username,
+concat(
+  initial_assessment_event.data -> 'eventDetails' -> 'assessedBy' -> 'staffMember' ->> 'forenames', 
+  ' ',
+  initial_assessment_event.data -> 'eventDetails' -> 'assessedBy' -> 'staffMember' ->> 'surname'
+) as initial_assessor_name,
+to_char(initial_assessment_clarification_notes.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as initial_assessment_further_information_requested_on,
+to_char(initial_assessment_clarification_notes.response_received_on, 'YYYY-MM-DD') as initial_assessment_further_information_received_at,
+to_char(cast(initial_assessment_event.data -> 'eventDetails' ->> 'assessedAt' as timestamp), 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as initial_assessment_decision_date,
+initial_assessment_event.data -> 'eventDetails' ->> 'decision' as initial_assessment_decision,
+initial_assessment_event.data -> 'eventDetails' ->> 'decisionRationale' as initial_assessment_decision_rationale,
+(select count(*) from appeals where appeals.application_id = application.id) as assessment_appeal_count,
+latest_appeal.decision as last_appealed_assessment_decision,
+to_char(latest_appeal.appeal_date, 'YYYY-MM-DD') as last_appealed_assessment_date,
+to_char(latest_appeal_assessment.allocated_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as last_allocated_to_appealed_assessor_date,
+latest_appeal_assessment_ap_type_metadata.value as last_allocated_to_appealed_assessor_premises_type,
+latest_appeal_assessment_event.data -> 'eventDetails' -> 'assessedBy' -> 'staffMember' ->> 'username' as last_appealed_assessor_username,
+to_char(withdrawal_event.occurred_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as application_withdrawal_date,
+withdrawal_event.data -> 'eventDetails' ->> 'withdrawalReason' as application_withdrawal_reason
+from
+applications application
+inner join approved_premises_applications apa on application.id = apa.id
+inner join domain_events submission_event on submission_event.type = 'APPROVED_PREMISES_APPLICATION_SUBMITTED'
+ and application.id = submission_event.application_id
+left join domain_events_metadata submission_ap_type_metadata on submission_ap_type_metadata.domain_event_id = submission_event.id 
+ and submission_ap_type_metadata.name = 'CAS1_REQUESTED_AP_TYPE'  
+ 
+left outer join domain_events_metadata reason_for_short_notice_metadata on reason_for_short_notice_metadata.domain_event_id = submission_event.id 
+ and reason_for_short_notice_metadata.name = 'CAS1_APP_REASON_FOR_SHORT_NOTICE' 
+left outer join domain_events_metadata reason_for_short_notice_other_metadata on reason_for_short_notice_other_metadata.domain_event_id = submission_event.id 
+ and reason_for_short_notice_other_metadata.name = 'CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER'  
+left join domain_events withdrawal_event on withdrawal_event.type = 'APPROVED_PREMISES_APPLICATION_WITHDRAWN'
+ and application.id = withdrawal_event.application_id
+ 
+left join (
+  select distinct on (application_id)
+         assessments.*
+  from assessments
+  where reallocated_at IS NULL
+  order by application_id, created_at asc
+) initial_assessment on initial_assessment.application_id = application.id
+
+left join domain_events as initial_assessment_event on 
+  initial_assessment_event.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED' AND
+  initial_assessment_event.assessment_id = initial_assessment.id
+left join domain_events_metadata initial_assessment_ap_type_metadata on initial_assessment_ap_type_metadata.domain_event_id = initial_assessment_event.id 
+ and initial_assessment_ap_type_metadata.name = 'CAS1_REQUESTED_AP_TYPE' 
+ 
+left join (
+  select distinct on (assessment_id)
+          assessment_clarification_notes.*
+  from assessment_clarification_notes
+  order by assessment_id, created_at asc
+) initial_assessment_clarification_notes on initial_assessment_clarification_notes.assessment_id = initial_assessment.id
+
+left join (
+  select distinct on (application_id)
+         appeals.*
+  from appeals
+  order by application_id, created_at desc
+) latest_appeal on latest_appeal.application_id = application.id
+
+left join (
+  select distinct on (application_id)
+         assess.*
+  from assessments assess inner join approved_premises_assessments apa_assess on assess.id = apa_assess.assessment_id
+  where assess.reallocated_at IS NULL and apa_assess.created_from_appeal is true
+  order by assess.application_id, assess.created_at desc
+) latest_appeal_assessment on latest_appeal_assessment.application_id = application.id
+
+left join domain_events as latest_appeal_assessment_event on 
+  latest_appeal_assessment_event.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED' AND
+  latest_appeal_assessment_event.assessment_id = latest_appeal_assessment.id
+left join domain_events_metadata latest_appeal_assessment_ap_type_metadata on latest_appeal_assessment_ap_type_metadata.domain_event_id = latest_appeal_assessment_event.id 
+ and latest_appeal_assessment_ap_type_metadata.name = 'CAS1_REQUESTED_AP_TYPE' 
+
+left join users as latest_appeal_assessment_assessor on latest_appeal_assessment_assessor.id = latest_appeal_assessment.allocated_to_user_id
+left join ap_areas as ap_area on ap_area.id = apa.ap_area_id
+
+where application.service = 'approved-premises' AND
+      application.submitted_at IS NOT NULL
+    """
+
+    const val QUERY =
+      """
+$COMPLETE_DATASET_QUERY
+AND (
+  (application.submitted_at >= :startDateTimeInclusive AND application.submitted_at <= :endDateTimeInclusive) OR
+  (withdrawal_event.occurred_at >= :startDateTimeInclusive AND withdrawal_event.occurred_at <= :endDateTimeInclusive)
+)
+order by application.submitted_at ASC, application.id ASC 
+;
+"""
+  }
+
+  fun generateForSubmissionOrWithdrawalDate(
+    startDateTimeInclusive: LocalDateTime,
+    endDateTimeInclusive: LocalDateTime,
+    jbdcResultSetConsumer: JdbcResultSetConsumer,
+  ) =
+    reportJdbcTemplate.query(
+      QUERY,
+      mapOf<String, Any>(
+        "startDateTimeInclusive" to startDateTimeInclusive,
+        "endDateTimeInclusive" to endDateTimeInclusive,
+      ),
+      jbdcResultSetConsumer,
+    )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/ApplicationReportProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/properties/ApplicationReportProperties.kt
@@ -7,4 +7,5 @@ data class ApplicationReportProperties(
   val year: Int,
   val month: Int,
   val deliusUsername: String,
+  val includePii: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/util/CsvJdbcResultSetConsumer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/util/CsvJdbcResultSetConsumer.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util
+
+import com.opencsv.CSVWriterBuilder
+import com.opencsv.ICSVWriter
+import com.opencsv.ResultSetColumnNameHelperService
+import java.io.OutputStream
+import java.nio.charset.Charset
+import java.sql.ResultSet
+
+class CsvJdbcResultSetConsumer(
+  private val outputStream: OutputStream,
+  private val columnsToExclude: List<String> = emptyList(),
+) : JdbcResultSetConsumer, AutoCloseable {
+  private lateinit var writer: ICSVWriter
+  private lateinit var resultSet: ResultSet
+
+  override fun consume(resultSet: ResultSet) {
+    this.resultSet = resultSet
+
+    val columnsToExcludeLowercase = columnsToExclude.map { it.lowercase() }
+    val columnsToInclude = getAllColNames(resultSet)
+      .filter { !columnsToExcludeLowercase.contains(it.lowercase()) }
+
+    val columnNameHelper = ResultSetColumnNameHelperService()
+    val columnNames = columnsToInclude.toTypedArray()
+    val columnHeaders = columnsToInclude.toTypedArray()
+    columnNameHelper.setColumnNames(columnNames, columnHeaders)
+
+    writer = CSVWriterBuilder(outputStream.writer(Charset.defaultCharset()))
+      .withResultSetHelper(columnNameHelper)
+      .build()
+
+    val includeHeaders = true
+    writer.writeAll(resultSet, includeHeaders)
+  }
+
+  private fun getAllColNames(resultSet: ResultSet): List<String> {
+    val metadata = resultSet.metaData
+    val cols = mutableListOf<String>()
+    for (it in 1.rangeTo(metadata.columnCount)) {
+      cols.add(metadata.getColumnName(it))
+    }
+    return cols
+  }
+
+  override fun close() {
+    writer.close()
+    resultSet.close()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/util/ExcelJdbcResultSetConsumer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/util/ExcelJdbcResultSetConsumer.kt
@@ -20,8 +20,8 @@ import java.sql.Types
  * Kotlin data types into corresponding Excel types. This could be improved as required, consulting
  * DataFrame's [DataFrame.writeExcel] function for an example of how data types could be mapped.
  *
- * Given (2), it's recommended that the SQL is written to format any non string types as required
- * (e.g. format date/timestamps as they should appear in the XLSX)
+ * Given (2), it's recommended that the SQL is written to covert any non string types into a string in
+ * the required format (e.g. format date/timestamps in the SQL as they should appear in the XLSX)
  */
 class ExcelJdbcResultSetConsumer : JdbcResultSetConsumer, AutoCloseable {
   private val workbook = WorkbookFactory.create(true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -57,6 +57,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.OffsetDateTime
@@ -96,6 +97,7 @@ class ApplicationService(
   private val cas1ApplicationEmailService: Cas1ApplicationEmailService,
   private val placementApplicationAutomaticRepository: PlacementApplicationAutomaticRepository,
   private val applicationListener: ApplicationListener,
+  private val clock: Clock,
 ) {
   fun getApplication(applicationId: UUID) = applicationRepository.findByIdOrNull(applicationId)
 
@@ -771,11 +773,13 @@ class ApplicationService(
       }
     }
 
+    val now = OffsetDateTime.now(clock)
+
     application.apply {
       isWomensApplication = submitApplication.isWomensApplication
       this.isEmergencyApplication = isEmergencyApplication
       this.apType = apType
-      submittedAt = OffsetDateTime.now()
+      submittedAt = now
       document = serializedTranslatedDocument
       releaseType = submitApplication.releaseType.toString()
       targetLocation = submitApplication.targetLocation

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -128,7 +128,7 @@ class Cas1ApplicationDomainEventService(
     withdrawingUser: UserEntity,
   ) {
     val domainEventId = UUID.randomUUID()
-    val eventOccurredAt = Instant.now()
+    val eventOccurredAt = Instant.now(clock)
 
     domainEventService.saveApplicationWithdrawnEvent(
       DomainEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapOfNonNullValues
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -43,6 +44,7 @@ class Cas1ApplicationDomainEventService(
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
   private val domainEventTransformer: DomainEventTransformer,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+  private val clock: Clock,
 ) {
 
   @SuppressWarnings("ThrowsCount", "TooGenericExceptionThrown")
@@ -193,7 +195,7 @@ class Cas1ApplicationDomainEventService(
         else -> throw RuntimeException("Unknown gender: ${offenderDetails.gender}")
       },
       targetLocation = submitApplication.targetLocation,
-      submittedAt = Instant.now(),
+      submittedAt = Instant.now(clock),
       submittedBy = getApplicationSubmittedSubmittedBy(staffDetails, caseDetail),
       sentenceLengthInMonths = null,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1Placement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntityReportRowRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ApplicationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.DailyMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.LostBedsReportGenerator
@@ -21,9 +22,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.Cas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.DailyMetricReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.LostBedReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.PlacementApplicationReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.CsvJdbcResultSetConsumer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.ExcelJdbcResultSetConsumer
 import java.io.OutputStream
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.temporal.TemporalAdjusters
 
 @Service
@@ -32,17 +35,46 @@ class Cas1ReportService(
   private val applicationEntityReportRowRepository: ApplicationEntityReportRowRepository,
   private val bedRepository: BedRepository,
   private val cas1PlacementMatchingOutcomesReportRepository: Cas1PlacementMatchingOutcomesReportRepository,
+  private val cas1ApplicationReportRepository: Cas1ApplicationReportRepository,
   private val domainEventRepository: DomainEventRepository,
   private val lostBedsRepository: LostBedsRepository,
   private val objectMapper: ObjectMapper,
   private val placementApplicationEntityReportRowRepository: PlacementApplicationEntityReportRowRepository,
 ) {
+
+  companion object {
+    val PII_COLUMN_NAMES = listOf(
+      "referrer_username",
+      "referrer_name",
+      "applicant_reason_for_late_application_detail",
+      "initial_assessor_reason_for_late_application",
+      "initial_assessor_username",
+      "initial_assessor_name",
+      "last_appealed_assessor_username",
+    )
+  }
+
   fun createApplicationReport(properties: ApplicationReportProperties, outputStream: OutputStream) {
     ApplicationReportGenerator()
       .createReport(applicationEntityReportRowRepository.generateApprovedPremisesReportRowsForCalendarMonth(properties.month, properties.year), properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)
       }
+  }
+
+  fun createApplicationReportV2(properties: ApplicationReportProperties, outputStream: OutputStream) {
+    val columnsToExclude = if (properties.includePii) { emptyList() } else { PII_COLUMN_NAMES }
+
+    CsvJdbcResultSetConsumer(
+      outputStream = outputStream,
+      columnsToExclude = columnsToExclude,
+    ).use { consumer ->
+      cas1ApplicationReportRepository.generateForSubmissionOrWithdrawalDate(
+        startDateTimeInclusive = getFirstSecondOfMonth(properties.year, properties.month),
+        endDateTimeInclusive = getLastSecondOfMonth(properties.year, properties.month),
+        jbdcResultSetConsumer = consumer,
+      )
+    }
   }
 
   fun createDailyMetricsReport(properties: DailyMetricReportProperties, outputStream: OutputStream) {
@@ -92,4 +124,10 @@ class Cas1ReportService(
       consumer.writeBufferedWorkbook(outputStream)
     }
   }
+
+  @SuppressWarnings("MagicNumber")
+  private fun getFirstSecondOfMonth(year: Int, month: Int) = LocalDate.of(year, month, 1).atStartOfDay()
+
+  @SuppressWarnings("MagicNumber")
+  private fun getLastSecondOfMonth(year: Int, month: Int) = YearMonth.of(year, month).atEndOfMonth().atTime(23, 59, 59, 999999999)
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4739,6 +4739,7 @@ components:
       type: string
       enum:
         - applications
+        - applicationsV2
         - dailyMetrics
         - lostBeds
         - placementApplications

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9290,6 +9290,7 @@ components:
       type: string
       enum:
         - applications
+        - applicationsV2
         - dailyMetrics
         - lostBeds
         - placementApplications

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5297,6 +5297,7 @@ components:
       type: string
       enum:
         - applications
+        - applicationsV2
         - dailyMetrics
         - lostBeds
         - placementApplications

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5330,6 +5330,7 @@ components:
       type: string
       enum:
         - applications
+        - applicationsV2
         - dailyMetrics
         - lostBeds
         - placementApplications

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4830,6 +4830,7 @@ components:
       type: string
       enum:
         - applications
+        - applicationsV2
         - dailyMetrics
         - lostBeds
         - placementApplications

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationJsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationJsonSchemaEntityFactory.kt
@@ -12,6 +12,11 @@ class ApprovedPremisesApplicationJsonSchemaEntityFactory : Factory<ApprovedPremi
   private var addedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var schema: Yielded<String> = { "{}" }
 
+  fun withDefaults() = apply {
+    withAddedAt(OffsetDateTime.now())
+    withPermissiveSchema()
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentJsonSchemaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesAssessmentJsonSchemaEntityFactory.kt
@@ -12,6 +12,11 @@ class ApprovedPremisesAssessmentJsonSchemaEntityFactory : Factory<ApprovedPremis
   private var addedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var schema: Yielded<String> = { "{}" }
 
+  fun withDefaults() = apply {
+    withAddedAt(OffsetDateTime.now())
+    withPermissiveSchema()
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
@@ -227,6 +227,10 @@ class NameFactory : Factory<Name> {
 class ManagerFactory : Factory<Manager> {
   var team: Yielded<Team> = { TeamFactory().produce() }
 
+  fun withTeam(team: Team) = apply {
+    this.team = { team }
+  }
+
   override fun produce(): Manager = Manager(
     team = this.team(),
   )
@@ -236,6 +240,14 @@ class TeamFactory : Factory<Team> {
   var code: Yielded<String> = { randomStringUpperCase(10) }
   var name: Yielded<String> = { randomStringUpperCase(10) }
   var ldu: Yielded<Ldu> = { LduFactory().produce() }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withLdu(ldu: Ldu) = apply {
+    this.ldu = { ldu }
+  }
 
   override fun produce(): Team = Team(
     code = this.code(),
@@ -247,6 +259,10 @@ class TeamFactory : Factory<Team> {
 class LduFactory : Factory<Ldu> {
   var code: Yielded<String> = { randomStringUpperCase(10) }
   var name: Yielded<String> = { randomStringUpperCase(10) }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
 
   override fun produce(): Ldu = Ldu(
     code = this.code(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -511,6 +511,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var domainEventAsserter: DomainEventAsserter
 
+  @Autowired
+  lateinit var clock: MutableClockConfiguration.MutableClock
+
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MutableClockConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MutableClockConfiguration.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.event.annotation.BeforeTestMethod
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+@Configuration
+class MutableClockConfiguration {
+
+  val clock: MutableClock
+    @Bean
+    @Primary
+    get() = MutableClock()
+
+  @BeforeTestMethod
+  fun reset() {
+    clock.reset()
+  }
+
+  class MutableClock : Clock() {
+    var fixedTime: Instant? = null
+
+    fun reset() = run { fixedTime = null }
+
+    fun setNow(now: LocalDateTime) {
+      fixedTime = now.toInstant(ZoneOffset.UTC)
+    }
+
+    override fun instant(): Instant {
+      return fixedTime ?: Instant.now()
+    }
+
+    override fun withZone(zone: ZoneId?): Clock {
+      error("Not supported")
+    }
+
+    override fun getZone(): ZoneId = ZoneId.systemDefault()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationReportTest.kt
@@ -1,0 +1,1079 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import com.opencsv.CSVReaderBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
+import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.api.toList
+import org.jetbrains.kotlinx.dataframe.io.readCSV
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentRejection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewAppeal
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LduFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ManagerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TeamFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseDetail
+import java.io.StringReader
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.util.UUID
+
+@SuppressWarnings("LongParameterList")
+class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
+
+  @Autowired
+  lateinit var realApplicationRepository: ApplicationRepository
+
+  @Autowired
+  lateinit var cas1SimpleApiClient: Cas1SimpleApiClient
+
+  lateinit var applicationSchema: ApprovedPremisesApplicationJsonSchemaEntity
+  lateinit var assessmentSchema: ApprovedPremisesAssessmentJsonSchemaEntity
+
+  val appSubmittedWithSuccessfulAppealsClarificationsAndWithdrawnManager = AppSubmittedWithSuccessfulAppealsClarificationsAndWithdrawnManager()
+  val appSubmittedWithAcceptedAssessmentManager = AppSubmittedWithAcceptedAssessmentManager()
+  val appSubmittedWithNoAssessmentManager = AppSubmittedNoAssessmentManager()
+  val appWithdrawnDuringReportingPeriod = AppWithdrawnDuringReportingPeriod()
+  val appSubmittedBeforeReportingPeriod = AppSubmittedBeforeReportingPeriod()
+  val appSubmittedAfterReportingPeriod = AppSubmittedAfterReportingPeriod()
+
+  @BeforeAll
+  fun setup() {
+    GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+    applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist { withDefaults() }
+    assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist { withDefaults() }
+
+    appSubmittedWithSuccessfulAppealsClarificationsAndWithdrawnManager.createApplication()
+    appSubmittedWithAcceptedAssessmentManager.createApplication()
+    appSubmittedWithNoAssessmentManager.createApplication()
+    appWithdrawnDuringReportingPeriod.createApplication()
+
+    appSubmittedBeforeReportingPeriod.createApplication()
+    appSubmittedAfterReportingPeriod.createApplication()
+  }
+
+  @Test
+  fun `Get application report is empty if no applications`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
+
+      webTestClient.get()
+        .uri(getReportUrl(year = 2019, month = 2))
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valuesMatch("content-disposition", "attachment; filename=\"applications-2019-02-[0-9_]*.csv\"")
+        .expectBody()
+        .consumeWith {
+          val actual = DataFrame
+            .readCSV(it.responseBody!!.inputStream())
+            .convertTo<ApplicationReportRow>(ExcessiveColumns.Remove)
+            .toList()
+
+          assertThat(actual.size).isEqualTo(0)
+        }
+    }
+  }
+
+  @Test
+  fun `Get application report returns OK with correct applications, including PII`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
+
+      webTestClient.get()
+        .uri(getReportUrl(year = 2020, month = 2, includePii = true))
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valuesMatch("content-disposition", "attachment; filename=\"applications-2020-02-[0-9_]*.csv\"")
+        .expectBody()
+        .consumeWith {
+          val actual = DataFrame
+            .readCSV(it.responseBody!!.inputStream())
+            .convertTo<ApplicationReportRow>(ExcessiveColumns.Remove)
+            .toList()
+
+          assertThat(actual.size).isEqualTo(4)
+
+          appWithdrawnDuringReportingPeriod.assertRow(actual[0])
+          appSubmittedWithSuccessfulAppealsClarificationsAndWithdrawnManager.assertRow(actual[1])
+          appSubmittedWithAcceptedAssessmentManager.assertRow(actual[2])
+          appSubmittedWithNoAssessmentManager.assertRow(actual[3])
+        }
+    }
+  }
+
+  @Test
+  fun `Get application report returns OK with correct applications, excludes PII`() {
+    `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
+
+      webTestClient.get()
+        .uri(getReportUrl(year = 2020, month = 2, includePii = false))
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valuesMatch("content-disposition", "attachment; filename=\"applications-2020-02-[0-9_]*.csv\"")
+        .expectBody()
+        .consumeWith { response ->
+          val completeCsvString = response.responseBody!!.inputStream().bufferedReader().use { it.readText() }
+
+          val csvReader = CSVReaderBuilder(StringReader(completeCsvString)).build()
+          val headers = csvReader.readNext().toList()
+
+          assertThat(headers).doesNotContain("referrer_username")
+          assertThat(headers).doesNotContain("referrer_name")
+          assertThat(headers).doesNotContain("applicant_reason_for_late_application_detail")
+          assertThat(headers).doesNotContain("initial_assessor_reason_for_late_application")
+          assertThat(headers).doesNotContain("initial_assessor_username")
+          assertThat(headers).doesNotContain("initial_assessor_name")
+          assertThat(headers).doesNotContain("last_appealed_assessor_username")
+
+          val actual = DataFrame
+            .readCSV(completeCsvString.byteInputStream())
+            .convertTo<ApplicationReportRow>(ExcessiveColumns.Remove)
+            .toList()
+
+          assertThat(actual.size).isEqualTo(4)
+
+          appSubmittedWithSuccessfulAppealsClarificationsAndWithdrawnManager.assertRow(
+            row = actual[1],
+            shouldIncludePii = false,
+          )
+        }
+    }
+  }
+
+  inner class AppSubmittedWithSuccessfulAppealsClarificationsAndWithdrawnManager {
+    lateinit var application: ApprovedPremisesApplicationEntity
+
+    fun createApplication() {
+      val (assessor1, assessor1Jwt) = `Given a User`(
+        roles = listOf(UserRole.CAS1_ASSESSOR),
+        qualifications = UserQualification.entries,
+        staffUserDetailsConfigBlock = {
+          withUsername("ASSESSOR1")
+          withForenames("Judy Jude")
+          withSurname("Juderson")
+        },
+        probationRegion = probationRegionEntityFactory.produceAndPersist() {
+          withApArea(
+            apAreaEntityFactory.produceAndPersist() {
+              withName("Ap Area 1")
+            },
+          )
+        },
+      )
+
+      val (assessor2, assessor2Jwt) = `Given a User`(
+        roles = listOf(UserRole.CAS1_ASSESSOR),
+        qualifications = UserQualification.entries,
+        staffUserDetailsConfigBlock = {
+          withUsername("ASSESSOR2")
+        },
+      )
+
+      application = createAndSubmitApplication(
+        applicantDetails = `Given a User`(
+          staffUserDetailsConfigBlock = {
+            withUsername("USER1")
+            withForenames("Jeff Jeffity")
+            withSurname("Jefferson")
+            withProbationAreaDescription("refRegion1")
+          },
+        ),
+        nomsNumber = "noms1",
+        apType = ApType.normal,
+        crn = "AppSubmittedWithSuccessfulAppealsClarificationsAndWithdrawn",
+        dateOfBirth = LocalDate.now().minusYears(25),
+        gender = "male",
+        tier = "C",
+        mappaCategory = "cat1",
+        mappaLevel = "level1",
+        offenceId = "offenceId1",
+        sentenceType = SentenceTypeOption.nonStatutory,
+        releaseType = ReleaseTypeOption.licence,
+        apAreaName = "apArea1",
+        lduName = "ldu1",
+        teamName = "refTeam1",
+        targetLocation = "location1",
+        submittedAt = LocalDateTime.of(2020, 2, 1, 12, 35, 0),
+        timelinessCategory = Cas1ApplicationTimelinessCategory.standard,
+        reasonForShortNotice = "reasonForShortNotice1",
+        reasonForShortNoticeOther = "reasonForShortNoticeOther1",
+      )
+      allocateLatestAssessment(
+        applicationId = application.id,
+        assessor = assessor1,
+        allocatedAt = LocalDateTime.of(2020, 2, 2, 13, 45, 0),
+      )
+      createClarificationsForLatestAssessment(
+        applicationId = application.id,
+        initialClarificationCreatedAt = LocalDateTime.of(2020, 3, 3, 6, 5, 30),
+        initialClarificationResponseReceivedAt = LocalDate.of(2020, 3, 4),
+        assessorJwt = assessor1Jwt,
+      )
+      updateLatestAssessment(
+        applicationId = application.id,
+        agreeWithShortNoticeReason = "agreeWithShortNoticeReason1",
+        agreeWithShortNoticeReasonComments = "agreeWithShortNoticeReasonComments1",
+        reasonForLateApplication = "reasonForLateApplication1",
+        assessorJwt = assessor1Jwt,
+      )
+      rejectLatestAssessment(
+        application = application,
+        decisionDate = LocalDateTime.of(2020, 4, 1, 9, 15, 45),
+        rationale = "theRejectionRationale1",
+        assessorJwt = assessor1Jwt,
+      )
+      createAppeal(
+        application = application,
+        decision = AppealDecision.rejected,
+        allocationDate = LocalDateTime.of(2020, 4, 5, 14, 15, 10),
+        acceptanceDate = LocalDate.of(2020, 4, 6),
+      )
+      createAppeal(
+        application = application,
+        decision = AppealDecision.accepted,
+        allocationDate = LocalDateTime.of(2020, 4, 7, 14, 15, 10),
+        acceptanceDate = LocalDate.of(2020, 4, 8),
+      )
+      allocateLatestAssessment(
+        applicationId = application.id,
+        assessor = assessor2,
+        allocatedAt = LocalDateTime.of(2020, 4, 9, 1, 0, 0),
+      )
+      updateLatestAssessment(
+        applicationId = application.id,
+        agreeWithShortNoticeReason = "agreeWithShortNoticeReason2",
+        agreeWithShortNoticeReasonComments = "agreeWithShortNoticeReasonComments2",
+        reasonForLateApplication = "reasonForLateApplication2",
+        assessorJwt = assessor2Jwt,
+      )
+      acceptLatestAssessment(
+        applicationId = application.id,
+        apType = ApType.pipe,
+        decisionDate = LocalDateTime.of(2020, 5, 1, 9, 15, 45),
+        assessorJwt = assessor2Jwt,
+      )
+      withdrawApplication(
+        applicationId = application.id,
+        withdrawalDate = LocalDateTime.of(2021, 12, 25, 2, 0, 0),
+        reason = WithdrawalReason.duplicateApplication,
+      )
+    }
+
+    fun assertRow(row: ApplicationReportRow, shouldIncludePii: Boolean = true) {
+      assertThat(row.application_id).isEqualTo(application.id.toString())
+      assertThat(row.crn).isEqualTo("AppSubmittedWithSuccessfulAppealsClarificationsAndWithdrawn")
+      assertThat(row.noms).isEqualTo("noms1")
+      assertThat(row.age_in_years).isEqualTo("25")
+      assertThat(row.gender).isEqualTo("Male")
+      assertThat(row.ethnicity).isEqualTo("not yet provided")
+      assertThat(row.nationality).isEqualTo("not yet provided")
+      assertThat(row.religion).isEqualTo("not yet provided")
+      assertThat(row.has_physical_disability).isEqualTo("not yet provided")
+      assertThat(row.has_learning_social_communication_difficulty).isEqualTo("not yet provided")
+      assertThat(row.has_mental_health_condition).isEqualTo("not yet provided")
+      assertThat(row.tier).isEqualTo("C")
+      assertThat(row.mappa).isEqualTo("CAT cat1/LEVEL level1")
+      assertThat(row.offence_id).isEqualTo("offenceId1")
+      assertThat(row.premises_type).isEqualTo("NORMAL")
+      assertThat(row.sentence_type).isEqualTo("nonStatutory")
+      assertThat(row.release_type).isEqualTo("licence")
+      assertThat(row.application_origin_cru).isEqualTo("apArea1")
+      assertThat(row.referral_ldu).isEqualTo("ldu1")
+      assertThat(row.referral_region).isEqualTo("refRegion1")
+      assertThat(row.referral_team).isEqualTo("refTeam1")
+
+      if (shouldIncludePii) {
+        assertThat(row.referrer_username).isEqualTo("USER1")
+        assertThat(row.referrer_name).isEqualTo("Jeff Jeffity Jefferson")
+      } else {
+        assertThat(row.referrer_username).isNull()
+        assertThat(row.referrer_name).isNull()
+      }
+
+      assertThat(row.target_location).isEqualTo("location1")
+      assertThat(row.application_submission_date).isEqualTo("2020-02-01T12:35:00Z")
+      assertThat(row.application_timeliness_status).isEqualTo("standard")
+      assertThat(row.applicant_reason_for_late_application).isEqualTo("reasonForShortNotice1")
+
+      if (shouldIncludePii) {
+        assertThat(row.applicant_reason_for_late_application_detail).isEqualTo("reasonForShortNoticeOther1")
+      } else {
+        assertThat(row.applicant_reason_for_late_application_detail).isNull()
+      }
+
+      assertThat(row.initial_assessor_agree_with_short_notice_reason).isEqualTo("agreeWithShortNoticeReason1")
+
+      if (shouldIncludePii) {
+        assertThat(row.initial_assessor_reason_for_late_application).isEqualTo("agreeWithShortNoticeReasonComments1")
+      } else {
+        assertThat(row.initial_assessor_reason_for_late_application).isNull()
+      }
+
+      assertThat(row.initial_assessor_reason_for_late_application_detail).isEqualTo("reasonForLateApplication1")
+      assertThat(row.initial_assessor_premises_type).isNull()
+      assertThat(row.last_allocated_to_initial_assessor_date).isEqualTo("2020-02-02T13:45:00Z")
+      assertThat(row.initial_assessor_cru).isEqualTo("Ap Area 1")
+
+      if (shouldIncludePii) {
+        assertThat(row.initial_assessor_username).isEqualTo("ASSESSOR1")
+        assertThat(row.initial_assessor_name).isEqualTo("Judy Jude Juderson")
+      } else {
+        assertThat(row.initial_assessor_username).isNull()
+        assertThat(row.initial_assessor_name).isNull()
+      }
+
+      assertThat(row.initial_assessment_further_information_requested_on).isEqualTo("2020-03-03T06:05:30Z")
+      assertThat(row.initial_assessment_further_information_received_at).isEqualTo("2020-03-04")
+      assertThat(row.initial_assessment_decision_date).isEqualTo("2020-04-01T09:15:45Z")
+      assertThat(row.initial_assessment_decision).isEqualTo("REJECTED")
+      assertThat(row.initial_assessment_decision_rationale).isEqualTo("theRejectionRationale1")
+      assertThat(row.assessment_appeal_count).isEqualTo("2")
+      assertThat(row.last_appealed_assessment_decision).isEqualTo("accepted")
+      assertThat(row.last_appealed_assessment_date).isEqualTo("2020-04-08")
+      assertThat(row.last_allocated_to_appealed_assessor_date).isEqualTo("2020-04-09T01:00:00Z")
+      assertThat(row.last_allocated_to_appealed_assessor_premises_type).isEqualTo("PIPE")
+
+      if (shouldIncludePii) {
+        assertThat(row.last_appealed_assessor_username).isEqualTo("ASSESSOR2")
+      } else {
+        assertThat(row.last_appealed_assessor_username).isNull()
+      }
+
+      assertThat(row.application_withdrawal_date).isEqualTo("2021-12-25T02:00:00Z")
+      assertThat(row.application_withdrawal_reason).isEqualTo("duplicate_application")
+    }
+  }
+
+  inner class AppSubmittedWithAcceptedAssessmentManager {
+    lateinit var application: ApprovedPremisesApplicationEntity
+
+    fun createApplication() {
+      val (assessor4, assessor4jwt) = `Given a User`(
+        roles = listOf(UserRole.CAS1_ASSESSOR),
+        qualifications = UserQualification.entries,
+        staffUserDetailsConfigBlock = {
+          withUsername("ASSESSOR4")
+          withForenames("Assessor")
+          withSurname("Assessing")
+        },
+        probationRegion = probationRegionEntityFactory.produceAndPersist() {
+          withApArea(
+            apAreaEntityFactory.produceAndPersist() {
+              withName("Ap Area 4")
+            },
+          )
+        },
+      )
+
+      application = createAndSubmitApplication(
+        applicantDetails = `Given a User`(
+          staffUserDetailsConfigBlock = {
+            withUsername("USER3")
+            withForenames("Test")
+            withSurname("Testing")
+            withProbationAreaDescription("refRegion3")
+          },
+        ),
+        nomsNumber = "noms3",
+        apType = ApType.pipe,
+        crn = "AppSubmittedWithAcceptedAssessment",
+        dateOfBirth = LocalDate.now().minusYears(50),
+        gender = "female",
+        tier = "X",
+        mappaCategory = "cat3",
+        mappaLevel = "level3",
+        offenceId = "offenceId3",
+        sentenceType = SentenceTypeOption.bailPlacement,
+        releaseType = ReleaseTypeOption.rotl,
+        apAreaName = "apArea3",
+        lduName = "ldu3",
+        teamName = "refTeam3",
+        targetLocation = "location3",
+        submittedAt = LocalDateTime.of(2020, 2, 15, 11, 25, 0),
+        timelinessCategory = Cas1ApplicationTimelinessCategory.emergency,
+        reasonForShortNotice = "reasonForShortNotice3",
+        reasonForShortNoticeOther = "reasonForShortNoticeOther3",
+      )
+      allocateLatestAssessment(
+        applicationId = application.id,
+        assessor = assessor4,
+        allocatedAt = LocalDateTime.of(2023, 9, 11, 3, 25, 10),
+      )
+      updateLatestAssessment(
+        applicationId = application.id,
+        agreeWithShortNoticeReason = "agreeWithShortNoticeReason4",
+        agreeWithShortNoticeReasonComments = "agreeWithShortNoticeReasonComments4",
+        reasonForLateApplication = "reasonForLateApplication4",
+        assessorJwt = assessor4jwt,
+      )
+      acceptLatestAssessment(
+        applicationId = application.id,
+        apType = ApType.mhapStJosephs,
+        decisionDate = LocalDateTime.of(2020, 12, 1, 9, 15, 45),
+        assessorJwt = assessor4jwt,
+      )
+    }
+
+    fun assertRow(row: ApplicationReportRow) {
+      assertThat(row.application_id).isEqualTo(application.id.toString())
+      assertThat(row.crn).isEqualTo("AppSubmittedWithAcceptedAssessment")
+      assertThat(row.noms).isEqualTo("noms3")
+      assertThat(row.age_in_years).isEqualTo("50")
+      assertThat(row.gender).isEqualTo("Female")
+      assertThat(row.ethnicity).isEqualTo("not yet provided")
+      assertThat(row.nationality).isEqualTo("not yet provided")
+      assertThat(row.religion).isEqualTo("not yet provided")
+      assertThat(row.has_physical_disability).isEqualTo("not yet provided")
+      assertThat(row.has_learning_social_communication_difficulty).isEqualTo("not yet provided")
+      assertThat(row.has_mental_health_condition).isEqualTo("not yet provided")
+      assertThat(row.tier).isEqualTo("X")
+      assertThat(row.mappa).isEqualTo("CAT cat3/LEVEL level3")
+      assertThat(row.offence_id).isEqualTo("offenceId3")
+      assertThat(row.premises_type).isEqualTo("PIPE")
+      assertThat(row.sentence_type).isEqualTo("bailPlacement")
+      assertThat(row.release_type).isEqualTo("rotl")
+      assertThat(row.application_origin_cru).isEqualTo("apArea3")
+      assertThat(row.referral_ldu).isEqualTo("ldu3")
+      assertThat(row.referral_region).isEqualTo("refRegion3")
+      assertThat(row.referral_team).isEqualTo("refTeam3")
+      assertThat(row.referrer_username).isEqualTo("USER3")
+      assertThat(row.referrer_name).isEqualTo("Test Testing")
+      assertThat(row.target_location).isEqualTo("location3")
+      assertThat(row.application_submission_date).isEqualTo("2020-02-15T11:25:00Z")
+      assertThat(row.application_timeliness_status).isEqualTo("emergency")
+      assertThat(row.applicant_reason_for_late_application).isEqualTo("reasonForShortNotice3")
+      assertThat(row.applicant_reason_for_late_application_detail).isEqualTo("reasonForShortNoticeOther3")
+
+      assertThat(row.initial_assessor_agree_with_short_notice_reason).isEqualTo("agreeWithShortNoticeReason4")
+      assertThat(row.initial_assessor_reason_for_late_application).isEqualTo("agreeWithShortNoticeReasonComments4")
+      assertThat(row.initial_assessor_reason_for_late_application_detail).isEqualTo("reasonForLateApplication4")
+      assertThat(row.initial_assessor_premises_type).isEqualTo("MHAP_ST_JOSEPHS")
+      assertThat(row.last_allocated_to_initial_assessor_date).isEqualTo("2023-09-11T03:25:10Z")
+      assertThat(row.initial_assessor_cru).isEqualTo("Ap Area 4")
+      assertThat(row.initial_assessor_username).isEqualTo("ASSESSOR4")
+      assertThat(row.initial_assessor_name).isEqualTo("Assessor Assessing")
+      assertThat(row.initial_assessment_further_information_requested_on).isNull()
+      assertThat(row.initial_assessment_further_information_received_at).isNull()
+      assertThat(row.initial_assessment_decision_date).isEqualTo("2020-12-01T09:15:45Z")
+      assertThat(row.initial_assessment_decision).isEqualTo("ACCEPTED")
+      assertThat(row.initial_assessment_decision_rationale).isNull()
+      assertThat(row.assessment_appeal_count).isEqualTo("0")
+      assertThat(row.last_appealed_assessment_decision).isNull()
+      assertThat(row.last_appealed_assessment_date).isNull()
+      assertThat(row.last_allocated_to_appealed_assessor_date).isNull()
+      assertThat(row.last_allocated_to_appealed_assessor_premises_type).isNull()
+      assertThat(row.last_appealed_assessor_username).isNull()
+
+      assertThat(row.application_withdrawal_date).isNull()
+      assertThat(row.application_withdrawal_reason).isNull()
+    }
+  }
+
+  inner class AppSubmittedNoAssessmentManager {
+    lateinit var application: ApprovedPremisesApplicationEntity
+
+    fun createApplication() {
+      val (assessor3, _) = `Given a User`(
+        roles = listOf(UserRole.CAS1_ASSESSOR),
+        qualifications = UserQualification.entries,
+        staffUserDetailsConfigBlock = {
+          withUsername("ASSESSOR3")
+        },
+      )
+
+      application = createAndSubmitApplication(
+        applicantDetails = `Given a User`(
+          staffUserDetailsConfigBlock = {
+            withUsername("USER2")
+            withForenames("App")
+            withSurname("Licant")
+            withProbationAreaDescription("refRegion2")
+          },
+        ),
+        nomsNumber = "noms2",
+        apType = ApType.esap,
+        crn = "AppSubmittedNoAssessment",
+        dateOfBirth = LocalDate.now().minusYears(20),
+        gender = "female",
+        tier = "B",
+        mappaCategory = "cat2",
+        mappaLevel = "level2",
+        offenceId = "offenceId2",
+        sentenceType = SentenceTypeOption.ipp,
+        releaseType = ReleaseTypeOption.notApplicable,
+        apAreaName = "apArea2",
+        lduName = "ldu2",
+        teamName = "refTeam2",
+        targetLocation = "location2",
+        submittedAt = LocalDateTime.of(2020, 2, 29, 11, 25, 0),
+        timelinessCategory = Cas1ApplicationTimelinessCategory.shortNotice,
+        reasonForShortNotice = null,
+        reasonForShortNoticeOther = null,
+      )
+      allocateLatestAssessment(
+        applicationId = application.id,
+        assessor = assessor3,
+        allocatedAt = LocalDateTime.of(2023, 8, 11, 3, 25, 10),
+      )
+    }
+
+    fun assertRow(row: ApplicationReportRow) {
+      assertThat(row.application_id).isEqualTo(application.id.toString())
+      assertThat(row.crn).isEqualTo("AppSubmittedNoAssessment")
+      assertThat(row.noms).isEqualTo("noms2")
+      assertThat(row.age_in_years).isEqualTo("20")
+      assertThat(row.gender).isEqualTo("Female")
+      assertThat(row.ethnicity).isEqualTo("not yet provided")
+      assertThat(row.nationality).isEqualTo("not yet provided")
+      assertThat(row.religion).isEqualTo("not yet provided")
+      assertThat(row.has_physical_disability).isEqualTo("not yet provided")
+      assertThat(row.has_learning_social_communication_difficulty).isEqualTo("not yet provided")
+      assertThat(row.has_mental_health_condition).isEqualTo("not yet provided")
+      assertThat(row.tier).isEqualTo("B")
+      assertThat(row.mappa).isEqualTo("CAT cat2/LEVEL level2")
+      assertThat(row.offence_id).isEqualTo("offenceId2")
+      assertThat(row.premises_type).isEqualTo("ESAP")
+      assertThat(row.sentence_type).isEqualTo("ipp")
+      assertThat(row.release_type).isEqualTo("notApplicable")
+      assertThat(row.application_origin_cru).isEqualTo("apArea2")
+      assertThat(row.referral_ldu).isEqualTo("ldu2")
+      assertThat(row.referral_region).isEqualTo("refRegion2")
+      assertThat(row.referral_team).isEqualTo("refTeam2")
+      assertThat(row.referrer_username).isEqualTo("USER2")
+      assertThat(row.referrer_name).isEqualTo("App Licant")
+      assertThat(row.target_location).isEqualTo("location2")
+      assertThat(row.application_submission_date).isEqualTo("2020-02-29T11:25:00Z")
+      assertThat(row.application_timeliness_status).isEqualTo("shortNotice")
+      assertThat(row.applicant_reason_for_late_application).isNull()
+      assertThat(row.applicant_reason_for_late_application_detail).isNull()
+
+      assertThat(row.initial_assessor_agree_with_short_notice_reason).isNull()
+      assertThat(row.initial_assessor_reason_for_late_application).isNull()
+      assertThat(row.initial_assessor_reason_for_late_application_detail).isNull()
+      assertThat(row.initial_assessor_premises_type).isNull()
+      assertThat(row.last_allocated_to_initial_assessor_date).isEqualTo("2023-08-11T03:25:10Z")
+      assertThat(row.initial_assessor_cru).isNull()
+      assertThat(row.initial_assessor_username).isNull()
+      assertThat(row.initial_assessment_further_information_requested_on).isNull()
+      assertThat(row.initial_assessment_further_information_received_at).isNull()
+      assertThat(row.initial_assessment_decision_date).isNull()
+      assertThat(row.initial_assessment_decision).isNull()
+      assertThat(row.initial_assessment_decision_rationale).isNull()
+      assertThat(row.assessment_appeal_count).isEqualTo("0")
+      assertThat(row.last_appealed_assessment_decision).isNull()
+      assertThat(row.last_appealed_assessment_date).isNull()
+      assertThat(row.last_allocated_to_appealed_assessor_date).isNull()
+      assertThat(row.last_allocated_to_appealed_assessor_premises_type).isNull()
+      assertThat(row.last_appealed_assessor_username).isNull()
+
+      assertThat(row.application_withdrawal_date).isNull()
+      assertThat(row.application_withdrawal_reason).isNull()
+    }
+  }
+
+  inner class AppWithdrawnDuringReportingPeriod {
+    lateinit var application: ApprovedPremisesApplicationEntity
+
+    fun createApplication() {
+      application = createAndSubmitApplication(
+        applicantDetails = `Given a User`(),
+        nomsNumber = "noms10",
+        apType = ApType.esap,
+        crn = "appWithdrawnDuringReportingPeriod",
+        dateOfBirth = LocalDate.now().minusYears(20),
+        gender = "female",
+        tier = "B",
+        mappaCategory = "cat2",
+        mappaLevel = "level2",
+        offenceId = "offenceId2",
+        sentenceType = SentenceTypeOption.ipp,
+        releaseType = ReleaseTypeOption.notApplicable,
+        apAreaName = "apArea2",
+        lduName = "ldu2",
+        teamName = "refTeam2",
+        targetLocation = "location2",
+        submittedAt = LocalDateTime.of(2020, 1, 30, 11, 25, 0),
+        timelinessCategory = Cas1ApplicationTimelinessCategory.shortNotice,
+        reasonForShortNotice = null,
+        reasonForShortNoticeOther = null,
+      )
+      withdrawApplication(
+        applicationId = application.id,
+        withdrawalDate = LocalDateTime.of(2020, 2, 12, 11, 25, 0),
+        WithdrawalReason.death,
+      )
+    }
+
+    fun assertRow(row: ApplicationReportRow) {
+      assertThat(row.application_id).isEqualTo(application.id.toString())
+      assertThat(row.crn).isEqualTo("appWithdrawnDuringReportingPeriod")
+
+      assertThat(row.application_withdrawal_date).isEqualTo("2020-02-12T11:25:00Z")
+      assertThat(row.application_withdrawal_reason).isEqualTo("death")
+    }
+  }
+
+  inner class AppSubmittedBeforeReportingPeriod {
+    lateinit var application: ApprovedPremisesApplicationEntity
+
+    fun createApplication() {
+      application = createAndSubmitApplication(
+        applicantDetails = `Given a User`(),
+        nomsNumber = "noms2",
+        apType = ApType.esap,
+        crn = "submittedAppBeforeReportDate",
+        dateOfBirth = LocalDate.now().minusYears(20),
+        gender = "female",
+        tier = "B",
+        mappaCategory = "cat2",
+        mappaLevel = "level2",
+        offenceId = "offenceId2",
+        sentenceType = SentenceTypeOption.ipp,
+        releaseType = ReleaseTypeOption.notApplicable,
+        apAreaName = "apArea2",
+        lduName = "ldu2",
+        teamName = "refTeam2",
+        targetLocation = "location2",
+        submittedAt = LocalDateTime.of(2020, 1, 30, 11, 25, 0),
+        timelinessCategory = Cas1ApplicationTimelinessCategory.shortNotice,
+        reasonForShortNotice = null,
+        reasonForShortNoticeOther = null,
+      )
+    }
+  }
+
+  inner class AppSubmittedAfterReportingPeriod {
+    lateinit var application: ApprovedPremisesApplicationEntity
+
+    fun createApplication() {
+      application = createAndSubmitApplication(
+        applicantDetails = `Given a User`(),
+        nomsNumber = "noms2",
+        apType = ApType.esap,
+        crn = "submittedAppBeforeReportDate",
+        dateOfBirth = LocalDate.now().minusYears(20),
+        gender = "female",
+        tier = "B",
+        mappaCategory = "cat2",
+        mappaLevel = "level2",
+        offenceId = "offenceId2",
+        sentenceType = SentenceTypeOption.ipp,
+        releaseType = ReleaseTypeOption.notApplicable,
+        apAreaName = "apArea2",
+        lduName = "ldu2",
+        teamName = "refTeam2",
+        targetLocation = "location2",
+        submittedAt = LocalDateTime.of(2020, 3, 1, 1, 0, 0),
+        timelinessCategory = Cas1ApplicationTimelinessCategory.shortNotice,
+        reasonForShortNotice = null,
+        reasonForShortNoticeOther = null,
+      )
+    }
+  }
+
+  @SuppressWarnings("ConstructorParameterNaming")
+  data class ApplicationReportRow(
+    val application_id: String,
+    val crn: String,
+    val noms: String?,
+    val age_in_years: String?,
+    val gender: String?,
+    val ethnicity: String,
+    val nationality: String,
+    val religion: String,
+    val has_physical_disability: String,
+    val has_learning_social_communication_difficulty: String,
+    val has_mental_health_condition: String,
+    val tier: String?,
+    val mappa: String?,
+    val offence_id: String?,
+    val premises_type: String?,
+    val sentence_type: String?,
+    val release_type: String?,
+    val application_origin_cru: String?,
+    val referral_ldu: String?,
+    val referral_region: String?,
+    val referral_team: String?,
+    val referrer_username: String?,
+    val referrer_name: String?,
+    val target_location: String?,
+    val application_submission_date: String?,
+    val application_timeliness_status: String?,
+    val applicant_reason_for_late_application: String?,
+    val applicant_reason_for_late_application_detail: String?,
+    val initial_assessor_agree_with_short_notice_reason: String?,
+    val initial_assessor_reason_for_late_application: String?,
+    val initial_assessor_reason_for_late_application_detail: String?,
+    val initial_assessor_premises_type: String?,
+    val last_allocated_to_initial_assessor_date: String?,
+    val initial_assessor_cru: String?,
+    val initial_assessor_username: String?,
+    val initial_assessor_name: String?,
+    val initial_assessment_further_information_requested_on: String?,
+    val initial_assessment_further_information_received_at: String?,
+    val initial_assessment_decision_date: String?,
+    val initial_assessment_decision: String?,
+    val initial_assessment_decision_rationale: String?,
+    val assessment_appeal_count: String?,
+    val last_appealed_assessment_decision: String?,
+    val last_appealed_assessment_date: String?,
+    val last_allocated_to_appealed_assessor_date: String?,
+    val last_allocated_to_appealed_assessor_premises_type: String?,
+    val last_appealed_assessor_username: String?,
+    val application_withdrawal_date: String?,
+    val application_withdrawal_reason: String?,
+  )
+
+  private fun createAndSubmitApplication(
+    applicantDetails: Pair<UserEntity, String>,
+    nomsNumber: String,
+    apType: ApType,
+    crn: String,
+    dateOfBirth: LocalDate,
+    gender: String,
+    tier: String,
+    mappaCategory: String,
+    mappaLevel: String,
+    offenceId: String,
+    sentenceType: SentenceTypeOption,
+    releaseType: ReleaseTypeOption,
+    apAreaName: String,
+    lduName: String,
+    teamName: String,
+    targetLocation: String,
+    submittedAt: LocalDateTime,
+    timelinessCategory: Cas1ApplicationTimelinessCategory,
+    reasonForShortNotice: String?,
+    reasonForShortNoticeOther: String?,
+  ): ApprovedPremisesApplicationEntity {
+    val (applicant, jwt) = applicantDetails
+    val (offenderDetails, _) = `Given an Offender`(
+      offenderDetailsConfigBlock = {
+        withCrn(crn)
+        withDateOfBirth(dateOfBirth)
+        withGender(gender)
+        withNomsNumber(nomsNumber)
+      },
+    )
+
+    APDeliusContext_mockSuccessfulCaseDetailCall(
+      offenderDetails.otherIds.crn,
+      CaseDetailFactory()
+        .from(offenderDetails.asCaseDetail())
+        .withMappaDetail(
+          MappaDetail(
+            level = 59,
+            levelDescription = mappaLevel,
+            category = 2,
+            categoryDescription = mappaCategory,
+            startDate = LocalDate.now(),
+            lastUpdated = ZonedDateTime.now(),
+          ),
+        )
+        .withCase(
+          CaseSummaryFactory()
+            .withManager(
+              ManagerFactory()
+                .withTeam(
+                  TeamFactory()
+                    .withName(teamName)
+                    .withLdu(LduFactory().withName(lduName).produce()).produce(),
+                )
+                .produce(),
+            )
+            .produce(),
+        )
+        .produce(),
+    )
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCreatedByUser(applicant)
+      withCrn(offenderDetails.otherIds.crn)
+      withNomsNumber(offenderDetails.otherIds.nomsNumber!!)
+      withApplicationSchema(applicationSchema)
+      withData("{}")
+      withOffenceId(offenceId)
+      withRiskRatings(
+        PersonRisksFactory()
+          .withTier(
+            RiskWithStatus(
+              status = RiskStatus.Retrieved,
+              value = RiskTier(
+                level = tier,
+                lastUpdated = LocalDate.now(),
+              ),
+            ),
+          ).produce(),
+      )
+    }
+
+    clock.setNow(submittedAt)
+
+    val apArea = apAreaEntityFactory.produceAndPersist {
+      withName(apAreaName)
+    }
+
+    cas1SimpleApiClient.applicationSubmit(
+      this,
+      application.id,
+      jwt,
+      SubmitApprovedPremisesApplication(
+        translatedDocument = {},
+        isWomensApplication = false,
+        isEmergencyApplication = false,
+        targetLocation = targetLocation,
+        releaseType = releaseType,
+        type = "CAS1",
+        sentenceType = sentenceType,
+        applicantUserDetails = Cas1ApplicationUserDetails("applicantName", "applicantEmail", "applicationPhone"),
+        caseManagerIsNotApplicant = false,
+        reasonForShortNotice = reasonForShortNotice,
+        reasonForShortNoticeOther = reasonForShortNoticeOther,
+        apType = apType,
+        noticeType = timelinessCategory,
+        apAreaId = apArea.id,
+      ),
+    )
+
+    return realApplicationRepository.findByIdOrNull(application.id) as ApprovedPremisesApplicationEntity
+  }
+
+  private fun createClarificationsForLatestAssessment(
+    applicationId: UUID,
+    assessorJwt: String,
+    initialClarificationCreatedAt: LocalDateTime,
+    initialClarificationResponseReceivedAt: LocalDate,
+  ) {
+    val assessmentId = getLatestAssessment(applicationId).id
+
+    clock.setNow(initialClarificationCreatedAt)
+
+    val initialNote = cas1SimpleApiClient.assessmentCreateClarificationNote(
+      this,
+      assessmentId,
+      assessorJwt,
+      NewClarificationNote(query = "This is the initial query"),
+    )
+
+    cas1SimpleApiClient.assessmentUpdateClarificationNote(
+      this,
+      assessmentId,
+      initialNote.id,
+      assessorJwt,
+      UpdatedClarificationNote(
+        response = "This is the initial response",
+        responseReceivedOn = initialClarificationResponseReceivedAt!!,
+      ),
+    )
+
+    clock.setNow(initialClarificationCreatedAt.plusDays(12))
+
+    val subsequentNote = cas1SimpleApiClient.assessmentCreateClarificationNote(
+      this,
+      assessmentId,
+      assessorJwt,
+      NewClarificationNote(query = "This is an additional query that should be ignored in the report"),
+    )
+
+    cas1SimpleApiClient.assessmentUpdateClarificationNote(
+      this,
+      assessmentId,
+      subsequentNote.id,
+      assessorJwt,
+      UpdatedClarificationNote(
+        response = "This is the subsequent response",
+        responseReceivedOn = LocalDate.now(),
+      ),
+    )
+  }
+
+  private fun allocateLatestAssessment(
+    applicationId: UUID,
+    allocatedAt: LocalDateTime,
+    assessor: UserEntity,
+  ) {
+    clock.setNow(allocatedAt)
+
+    cas1SimpleApiClient.assessmentReallocate(
+      this,
+      realApplicationRepository.findByIdOrNull(applicationId)!!.getLatestAssessment()!!.id,
+      assessor.id,
+    )
+  }
+
+  fun updateLatestAssessment(
+    applicationId: UUID,
+    assessorJwt: String,
+    agreeWithShortNoticeReason: String,
+    agreeWithShortNoticeReasonComments: String,
+    reasonForLateApplication: String,
+  ) {
+    val assessmentId = getLatestAssessment(applicationId).id
+
+    cas1SimpleApiClient.assessmentUpdate(
+      this,
+      assessmentId,
+      assessorJwt,
+      UpdateAssessment(
+        data = mapOf(
+          "suitability-assessment" to mapOf(
+            "application-timeliness" to mapOf(
+              "agreeWithShortNoticeReason" to agreeWithShortNoticeReason,
+              "agreeWithShortNoticeReasonComments" to agreeWithShortNoticeReasonComments,
+              "reasonForLateApplication" to reasonForLateApplication,
+            ),
+          ),
+        ),
+      ),
+    )
+  }
+
+  private fun acceptLatestAssessment(
+    applicationId: UUID,
+    apType: ApType,
+    decisionDate: LocalDateTime,
+    assessorJwt: String,
+  ) {
+    val assessmentId = getLatestAssessment(applicationId).id
+
+    val essentialCriteria = listOf(PlacementCriteria.isArsonSuitable, PlacementCriteria.isESAP)
+    val desirableCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
+
+    val placementRequirements = PlacementRequirements(
+      gender = Gender.male,
+      type = ApType.normal,
+      location = postCodeDistrictFactory.produceAndPersist().outcode,
+      radius = 50,
+      essentialCriteria = essentialCriteria,
+      desirableCriteria = desirableCriteria,
+    )
+
+    clock.setNow(decisionDate)
+
+    cas1SimpleApiClient.assessmentAccept(
+      this,
+      assessmentId,
+      assessorJwt,
+      AssessmentAcceptance(
+        document = mapOf("document" to "value"),
+        requirements = placementRequirements,
+        placementDates = null,
+        apType = apType,
+      ),
+    )
+  }
+
+  private fun rejectLatestAssessment(
+    application: ApprovedPremisesApplicationEntity,
+    decisionDate: LocalDateTime,
+    rationale: String,
+    assessorJwt: String,
+  ) {
+    val assessmentId = getLatestAssessment(application.id).id
+
+    clock.setNow(decisionDate)
+
+    cas1SimpleApiClient.assessmentReject(
+      this,
+      assessmentId,
+      assessorJwt,
+      AssessmentRejection(
+        document = mapOf("document" to "value"),
+        rejectionRationale = rationale,
+      ),
+    )
+  }
+
+  private fun createAppeal(
+    application: ApprovedPremisesApplicationEntity,
+    decision: AppealDecision,
+    allocationDate: LocalDateTime,
+    acceptanceDate: LocalDate,
+  ) {
+    clock.setNow(allocationDate)
+
+    cas1SimpleApiClient.assessmentAppealCreate(
+      this,
+      application.id,
+      NewAppeal(
+        appealDate = acceptanceDate,
+        appealDetail = "the detail",
+        decision = decision,
+        decisionDetail = "the decision detail",
+      ),
+    )
+  }
+
+  private fun withdrawApplication(
+    applicationId: UUID,
+    withdrawalDate: LocalDateTime,
+    reason: WithdrawalReason,
+  ) {
+    clock.setNow(withdrawalDate)
+
+    cas1SimpleApiClient.applicationWithdraw(
+      this,
+      applicationId,
+      NewWithdrawal(
+        reason,
+      ),
+    )
+  }
+
+  private fun getLatestAssessment(applicationId: UUID) = getApplication(applicationId).getLatestAssessment()!!
+
+  private fun getApplication(applicationId: UUID) =
+    realApplicationRepository.findByIdOrNull(applicationId)!! as ApprovedPremisesApplicationEntity
+
+  private fun getReportUrl(year: Int, month: Int, includePii: Boolean = true) = "/cas1/reports/applicationsV2?year=$year&month=$month&includePii=$includePii"
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
@@ -1,0 +1,170 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.springframework.stereotype.Component
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentRejection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewAppeal
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import java.util.UUID
+
+@Component
+class Cas1SimpleApiClient {
+
+  fun applicationSubmit(
+    integrationTestBase: IntegrationTestBase,
+    id: UUID,
+    applicantJwt: String,
+    body: SubmitApprovedPremisesApplication,
+  ) {
+    integrationTestBase.webTestClient.post()
+      .uri("/applications/$id/submission")
+      .header("Authorization", "Bearer $applicantJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  fun applicationWithdraw(
+    integrationTestBase: IntegrationTestBase,
+    id: UUID,
+    body: NewWithdrawal,
+  ) {
+    val managerJwt = integrationTestBase.`Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)).second
+
+    integrationTestBase.webTestClient.post()
+      .uri("/applications/$id/withdrawal")
+      .header("Authorization", "Bearer $managerJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  fun assessmentAppealCreate(
+    integrationTestBase: IntegrationTestBase,
+    applicationId: UUID,
+    body: NewAppeal,
+  ) {
+    val appealsManagerJwt = integrationTestBase.`Given a User`(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)).second
+
+    integrationTestBase.webTestClient.post()
+      .uri("/applications/$applicationId/appeals")
+      .header("Authorization", "Bearer $appealsManagerJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isCreated
+  }
+
+  fun assessmentUpdate(
+    integrationTestBase: IntegrationTestBase,
+    assessmentId: UUID,
+    assessorJwt: String,
+    body: UpdateAssessment,
+  ) {
+    integrationTestBase.webTestClient.put()
+      .uri("/assessments/$assessmentId")
+      .header("Authorization", "Bearer $assessorJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  fun assessmentAccept(
+    integrationTestBase: IntegrationTestBase,
+    assessmentId: UUID,
+    assessorJwt: String,
+    body: AssessmentAcceptance,
+  ) {
+    integrationTestBase.webTestClient.post()
+      .uri("/assessments/$assessmentId/acceptance")
+      .header("Authorization", "Bearer $assessorJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  fun assessmentReject(
+    integrationTestBase: IntegrationTestBase,
+    assessmentId: UUID,
+    assessorJwt: String,
+    body: AssessmentRejection,
+  ) {
+    integrationTestBase.webTestClient.post()
+      .uri("/assessments/$assessmentId/rejection")
+      .header("Authorization", "Bearer $assessorJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  fun assessmentReallocate(
+    integrationTestBase: IntegrationTestBase,
+    assessmentId: UUID,
+    targetUserId: UUID,
+  ) {
+    val managerJwt = integrationTestBase.`Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)).second
+
+    integrationTestBase.webTestClient.post()
+      .uri("/tasks/assessment/$assessmentId/allocations")
+      .header("Authorization", "Bearer $managerJwt")
+      .header("X-Service-Name", ServiceName.approvedPremises.value)
+      .bodyValue(
+        NewReallocation(
+          userId = targetUserId,
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isCreated
+  }
+
+  fun assessmentCreateClarificationNote(
+    integrationTestBase: IntegrationTestBase,
+    assessmentId: UUID,
+    assessorJwt: String,
+    body: NewClarificationNote,
+  ): ClarificationNote {
+    return integrationTestBase.webTestClient.post()
+      .uri("/assessments/$assessmentId/notes")
+      .header("Authorization", "Bearer $assessorJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult<ClarificationNote>()
+      .responseBody
+      .blockFirst()!!
+  }
+
+  fun assessmentUpdateClarificationNote(
+    integrationTestBase: IntegrationTestBase,
+    assessmentId: UUID,
+    noteId: UUID,
+    assessorJwt: String,
+    body: UpdatedClarificationNote,
+  ) {
+    integrationTestBase.webTestClient.put()
+      .uri("/assessments/$assessmentId/notes/$noteId")
+      .header("Authorization", "Bearer $assessorJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -93,6 +93,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import java.sql.Timestamp
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -148,6 +149,7 @@ class ApplicationServiceTest {
     mockCas1ApplicationEmailService,
     mockPlacementApplicationAutomaticRepository,
     mockApplicationListener,
+    Clock.systemDefaultZone(),
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -88,6 +88,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Placeme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertAssessmentHasSystemNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -136,6 +137,7 @@ class AssessmentServiceTest {
     cas1PlacementRequestEmailService,
     assessmentListener,
     assessmentClarificationNoteListener,
+    Clock.systemDefaultZone(),
   )
 
   @Test
@@ -955,7 +957,7 @@ class AssessmentServiceTest {
     val validationResult = (result as AuthorisableActionResult.Success).entity
     assertThat(validationResult is ValidatableActionResult.GeneralValidationError)
     val generalValidationError = validationResult as ValidatableActionResult.GeneralValidationError
-    assertThat(generalValidationError.message).isEqualTo("The application has been reallocated, this assessment is read only")
+    assertThat(generalValidationError.message).isEqualTo("The assessment has been reallocated, this assessment is read only")
   }
 
   @Test
@@ -2258,6 +2260,7 @@ class AssessmentServiceTest {
       cas1PlacementRequestEmailService,
       assessmentListener,
       assessmentClarificationNoteListener,
+      Clock.systemDefaultZone(),
     )
 
     private val user = UserEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -64,6 +64,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertAssessmentHasSystemNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -113,6 +114,7 @@ class AcceptAssessmentTest {
     cas1PlacementRequestEmailServiceMock,
     assessmentListener,
     assessmentClarificationNoteListener,
+    Clock.systemDefaultZone(),
   )
 
   lateinit var user: UserEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationDomainEventServiceTest.kt
@@ -50,6 +50,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.Period
@@ -69,6 +70,7 @@ class Cas1ApplicationDomainEventServiceTest {
     mockApDeliusContextApiClient,
     mockDomainEventTransformer,
     UrlTemplate("http://frontend/applications/#id"),
+    Clock.systemDefaultZone(),
   )
 
   val applicationId: UUID = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,6 +18,8 @@ spring:
     properties:
       hibernate:
         enable_lazy_load_no_trans: true
+  main:
+    allow-bean-definition-overriding: true
   redis:
     host: localhost
     port: 6377


### PR DESCRIPTION
See https://dsdmoj.atlassian.net/browse/APS-854 for a link to a spreadsheet that defines the updated report

This commit provides a rewrite of the CAS1 RAW Applications Data Report, adding and removing several fields and outputting the report as a CSV.

The commit also adds the Cas1SimpleApiClient in an attempt to make tests interacting with the API to setup test data more readable.

Instead of replacing the original report, this report is added as a new version of the original report. This allows us to feature flag the availability of the report on the UI as we’re not currently in a position to backfill required data in production.