### PR TITLE
APS-892 - Added isWithdrawn property to placementApplication entity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
@@ -226,14 +225,13 @@ class PlacementApplicationService(
     val placementApplication =
       placementApplicationRepository.findByIdOrNull(id) ?: return CasResult.NotFound()
 
-    if (placementApplication.isWithdrawn()) {
+    if (placementApplication.isWithdrawn) {
       return CasResult.Success(placementApplication)
     }
 
     val wasBeingAssessedBy = if (placementApplication.isBeingAssessed()) { placementApplication.allocatedToUser } else null
 
-    placementApplication.decision = PlacementApplicationDecision.WITHDRAW
-    placementApplication.decisionMadeAt = OffsetDateTime.now()
+    placementApplication.isWithdrawn = true
     placementApplication.withdrawalReason = when (withdrawalContext.triggeringEntityType) {
       WithdrawableEntityType.Application -> PlacementApplicationWithdrawalReason.RELATED_APPLICATION_WITHDRAWN
       WithdrawableEntityType.PlacementApplication -> userProvidedReason

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -39,7 +39,7 @@ class PlacementApplicationTransformer(
       outdatedSchema = !jpa.schemaUpToDate,
       submittedAt = jpa.submittedAt?.toInstant(),
       canBeWithdrawn = jpa.isInWithdrawableState(),
-      isWithdrawn = jpa.isWithdrawn(),
+      isWithdrawn = jpa.isWithdrawn,
       withdrawalReason = getWithdrawalReason(jpa.withdrawalReason),
       type = PlacementApplicationType.additional,
       placementDates = jpa.placementDates.map { PlacementDates(it.expectedArrival, it.duration) },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -22,7 +22,7 @@ class RequestForPlacementTransformer(
     id = placementApplicationEntity.id,
     createdByUserId = placementApplicationEntity.createdByUser.id,
     createdAt = placementApplicationEntity.createdAt.toInstant(),
-    isWithdrawn = placementApplicationEntity.isWithdrawn(),
+    isWithdrawn = placementApplicationEntity.isWithdrawn,
     type = RequestForPlacementType.manual,
     placementDates = placementApplicationEntity.placementDates.map { it.toPlacementDates() },
     submittedAt = placementApplicationEntity.submittedAt?.toInstant(),
@@ -76,7 +76,7 @@ class RequestForPlacementTransformer(
   )
 
   private fun PlacementApplicationEntity.deriveStatus(): RequestForPlacementStatus = when {
-    this.isWithdrawn() -> RequestForPlacementStatus.requestWithdrawn
+    this.isWithdrawn -> RequestForPlacementStatus.requestWithdrawn
     this.placementRequests.any { pr -> pr.hasActiveBooking() } -> RequestForPlacementStatus.placementBooked
     this.decision == PlacementApplicationDecision.REJECTED -> RequestForPlacementStatus.requestRejected
     this.decision == PlacementApplicationDecision.ACCEPTED -> RequestForPlacementStatus.awaitingMatch

--- a/src/main/resources/db/migration/all/20240613080116__add_is_withdrawn_to_placement_application.sql
+++ b/src/main/resources/db/migration/all/20240613080116__add_is_withdrawn_to_placement_application.sql
@@ -1,0 +1,2 @@
+ALTER TABLE placement_applications
+    ADD COLUMN is_withdrawn BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/main/resources/db/migration/all/20240613082914__backfill_withdrawn_placement_applications.sql
+++ b/src/main/resources/db/migration/all/20240613082914__backfill_withdrawn_placement_applications.sql
@@ -1,0 +1,5 @@
+UPDATE placement_applications
+SET is_withdrawn = TRUE
+WHERE
+    decision = 'WITHDRAW' OR
+    decision = 'WITHDRAWN_BY_PP'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -35,6 +35,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var withdrawalReason: Yielded<PlacementApplicationWithdrawalReason?> = { null }
   private var dueAt: Yielded<OffsetDateTime?> = { OffsetDateTime.now().randomDateTimeAfter(10) }
   private var submissionGroupId: Yielded<UUID> = { UUID.randomUUID() }
+  private var isWithdrawn: Yielded<Boolean> = { false }
 
   fun withDefaults() = apply {
     this.createdByUser = { UserEntityFactory().withDefaultProbationRegion().produce() }
@@ -104,6 +105,10 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     this.dueAt = { dueAt }
   }
 
+  fun withIsWithdrawn(isWithdrawn: Boolean) = apply {
+    this.isWithdrawn = { isWithdrawn }
+  }
+
   override fun produce(): PlacementApplicationEntity = PlacementApplicationEntity(
     id = this.id(),
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an application"),
@@ -125,5 +130,6 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     withdrawalReason = this.withdrawalReason(),
     dueAt = this.dueAt(),
     submissionGroupId = this.submissionGroupId(),
+    isWithdrawn = this.isWithdrawn(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -409,7 +409,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
     assertThat(reportRow.requestedDurationDays).isEqualTo(expectedRow.placementDate!!.duration)
 
     if (expectedRow.isAccepted) {
-      assertThat(reportRow.decision).isEqualTo(if (expectedRow.isWithdrawn) "WITHDRAW" else "ACCEPTED")
+      assertThat(reportRow.decision).isEqualTo("ACCEPTED")
       assertThat(reportRow.decisionMadeAt).isToday()
     } else {
       assertThat(reportRow.decision).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1273,8 +1273,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
           val updatedPlacementApplication =
             placementApplicationRepository.findByIdOrNull(placementApplicationEntity.id)!!
 
-          assertThat(updatedPlacementApplication.decision).isEqualTo(uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.WITHDRAW)
-          assertThat(updatedPlacementApplication.decisionMadeAt).isWithinTheLastMinute()
+          assertThat(updatedPlacementApplication.isWithdrawn).isTrue()
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/RequestsForPlacementTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/RequestsForPlacementTest.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
@@ -84,7 +83,7 @@ class RequestsForPlacementTest : IntegrationTestBase() {
             withSchemaVersion(schema)
             withCreatedByUser(user)
             withSubmittedAt(OffsetDateTime.now())
-            withDecision(PlacementApplicationDecision.WITHDRAW)
+            withIsWithdrawn(true)
             withWithdrawalReason(PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED)
           }
 
@@ -143,7 +142,7 @@ class RequestsForPlacementTest : IntegrationTestBase() {
 
           assertThat(requestForPlacements[3].id).isEqualTo(withdrawnPlacementRequest.id)
           assertThat(requestForPlacements[3].type).isEqualTo(RequestForPlacementType.automatic)
-          assertThat(requestForPlacements[3].status).isEqualTo(RequestForPlacementStatus.requestWithdrawn)
+          assertThat(requestForPlacements[3].isWithdrawn).isTrue()
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -136,7 +136,7 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
 
   private fun assertPlacementApplicationNotWithdrawn(placementApplication: PlacementApplicationEntity) {
     val updatedPlacementApplication = placementApplicationRepository.findByIdOrNull(placementApplication.id)!!
-    Assertions.assertThat(updatedPlacementApplication.isWithdrawn()).isFalse()
+    Assertions.assertThat(updatedPlacementApplication.isWithdrawn).isFalse()
     Assertions.assertThat(updatedPlacementApplication.withdrawalReason).isNull()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -9,9 +9,6 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
-import org.junit.jupiter.params.provider.NullSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
@@ -30,7 +27,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementApplicationTransformer
@@ -215,34 +211,6 @@ class PlacementApplicationTransformerTest {
         ),
       ),
     )
-  }
-
-  @ParameterizedTest
-  @EnumSource(PlacementApplicationDecision::class)
-  @NullSource
-  fun `transformJpaToApi returns isWithdrawn based upon decision`(decision: PlacementApplicationDecision?) {
-    val data = "{\"data\": \"something\"}"
-    val document = "{\"document\": \"something\"}"
-    val placementApplication = PlacementApplicationEntityFactory()
-      .withCreatedByUser(user)
-      .withApplication(applicationMock)
-      .withData(data)
-      .withDocument(document)
-      .withDecision(decision)
-      .withWithdrawalReason(PlacementApplicationWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST)
-      .produce()
-
-    val result = placementApplicationTransformer.transformJpaToApi(placementApplication)
-
-    when (decision) {
-      PlacementApplicationDecision.ACCEPTED -> assertThat(result.isWithdrawn).isEqualTo(false)
-      PlacementApplicationDecision.REJECTED -> assertThat(result.isWithdrawn).isEqualTo(false)
-      PlacementApplicationDecision.WITHDRAW -> assertThat(result.isWithdrawn).isEqualTo(true)
-      PlacementApplicationDecision.WITHDRAWN_BY_PP -> assertThat(result.isWithdrawn).isEqualTo(true)
-      null -> assertThat(result.isWithdrawn).isEqualTo(false)
-    }
-
-    assertThat(result.withdrawalReason).isEqualTo(WithdrawPlacementRequestReason.errorInPlacementRequest)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
@@ -83,7 +83,7 @@ class RequestForPlacementTransformerTest {
       assertThat(result.id).isEqualTo(placementApplication.id)
       assertThat(result.createdByUserId).isEqualTo(placementApplication.createdByUser.id)
       assertThat(result.createdAt).isEqualTo(placementApplication.createdAt.toInstant())
-      assertThat(result.isWithdrawn).isEqualTo(placementApplication.isWithdrawn())
+      assertThat(result.isWithdrawn).isEqualTo(placementApplication.isWithdrawn)
       assertThat(result.type).isEqualTo(RequestForPlacementType.manual)
       assertPlacementDatesMatchPlacementDateEntities(result.placementDates, placementApplication.placementDates)
       assertThat(result.submittedAt).isEqualTo(placementApplication.submittedAt?.toInstant())
@@ -95,7 +95,7 @@ class RequestForPlacementTransformerTest {
     }
 
     @Test
-    fun `Derives the correct status for a withdrawn placement application`() {
+    fun `Maintains the correct status for a withdrawn placement application`() {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(user)
         .produce()
@@ -105,7 +105,7 @@ class RequestForPlacementTransformerTest {
         .withApplication(application)
         .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
         .withDecisionMadeAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
-        .withDecision(PlacementApplicationDecision.WITHDRAW)
+        .withIsWithdrawn(true)
         .withWithdrawalReason(randomOf(PlacementApplicationWithdrawalReason.entries))
         .produce()
 


### PR DESCRIPTION
This allows current 'decision' value to be kept when an application is withdrawn rather than being overwritten with a withdrawn decision. 
Backfill script will set the isWithdrawn property on existing records where a withdrawn decision already exists. 
WITHDRAW and WITHDRAWN_BY_PP PlacementApplicationDecision values are marked deprecated in the entity.

**NOTE** : This cannot be merged until APS-893 has gone live.  
APS-893 covers the removal of the two deprecated decisions ('WITHDRAW', 'WITHDRAWN_BY_PP') in the UI. 
Merging this change in prior to the corresponding UI change will result in additional records to be backfilled.