### PR TITLE
APS-914 update profile response for non staff members

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ProfileApiDelegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProfileResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -18,5 +19,11 @@ class ProfileController(
     val userEntity = userService.getUserForRequest()
 
     return ResponseEntity(userTransformer.transformJpaToApi(userEntity, xServiceName), HttpStatus.OK)
+  }
+
+  override fun profileV2Get(xServiceName: ServiceName): ResponseEntity<ProfileResponse> {
+    val username = userService.getDeliusUserNameForRequest()
+    val userResponse = userService.getUserForProfile(username)
+    return ResponseEntity(userTransformer.transformProfileResponseToApi(username, userResponse, xServiceName), HttpStatus.OK)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -137,7 +137,7 @@ class UsersController(
       throw ForbiddenProblem()
     }
 
-    val userEntity = userService.getExistingUserOrCreate(name, true)
+    val userEntity = userService.getExistingUserOrCreate(name, throwExceptionOnStaffRecordNotFound = false)
     if (!userEntity.staffRecordFound) throw NotFoundProblem(name, "user", "username")
     val userTransformed = userTransformer.transformJpaToApi(userEntity.user!!, xServiceName)
     return ResponseEntity.ok(userTransformed)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -138,7 +138,8 @@ class UsersController(
     }
 
     val userEntity = userService.getExistingUserOrCreate(name, true)
-    val userTransformed = userTransformer.transformJpaToApi(userEntity, xServiceName)
+    if (!userEntity.staffRecordFound) throw NotFoundProblem(name, "user", "username")
+    val userTransformed = userTransformer.transformJpaToApi(userEntity.user!!, xServiceName)
     return ResponseEntity.ok(userTransformed)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/GetUserResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/GetUserResponse.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+
+data class GetUserResponse(
+  val user: UserEntity?,
+  var staffRecordFound: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProfileResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUserRole
@@ -12,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.GetUserResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.UserWorkload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as ApiUserQualification
@@ -69,6 +71,13 @@ class UserTransformer(
       service = ServiceName.temporaryAccommodation.value,
     )
     ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
+  }
+
+  fun transformProfileResponseToApi(userName: String, userResponse: GetUserResponse, xServiceName: ServiceName): ProfileResponse {
+    if (!userResponse.staffRecordFound) {
+      return ProfileResponse(userName, ProfileResponse.LoadError.staffRecordNotFound, user = null)
+    }
+    return ProfileResponse(userName, loadError = null, transformJpaToApi(userResponse.user!!, xServiceName))
   }
 
   private fun transformApprovedPremisesRoleToApi(userRole: UserRoleAssignmentEntity): ApprovedPremisesUserRole? = when (userRole.role) {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3006,6 +3006,19 @@ components:
       required:
         - roles
         - qualifications
+    ProfileResponse:
+      type: object
+      properties:
+        deliusUsername:
+          type: string
+        loadError:
+          type: string
+          enum:
+            - staff_record_not_found
+        user:
+          $ref: '#/components/schemas/User'
+      required:
+        - deliusUsername
     TemporaryAccommodationUser:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3954,6 +3954,31 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /profile/v2:
+    get:
+      tags:
+        - Auth
+      summary: Returns information on the logged in user
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '_shared.yml#/components/schemas/ServiceName'
+      responses:
+        200:
+          description: successfully retrieved information on user
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ProfileResponse'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /users:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3956,6 +3956,31 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /profile/v2:
+    get:
+      tags:
+        - Auth
+      summary: Returns information on the logged in user
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+      responses:
+        200:
+          description: successfully retrieved information on user
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ProfileResponse'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /users:
     get:
       tags:
@@ -7557,6 +7582,19 @@ components:
       required:
         - roles
         - qualifications
+    ProfileResponse:
+      type: object
+      properties:
+        deliusUsername:
+          type: string
+        loadError:
+          type: string
+          enum:
+            - staff_record_not_found
+        user:
+          $ref: '#/components/schemas/User'
+      required:
+        - deliusUsername
     TemporaryAccommodationUser:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3563,6 +3563,19 @@ components:
       required:
         - roles
         - qualifications
+    ProfileResponse:
+      type: object
+      properties:
+        deliusUsername:
+          type: string
+        loadError:
+          type: string
+          enum:
+            - staff_record_not_found
+        user:
+          $ref: '#/components/schemas/User'
+      required:
+        - deliusUsername
     TemporaryAccommodationUser:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3597,6 +3597,19 @@ components:
       required:
         - roles
         - qualifications
+    ProfileResponse:
+      type: object
+      properties:
+        deliusUsername:
+          type: string
+        loadError:
+          type: string
+          enum:
+            - staff_record_not_found
+        user:
+          $ref: '#/components/schemas/User'
+      required:
+        - deliusUsername
     TemporaryAccommodationUser:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3097,6 +3097,19 @@ components:
       required:
         - roles
         - qualifications
+    ProfileResponse:
+      type: object
+      properties:
+        deliusUsername:
+          type: string
+        loadError:
+          type: string
+          enum:
+            - staff_record_not_found
+        user:
+          $ref: '#/components/schemas/User'
+      required:
+        - deliusUsername
     TemporaryAccommodationUser:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -937,7 +937,7 @@ abstract class IntegrationTestBase {
       )
     }
 
-  fun mockOAuth2ClientCredentialsCallIfRequired(block: () -> Unit) {
+  fun mockOAuth2ClientCredentialsCallIfRequired(block: () -> Unit = {}) {
     if (!clientCredentialsCallMocked) {
       mockClientCredentialsJwtRequest()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -1,10 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProfileResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUserRole
@@ -14,71 +18,379 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.util.UUID
 
 class ProfileTest : IntegrationTestBase() {
-  @Test
-  fun `Getting own profile without a JWT returns 401`() {
-    webTestClient.get()
-      .uri("/profile")
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
 
-  @Test
-  fun `Getting own profile with a non-Delius JWT returns 403`() {
-    val jwt = jwtAuthHelper.createClientCredentialsJwt(
-      username = "username",
-      authSource = "nomis",
-    )
+  @Nested
+  inner class Profile {
+    val profileEndpoint = "/profile"
 
-    webTestClient.get()
-      .uri("/profile")
-      .header("Authorization", "Bearer $jwt")
-      .exchange()
-      .expectStatus()
-      .isForbidden
-  }
+    @Test
+    fun `Getting own Approved Premises profile returns OK with correct body`() {
+      val id = UUID.randomUUID()
+      val deliusUsername = "JIMJIMMERSON"
+      val email = "foo@bar.com"
+      val telephoneNumber = "123445677"
 
-  @Test
-  fun `Getting own profile with no X-Service-Name header returns 400`() {
-    `Given a User` { userEntity, jwt ->
-      webTestClient.get()
-        .uri("/profile")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .is4xxClientError
-        .expectBody()
-        .jsonPath("title").isEqualTo("Bad Request")
-        .jsonPath("detail").isEqualTo("Missing required header X-Service-Name")
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      }
+
+      `Given a User`(
+        id = id,
+        roles = listOf(UserRole.CAS1_ASSESSOR),
+        qualifications = listOf(UserQualification.PIPE),
+        staffUserDetailsConfigBlock = {
+          withUsername(deliusUsername)
+          withEmail(email)
+          withTelephoneNumber(telephoneNumber)
+        },
+        probationRegion = region,
+      ) { userEntity, jwt ->
+        val userApArea = userEntity.apArea!!
+
+        webTestClient.get()
+          .uri(profileEndpoint)
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.approvedPremises.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              ApprovedPremisesUser(
+                id = id,
+                region = ProbationRegion(region.id, region.name),
+                deliusUsername = deliusUsername,
+                email = email,
+                name = userEntity.name,
+                telephoneNumber = telephoneNumber,
+                roles = listOf(ApprovedPremisesUserRole.assessor),
+                qualifications = listOf(uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification.pipe),
+                service = "CAS1",
+                isActive = true,
+                apArea = ApArea(userApArea.id, userApArea.identifier, userApArea.name),
+              ),
+            ),
+          )
+      }
     }
-  }
 
-  @Test
-  fun `Getting own Approved Premises profile returns OK with correct body`() {
-    val id = UUID.randomUUID()
-    val deliusUsername = "JIMJIMMERSON"
-    val email = "foo@bar.com"
-    val telephoneNumber = "123445677"
+    @Test
+    fun `Getting own Temporary Accommodation profile returns OK with correct body`() {
+      val id = UUID.randomUUID()
+      val deliusUsername = "JIMJIMMERSON"
+      val email = "foo@bar.com"
+      val telephoneNumber = "123445677"
 
-    val region = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
+      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+        subject = deliusUsername,
+        authSource = "delius",
+        roles = listOf("ROLE_PROBATION"),
+      )
 
-    `Given a User`(
-      id = id,
-      roles = listOf(UserRole.CAS1_ASSESSOR),
-      qualifications = listOf(UserQualification.PIPE),
-      staffUserDetailsConfigBlock = {
-        withUsername(deliusUsername)
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      }
+
+      val userEntity = userEntityFactory.produceAndPersist {
+        withId(id)
+        withYieldedProbationRegion { region }
+        withDeliusUsername(deliusUsername)
         withEmail(email)
         withTelephoneNumber(telephoneNumber)
-      },
-      probationRegion = region,
-    ) { userEntity, jwt ->
-      val userApArea = userEntity.apArea!!
+      }
+
+      userRoleAssignmentEntityFactory.produceAndPersist {
+        withUser(userEntity)
+        withRole(UserRole.CAS3_ASSESSOR)
+      }
+
+      userQualificationAssignmentEntityFactory.produceAndPersist {
+        withUser(userEntity)
+        withQualification(UserQualification.PIPE)
+      }
 
       webTestClient.get()
-        .uri("/profile")
+        .uri(profileEndpoint)
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            TemporaryAccommodationUser(
+              id = id,
+              region = ProbationRegion(region.id, region.name),
+              deliusUsername = deliusUsername,
+              email = email,
+              name = userEntity.name,
+              telephoneNumber = telephoneNumber,
+              roles = listOf(TemporaryAccommodationUserRole.assessor),
+              service = ServiceName.temporaryAccommodation.value,
+              isActive = true,
+            ),
+          ),
+        )
+    }
+
+    @Test
+    fun `Getting own Temporary Accommodation profile returns OK for CAS3_REPORTER with correct body`() {
+      val id = UUID.randomUUID()
+      val deliusUsername = "JIMJIMMERSON"
+      val email = "foo@bar.com"
+      val telephoneNumber = "123445677"
+
+      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+        subject = deliusUsername,
+        authSource = "delius",
+        roles = listOf("ROLE_PROBATION"),
+      )
+
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      }
+
+      val userEntity = userEntityFactory.produceAndPersist {
+        withId(id)
+        withYieldedProbationRegion { region }
+        withDeliusUsername(deliusUsername)
+        withEmail(email)
+        withTelephoneNumber(telephoneNumber)
+      }
+
+      userRoleAssignmentEntityFactory.produceAndPersist {
+        withUser(userEntity)
+        withRole(UserRole.CAS3_REPORTER)
+      }
+
+      userQualificationAssignmentEntityFactory.produceAndPersist {
+        withUser(userEntity)
+        withQualification(UserQualification.PIPE)
+      }
+
+      webTestClient.get()
+        .uri(profileEndpoint)
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            TemporaryAccommodationUser(
+              id = id,
+              region = ProbationRegion(region.id, region.name),
+              deliusUsername = deliusUsername,
+              email = email,
+              name = userEntity.name,
+              telephoneNumber = telephoneNumber,
+              roles = listOf(TemporaryAccommodationUserRole.reporter),
+              service = ServiceName.temporaryAccommodation.value,
+              isActive = true,
+            ),
+          ),
+        )
+    }
+  }
+
+  @Nested
+  inner class ProfileV2 {
+    val profileV2Endpoint = "/profile/v2"
+
+    @Test
+    fun `Getting own Approved Premises profile returns OK with correct body`() {
+      val id = UUID.randomUUID()
+      val deliusUsername = "JIMJIMMERSON"
+      val email = "foo@bar.com"
+      val telephoneNumber = "123445677"
+
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      }
+
+      `Given a User`(
+        id = id,
+        roles = listOf(UserRole.CAS1_ASSESSOR),
+        qualifications = listOf(UserQualification.PIPE),
+        staffUserDetailsConfigBlock = {
+          withUsername(deliusUsername)
+          withEmail(email)
+          withTelephoneNumber(telephoneNumber)
+        },
+        probationRegion = region,
+      ) { userEntity, jwt ->
+        val userApArea = userEntity.apArea!!
+
+        webTestClient.get()
+          .uri(profileV2Endpoint)
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.approvedPremises.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              ProfileResponse(
+                deliusUsername = "JIMJIMMERSON",
+                loadError = null,
+                ApprovedPremisesUser(
+                  id = id,
+                  region = ProbationRegion(region.id, region.name),
+                  deliusUsername = deliusUsername,
+                  email = email,
+                  name = userEntity.name,
+                  telephoneNumber = telephoneNumber,
+                  roles = listOf(ApprovedPremisesUserRole.assessor),
+                  qualifications = listOf(uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification.pipe),
+                  service = "CAS1",
+                  isActive = true,
+                  apArea = ApArea(userApArea.id, userApArea.identifier, userApArea.name),
+                ),
+              ),
+            ),
+          )
+      }
+    }
+
+    @Test
+    fun `Getting own Temporary Accommodation profile returns OK with correct body`() {
+      val id = UUID.randomUUID()
+      val deliusUsername = "JIMJIMMERSON"
+      val email = "foo@bar.com"
+      val telephoneNumber = "123445677"
+
+      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+        subject = deliusUsername,
+        authSource = "delius",
+        roles = listOf("ROLE_PROBATION"),
+      )
+
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      }
+
+      val userEntity = userEntityFactory.produceAndPersist {
+        withId(id)
+        withYieldedProbationRegion { region }
+        withDeliusUsername(deliusUsername)
+        withEmail(email)
+        withTelephoneNumber(telephoneNumber)
+      }
+
+      userRoleAssignmentEntityFactory.produceAndPersist {
+        withUser(userEntity)
+        withRole(UserRole.CAS3_ASSESSOR)
+      }
+
+      userQualificationAssignmentEntityFactory.produceAndPersist {
+        withUser(userEntity)
+        withQualification(UserQualification.PIPE)
+      }
+
+      webTestClient.get()
+        .uri(profileV2Endpoint)
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            ProfileResponse(
+              deliusUsername = "JIMJIMMERSON",
+              loadError = null,
+              TemporaryAccommodationUser(
+                id = id,
+                region = ProbationRegion(region.id, region.name),
+                deliusUsername = deliusUsername,
+                email = email,
+                name = userEntity.name,
+                telephoneNumber = telephoneNumber,
+                roles = listOf(TemporaryAccommodationUserRole.assessor),
+                service = ServiceName.temporaryAccommodation.value,
+                isActive = true,
+              ),
+            ),
+          ),
+        )
+    }
+
+    @Test
+    fun `Getting own Temporary Accommodation profile returns OK for CAS3_REPORTER with correct body`() {
+      val id = UUID.randomUUID()
+      val deliusUsername = "JIMJIMMERSON"
+      val email = "foo@bar.com"
+      val telephoneNumber = "123445677"
+
+      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+        subject = deliusUsername,
+        authSource = "delius",
+        roles = listOf("ROLE_PROBATION"),
+      )
+
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      }
+
+      val userEntity = userEntityFactory.produceAndPersist {
+        withId(id)
+        withYieldedProbationRegion { region }
+        withDeliusUsername(deliusUsername)
+        withEmail(email)
+        withTelephoneNumber(telephoneNumber)
+      }
+
+      userRoleAssignmentEntityFactory.produceAndPersist {
+        withUser(userEntity)
+        withRole(UserRole.CAS3_REPORTER)
+      }
+
+      userQualificationAssignmentEntityFactory.produceAndPersist {
+        withUser(userEntity)
+        withQualification(UserQualification.PIPE)
+      }
+
+      webTestClient.get()
+        .uri(profileV2Endpoint)
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            ProfileResponse(
+              deliusUsername = "JIMJIMMERSON",
+              loadError = null,
+              TemporaryAccommodationUser(
+                id = id,
+                region = ProbationRegion(region.id, region.name),
+                deliusUsername = deliusUsername,
+                email = email,
+                name = userEntity.name,
+                telephoneNumber = telephoneNumber,
+                roles = listOf(TemporaryAccommodationUserRole.reporter),
+                service = ServiceName.temporaryAccommodation.value,
+                isActive = true,
+              ),
+            ),
+          ),
+        )
+    }
+
+    @Test
+    fun `Getting profile with no Delius staff record returns correct response`() {
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("nonStaffUser")
+      mockOAuth2ClientCredentialsCallIfRequired()
+
+      webTestClient.get()
+        .uri(profileV2Endpoint)
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -87,141 +399,59 @@ class ProfileTest : IntegrationTestBase() {
         .expectBody()
         .json(
           objectMapper.writeValueAsString(
-            ApprovedPremisesUser(
-              id = id,
-              region = ProbationRegion(region.id, region.name),
-              deliusUsername = deliusUsername,
-              email = email,
-              name = userEntity.name,
-              telephoneNumber = telephoneNumber,
-              roles = listOf(ApprovedPremisesUserRole.assessor),
-              qualifications = listOf(uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification.pipe),
-              service = "CAS1",
-              isActive = true,
-              apArea = ApArea(userApArea.id, userApArea.identifier, userApArea.name),
+            ProfileResponse(
+              deliusUsername = "nonStaffUser",
+              loadError = ProfileResponse.LoadError.staffRecordNotFound,
+              null,
             ),
           ),
         )
     }
   }
 
-  @Test
-  fun `Getting own Temporary Accommodation profile returns OK with correct body`() {
-    val id = UUID.randomUUID()
-    val deliusUsername = "JIMJIMMERSON"
-    val email = "foo@bar.com"
-    val telephoneNumber = "123445677"
+  @Nested
+  inner class ProblemsCommonTests {
 
-    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
-      subject = deliusUsername,
-      authSource = "delius",
-      roles = listOf("ROLE_PROBATION"),
-    )
-
-    val region = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+    @ParameterizedTest
+    @ValueSource(strings = ["/profile", "/profile/v2"])
+    fun `Getting own profile without a JWT returns 401`(endpoint: String) {
+      webTestClient.get()
+        .uri(endpoint)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
     }
 
-    val userEntity = userEntityFactory.produceAndPersist {
-      withId(id)
-      withYieldedProbationRegion { region }
-      withDeliusUsername(deliusUsername)
-      withEmail(email)
-      withTelephoneNumber(telephoneNumber)
-    }
-
-    userRoleAssignmentEntityFactory.produceAndPersist {
-      withUser(userEntity)
-      withRole(UserRole.CAS3_ASSESSOR)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(userEntity)
-      withQualification(UserQualification.PIPE)
-    }
-
-    webTestClient.get()
-      .uri("/profile")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(
-        objectMapper.writeValueAsString(
-          TemporaryAccommodationUser(
-            id = id,
-            region = ProbationRegion(region.id, region.name),
-            deliusUsername = deliusUsername,
-            email = email,
-            name = userEntity.name,
-            telephoneNumber = telephoneNumber,
-            roles = listOf(TemporaryAccommodationUserRole.assessor),
-            service = ServiceName.temporaryAccommodation.value,
-            isActive = true,
-          ),
-        ),
+    @ParameterizedTest
+    @ValueSource(strings = ["/profile", "/profile/v2"])
+    fun `Getting own profile with a non-Delius JWT returns 403`(endpoint: String) {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
       )
-  }
 
-  @Test
-  fun `Getting own Temporary Accommodation profile returns OK for CAS3_REPORTER with correct body`() {
-    val id = UUID.randomUUID()
-    val deliusUsername = "JIMJIMMERSON"
-    val email = "foo@bar.com"
-    val telephoneNumber = "123445677"
-
-    val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
-      subject = deliusUsername,
-      authSource = "delius",
-      roles = listOf("ROLE_PROBATION"),
-    )
-
-    val region = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      webTestClient.get()
+        .uri(endpoint)
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
     }
 
-    val userEntity = userEntityFactory.produceAndPersist {
-      withId(id)
-      withYieldedProbationRegion { region }
-      withDeliusUsername(deliusUsername)
-      withEmail(email)
-      withTelephoneNumber(telephoneNumber)
+    @ParameterizedTest
+    @ValueSource(strings = ["/profile", "/profile/v2"])
+    fun `Getting own profile with no X-Service-Name header returns 400`(endpoint: String) {
+      `Given a User` { userEntity, jwt ->
+        webTestClient.get()
+          .uri(endpoint)
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .is4xxClientError
+          .expectBody()
+          .jsonPath("title").isEqualTo("Bad Request")
+          .jsonPath("detail").isEqualTo("Missing required header X-Service-Name")
+      }
     }
-
-    userRoleAssignmentEntityFactory.produceAndPersist {
-      withUser(userEntity)
-      withRole(UserRole.CAS3_REPORTER)
-    }
-
-    userQualificationAssignmentEntityFactory.produceAndPersist {
-      withUser(userEntity)
-      withQualification(UserQualification.PIPE)
-    }
-
-    webTestClient.get()
-      .uri("/profile")
-      .header("Authorization", "Bearer $jwt")
-      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(
-        objectMapper.writeValueAsString(
-          TemporaryAccommodationUser(
-            id = id,
-            region = ProbationRegion(region.id, region.name),
-            deliusUsername = deliusUsername,
-            email = email,
-            name = userEntity.name,
-            telephoneNumber = telephoneNumber,
-            roles = listOf(TemporaryAccommodationUserRole.reporter),
-            service = ServiceName.temporaryAccommodation.value,
-            isActive = true,
-          ),
-        ),
-      )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -82,7 +82,7 @@ class UserServiceTest {
   inner class GetExistingUserOrCreate {
 
     @Test
-    fun `getExistingUserOrCreate with username param calls overloaded function with second parameter`() {
+    fun `getExistingUserOrCreate calls overloaded function with throwExceptionOnStaffRecordNotFound parameter set false`() {
       val username = "SOMEPERSON"
 
       val user = UserEntityFactory()
@@ -96,7 +96,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getExistingUserOrCreate with invalid username does not throw error when dontThrowExceptionOnStaffRecordNotFound set true`() {
+    fun `getExistingUserOrCreate when user has no delius staff record and throwExceptionOnStaffRecordNotFound is false does not throw error`() {
       val username = "SOMEPERSON"
 
       every { mockUserRepository.findByDeliusUsername(username) } returns null
@@ -107,14 +107,14 @@ class UserServiceTest {
         body = null,
       )
 
-      val result = userService.getExistingUserOrCreate(username, true)
+      val result = userService.getExistingUserOrCreate(username, throwExceptionOnStaffRecordNotFound = false)
 
-      assertThat(result.staffRecordFound).isEqualTo(false)
-      assertThat(result.user).isEqualTo(null)
+      assertThat(result.staffRecordFound).isFalse()
+      assertThat(result.user).isNull()
     }
 
     @Test
-    fun `getExistingUserOrCreate with invalid username throws error when throw flag is set`() {
+    fun `getExistingUserOrCreate when user has no delius staff record and throwExceptionOnStaffRecordNotFound is true throws error`() {
       val username = "SOMEPERSON"
 
       every { mockUserRepository.findByDeliusUsername(username) } returns null
@@ -125,17 +125,17 @@ class UserServiceTest {
         body = null,
       )
 
-      assertThrows<RuntimeException> { userService.getExistingUserOrCreate(username, false) }
+      assertThrows<RuntimeException> { userService.getExistingUserOrCreate(username, true) }
     }
 
     @Test
-    fun `getExistingUserOrCreate with invalid username throws error when flag is set and clientResult is failure`() {
+    fun `getExistingUserOrCreate when user has no delius staff record and throwExceptionOnStaffRecordNotFound is true and clientResult is failure throws error`() {
       val username = "SOMEPERSON"
 
       every { mockUserRepository.findByDeliusUsername(username) } returns null
       every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Failure.PreemptiveCacheTimeout("", "", 0)
 
-      assertThrows<RuntimeException> { userService.getExistingUserOrCreate(username, false) }
+      assertThrows<RuntimeException> { userService.getExistingUserOrCreate(username, true) }
     }
 
     @Test


### PR DESCRIPTION
Adds a new /profile/v2 endpoint which provides a more meaningful response in the event that a Staff record, for the logged in user, can't be found in Delius. 

Instead of a 500 response, which the current profile endpoint returns when the staff record can't be found, the new endpoint will return a new response which provides:

- deliusUserName (username / record searched for in Delius)
- loadError (present when the staff record cannot be found)
- user (present when the corresponding record has been found in Delius)