### PR TITLE
APS-823 - Use internal enum for CAS1 assess aptype metadata

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CruService
@@ -193,7 +194,7 @@ class Cas1AssessmentDomainEventService(
           ),
         ),
         metadata = mapOf(
-          MetaDataName.CAS1_REQUESTED_AP_TYPE to apType?.name,
+          MetaDataName.CAS1_REQUESTED_AP_TYPE to apType?.asApprovedPremisesType()?.name,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -6,7 +6,6 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -171,7 +170,7 @@ class Cas1AssessmentDomainEventServiceTest {
       verify(exactly = 1) {
         domainEventService.saveAssessmentAllocatedEvent(
           withArg {
-            Assertions.assertThat(it.data.eventDetails.allocatedBy).isNull()
+            assertThat(it.data.eventDetails.allocatedBy).isNull()
           },
           TriggerSourceType.SYSTEM,
         )
@@ -267,7 +266,7 @@ class Cas1AssessmentDomainEventServiceTest {
               data.assessedBy == expectedAssessor &&
               data.decision == "ACCEPTED" &&
               data.decisionRationale == null &&
-              it.metadata[MetaDataName.CAS1_REQUESTED_AP_TYPE].equals(ApType.normal.value)
+              it.metadata[MetaDataName.CAS1_REQUESTED_AP_TYPE].equals("NORMAL")
           },
         )
       }


### PR DESCRIPTION
We were previously using the value of the API type to populate the MetaDataName.CAS1_REQUESTED_AP_TYPE metadata. This is inconsistant with how we capture this value on application submission.