### PR TITLE
APS-855 - CAS1 Report PII shouldn’t be returned by default

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
@@ -42,7 +42,7 @@ class Cas1ReportsController(
     reportName: Cas1ReportName,
     year: Int,
     month: Int,
-    includePii: Boolean,
+    includePii: Boolean?,
   ): ResponseEntity<StreamingResponseBody> {
     if (xServiceName !== ServiceName.approvedPremises) {
       throw NotAllowedProblem("This endpoint only supports CAS1")
@@ -73,7 +73,7 @@ class Cas1ReportsController(
             year = year,
             month = month,
             deliusUsername = userService.getUserForRequest().deliusUsername,
-            includePii = includePii,
+            includePii = includePii ?: false,
           ),
           outputStream,
         )
@@ -110,7 +110,7 @@ class Cas1ReportsController(
           RequestsForPlacementReportProperties(
             year = year,
             month = month,
-            includePii = includePii,
+            includePii = includePii ?: false,
           ),
           outputStream,
         )

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -472,10 +472,9 @@ paths:
         - name: includePii
           in: query
           required: false
-          description: If Personally Identifiable Information (PII) should be included in the report
+          description: If Personally Identifiable Information (PII) should be included in the report. Defaults to `false`
           schema:
             type: boolean
-            default: false
       responses:
         200:
           description: Successfully retrieved the report

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -474,10 +474,9 @@ paths:
         - name: includePii
           in: query
           required: false
-          description: If Personally Identifiable Information (PII) should be included in the report
+          description: If Personally Identifiable Information (PII) should be included in the report. Defaults to `false`
           schema:
             type: boolean
-            default: false
       responses:
         200:
           description: Successfully retrieved the report

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MutableClockConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MutableClockConfiguration.kt
@@ -32,6 +32,10 @@ class MutableClockConfiguration {
       fixedTime = now.toInstant(ZoneOffset.UTC)
     }
 
+    fun advanceOneMinute() {
+      fixedTime = (fixedTime ?: Instant.now()).plusSeconds(60)
+    }
+
     override fun instant(): Instant {
       return fixedTime ?: Instant.now()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationReportTest.kt
@@ -100,7 +100,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
 
       webTestClient.get()
-        .uri(getReportUrl(year = 2019, month = 2))
+        .uri(getReportUrl(year = 2019, month = 2, includePii = true))
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -149,11 +149,11 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
   }
 
   @Test
-  fun `Get application report returns OK with correct applications, excludes PII`() {
+  fun `Get application report returns OK with correct applications, excludes PII by default`() {
     `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
 
       webTestClient.get()
-        .uri(getReportUrl(year = 2020, month = 2, includePii = false))
+        .uri(getReportUrl(year = 2020, month = 2, includePii = null))
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -1075,5 +1075,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
   private fun getApplication(applicationId: UUID) =
     realApplicationRepository.findByIdOrNull(applicationId)!! as ApprovedPremisesApplicationEntity
 
-  private fun getReportUrl(year: Int, month: Int, includePii: Boolean = true) = "/cas1/reports/applicationsV2?year=$year&month=$month&includePii=$includePii"
+  private fun getReportUrl(year: Int, month: Int, includePii: Boolean?) =
+    "/cas1/reports/applicationsV2?year=$year&month=$month" +
+      if (includePii != null) { "&includePii=$includePii" } else { "" }
 }


### PR DESCRIPTION
Previously we relied on the open-api default value of ‘false’ for includePii, but testing has shown that this is resolving to true in code.

This commit manages the default values in controllers instead, and updates the reports tests that check PII to ensure the default behaviour is observed