### PR TITLE
APS-853 migration job to backfill app reason for short notice

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -139,6 +139,18 @@ AND (
     year: Int,
   ): List<ApprovedPremisesApplicationMetricsSummary>
 
+  @Query(
+    """
+      SELECT cast(a.id as varchar) 
+      FROM applications a
+      WHERE a.submitted_at IS NOT NULL AND 
+            a.service = 'approved-premises' AND
+            length(trim(a.data -> 'basic-information' -> 'reason-for-short-notice' ->> 'reason')) > 0 
+    """,
+    nativeQuery = true,
+  )
+  fun findAllSubmittedApprovedPremisesApplicationsWithShortNotice(): List<UUID>
+
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.crn = :crn")
   fun <T : ApplicationEntity> findByCrn(crn: String, type: Class<T>): List<ApplicationEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -78,6 +78,8 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 
   fun findByApplicationId(applicationId: UUID): List<DomainEventEntity>
 
+  fun getByApplicationIdAndType(applicationId: UUID, type: DomainEventType): DomainEventEntity
+
   @Modifying
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/ApAreaMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/ApAreaMigrationJob.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
@@ -8,6 +8,7 @@ import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import java.util.UUID
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/ApplicationStatusMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/ApplicationStatusMigrationJob.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
 
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Slice
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import javax.persistence.EntityManager
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1BackfillUserApArea.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1BackfillUserApArea.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
 
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
 class Cas1BackfillUserApArea(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1FixPlacementApplicationLinksJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1FixPlacementApplicationLinksJob.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import java.util.UUID
 import javax.persistence.EntityManager
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1OutOfServiceBedReasonMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1OutOfServiceBedReasonMigrationJob.kt
@@ -1,9 +1,10 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import java.time.OffsetDateTime
 
 class Cas1OutOfServiceBedReasonMigrationJob(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1ReasonForShortNoticeMetadataMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1ReasonForShortNoticeMetadataMigrationJob.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
+
+import com.jayway.jsonpath.Configuration
+import com.jayway.jsonpath.JsonPath
+import com.jayway.jsonpath.Option
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+
+class Cas1ReasonForShortNoticeMetadataMigrationJob(
+  private val applicationRepository: ApplicationRepository,
+  private val domainEventRepository: DomainEventRepository,
+  private val transactionTemplate: TransactionTemplate,
+  private val jdbcTemplate: JdbcTemplate,
+) : MigrationJob() {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = false
+
+  override fun process() {
+    log.info("Starting Reason for Short Notice Migration process...")
+
+    val jsonPathConfig = Configuration.builder().options(Option.DEFAULT_PATH_LEAF_TO_NULL).build()
+
+    val applicationIds = applicationRepository.findAllSubmittedApprovedPremisesApplicationsWithShortNotice()
+
+    log.info("There are ${applicationIds.size} applications to update")
+
+    for (applicationId in applicationIds) {
+      log.debug("Updating $applicationId")
+
+      val application = applicationRepository.findByIdOrNull(applicationId)!! as ApprovedPremisesApplicationEntity
+
+      val json = JsonPath.parse(application.data, jsonPathConfig)
+      val reasonForShortNotice = json.read<String>("basic-information.reason-for-short-notice.reason")
+      val reasonForShortNoticeOther = json.read<String>("basic-information.reason-for-short-notice.other")
+      val submittedEvent = domainEventRepository.getByApplicationIdAndType(
+        applicationId = applicationId,
+        type = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
+      )
+
+      transactionTemplate.executeWithoutResult {
+        insertMetadataIfNotEmpty(submittedEvent, MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE, reasonForShortNotice)
+        insertMetadataIfNotEmpty(submittedEvent, MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER, reasonForShortNoticeOther)
+      }
+    }
+
+    log.info("Short Notice Migration process complete")
+  }
+
+  private fun insertMetadataIfNotEmpty(
+    domainEvent: DomainEventEntity,
+    name: MetaDataName,
+    value: String?,
+  ) {
+    if (value.isNullOrEmpty()) {
+      log.debug("Not setting $name as provided value is null or empty")
+      return
+    }
+
+    if (domainEvent.metadata.containsKey(name)) {
+      log.debug("Not overwriting $name as a value already exists")
+      return
+    }
+
+    jdbcTemplate.update(
+      "INSERT into domain_events_metadata(domain_event_id,name,value) VALUES(?,?,?)",
+      domainEvent.id,
+      name.name,
+      value,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1UserDetailsMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1UserDetailsMigrationJob.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
 
 import org.json.JSONObject
 import org.slf4j.LoggerFactory
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import java.util.UUID
 import javax.persistence.EntityManager
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/TaskDueMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/TaskDueMigrationJob.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
 
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskDeadlineService
 import javax.persistence.EntityManager
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -22,13 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigrationJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.ApAreaMigrationJobApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.BookingStatusMigrationJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1BackfillUserApArea
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1OutOfServiceBedReasonMigrationJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1UserDetailsMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2AssessmentMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2NoteMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2StatusUpdateMigrationJob
@@ -38,10 +32,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.NoticeTypeMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.NoticeTypeMigrationJobApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.TaskDueMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateAllUsersFromCommunityApiJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.UpdateSentenceTypeAndSituationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.ApAreaMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.ApAreaMigrationJobApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillUserApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1FixPlacementApplicationLinksJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1OutOfServiceBedReasonMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UserDetailsMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.TaskDueMigrationJob
 import javax.persistence.EntityManager
 
 @Service

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import io.sentry.Sentry
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationContext
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
@@ -40,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.ApAreaMig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillUserApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1FixPlacementApplicationLinksJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1OutOfServiceBedReasonMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1ReasonForShortNoticeMetadataMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UserDetailsMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.TaskDueMigrationJob
 import javax.persistence.EntityManager
@@ -154,6 +157,13 @@ class MigrationJobService(
           applicationContext.getBean(UserRepository::class.java),
           applicationContext.getBean(UserService::class.java),
           applicationContext.getBean(MigrationLogger::class.java),
+        )
+
+        MigrationJobType.cas1PopulateAppReasonForShortNoticeMetadata -> Cas1ReasonForShortNoticeMetadataMigrationJob(
+          applicationContext.getBean(ApplicationRepository::class.java),
+          applicationContext.getBean(DomainEventRepository::class.java),
+          applicationContext.getBean(TransactionTemplate::class.java),
+          applicationContext.getBean(JdbcTemplate::class.java),
         )
       }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3690,6 +3690,7 @@ components:
         - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
+        - update_cas1_populate_app_reason_for_short_notice_metadata
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8241,6 +8241,7 @@ components:
         - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
+        - update_cas1_populate_app_reason_for_short_notice_metadata
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4248,6 +4248,7 @@ components:
         - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
+        - update_cas1_populate_app_reason_for_short_notice_metadata
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4281,6 +4281,7 @@ components:
         - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
+        - update_cas1_populate_app_reason_for_short_notice_metadata
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3781,6 +3781,7 @@ components:
         - update_cas1_out_of_service_bed_reasons
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
+        - update_cas1_populate_app_reason_for_short_notice_metadata
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -6,6 +6,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
@@ -27,6 +28,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var triggerSource: Yielded<TriggerSourceType?> = { null }
   private var triggeredByUserId: Yielded<UUID?> = { null }
   private var nomsNumber: Yielded<String?> = { randomStringMultiCaseWithNumbers(8) }
+  private var metadata: Yielded<Map<MetaDataName, String?>> = { emptyMap() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -90,6 +92,10 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     this.nomsNumber = { nomsNumber }
   }
 
+  fun withMetadata(metadata: Map<MetaDataName, String>) = apply {
+    this.metadata = { metadata }
+  }
+
   override fun produce(): DomainEventEntity = DomainEventEntity(
     id = this.id(),
     applicationId = this.applicationId(),
@@ -104,5 +110,6 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     triggerSource = null,
     triggeredByUserId = this.triggeredByUserId(),
     nomsNumber = this.nomsNumber(),
+    metadata = this.metadata(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/ApAreaMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/ApAreaMigrationTest.kt
@@ -1,14 +1,15 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.midlandsApplicationIds
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.northEastApplicationIds
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.seeApplicationIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.midlandsApplicationIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.northEastApplicationIds
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.seeApplicationIds
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
 import java.time.OffsetDateTime
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1ReasonForShortNoticeMetadataMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1ReasonForShortNoticeMetadataMigrationTest.kt
@@ -1,0 +1,151 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
+import java.time.OffsetDateTime
+
+class Cas1ReasonForShortNoticeMetadataMigrationTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  lateinit var application: ApprovedPremisesApplicationEntity
+
+  @BeforeEach
+  fun setup() {
+    val (user, _) = `Given a User`()
+    val (offenderDetails, _) = `Given an Offender`()
+
+    application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withCreatedByUser(user)
+      withCrn(offenderDetails.otherIds.crn)
+      withConvictionId(12345)
+      withApplicationSchema(approvedPremisesApplicationJsonSchemaRepository.findAll().first())
+      withSubmittedAt(OffsetDateTime.now())
+      withData("{ }")
+    }
+  }
+
+  @Test
+  fun do_nothing_if_no_short_notice_reason_on_application() {
+    domainEventFactory.produceAndPersist {
+      withApplicationId(application.id)
+      withType(DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED)
+    }
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1PopulateAppReasonForShortNoticeMetadata)
+
+    val submittedDomainEvent = domainEventRepository.findByApplicationId(application.id)
+      .first { it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
+    assertThat(submittedDomainEvent.metadata).isEmpty()
+  }
+
+  @Test
+  fun populate_short_notice_metadata_reason_and_other_if_defined() {
+    domainEventFactory.produceAndPersist {
+      withApplicationId(application.id)
+      withType(DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED)
+    }
+
+    application.data = """
+         {
+            "basic-information": {
+                "reason-for-short-notice": {
+                    "reason": "riskEscalated",
+                    "other": "some reason here"
+                }
+            }
+         }
+    """.trimMargin()
+    approvedPremisesApplicationRepository.save(application)
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1PopulateAppReasonForShortNoticeMetadata)
+
+    val submittedDomainEvent = domainEventRepository.findByApplicationId(application.id)
+      .first { it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
+    assertThat(submittedDomainEvent.metadata).hasSize(2)
+    assertThat(submittedDomainEvent.metadata).isEqualTo(
+      mapOf(
+        MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE to "riskEscalated",
+        MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER to "some reason here",
+      ),
+    )
+  }
+
+  @Test
+  fun dont_populate_short_notice_other_metadata_if_not_defined() {
+    domainEventFactory.produceAndPersist {
+      withApplicationId(application.id)
+      withType(DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED)
+    }
+
+    application.data = """
+         {
+            "basic-information": {
+                "reason-for-short-notice": {
+                    "reason": "theReason"
+                }
+            }
+         }
+    """.trimMargin()
+    approvedPremisesApplicationRepository.save(application)
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1PopulateAppReasonForShortNoticeMetadata)
+
+    val submittedDomainEvent = domainEventRepository.findByApplicationId(application.id)
+      .first { it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
+    assertThat(submittedDomainEvent.metadata).hasSize(1)
+    assertThat(submittedDomainEvent.metadata).isEqualTo(
+      mapOf(
+        MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE to "theReason",
+      ),
+    )
+  }
+
+  @Test
+  fun dont_overwrite_existing_metadata() {
+    domainEventFactory.produceAndPersist {
+      withApplicationId(application.id)
+      withType(DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED)
+      withMetadata(
+        mapOf(
+          MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE to "originalShortReasonValue",
+          MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER to "originalShortNoticeOtherValue",
+        ),
+      )
+    }
+
+    application.data = """
+         {
+            "basic-information": {
+                "reason-for-short-notice": {
+                    "reason": "newReason",
+                    "other": "newOther"
+                }
+            }
+         }
+    """.trimMargin()
+    approvedPremisesApplicationRepository.save(application)
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1PopulateAppReasonForShortNoticeMetadata)
+
+    val submittedDomainEvent = domainEventRepository.findByApplicationId(application.id)
+      .first { it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
+    assertThat(submittedDomainEvent.metadata).hasSize(2)
+    assertThat(submittedDomainEvent.metadata).isEqualTo(
+      mapOf(
+        MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE to "originalShortReasonValue",
+        MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER to "originalShortNoticeOtherValue",
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1FixPlacementApplicationLinksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1FixPlacementApplicationLinksTest.kt
@@ -1,9 +1,10 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.MigrationJobTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1OutOfServiceBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1OutOfServiceBedsTest.kt
@@ -1,9 +1,10 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.MigrationJobTestBase
 
 class MigrateCas1OutOfServiceBedsTest : MigrationJobTestBase() {
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1UserDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1UserDetailsTest.kt
@@ -1,8 +1,9 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.MigrationJobTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import java.time.OffsetDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1FixPlacementApplicationLinksJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1FixPlacementApplicationLinksJobTest.kt
@@ -26,13 +26,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1FixPlacementApplicationLinksJob.ManualLinkFix
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1FixPlacementApplicationLinksJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1FixPlacementApplicationLinksJob.ManualLinkFix
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUtcOffsetDateTime
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import javax.persistence.EntityManager
-import kotlin.math.log
 
 class Cas1FixPlacementApplicationLinksJobTest {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1OutOfServiceBedReasonMigrationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/migration/Cas1OutOfServiceBedReasonMigrationJobTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas1OutOfServiceBedReasonMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1OutOfServiceBedReasonMigrationJob
 import java.time.OffsetDateTime
 import java.util.UUID
 


### PR DESCRIPTION
This PR adds a migration job to backfill app reason for short notice and short notice description into metadata.

Whilst we could have used a SQL based migration for this, testing in pre-prod showed this took over 40 seconds to run for each metadata value which would lead to a non-trivial prod outage on deploy (assuming it runs without issue over that length of time).

This PR also moves all the cas1 migration jobs into a cas1 specific package