### PR TITLE
APS-365 - Remove trailing slashes from test URLs

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -732,7 +732,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
     val (_, jwt) = appealManagerDetails
 
     webTestClient.post()
-      .uri("/applications/${assessment.application.id}/appeals/")
+      .uri("/applications/${assessment.application.id}/appeals")
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewAppeal(
@@ -753,7 +753,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
     val (_, jwt) = appealManagerDetails
 
     webTestClient.post()
-      .uri("/applications/${assessment.application.id}/appeals/")
+      .uri("/applications/${assessment.application.id}/appeals")
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewAppeal(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -812,7 +812,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
     val (_, jwt) = appealManagerDetails
 
     webTestClient.post()
-      .uri("/applications/${assessment.application.id}/appeals/")
+      .uri("/applications/${assessment.application.id}/appeals")
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewAppeal(
@@ -836,7 +836,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
     val (_, jwt) = appealManagerDetails
 
     webTestClient.post()
-      .uri("/applications/${assessment.application.id}/appeals/")
+      .uri("/applications/${assessment.application.id}/appeals")
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewAppeal(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -126,7 +126,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/applications/")
+        .uri("/cas2/applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()


### PR DESCRIPTION
Trailing slashes are unneccesary and we’ve found these are causing issues after upgrading to spring boot 3