### PR TITLE
APS-914 - Removed unused argument in getExistingUserOrCreate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -33,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.UserWorkload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffProbationArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1UserMappingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.AllocationType
@@ -285,7 +283,7 @@ class UserService(
     }
   }
 
-  fun getExistingUserOrCreate(username: String, throwProblemOn404: Boolean = false): UserEntity {
+  fun getExistingUserOrCreate(username: String): UserEntity {
     val normalisedUsername = username.uppercase()
 
     val existingUser = userRepository.findByDeliusUsername(normalisedUsername)
@@ -296,11 +294,7 @@ class UserService(
     val staffUserDetails = when (staffUserDetailsResponse) {
       is ClientResult.Success -> staffUserDetailsResponse.body
       is ClientResult.Failure.StatusCode -> {
-        if (throwProblemOn404 && staffUserDetailsResponse.status.equals(HttpStatus.NOT_FOUND)) {
-          throw NotFoundProblem(username, "user", "username")
-        } else {
-          staffUserDetailsResponse.throwException()
-        }
+        staffUserDetailsResponse.throwException()
       }
 
       is ClientResult.Failure -> staffUserDetailsResponse.throwException()


### PR DESCRIPTION
The ‘throwProblemOn404’ argument is not used. This commit removes it in preparation for future improvements to how 404s are handled in the UserService