### PR TITLE
APS-863 Don’t use JPA Callbacks to Update App Status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.ApplicationListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -23,7 +22,6 @@ import javax.persistence.Convert
 import javax.persistence.DiscriminatorColumn
 import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
-import javax.persistence.EntityListeners
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.persistence.Id
@@ -298,7 +296,6 @@ abstract class ApplicationEntity(
   abstract fun getRequiredQualifications(): List<UserQualification>
 }
 
-@EntityListeners(ApplicationListener::class)
 @Entity
 @DiscriminatorValue("approved-premises")
 @Table(name = "approved_premises_applications")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentClarificationNoteListener
 import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -16,7 +15,6 @@ import java.util.UUID
 import javax.persistence.DiscriminatorColumn
 import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
-import javax.persistence.EntityListeners
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.persistence.Id
@@ -405,7 +403,6 @@ interface AssessmentClarificationNoteRepository : JpaRepository<AssessmentClarif
   fun findByAssessmentIdAndId(assessmentId: UUID, id: UUID): AssessmentClarificationNoteEntity?
 }
 
-@EntityListeners(AssessmentClarificationNoteListener::class)
 @Entity
 @Table(name = "assessment_clarification_notes")
 data class AssessmentClarificationNoteEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentClarificationNoteListener
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentListener
 import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -274,7 +273,6 @@ abstract class AssessmentEntity(
   var version: Long = 1,
 )
 
-@EntityListeners(AssessmentListener::class)
 @Entity
 @DiscriminatorValue("approved-premises")
 @Table(name = "approved_premises_assessments")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.BookingListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.BookingSummaryForAvailability
 import java.sql.Timestamp
 import java.time.LocalDate
@@ -16,7 +15,6 @@ import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 import javax.persistence.Entity
-import javax.persistence.EntityListeners
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.persistence.Id
@@ -205,7 +203,6 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   fun updateBookingAdhocStatus(bookingId: UUID, adhoc: Boolean): Int
 }
 
-@EntityListeners(BookingListener::class)
 @Entity
 @Table(name = "bookings")
 data class BookingEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/ApplicationListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/ApplicationListener.kt
@@ -3,11 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
-import javax.persistence.PreUpdate
 
 @Component
 class ApplicationListener {
-  @PreUpdate
+
   fun preUpdate(application: ApprovedPremisesApplicationEntity) {
     if (application.isInapplicable == true) {
       application.status = ApprovedPremisesApplicationStatus.INAPPLICABLE

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentClarificationNoteListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentClarificationNoteListener.kt
@@ -4,19 +4,16 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
-import javax.persistence.PrePersist
-import javax.persistence.PreUpdate
 
 @Component
 class AssessmentClarificationNoteListener {
-  @PrePersist
+
   fun prePersist(clarificationNote: AssessmentClarificationNoteEntity) {
     if (clarificationNote.response == null && clarificationNote.assessment.application is ApprovedPremisesApplicationEntity) {
       (clarificationNote.assessment.application as ApprovedPremisesApplicationEntity).status = ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION
     }
   }
 
-  @PreUpdate
   fun preUpdate(clarificationNote: AssessmentClarificationNoteEntity) {
     if (clarificationNote.response != null && clarificationNote.assessment.application is ApprovedPremisesApplicationEntity) {
       (clarificationNote.assessment.application as ApprovedPremisesApplicationEntity).status = ApprovedPremisesApplicationStatus.ASSESSMENT_IN_PROGRESS

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt
@@ -23,6 +23,8 @@ class AssessmentListener {
 
     if (application.status == ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION && assessment.decision == null) {
       return
+    } else if (assessment.isWithdrawn) {
+      return
     } else if (assessment.decision == null && assessment.data != null) {
       application.status = ApprovedPremisesApplicationStatus.ASSESSMENT_IN_PROGRESS
     } else if (assessment.decision == AssessmentDecision.ACCEPTED) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/AssessmentListener.kt
@@ -5,12 +5,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
-import javax.persistence.PrePersist
-import javax.persistence.PreUpdate
 
 @Component
 class AssessmentListener {
-  @PrePersist
   fun prePersist(assessment: ApprovedPremisesAssessmentEntity) {
     if (assessment.allocatedToUser == null) {
       (assessment.application as ApprovedPremisesApplicationEntity).status =
@@ -21,7 +18,6 @@ class AssessmentListener {
     }
   }
 
-  @PreUpdate
   fun preUpdate(assessment: ApprovedPremisesAssessmentEntity) {
     val application = assessment.application as ApprovedPremisesApplicationEntity
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/BookingListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/listeners/BookingListener.kt
@@ -4,11 +4,9 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
-import javax.persistence.PrePersist
 
 @Component
 class BookingListener {
-  @PrePersist
   fun prePersist(booking: BookingEntity) {
     if (booking.application != null && booking.application is ApprovedPremisesApplicationEntity) {
       (booking.application as ApprovedPremisesApplicationEntity).status = ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -2393,6 +2393,7 @@ class AssessmentTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
             withCreatedByUser(userEntity)
             withApplicationSchema(applicationSchema)
+            withStatus(ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION)
           }
 
           val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
@@ -3023,6 +3024,7 @@ class AssessmentTest : IntegrationTestBase() {
           withCrn(offenderDetails.otherIds.crn)
           withCreatedByUser(userEntity)
           withApplicationSchema(applicationSchema)
+          withStatus(ApprovedPremisesApplicationStatus.REQUESTED_FURTHER_INFORMATION)
         }
 
         val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -1460,11 +1460,13 @@ class WithdrawalTest : IntegrationTestBase() {
   private fun assertApplicationNotWithdrawn(application: ApprovedPremisesApplicationEntity) {
     val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(application.id)!!
     assertThat(updatedApplication.isWithdrawn).isFalse
+    assertThat(updatedApplication.status).isNotEqualTo(ApprovedPremisesApplicationStatus.WITHDRAWN)
   }
 
   private fun assertApplicationWithdrawn(application: ApprovedPremisesApplicationEntity) {
     val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(application.id)!!
     assertThat(updatedApplication.isWithdrawn).isTrue
+    assertThat(updatedApplication.status).isEqualTo(ApprovedPremisesApplicationStatus.WITHDRAWN)
   }
 
   private fun assertPlacementRequestWithdrawn(placementRequest: PlacementRequestEntity, reason: PlacementRequestWithdrawalReason) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
@@ -62,6 +63,13 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
       else -> { }
     }
     withNoticeType(noticeType)
+    withStatus(
+      when (decision) {
+        AssessmentDecision.ACCEPTED -> ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT
+        AssessmentDecision.REJECTED -> ApprovedPremisesApplicationStatus.REJECTED
+        null -> ApprovedPremisesApplicationStatus.STARTED
+      },
+    )
   }
 
   val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -60,6 +60,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.ApplicationListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
@@ -119,6 +120,7 @@ class ApplicationServiceTest {
   private val mockCas1ApplicationDomainEventService = mockk<Cas1ApplicationDomainEventService>()
   private val mockCas1ApplicationUserDetailsRepository = mockk<Cas1ApplicationUserDetailsRepository>()
   private val mockCas1ApplicationEmailService = mockk<Cas1ApplicationEmailService>()
+  private val mockApplicationListener = mockk<ApplicationListener>()
 
   private val applicationService = ApplicationService(
     mockUserRepository,
@@ -141,6 +143,7 @@ class ApplicationServiceTest {
     mockCas1ApplicationDomainEventService,
     mockCas1ApplicationUserDetailsRepository,
     mockCas1ApplicationEmailService,
+    mockApplicationListener,
   )
 
   @Test
@@ -1240,6 +1243,7 @@ class ApplicationServiceTest {
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
       every { mockJsonSchemaService.getNewestSchema(ApprovedPremisesApplicationJsonSchemaEntity::class.java) } returns newestSchema
       every { mockJsonSchemaService.validate(newestSchema, updatedData) } returns true
+      every { mockApplicationListener.preUpdate(any()) } returns Unit
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
     }
   }
@@ -2088,6 +2092,7 @@ class ApplicationServiceTest {
       every { mockApplicationRepository.findByIdOrNullWithWriteLock(applicationId) } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
       every { mockJsonSchemaService.validate(newestSchema, application.data!!) } returns true
+      every { mockApplicationListener.preUpdate(any()) } returns Unit
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
       every { mockOffenderService.getInmateDetailByNomsNumber(any(), any()) } returns AuthorisableActionResult.Success(
         InmateDetailFactory().withCustodyStatus(InmateStatus.OUT).produce(),
@@ -2732,6 +2737,7 @@ class ApplicationServiceTest {
 
       every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
       every { mockUserAccessService.userMayWithdrawApplication(user, application) } returns true
+      every { mockApplicationListener.preUpdate(any()) } returns Unit
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
       every { mockCas1ApplicationDomainEventService.applicationWithdrawn(any(), any()) } just Runs
       every { mockCas1ApplicationEmailService.applicationWithdrawn(any(), any()) } just Runs
@@ -2772,6 +2778,7 @@ class ApplicationServiceTest {
 
       every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
       every { mockUserAccessService.userMayWithdrawApplication(user, application) } returns true
+      every { mockApplicationListener.preUpdate(any()) } returns Unit
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
       every { mockCas1ApplicationDomainEventService.applicationWithdrawn(any(), any()) } just Runs
       every { mockCas1ApplicationEmailService.applicationWithdrawn(any(), any()) } just Runs
@@ -2809,6 +2816,7 @@ class ApplicationServiceTest {
 
       every { mockApplicationRepository.findByIdOrNull(application.id) } returns application
       every { mockUserAccessService.userMayWithdrawApplication(user, application) } returns true
+      every { mockApplicationListener.preUpdate(any()) } returns Unit
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
       every { mockCas1ApplicationEmailService.applicationWithdrawn(any(), any()) } returns Unit
       every { mockCas1ApplicationDomainEventService.applicationWithdrawn(any(), any()) } just Runs

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -68,6 +68,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -111,6 +112,7 @@ class AssessmentServiceTest {
   private val cas1AssessmentEmailServiceMock = mockk<Cas1AssessmentEmailService>()
   private val cas1AssessmentDomainEventService = mockk<Cas1AssessmentDomainEventService>()
   private val cas1PlacementRequestEmailService = mockk<Cas1PlacementRequestEmailService>()
+  private val assessmentListener = mockk<AssessmentListener>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -133,6 +135,7 @@ class AssessmentServiceTest {
     cas1AssessmentEmailServiceMock,
     cas1AssessmentDomainEventService,
     cas1PlacementRequestEmailService,
+    assessmentListener,
   )
 
   @Test
@@ -1040,6 +1043,7 @@ class AssessmentServiceTest {
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns schema
 
+    every { assessmentListener.preUpdate(any()) } returns Unit
     every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
     every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(
@@ -1422,6 +1426,7 @@ class AssessmentServiceTest {
 
     every { jsonSchemaServiceMock.validate(schema, "{\"test\": \"data\"}") } returns true
 
+    every { assessmentListener.preUpdate(any()) } returns Unit
     every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
     every { cas1AssessmentEmailServiceMock.assessmentRejected(any()) } just Runs
@@ -1952,6 +1957,8 @@ class AssessmentServiceTest {
         schema = "{}",
       )
 
+      every { assessmentListener.prePersist(any()) } returns Unit
+      every { assessmentListener.preUpdate(any()) } returns Unit
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
       every { cas1AssessmentEmailServiceMock.assessmentAllocated(any(), any(), any(), any(), any()) } just Runs
@@ -2246,6 +2253,7 @@ class AssessmentServiceTest {
       cas1AssessmentEmailServiceMock,
       cas1AssessmentDomainEventService,
       cas1PlacementRequestEmailService,
+      assessmentListener,
     )
 
     private val user = UserEntityFactory()
@@ -2313,6 +2321,8 @@ class AssessmentServiceTest {
       } returns assessmentClarificationNoteEntity
 
       every { assessmentClarificationNoteRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentClarificationNoteEntity }
+
+      every { assessmentListener.preUpdate(any()) } returns Unit
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentEntity }
 
       every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(
@@ -2516,6 +2526,7 @@ class AssessmentServiceTest {
 
       val dueAt = OffsetDateTime.now()
 
+      every { assessmentListener.prePersist(any()) } returns Unit
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
       every { userAllocatorMock.getUserForAssessmentAllocation(any()) } returns userWithLeastAllocatedAssessments
@@ -2583,6 +2594,7 @@ class AssessmentServiceTest {
 
       val dueAt = OffsetDateTime.now()
 
+      every { assessmentListener.prePersist(any()) } returns Unit
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
 
       every { userAllocatorMock.getUserForAssessmentAllocation(any()) } returns null
@@ -2672,6 +2684,7 @@ class AssessmentServiceTest {
         .produce()
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
+      every { assessmentListener.preUpdate(any()) } returns Unit
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
       every { cas1AssessmentEmailServiceMock.assessmentWithdrawn(any(), any(), any(), any()) } just Runs
 
@@ -2705,6 +2718,7 @@ class AssessmentServiceTest {
         .produce()
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
+      every { assessmentListener.preUpdate(any()) } returns Unit
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
       every { cas1AssessmentEmailServiceMock.assessmentWithdrawn(any(), any(), any(), any()) } just Runs
 
@@ -2738,6 +2752,7 @@ class AssessmentServiceTest {
         .produce()
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
+      every { assessmentListener.preUpdate(any()) } returns Unit
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
       every { cas1AssessmentEmailServiceMock.assessmentWithdrawn(any(), any(), any(), any()) } just Runs
 
@@ -2771,6 +2786,7 @@ class AssessmentServiceTest {
         .produce()
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
+      every { assessmentListener.preUpdate(any()) } returns Unit
       every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
       every { cas1AssessmentEmailServiceMock.assessmentWithdrawn(any(), any(), any(), any()) } just Runs
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -68,6 +68,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentClarificationNoteListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -113,6 +114,7 @@ class AssessmentServiceTest {
   private val cas1AssessmentDomainEventService = mockk<Cas1AssessmentDomainEventService>()
   private val cas1PlacementRequestEmailService = mockk<Cas1PlacementRequestEmailService>()
   private val assessmentListener = mockk<AssessmentListener>()
+  private val assessmentClarificationNoteListener = mockk<AssessmentClarificationNoteListener>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -136,6 +138,7 @@ class AssessmentServiceTest {
     cas1AssessmentDomainEventService,
     cas1PlacementRequestEmailService,
     assessmentListener,
+    assessmentClarificationNoteListener,
   )
 
   @Test
@@ -580,6 +583,7 @@ class AssessmentServiceTest {
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
+      every { assessmentClarificationNoteListener.prePersist(any()) } returns Unit
       every { assessmentClarificationNoteRepositoryMock.save(any()) } answers {
         it.invocation.args[0] as AssessmentClarificationNoteEntity
       }
@@ -598,6 +602,7 @@ class AssessmentServiceTest {
       assertThat(result is AuthorisableActionResult.Success).isTrue
       result as AuthorisableActionResult.Success
 
+      every { assessmentClarificationNoteListener.prePersist(any()) } returns Unit
       verify(exactly = 1) {
         assessmentClarificationNoteRepositoryMock.save(
           match {
@@ -644,6 +649,7 @@ class AssessmentServiceTest {
 
       every { assessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
+      every { assessmentClarificationNoteListener.prePersist(any()) } returns Unit
       every { assessmentClarificationNoteRepositoryMock.save(any()) } answers {
         it.invocation.args[0] as AssessmentClarificationNoteEntity
       }
@@ -662,6 +668,7 @@ class AssessmentServiceTest {
       assertThat(result is AuthorisableActionResult.Success).isTrue
       result as AuthorisableActionResult.Success
 
+      every { assessmentClarificationNoteListener.prePersist(any()) } returns Unit
       verify(exactly = 1) {
         assessmentClarificationNoteRepositoryMock.save(
           match {
@@ -2254,6 +2261,7 @@ class AssessmentServiceTest {
       cas1AssessmentDomainEventService,
       cas1PlacementRequestEmailService,
       assessmentListener,
+      assessmentClarificationNoteListener,
     )
 
     private val user = UserEntityFactory()
@@ -2320,6 +2328,7 @@ class AssessmentServiceTest {
         )
       } returns assessmentClarificationNoteEntity
 
+      every { assessmentClarificationNoteListener.preUpdate(any()) } returns Unit
       every { assessmentClarificationNoteRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentClarificationNoteEntity }
 
       every { assessmentListener.preUpdate(any()) } returns Unit

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejec
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
@@ -88,6 +89,7 @@ class AcceptAssessmentTest {
   private val cas1AssessmentEmailServiceMock = mockk<Cas1AssessmentEmailService>()
   private val cas1PlacementRequestEmailServiceMock = mockk<Cas1PlacementRequestEmailService>()
   private val cas1AssessmentDomainEventServiceMock = mockk<Cas1AssessmentDomainEventService>()
+  private val assessmentListener = mockk<AssessmentListener>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -110,6 +112,7 @@ class AcceptAssessmentTest {
     cas1AssessmentEmailServiceMock,
     cas1AssessmentDomainEventServiceMock,
     cas1PlacementRequestEmailServiceMock,
+    assessmentListener,
   )
 
   lateinit var user: UserEntity
@@ -337,6 +340,7 @@ class AcceptAssessmentTest {
 
     every { jsonSchemaServiceMock.validate(assessmentSchema, "{\"test\": \"data\"}") } returns true
 
+    every { assessmentListener.preUpdate(any()) } returns Unit
     every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentEntity }
 
     val offenderDetails = OffenderDetailsSummaryFactory().produce()
@@ -406,6 +410,7 @@ class AcceptAssessmentTest {
 
     every { jsonSchemaServiceMock.validate(assessmentSchema, "{\"test\": \"data\"}") } returns true
 
+    every { assessmentListener.preUpdate(any()) } returns Unit
     every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentEntity }
 
     every { placementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements) } returns ValidatableActionResult.Success(placementRequirementEntity)
@@ -490,6 +495,7 @@ class AcceptAssessmentTest {
 
     every { jsonSchemaServiceMock.validate(assessmentSchema, "{\"test\": \"data\"}") } returns true
 
+    every { assessmentListener.preUpdate(any()) } returns Unit
     every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentEntity }
 
     every { placementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements) } returns ValidatableActionResult.GeneralValidationError("Couldn't create Placement Requirements")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejec
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentClarificationNoteListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -90,6 +91,7 @@ class AcceptAssessmentTest {
   private val cas1PlacementRequestEmailServiceMock = mockk<Cas1PlacementRequestEmailService>()
   private val cas1AssessmentDomainEventServiceMock = mockk<Cas1AssessmentDomainEventService>()
   private val assessmentListener = mockk<AssessmentListener>()
+  private val assessmentClarificationNoteListener = mockk<AssessmentClarificationNoteListener>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -113,6 +115,7 @@ class AcceptAssessmentTest {
     cas1AssessmentDomainEventServiceMock,
     cas1PlacementRequestEmailServiceMock,
     assessmentListener,
+    assessmentClarificationNoteListener,
   )
 
   lateinit var user: UserEntity


### PR DESCRIPTION
Before this PR we used JPA Listeners to manage updating the application status when a miscellaneous entities were persisted.

Not only does this make comprehension of the code difficult, it technically isn’t allowed according to the JPA Spec, and has caused us issues when attempting to update to Spring 3 / Hibernate 6:

“In general, the lifecycle method of a portable application should not invoke EntityManager or Query operations, access other entity instances, or modify relationships within the same persistence context. A lifecycle callback method may modify the non-relationship state of the entity on which it is invoked.”

This commit calls the Listener components directly as an intermediate step towards using a state machine to manage application state.

As part of this change the order that the ‘listeners’ were invoked in has changed, leading to the AssessmentListener overwriting the Withdrawn Application Status. AssessmentListener has been updated to correct this, and the WithdrawalTest updated to assert on application state after withdrawal. This is a good example of why using listeners for managing status is opaque, confusing and as such, should be discouraged!