### PR TITLE
CAS-322 Migrate CAS3 users PDU from nDelius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -220,7 +220,7 @@ class UserService(
 
     when (val probationDeliveryUnit = findDeliusUserLastPdu(deliusUser)) {
       null -> {
-        val userLastBoroughCode = deliusUser.teams?.maxByOrNull { it.startDate }?.borough?.code
+        val userLastBoroughCode = deliusUser.teams?.filter { it.endDate == null }?.maxByOrNull { it.startDate }?.borough?.code
         throw Exception("Unable to find community API borough code $userLastBoroughCode in CAS")
       }
 
@@ -350,14 +350,10 @@ class UserService(
   }
 
   private fun findDeliusUserLastPdu(deliusUser: StaffUserDetails): ProbationDeliveryUnitEntity? {
-    val lastTeamDate = deliusUser.teams?.maxOfOrNull { t -> t.startDate }
-
-    if (lastTeamDate != null) {
-      deliusUser.teams.filter { it.startDate == lastTeamDate }.forEach {
-        val probationDeliveryUnit = probationDeliveryUnitRepository.findByDeliusCode(it.borough.code)
-        if (probationDeliveryUnit != null) {
-          return probationDeliveryUnit
-        }
+    deliusUser.teams?.filter { t -> t.endDate == null }?.sortedByDescending { t -> t.startDate }?.forEach {
+      val probationDeliveryUnit = probationDeliveryUnitRepository.findByDeliusCode(it.borough.code)
+      if (probationDeliveryUnit != null) {
+        return probationDeliveryUnit
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateUsersPduFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateUsersPduFromCommunityApiMigrationTest.kt
@@ -117,12 +117,32 @@ class Cas3UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
         .withUsername(userTwo.deliusUsername)
         .withTeams(
           listOf(
-            StaffUserTeamMembershipFactory().withBorough(
-              KeyValue(
-                code = "PDUCODE3",
-                description = "PDUDESCRIPTION3",
-              ),
-            )
+            StaffUserTeamMembershipFactory()
+              .withBorough(
+                KeyValue(
+                  code = "PDUCODE2",
+                  description = "PDUDESCRIPTION2",
+                ),
+              )
+              .withStartDate(LocalDate.parse("2020-05-19"))
+              .produce(),
+            StaffUserTeamMembershipFactory()
+              .withBorough(
+                KeyValue(
+                  code = "PDUCODENotExistInCas",
+                  description = "PDUDESCRIPTIONNotExistInCas",
+                ),
+              )
+              .withStartDate(LocalDate.parse("2024-02-05"))
+              .produce(),
+            StaffUserTeamMembershipFactory()
+              .withBorough(
+                KeyValue(
+                  code = "PDUCODE3",
+                  description = "PDUDESCRIPTION3",
+                ),
+              )
+              .withStartDate(LocalDate.parse("2022-09-12"))
               .produce(),
           ),
         )
@@ -134,12 +154,13 @@ class Cas3UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
         .withUsername(userThree.deliusUsername)
         .withTeams(
           listOf(
-            StaffUserTeamMembershipFactory().withBorough(
-              KeyValue(
-                code = "PDUCODE1",
-                description = "PDUDESCRIPTION1",
-              ),
-            )
+            StaffUserTeamMembershipFactory()
+              .withBorough(
+                KeyValue(
+                  code = "PDUCODE1",
+                  description = "PDUDESCRIPTION1",
+                ),
+              )
               .produce(),
           ),
         )
@@ -151,12 +172,24 @@ class Cas3UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
         .withUsername(userFour.deliusUsername)
         .withTeams(
           listOf(
-            StaffUserTeamMembershipFactory().withBorough(
-              KeyValue(
-                code = "PDUCODE2",
-                description = "PDUDESCRIPTION2",
-              ),
-            )
+            StaffUserTeamMembershipFactory()
+              .withBorough(
+                KeyValue(
+                  code = "PDUCODE1",
+                  description = "PDUDESCRIPTION1",
+                ),
+              )
+              .withStartDate(LocalDate.parse("2020-02-05"))
+              .withEndDate(LocalDate.parse("2022-03-05"))
+              .produce(),
+            StaffUserTeamMembershipFactory()
+              .withBorough(
+                KeyValue(
+                  code = "PDUCODE2",
+                  description = "PDUDESCRIPTION2",
+                ),
+              )
+              .withStartDate(LocalDate.parse("2023-08-07"))
               .produce(),
           ),
         )


### PR DESCRIPTION
This [PR CAS-322 ](https://dsdmoj.atlassian.net/browse/CAS-322) is to improve the migration process to assign to the user a PDU that match the latest active team with a valid PDU in CAS3. In same cases the user have many teams in nDelius not all of them have a valid PDU in CAS3. 