### PR TITLE
CHORE: Increase memory in dev env

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,7 +9,14 @@ generic-service:
     host: approved-premises-api-dev.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-approved-premises-api-dev-cert
 
+  resources:
+    limits:
+      memory: 1.5Gi
+    requests:
+      memory: 1Gi
+
   env:
+    JAVA_OPTS: "-Xmx1000m"
     SPRING_PROFILES_ACTIVE: dev
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.nonprod.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
In the dev environment we are seeing a lot of "OutOfMemory" errors

https://ministryofjustice.sentry.io/issues/4087001141/events/c756ea1594044f2c876c7501549d1afe/?environment=dev&project=4503931792392192

17 in the last 24 hours
61 in the 30 days

These are contributing to intermittent E2E test failures.

In this commit I believe we increase:

- memory limit from 1 to 1.5Gi
- request memory from 512Mi to 1Gi
- XMx (max heap) to 1000m

This is based on a previous config change made to the prod env: https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/d72ef2136c811a2ee417d948682569ef502bc695

NOTE
`kubectl top pod` tells us that MEMORY is currently 857Mi