### PR TITLE
Set local allocation rules to match dev

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -62,7 +62,7 @@ user-allocations:
         north-west: JIMSNOWLDAP
         midlands: JIMSNOWLDAP
         south-east-eastern: JIMSNOWLDAP
-        south-west-south central: JIMSNOWLDAP
+        south-west-south-central: JIMSNOWLDAP
         wales: JIMSNOWLDAP
         nat: JIMSNOWLDAP
     female-assessments:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -65,8 +65,6 @@ user-allocations:
         south-west-south central: JIMSNOWLDAP
         wales: JIMSNOWLDAP
         nat: JIMSNOWLDAP
-    reallocated-assessments:
-      enabled: true
     female-assessments:
       enabled: true
     appealed-assessments:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,8 +49,8 @@ preemptive-cache-logging-enabled: true
 user-allocations:
   rules:
     legacy-allocator:
-      enabled: true
-      priority: 1
+      enabled: false
+      priority: -1
     esap-assessments:
       enabled: true
       allocate-to-user: JIMSNOWLDAP
@@ -69,3 +69,6 @@ user-allocations:
       enabled: true
     female-assessments:
       enabled: true
+    appealed-assessments:
+      enabled: true
+      priority: 0


### PR DESCRIPTION
In dev (and other enviornments) the environment variables are set in values-[env].yml files in the helm_deploy folder. All of these environments (except the deprecated test env) have legacy-allocator-enabled to be false. In order to make local development (via ap-tools) more like other environments I think legacy-allocator-enabled should be false.
Here I also set 'priority' to match other envs.