### PR TITLE
CHORE: Serve up new CAS1 OpenAPI spec via Swagger UI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -46,6 +46,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/swagger-ui/**", permitAll)
         authorize(HttpMethod.GET, "/v3/api-docs/swagger-config", permitAll)
         authorize(HttpMethod.GET, "/api.yml", permitAll)
+        authorize(HttpMethod.GET, "/cas1-api.yml", permitAll)
         authorize(HttpMethod.GET, "/cas2-api.yml", permitAll)
         authorize(HttpMethod.GET, "/_shared.yml", permitAll)
         authorize(HttpMethod.GET, "/domain-events-api.yml", permitAll)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,8 @@ springdoc:
     urls:
       - name: API
         url: "api.yml"
+      - name: CAS1 API
+        url: "cas1-api.yml"
       - name: CAS2 API
         url: "cas2-api.yml"
       - name: Domain events


### PR DESCRIPTION
Our new cas1-api.yml is being used to generate Kotlin code and Typecript types but isn't yet available to view via the Swagger UI interface.

This commit provides access via:

https://approved-premises-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html?urls.primaryName=CAS1%20API

<img width="1055" alt="swagger_ui" src="https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/2814ea21-4ddc-4cf0-9afa-58167bb95997">
