### PR TITLE
APS-872 Capture internal server errors in sentry

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -25,11 +25,13 @@ import org.zalando.problem.ThrowableProblem
 import org.zalando.problem.spring.web.advice.ProblemHandling
 import org.zalando.problem.spring.web.advice.io.MessageNotReadableAdviceTrait
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeserializationValidationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 
 @ControllerAdvice
 class ExceptionHandling(
   private val objectMapper: ObjectMapper,
   private val deserializationValidationService: DeserializationValidationService,
+  private val sentryService: SentryService,
 ) : ProblemHandling, MessageNotReadableAdviceTrait {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -63,6 +65,8 @@ class ExceptionHandling(
     }
 
     log.error("Unhandled exception type, returning generic 500 response", throwable)
+
+    sentryService.captureException(throwable)
 
     return InternalServerErrorProblem(
       detail = "There was an unexpected problem",


### PR DESCRIPTION
Before this change we would return an unhandled exception as a 500 ‘internal server error’ back to the UI, but not raise an alert in Sentry. This meant we were relying on the UI to raise a Sentry Alert. Not only is this not the correct ownership of responsibility, this meant that we were getting unhelpful alerting information being raised as the UI doesn’t know what caused the error.

This commit ensures all unhandled exceptions are logged in sentry.