### PR TITLE
APS-864 Generate unique id on all placement requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationAutomaticEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationAutomaticEntity.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface PlacementApplicationAutomaticRepository : JpaRepository<PlacementApplicationAutomaticEntity, UUID>
+
+@Entity
+@Table(name = "placement_applications_automatic")
+data class PlacementApplicationAutomaticEntity(
+  @Id
+  val id: UUID,
+
+  @ManyToOne
+  @JoinColumn(name = "application_id")
+  val application: ApplicationEntity,
+
+  val submittedAt: OffsetDateTime,
+  val expectedArrivalDate: OffsetDateTime,
+)

--- a/src/main/resources/db/migration/all/20240607130747__create_placement_applications_automatic_table.sql
+++ b/src/main/resources/db/migration/all/20240607130747__create_placement_applications_automatic_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE placement_applications_automatic (
+    id UUID NOT NULL,
+    application_id UUID NOT NULL,
+    submitted_at timestamp NOT NULL,
+    expected_arrival_date timestamp NOT NULL,
+
+    PRIMARY KEY (id),
+
+    CONSTRAINT fk_application_id
+        FOREIGN KEY(application_id)
+            REFERENCES applications(id)
+);
+
+CREATE INDEX ON placement_applications_automatic(application_id);

--- a/src/main/resources/db/migration/all/20240607134906__backfill_legacy_placement_applications_automatic_records.sql
+++ b/src/main/resources/db/migration/all/20240607134906__backfill_legacy_placement_applications_automatic_records.sql
@@ -1,0 +1,16 @@
+INSERT INTO placement_applications_automatic (id, application_id, submitted_at, expected_arrival_date)
+SELECT
+    gen_random_uuid (),
+    approved_premises_applications.id,
+    applications.submitted_at,
+    approved_premises_applications.arrival_date
+FROM
+    approved_premises_applications INNER JOIN applications
+    ON approved_premises_applications.id = applications.id
+
+WHERE
+    approved_premises_applications.arrival_date is not null and
+    applications.submitted_at is not null and
+    approved_premises_applications.id not in (
+        select distinct application_id from placement_applications_automatic
+    )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -56,6 +56,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
@@ -120,6 +122,7 @@ class ApplicationServiceTest {
   private val mockCas1ApplicationDomainEventService = mockk<Cas1ApplicationDomainEventService>()
   private val mockCas1ApplicationUserDetailsRepository = mockk<Cas1ApplicationUserDetailsRepository>()
   private val mockCas1ApplicationEmailService = mockk<Cas1ApplicationEmailService>()
+  private val mockPlacementApplicationAutomaticRepository = mockk<PlacementApplicationAutomaticRepository>()
   private val mockApplicationListener = mockk<ApplicationListener>()
 
   private val applicationService = ApplicationService(
@@ -143,6 +146,7 @@ class ApplicationServiceTest {
     mockCas1ApplicationDomainEventService,
     mockCas1ApplicationUserDetailsRepository,
     mockCas1ApplicationEmailService,
+    mockPlacementApplicationAutomaticRepository,
     mockApplicationListener,
   )
 
@@ -1767,6 +1771,7 @@ class ApplicationServiceTest {
       }
 
       verify(exactly = 1) { mockCas1ApplicationEmailService.applicationSubmitted(application) }
+      verify(exactly = 0) { mockPlacementApplicationAutomaticRepository.save(any()) }
     }
 
     @ParameterizedTest
@@ -1856,6 +1861,7 @@ class ApplicationServiceTest {
       }
 
       verify(exactly = 1) { mockCas1ApplicationEmailService.applicationSubmitted(application) }
+      verify(exactly = 1) { mockPlacementApplicationAutomaticRepository.save(any()) }
     }
 
     @ParameterizedTest
@@ -2114,6 +2120,9 @@ class ApplicationServiceTest {
       } returns Unit
 
       every { mockCas1ApplicationEmailService.applicationSubmitted(any()) } just Runs
+      every {
+        mockPlacementApplicationAutomaticRepository.save(any())
+      } answers { it.invocation.args[0] as PlacementApplicationAutomaticEntity }
     }
   }
 


### PR DESCRIPTION
For reporting purposes we need to generate a unique UUID for any request for placement that is part of the original application (i.e. where approved_premises_applications.arrival_date is defined)

This will be captured in a new table placement_applications_automatic and backfilled for existing applications which have an arrival_date defined.