### PR TITLE
APS-909 : Handle null failureDescription when booking not made.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -17,7 +17,6 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import javax.xml.datatype.DatatypeConstants.DAYS
 
 @SuppressWarnings("TooManyFunctions")
 @Component
@@ -113,7 +112,10 @@ class DomainEventDescriber(
 
   private fun buildBookingNotMadeDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getBookingNotMadeEvent(domainEventSummary.id())
-    return event.describe { "A placement was not made for the placement request. The reason was: ${it.eventDetails.failureDescription}" }
+    val failureReason = event?.data?.eventDetails?.failureDescription?.let {
+      " The reason was: $it"
+    } ?: ""
+    return event.describe { "A placement was not made for the placement request.$failureReason" }
   }
 
   private fun buildBookingCancelledDescription(domainEventSummary: DomainEventSummary): String? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -212,6 +212,24 @@ class DomainEventDescriberTest {
     assertThat(result).isEqualTo("A placement was not made for the placement request. The reason was: $reason")
   }
 
+  @Test
+  fun `Returns expected description for booking not made event with no failure description`() {
+    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE)
+    val bookingNotMade = BookingNotMadeFactory().produce().copy(failureDescription = null)
+
+    every { mockDomainEventService.getBookingNotMadeEvent(any()) } returns buildDomainEvent {
+      BookingNotMadeEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = EventType.bookingNotMade,
+        eventDetails = bookingNotMade,
+      )
+    }
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("A placement was not made for the placement request.")
+  }
+
   @ParameterizedTest
   @CsvSource(value = ["Reason A", "Reason B"])
   fun `Returns expected description for booking cancelled event`(reason: String) {


### PR DESCRIPTION
Resolves issue with 'null' appearing as a reason, on the timeline, when a booking is not made and failureDescription has not been populated (is null).
