### PR TITLE
[APS-847][APS-848][APS-849] Implement filtering, sorting, and pagination for `GET /cas1/out-of-service-beds` API endpoint

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4876,6 +4876,16 @@ components:
         - id
         - name
         - isActive
+    Cas1OutOfServiceBedSortField:
+      type: string
+      enum:
+        - premisesName
+        - roomName
+        - bedName
+        - outOfServiceFrom
+        - outOfServiceTo
+        - reason
+        - daysLost
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -482,6 +482,47 @@ paths:
       tags:
         - out-of-service beds
       summary: Lists all Out-Of-Service Beds entries
+      parameters:
+        - name: temporality
+          in: query
+          description: If provided, restrict the results to only those with the given temporality/ies.
+          schema:
+            type: array
+            items:
+              $ref: '_shared.yml#/components/schemas/Temporality'
+        - name: premisesId
+          in: query
+          description: If provided, restrict the results to only those in the premises with the given ID.
+          schema:
+            type: string
+            format: uuid
+        - name: apAreaId
+          in: query
+          description: If provided, restrict the results to only those within the AP area with the given ID.
+          schema:
+            type: string
+            format: uuid
+        - name: sortDirection
+          in: query
+          description: The direction to sort the results by. If blank, will sort in descending order
+          schema:
+            $ref: '_shared.yml#/components/schemas/SortDirection'
+        - name: sortBy
+          in: query
+          description: The field to sort the results by.
+          schema:
+            $ref: '_shared.yml#/components/schemas/Cas1OutOfServiceBedSortField'
+        - name: page
+          in: query
+          required: false
+          description: Page number of results to return. If not provided results will not be paged
+          schema:
+            type: integer
+        - name: perPage
+          in: query
+          description: Number of items to return per page (defaults to 10)
+          schema:
+            type: integer
       responses:
         200:
           description: successful operation
@@ -491,6 +532,15 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Cas1OutOfServiceBed'
+          headers:
+            X-Pagination-CurrentPage:
+              $ref: '_shared.yml#/components/headers/X-Pagination-CurrentPage'
+            X-Pagination-TotalPages:
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalPages'
+            X-Pagination-TotalResults:
+              $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
+            X-Pagination-PageSize:
+              $ref: '_shared.yml#/components/headers/X-Pagination-PageSize'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9427,6 +9427,16 @@ components:
         - id
         - name
         - isActive
+    Cas1OutOfServiceBedSortField:
+      type: string
+      enum:
+        - premisesName
+        - roomName
+        - bedName
+        - outOfServiceFrom
+        - outOfServiceTo
+        - reason
+        - daysLost
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -484,6 +484,47 @@ paths:
       tags:
         - out-of-service beds
       summary: Lists all Out-Of-Service Beds entries
+      parameters:
+        - name: temporality
+          in: query
+          description: If provided, restrict the results to only those with the given temporality/ies.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Temporality'
+        - name: premisesId
+          in: query
+          description: If provided, restrict the results to only those in the premises with the given ID.
+          schema:
+            type: string
+            format: uuid
+        - name: apAreaId
+          in: query
+          description: If provided, restrict the results to only those within the AP area with the given ID.
+          schema:
+            type: string
+            format: uuid
+        - name: sortDirection
+          in: query
+          description: The direction to sort the results by. If blank, will sort in descending order
+          schema:
+            $ref: '#/components/schemas/SortDirection'
+        - name: sortBy
+          in: query
+          description: The field to sort the results by.
+          schema:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedSortField'
+        - name: page
+          in: query
+          required: false
+          description: Page number of results to return. If not provided results will not be paged
+          schema:
+            type: integer
+        - name: perPage
+          in: query
+          description: Number of items to return per page (defaults to 10)
+          schema:
+            type: integer
       responses:
         200:
           description: successful operation
@@ -493,6 +534,15 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas1OutOfServiceBed'
+          headers:
+            X-Pagination-CurrentPage:
+              $ref: '#/components/headers/X-Pagination-CurrentPage'
+            X-Pagination-TotalPages:
+              $ref: '#/components/headers/X-Pagination-TotalPages'
+            X-Pagination-TotalResults:
+              $ref: '#/components/headers/X-Pagination-TotalResults'
+            X-Pagination-PageSize:
+              $ref: '#/components/headers/X-Pagination-PageSize'
         401:
           $ref: '#/components/responses/401Response'
         403:
@@ -5377,6 +5427,16 @@ components:
         - id
         - name
         - isActive
+    Cas1OutOfServiceBedSortField:
+      type: string
+      enum:
+        - premisesName
+        - roomName
+        - bedName
+        - outOfServiceFrom
+        - outOfServiceTo
+        - reason
+        - daysLost
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5467,6 +5467,16 @@ components:
         - id
         - name
         - isActive
+    Cas1OutOfServiceBedSortField:
+      type: string
+      enum:
+        - premisesName
+        - roomName
+        - bedName
+        - outOfServiceFrom
+        - outOfServiceTo
+        - reason
+        - daysLost
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4967,6 +4967,16 @@ components:
         - id
         - name
         - isActive
+    Cas1OutOfServiceBedSortField:
+      type: string
+      enum:
+        - premisesName
+        - roomName
+        - bedName
+        - outOfServiceFrom
+        - outOfServiceTo
+        - reason
+        - daysLost
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PersistedFactory.kt
@@ -33,4 +33,12 @@ class PersistedFactory<EntityType : Any, PrimaryKeyType : Any, FactoryType : Fac
       repository.saveAndFlush(factory.produce())
     }
   }
+
+  fun produceAndPersistMultipleIndexed(amount: Int, configuration: FactoryType.(Int) -> Unit): List<EntityType> {
+    val factory = factoryProducer()
+    return (1..amount).map {
+      configuration(factory, it)
+      repository.saveAndFlush(factory.produce())
+    }
+  }
 }


### PR DESCRIPTION
> See [APS-847](https://dsdmoj.atlassian.net/browse/APS-847), [APS-848](https://dsdmoj.atlassian.net/browse/APS-848), and [APS-849](https://dsdmoj.atlassian.net/browse/APS-847) on the Approved Premises Jira board.

This PR introduces several query parameters to the `GET /cas1/out-of-service-beds` API endpoint to refine the results returned:
- `temporality`: If provided, filters the results to only those with the given temporality. This parameter accepts multiple values, e.g. `temporality=past&temporality=current`. The default if not provided is equivalent  to specifying `current` and `future` to maintain backwards compatibility.
- `premisesId`: If provided, filters the results to only those in the premises with the given ID.
- `apAreaId`: If provided, filters the results to only those within the AP area with the given ID.
- `sortDirection`: If provided, orders the results in the given direction. The default if not provided is `asc`.
- `sortBy`: If provided, orders the results according to the given field. The default if not provided is `outOfServiceFrom` to maintain backwards compatibility.
- `page`: If provided, filters the results to only those on the given page. If not provided, all results are returned unpaged.
- `perPage`: If provided, defines the page size. If not provided, the API will use its default page size.

[APS-847]: https://dsdmoj.atlassian.net/browse/APS-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APS-848]: https://dsdmoj.atlassian.net/browse/APS-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APS-849]: https://dsdmoj.atlassian.net/browse/APS-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ