### PR TITLE
APS-943 Backfill CAS1 Application Timeliness

### DIFF
--- a/src/main/resources/db/migration/all/20240621101458__cas1_backfill_application_timeliness.sql
+++ b/src/main/resources/db/migration/all/20240621101458__cas1_backfill_application_timeliness.sql
@@ -1,0 +1,23 @@
+-- This logic mimicks the logic used in the UI code (noticeTypeFromApplication.ts)
+with apps_to_update as (
+    SELECT
+        a.id,
+        a.submitted_at,
+        -- we use < because the logic in the ui that normally determines this only considers whole days, where
+        -- as postgres date comparison will consider 7 days and 1 hour as > 7 days
+        -- we truncate the arrival date to days because the API code sets arrival_date to 00:00 UTC,
+        -- where as the UI (that determined timeinless) sets it to 00:00 (Europe/London) for comparison
+        CASE
+            WHEN apa.arrival_date IS NOT NULL AND (date_trunc('day', apa.arrival_date)) - a.submitted_at < '8 days' THEN 'emergency'
+            WHEN apa.arrival_date IS NOT NULL AND (date_trunc('day', apa.arrival_date)) - a.submitted_at < '29 days' THEN 'shortNotice'
+            ELSE 'standard'
+            END as updated_notice_type
+    FROM approved_premises_applications apa
+             INNER JOIN applications a ON a.id = apa.id
+    WHERE a.submitted_at IS NOT NULL and apa.notice_type is null
+)
+
+update approved_premises_applications apa
+set notice_type = apps_to_update.updated_notice_type
+from apps_to_update
+where apa.id = apps_to_update.id and apa.notice_type is null;


### PR DESCRIPTION
This commit provides a SQL migration to populate the approved_premises_application.timeliness value for any application where it isn’t currently set. This is ensure the value is always available in reports.

This value was only populated in the database as-of 2024-03-20. This migration will only update applications where the value is currently null (i.e. from before 2024-03-20).

The logic used to determine the timeliness values matches that used in the UI (noticeTypeFromApplication.ts), which is applied as part of the application submission logic.