### PR TITLE
APS-850: new CAS1 specific report endpoint to replace existing, multiple report endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -199,6 +199,7 @@ tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("ope
   }
   typeMappings.put("DateTime", "Instant")
   importMappings.put("Instant", "java.time.Instant")
+  templateDir.set("$rootDir/openapi")
 }
 
 tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openApiGenerateCas2Namespace") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.ReportsCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.generateXlsxStreamingResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.ApplicationReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.Cas1PlacementMatchingOutcomesReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.DailyMetricReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.LostBedReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.PlacementApplicationReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ReportService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService
+
+private const val MONTH_MAX = 12
+private const val MONTH_MIN = 1
+
+@Service
+class Cas1ReportsController(
+  private val reportService: ReportService,
+  private val cas1ReportService: Cas1ReportService,
+  private val userService: UserService,
+  private val userAccessService: UserAccessService,
+) : ReportsCas1Delegate {
+
+  override fun reportsReportNameGet(
+    xServiceName: ServiceName,
+    reportName: Cas1ReportName,
+    year: Int,
+    month: Int,
+  ): ResponseEntity<StreamingResponseBody> {
+    if (xServiceName !== ServiceName.approvedPremises) {
+      throw NotAllowedProblem("This endpoint only supports CAS1")
+    }
+
+    if (!userAccessService.currentUserCanViewReport()) {
+      throw ForbiddenProblem()
+    }
+    validateMonth(month)
+
+    return when (reportName) {
+      Cas1ReportName.applications -> generateXlsxStreamingResponse {
+          outputStream ->
+        reportService.createCas1ApplicationPerformanceReport(
+          ApplicationReportProperties(xServiceName, year, month, userService.getUserForRequest().deliusUsername),
+          outputStream,
+        )
+      }
+      Cas1ReportName.dailyMetrics -> generateXlsxStreamingResponse {
+          outputStream ->
+        reportService.createDailyMetricsReport(DailyMetricReportProperties(xServiceName, year, month), outputStream)
+      }
+      Cas1ReportName.lostBeds -> generateXlsxStreamingResponse {
+          outputStream ->
+        reportService.createLostBedReport(LostBedReportProperties(xServiceName, null, year, month), outputStream)
+      }
+      Cas1ReportName.placementApplications -> generateXlsxStreamingResponse {
+          outputStream ->
+        reportService.createCas1PlacementApplicationReport(PlacementApplicationReportProperties(year, month), outputStream)
+      }
+      Cas1ReportName.placementMatchingOutcomes -> generateXlsxStreamingResponse {
+          outputStream ->
+        cas1ReportService.createPlacementMatchingOutcomesReport(Cas1PlacementMatchingOutcomesReportProperties(year, month), outputStream)
+      }
+    }
+  }
+
+  private fun validateMonth(month: Int) {
+    if (month < MONTH_MIN || month > MONTH_MAX) {
+      throw BadRequestProblem(errorDetail = "month must be between 1 and 12")
+    }
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4720,6 +4720,14 @@ components:
           type: string
       required:
         - name
+    Cas1ReportName:
+      type: string
+      enum:
+        - applications
+        - dailyMetrics
+        - lostBeds
+        - placementApplications
+        - placementMatchingOutcomes
     Cas3ReportType:
       type: string
       enum:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4380,9 +4380,10 @@ paths:
                 format: binary
   /reports/lost-beds:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet listing all of the lost beds for the month
+      summary: Returns a spreadsheet listing all of the lost beds for the month.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.lostBeds reportName.
       parameters:
         - name: X-Service-Name
           in: header
@@ -4419,9 +4420,10 @@ paths:
                 format: binary
   /reports/applications:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet listing all of the submitted applications for the month
+      summary: Returns a spreadsheet listing all of the submitted applications for the month.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.applications reportName.
       parameters:
         - name: X-Service-Name
           in: header
@@ -4547,9 +4549,10 @@ paths:
                 format: binary
   /reports/daily-metrics:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet of daily metrics for a given month/year.
+      summary: Returns a spreadsheet of daily metrics for a given month/year.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.dailyMetrics reportName.
       parameters:
         - name: X-Service-Name
           in: header
@@ -4611,9 +4614,10 @@ paths:
                 format: binary
   /reports/placement-applications:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet of placement applications for a given month/year.
+      summary: Returns a spreadsheet of placement applications for a given month/year.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.placementApplications reportName.
       parameters:
         - name: X-Service-Name
           in: header
@@ -4643,9 +4647,10 @@ paths:
                 format: binary
   /reports/placement-matching-outcomes:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet of placement applications for a given expected arrival month/year.
+      summary: Returns a spreadsheet of placement applications for a given expected arrival month/year.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.placementMatchingOutcomes reportName.
       parameters:
         - name: X-Service-Name
           in: header

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -439,6 +439,44 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /reports/{reportName}:
+    get:
+      tags:
+        - Reports
+      summary: Returns a spreadsheet of all data metrics for the 'reportName'.
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Validates user for this service has access to the report
+          schema:
+            $ref: '_shared.yml#/components/schemas/ServiceName'
+        - name: reportName
+          in: path
+          description: Name of the report to download
+          required: true
+          schema:
+            $ref: '_shared.yml#/components/schemas/Cas1ReportName'
+        - name: year
+          in: query
+          required: true
+          description: The report content will reflect that specified by the given year.
+          schema:
+            type: integer
+        - name: month
+          in: query
+          required: true
+          description: The report content will reflect that specified by the given month.
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Successfully retrieved the report
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary
   /out-of-service-beds:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9394,6 +9394,14 @@ components:
           type: string
       required:
         - name
+    Cas1ReportName:
+      type: string
+      enum:
+        - applications
+        - dailyMetrics
+        - lostBeds
+        - placementApplications
+        - placementMatchingOutcomes
     Cas3ReportType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4382,9 +4382,10 @@ paths:
                 format: binary
   /reports/lost-beds:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet listing all of the lost beds for the month
+      summary: Returns a spreadsheet listing all of the lost beds for the month.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.lostBeds reportName.
       parameters:
         - name: X-Service-Name
           in: header
@@ -4421,9 +4422,10 @@ paths:
                 format: binary
   /reports/applications:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet listing all of the submitted applications for the month
+      summary: Returns a spreadsheet listing all of the submitted applications for the month.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.applications reportName.
       parameters:
         - name: X-Service-Name
           in: header
@@ -4549,9 +4551,10 @@ paths:
                 format: binary
   /reports/daily-metrics:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet of daily metrics for a given month/year.
+      summary: Returns a spreadsheet of daily metrics for a given month/year.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.dailyMetrics reportName.
       parameters:
         - name: X-Service-Name
           in: header
@@ -4613,9 +4616,10 @@ paths:
                 format: binary
   /reports/placement-applications:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet of placement applications for a given month/year.
+      summary: Returns a spreadsheet of placement applications for a given month/year.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.placementApplications reportName.
       parameters:
         - name: X-Service-Name
           in: header
@@ -4645,9 +4649,10 @@ paths:
                 format: binary
   /reports/placement-matching-outcomes:
     get:
+      deprecated: true
       tags:
         - Reports
-      summary: Returns a spreadsheet of placement applications for a given expected arrival month/year.
+      summary: Returns a spreadsheet of placement applications for a given expected arrival month/year.  Deprecated - use CAS1 Report endpoint, with Cas1ReportName.placementMatchingOutcomes reportName.
       parameters:
         - name: X-Service-Name
           in: header

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -441,6 +441,44 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /reports/{reportName}:
+    get:
+      tags:
+        - Reports
+      summary: Returns a spreadsheet of all data metrics for the 'reportName'.
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Validates user for this service has access to the report
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+        - name: reportName
+          in: path
+          description: Name of the report to download
+          required: true
+          schema:
+            $ref: '#/components/schemas/Cas1ReportName'
+        - name: year
+          in: query
+          required: true
+          description: The report content will reflect that specified by the given year.
+          schema:
+            type: integer
+        - name: month
+          in: query
+          required: true
+          description: The report content will reflect that specified by the given month.
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Successfully retrieved the report
+          content:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+              schema:
+                type: string
+                format: binary
   /out-of-service-beds:
     get:
       tags:
@@ -5183,6 +5221,14 @@ components:
           type: string
       required:
         - name
+    Cas1ReportName:
+      type: string
+      enum:
+        - applications
+        - dailyMetrics
+        - lostBeds
+        - placementApplications
+        - placementMatchingOutcomes
     Cas3ReportType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5311,6 +5311,14 @@ components:
           type: string
       required:
         - name
+    Cas1ReportName:
+      type: string
+      enum:
+        - applications
+        - dailyMetrics
+        - lostBeds
+        - placementApplications
+        - placementMatchingOutcomes
     Cas3ReportType:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4811,6 +4811,14 @@ components:
           type: string
       required:
         - name
+    Cas1ReportName:
+      type: string
+      enum:
+        - applications
+        - dailyMetrics
+        - lostBeds
+        - placementApplications
+        - placementMatchingOutcomes
     Cas3ReportType:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
@@ -1205,6 +1206,8 @@ class ReportsTest : IntegrationTestBase() {
 
   @Nested
   inner class GetLostBedsReport {
+    private val lostBedsEndpoint = "/cas1/reports/${Cas1ReportName.lostBeds.value}"
+
     @Test
     fun `Get lost beds report returns OK with correct body`() {
       `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { userEntity, jwt ->
@@ -1279,7 +1282,7 @@ class ReportsTest : IntegrationTestBase() {
             )
 
           webTestClient.get()
-            .uri("/reports/lost-beds?year=2023&month=4")
+            .uri("$lostBedsEndpoint?year=2023&month=4")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReportsTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ADMIN
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_ASSESSOR
+
+class Cas1ReportsTest : IntegrationTestBase() {
+  val cas1Report: String = Cas1ReportName.lostBeds.value
+  val approvedPremisesServiceName: String = ServiceName.approvedPremises.value
+
+  @Test
+  fun `Get report returns 400 if query parameters are missing`() {
+    `Given a User`(roles = listOf(CAS1_ADMIN)) { _, jwt ->
+      webTestClient.get()
+        .uri("/cas1/reports/$cas1Report")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", approvedPremisesServiceName)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.detail").isEqualTo("Missing required query parameter year")
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = [0, 13])
+  fun `Get report returns 400 if month provided is invalid`(month: Int) {
+    `Given a User`(roles = listOf(CAS1_ADMIN)) { _, jwt ->
+      webTestClient.get()
+        .uri("/cas1/reports/$cas1Report?year=2024&month=$month")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", approvedPremisesServiceName)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.detail").isEqualTo("month must be between 1 and 12")
+    }
+  }
+
+  @Test
+  fun `Get report returns 405 Not Allowed if serviceName header is not approvedPremises`() {
+    `Given a User`(roles = listOf(CAS3_ASSESSOR)) { _, jwt ->
+      webTestClient.get()
+        .uri("/cas1/reports/$cas1Report?year=2023&month=4")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.cas2.value)
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+        .expectBody()
+        .jsonPath("$.detail").isEqualTo("This endpoint only supports CAS1")
+    }
+  }
+
+  @Test
+  fun `Get report returns 403 Forbidden if user does not have CAS1 report access`() {
+    `Given a User`(roles = listOf(CAS3_ASSESSOR)) { _, jwt ->
+      webTestClient.get()
+        .uri("/cas1/reports/$cas1Report?year=2023&month=4")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", approvedPremisesServiceName)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Test
+  fun `Get report returns Server Error if report specified is invalid`() {
+    `Given a User`(roles = listOf(CAS1_ADMIN)) { _, jwt ->
+      webTestClient.get()
+        .uri("/cas1/reports/doesnotexist")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", approvedPremisesServiceName)
+        .exchange()
+        .expectStatus()
+        .is5xxServerError
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = Cas1ReportName::class)
+  fun `Get report returns OK response if user role is valid and parameters are valid `(reportName: Cas1ReportName) {
+    `Given a User`(roles = listOf(CAS1_ADMIN)) { _, jwt ->
+      webTestClient.get()
+        .uri("/cas1/reports/$reportName?year=2024&month=1")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", approvedPremisesServiceName)
+        .exchange()
+        .expectStatus()
+        .isOk
+    }
+  }
+}


### PR DESCRIPTION
Replaced  CAS1 Report endpoints with a single report endpoint, specified in the CAS1 API spec, which takes the required report as a path parameter (enum).

Original CAS1 Report endpoints have been marked as deprecated.