### PR TITLE
Fix E2E Slack Alerting on Failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,17 +441,20 @@ workflows:
             - request-prod-approval
       - cas1_e2e_tests:
           context:
+            - hmpps-common-vars
             - hmpps-community-accommodation
             - approved-premises-ui-e2e
           requires:
             - deploy_dev
       - cas2_e2e_tests:
           context:
+            - hmpps-common-vars
             - hmpps-community-accommodation
           requires:
             - deploy_dev
       - cas3_e2e_tests:
           context:
+            - hmpps-common-vars
             - hmpps-community-accommodation
           requires:
             - deploy_dev


### PR DESCRIPTION
If an E2E job fails on main in circle ci, we’re seeing the following error when attempting to send an alert to slack

```In order to use the Slack Orb (v4 +), an OAuth token must be present via the SLACK_ACCESS_TOKEN environment variable.```

This commit should resolve the issue by adding the hmpps-common-vars context to the three e2e jobs