### PR TITLE
Cas 365/remove id cast and mockkstatic

### DIFF
--- a/src/main/resources/db/migration/all/20240618100000__create_cas_2_summary_views_change_id_type.sql
+++ b/src/main/resources/db/migration/all/20240618100000__create_cas_2_summary_views_change_id_type.sql
@@ -1,0 +1,48 @@
+-- remove id cast to TEXT
+DROP VIEW IF EXISTS cas_2_application_summary CASCADE;
+CREATE OR REPLACE VIEW cas_2_application_summary AS SELECT
+    a.id,
+    a.crn,
+    a.noms_number,
+    CAST(a.created_by_user_id AS TEXT),
+    nu.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    asu.label,
+    CAST(asu.status_id AS TEXT),
+    a.referring_prison_code,
+    a.conditional_release_date,
+    asu.created_at AS status_created_at,
+    a.abandoned_at
+FROM cas_2_applications a
+LEFT JOIN (SELECT DISTINCT ON (application_id) su.application_id, su.label, su.status_id, su.created_at
+    FROM cas_2_status_updates su
+    ORDER BY su.application_id, su.created_at DESC) as asu
+    ON a.id = asu.application_id
+JOIN nomis_users nu ON nu.id = a.created_by_user_id;
+
+-- filter applications that do not have abandoned_at
+CREATE OR REPLACE VIEW cas_2_application_live_summary AS SELECT
+    a.id,
+    a.crn,
+    a.noms_number,
+    a.created_by_user_id,
+    a.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    a.label,
+    a.status_id,
+    a.referring_prison_code,
+    a.abandoned_at
+FROM cas_2_application_summary a
+WHERE (a.conditional_release_date IS NULL OR a.conditional_release_date >= current_date)
+AND a.abandoned_at IS NULL
+AND a.status_id IS NULL
+   OR (a.status_id = '004e2419-9614-4c1e-a207-a8418009f23d' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Referral withdrawn
+   OR (a.status_id = 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Referral cancelled
+   OR (a.status_id = '89458555-3219-44a2-9584-c4f715d6b565' AND a.status_created_at > (current_date - INTERVAL '14 DAY')) -- Awaiting arrival
+   OR (a.status_id NOT IN ('004e2419-9614-4c1e-a207-a8418009f23d',
+                           'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9',
+                           '89458555-3219-44a2-9584-c4f715d6b565'));


### PR DESCRIPTION
Without the fixes contained in this branch upgrading spring boot and Hibernate results in:

- a JPA class cast exception (since UUID id is cast to TEXT in SQL but then has type UUID in the entity)
- mockkstatic no longer working in the associated CAS 2 integration tests

Adding these features to main now since:
- it will help reduce the number of changes in the forthcoming merge of the upgrade branch
- there is no reason for them not to be merged in beforehand

Note that the new view creation SQL is as per [20240528100000__create_cas_2_summary_views_add_abandoned.sql](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/resources/db/migration/all/20240528100000__create_cas_2_summary_views_add_abandoned.sql) except `cas_2_application_summary` and it's dependent view `cas_2_application_live_summary` are dropped and then re-created without the `id` cast to `TEXT` on line 3.

It is not sufficient to just `REPLACE` the view since the type of the field is changing and hence the requirement to `DROP` and then `CREATE`.