### PR TITLE
APS-858: Add CRU_MEMBER role

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -142,6 +142,7 @@ class UsersController(
     return ResponseEntity.ok(userTransformed)
   }
 
+  @SuppressWarnings("CyclomaticComplexMethod")
   private fun transformApiRole(apiRole: ApprovedPremisesUserRole): JpaUserRole = when (apiRole) {
     ApprovedPremisesUserRole.roleAdmin -> JpaUserRole.CAS1_ADMIN
     ApprovedPremisesUserRole.applicant -> JpaUserRole.CAS1_APPLICANT
@@ -151,6 +152,7 @@ class UsersController(
     ApprovedPremisesUserRole.futureManager -> JpaUserRole.CAS1_FUTURE_MANAGER
     ApprovedPremisesUserRole.matcher -> JpaUserRole.CAS1_MATCHER
     ApprovedPremisesUserRole.workflowManager -> JpaUserRole.CAS1_WORKFLOW_MANAGER
+    ApprovedPremisesUserRole.cruMember -> JpaUserRole.CAS1_CRU_MEMBER
     ApprovedPremisesUserRole.reportViewer -> JpaUserRole.CAS1_REPORT_VIEWER
     ApprovedPremisesUserRole.excludedFromAssessAllocation -> JpaUserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION
     ApprovedPremisesUserRole.excludedFromMatchAllocation -> JpaUserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -308,6 +308,7 @@ enum class UserRole(val service: ServiceName) {
   CAS1_LEGACY_MANAGER(ServiceName.approvedPremises),
   CAS1_FUTURE_MANAGER(ServiceName.approvedPremises),
   CAS1_WORKFLOW_MANAGER(ServiceName.approvedPremises),
+  CAS1_CRU_MEMBER(ServiceName.approvedPremises),
   CAS1_APPLICANT(ServiceName.approvedPremises),
   CAS1_ADMIN(ServiceName.approvedPremises),
   CAS1_REPORT_VIEWER(ServiceName.approvedPremises),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -103,7 +103,7 @@ class UserAccessService(
     userCanViewOutOfServiceBeds(userService.getUserForRequest())
 
   fun userCanViewOutOfServiceBeds(user: UserEntity) =
-    user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
+    user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_CRU_MEMBER)
 
   fun currentUserCanManagePremisesLostBeds(premises: PremisesEntity) =
     userCanManagePremisesLostBeds(userService.getUserForRequest(), premises)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -79,6 +79,7 @@ class UserTransformer(
     UserRole.CAS1_LEGACY_MANAGER -> ApprovedPremisesUserRole.legacyManager
     UserRole.CAS1_FUTURE_MANAGER -> ApprovedPremisesUserRole.futureManager
     UserRole.CAS1_WORKFLOW_MANAGER -> ApprovedPremisesUserRole.workflowManager
+    UserRole.CAS1_CRU_MEMBER -> ApprovedPremisesUserRole.cruMember
     UserRole.CAS1_APPLICANT -> ApprovedPremisesUserRole.applicant
     UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION -> ApprovedPremisesUserRole.excludedFromMatchAllocation
     UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION -> ApprovedPremisesUserRole.excludedFromAssessAllocation

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserServiceUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserServiceUtils.kt
@@ -15,6 +15,7 @@ fun transformQualifications(qualification: ApiUserQualification): UserQualificat
   ApiUserQualification.recoveryFocused -> UserQualification.RECOVERY_FOCUSED
 }
 
+@SuppressWarnings("CyclomaticComplexMethod")
 fun transformUserRoles(approvedPremisesUserRole: ApprovedPremisesUserRole): UserRole = when (approvedPremisesUserRole) {
   ApprovedPremisesUserRole.assessor -> UserRole.CAS1_ASSESSOR
   ApprovedPremisesUserRole.matcher -> UserRole.CAS1_MATCHER
@@ -22,6 +23,7 @@ fun transformUserRoles(approvedPremisesUserRole: ApprovedPremisesUserRole): User
   ApprovedPremisesUserRole.legacyManager -> UserRole.CAS1_LEGACY_MANAGER
   ApprovedPremisesUserRole.futureManager -> UserRole.CAS1_FUTURE_MANAGER
   ApprovedPremisesUserRole.workflowManager -> UserRole.CAS1_WORKFLOW_MANAGER
+  ApprovedPremisesUserRole.cruMember -> UserRole.CAS1_CRU_MEMBER
   ApprovedPremisesUserRole.applicant -> UserRole.CAS1_APPLICANT
   ApprovedPremisesUserRole.roleAdmin -> UserRole.CAS1_ADMIN
   ApprovedPremisesUserRole.reportViewer -> UserRole.CAS1_REPORT_VIEWER

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3015,6 +3015,7 @@ components:
         - legacy_manager
         - future_manager
         - workflow_manager
+        - cru_member
         - applicant
         - role_admin
         - report_viewer

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7566,6 +7566,7 @@ components:
         - legacy_manager
         - future_manager
         - workflow_manager
+        - cru_member
         - applicant
         - role_admin
         - report_viewer

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3566,6 +3566,7 @@ components:
         - legacy_manager
         - future_manager
         - workflow_manager
+        - cru_member
         - applicant
         - role_admin
         - report_viewer

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3606,6 +3606,7 @@ components:
         - legacy_manager
         - future_manager
         - workflow_manager
+        - cru_member
         - applicant
         - role_admin
         - report_viewer

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3106,6 +3106,7 @@ components:
         - legacy_manager
         - future_manager
         - workflow_manager
+        - cru_member
         - applicant
         - role_admin
         - report_viewer

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
@@ -99,7 +99,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_WORKFLOW_MANAGER" ])
+    @EnumSource(value = UserRole::class, names = [ "CAS1_WORKFLOW_MANAGER", "CAS1_FUTURE_MANAGER", "CAS1_CRU_MEMBER" ])
     fun `Get All Out-Of-Service Beds returns OK with correct body when user has the role WORKFLOW_MANAGER`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -734,7 +734,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_WORKFLOW_MANAGER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_WORKFLOW_MANAGER", "CAS1_FUTURE_MANAGER", "CAS1_CRU_MEMBER" ])
   fun `userCanViewOutOfServiceBeds returns true if the user has the WORKFLOW_MANAGER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
@@ -751,7 +751,7 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_WORKFLOW_MANAGER" ])
+  @EnumSource(value = UserRole::class, names = [ "CAS1_WORKFLOW_MANAGER", "CAS1_FUTURE_MANAGER", "CAS1_CRU_MEMBER" ])
   fun `currentUserCanViewOutOfServiceBeds returns true if the current user has the WORKFLOW_MANAGER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 


### PR DESCRIPTION
This role will be used for members of the national CRU team. We'll
use it to grant access to

- managing out-of-service bed across all areas / premises
- withdrawing placements
- creating a manual adhoc placement

These are features which live within the "manage" section of the service
but aren't for the use of AP managers or AP staff.

Currently the `WORKFLOW_MANAGER` role has been used for this purpose
but this is confusing an incorrect as `WORKFLOW_MANAGER` is a role
for CRU team members who can (re)allocate tasks: assigning assessors.

We have a new feature "CRU Members views all out of service beds" which
in the UI is being offered to `FUTURE_MANAGER`s via a tile from the homepage.

This should actually be granted to the new `CRU_MEMBER` role. To get there
we'll:

- open this `UserAccessService.userCanViewOutOfServiceBeds(user)` function, which
  is distinct from `userCanManagePremisesLostBeds(user, premises)` function (scoped
  by premises) to both `CRU_MEMBER` and `FUTURE_MANAGER`

- add the `CRU_MEMBER` to list of roles which can be managed in the front end and
  allocate the role to the appropriate users

- remove both `WORKFLOW_MANAGER` and `FUTURE_MANAGER` from `userCanViewOutOfServiceBeds(user)`

## Overview of role changes

### Booking actions


| Action             | Roles                   | notes                                                   |
| ------------------ | ----------------------- | ------------------------------------------------------- |
| move person        | LEGACY_MANAGER, MANAGER | NE users of "v1 manage"                                 |
| change dates       | LEGACY_MANAGER, MANAGER | NE users of "v1 manage"                                 |
| arrived            | MANAGER                 | deprecated feature, will return improved in "v2 manage" |
| not arrived        | MANAGER                 | deprecated feature, will return improved in "v2 manage" |
| departed           | MANAGER                 | deprecated feature, will return improved in "v2 manage" |
| withdraw placement | WORKFLOW_MANAGER        | we'll switch to CRU_TEAM                                |

### Premises actions


| Action             | Roles            | notes                                                   |
| ------------------ | ---------------- | ------------------------------------------------------- |
| withdraw placement | WORKFLOW_MANAGER | we'll switch to CRU_TEAM                                |
| create placement   | WORKFLOW_MANAGER | we'll switch to CRU_TEAM                                |
| view calendar      | MANAGER          | deprecated feature, will return improved in "v2 manage" |
