### PR TITLE
Unexpired dates should not be more than 13 days in the past.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -225,7 +225,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       }
 
       fun unexpiredDateTime() = OffsetDateTime.now().randomDateTimeBefore()
-      fun expiredDateTime() = unexpiredDateTime().minusDays(14)
+      fun expiredDateTime() = unexpiredDateTime().minusDays(15)
 
       val unexpiredApplicationIds = mutableSetOf<UUID>()
       val expiredApplicationIds = mutableSetOf<UUID>()


### PR DESCRIPTION
For the CAS2ApplicationTest `return unexpired applications when applications GET is requested()` unexpired datetimes should be within the past 14 days and expired datetimes occur more than 14 days in the past.

Before this change: 

```
fun unexpiredDateTime() = OffsetDateTime.now().randomDateTimeBefore() // default 14
fun expiredDateTime() = unexpiredDateTime().minusDays(14)
```

However `unexpiredDateTime()` could feasibly generate a datetime with the same date as today in which case `expiredDateTime()` would generate a datetime 14 days in the past and therefore deemed unexpired.  For example:

If now is 15:30:42 on 21/06/24:

expiredDateTime = "21/06/24 15:30:42" - 14 days
expiredDateTime = "07/06/24 15:30:42"

The `cas_2_application_live_summary` [view SQL WHERE](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/b4665456942bef6abbecf88b395f8412a3335457/src/main/resources/db/migration/all/20240618100000__create_cas_2_summary_views_change_id_type.sql#L43) is `> (current_date - 14 days)`.  Since this SQL is comparing a DATE value with a DATETIME in the database, in this example, "07/06/24 15:30:42" is > "07/06/24" so the query returns this record (date values are "[assumed to represent midnight](https://www.postgresql.org/docs/current/functions-datetime.html)").  The query is working as expected however we do not want to be able to generate an `expiredDateTime` with a date exactly 14 days ago.

The fix is to set the `expiredDateTime()` to be 15 days before the `unexpiredDateTime()`:

```
fun unexpiredDateTime() = OffsetDateTime.now().randomDateTimeBefore() // default 14
fun expiredDateTime() = unexpiredDateTime().minusDays(15)
```

If now is 15:30:42 on 21/06/24:

expiredDateTime = "21/06/24 15:30:42" - 15 days
expiredDateTime = "06/06/24 15:30:42"

And now, the query will not return this record since `expiredDateTime` < `current_date()` - 14 days.

This test has been a 'flaky' test for some time so will hopefully bring some more stability to the pipeline.

The test has been run 100 times locally (using the `@RepeatedTest(100)` annotation) and didn't fail - so all good.