### PR TITLE
APS-853 - Backfill CAS1_REQUESTED_AP_TYPE metadata

### DIFF
--- a/src/main/resources/db/migration/all/20240614124559__backfill_cas1-ap-type-metadata-on-app-submission.sql
+++ b/src/main/resources/db/migration/all/20240614124559__backfill_cas1-ap-type-metadata-on-app-submission.sql
@@ -1,0 +1,13 @@
+INSERT INTO domain_events_metadata(domain_event_id,name,value)
+SELECT
+    d.id,
+    'CAS1_REQUESTED_AP_TYPE',
+    apa.ap_type
+FROM
+    domain_events d
+        INNER JOIN approved_premises_applications apa ON apa.id = d.application_id
+WHERE
+    d.type = 'APPROVED_PREMISES_APPLICATION_SUBMITTED' AND
+    d.id not in (
+        select distinct domain_event_id from domain_events_metadata where name = 'CAS1_REQUESTED_AP_TYPE'
+    );

--- a/src/main/resources/db/migration/all/20240614124560__backfill_cas1-ap-type-metadata-on-assessment.sql
+++ b/src/main/resources/db/migration/all/20240614124560__backfill_cas1-ap-type-metadata-on-assessment.sql
@@ -1,0 +1,25 @@
+-- we delete any existing entries because previously implementations of the UI populating
+-- this field was using the incorrect value
+DELETE FROM domain_events_metadata WHERE name = 'CAS1_REQUESTED_AP_TYPE' AND domain_event_id in (
+    select distinct id from domain_events where type = 'APPROVED_PREMISES_APPLICATION_ASSESSED'
+);
+
+INSERT INTO domain_events_metadata(domain_event_id,name,value)
+SELECT
+    d.id,
+    'CAS1_REQUESTED_AP_TYPE',
+    CASE
+        WHEN assessment.data -> 'matching-information' -> 'matching-information' ->> 'apType' = 'normal' THEN 'NORMAL'
+        WHEN assessment.data -> 'matching-information' -> 'matching-information' ->> 'apType' = 'isPIPE' THEN 'PIPE'
+        WHEN assessment.data -> 'matching-information' -> 'matching-information' ->> 'apType' = 'isESAP' THEN 'ESAP'
+        WHEN assessment.data -> 'matching-information' -> 'matching-information' ->> 'apType' = 'isRecoveryFocussed' THEN 'RFAP'
+        WHEN assessment.data -> 'matching-information' -> 'matching-information' ->> 'apType' = 'isMHAPElliottHouse' THEN 'MHAP_ST_JOSEPHS'
+        WHEN assessment.data -> 'matching-information' -> 'matching-information' ->> 'apType' = 'isMHAPStJosephs' THEN 'MHAP_ELLIOTT_HOUSE'
+        ELSE assessment.data -> 'matching-information' -> 'matching-information' ->> 'apType'
+        END
+FROM domain_events d
+         INNER JOIN assessments assessment ON assessment.id = d.assessment_id
+WHERE d.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED' AND
+    d.id not in (
+        select distinct domain_event_id from domain_events_metadata where name = 'CAS1_REQUESTED_AP_TYPE'
+    );


### PR DESCRIPTION
Now this is being via the API, we need to backfill any previously submitted and assessed application metadata

Note - this should only be merged once the corresponding UI functionality (APS-822) has gone live