### PR TITLE
APS-904 Block date changes on cancelled bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1684,7 +1684,7 @@ class BookingService(
     booking: BookingEntity,
     newDepartureDate: LocalDate,
     notes: String?,
-  ) = validated<ExtensionEntity> {
+  ) = validated {
     val expectedLastUnavailableDate =
       workingDayService.addWorkingDays(newDepartureDate, booking.turnaround?.workingDayCount ?: 0)
 
@@ -1745,6 +1745,10 @@ class BookingService(
 
     val expectedLastUnavailableDate =
       workingDayService.addWorkingDays(effectiveNewDepartureDate, booking.turnaround?.workingDayCount ?: 0)
+
+    if (booking.isCancelled) {
+      return generalError("This Booking is cancelled and as such cannot be modified")
+    }
 
     if (booking.service != ServiceName.approvedPremises.value) {
       val bedId = booking.bed?.id


### PR DESCRIPTION
Whilst unlikely, it is technically possible to change dates on the UI by bookmarking the date change page, or constructing the URL manually, as was observed in production. This commit ensures that such changes will be blocked, ensuring the database isn’t in a logically inconsistant state.