### PR TITLE
[APS-901] Implement immutable updates and timeline for CAS1 out-of-service beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -12,6 +12,7 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.Table
 
@@ -19,15 +20,41 @@ import javax.persistence.Table
 interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntity, UUID> {
   @Query(
     """
-    SELECT oosb
-    FROM Cas1OutOfServiceBedEntity oosb
+    SELECT
+      CAST(oosb.id AS TEXT)
+    FROM cas1_out_of_service_beds oosb
+    INNER JOIN (
+      SELECT
+        out_of_service_bed_id,
+        MAX(created_at) AS max_created_at
+      FROM cas1_out_of_service_bed_revisions
+      WHERE
+        (FALSE = :excludePast OR end_date >= CURRENT_DATE) AND
+        (FALSE = :excludeCurrent OR CURRENT_DATE NOT BETWEEN start_date AND end_date) AND
+        (FALSE = :excludeFuture OR start_date <= CURRENT_DATE)
+      GROUP BY out_of_service_bed_id
+    ) dd
+    ON oosb.id = dd.out_of_service_bed_id
+    LEFT JOIN cas1_out_of_service_bed_revisions d
+    ON dd.out_of_service_bed_id = d.out_of_service_bed_id
+    AND dd.max_created_at = d.created_at
+    LEFT JOIN premises p
+    ON oosb.premises_id = p.id
+    LEFT JOIN probation_regions pr
+    ON p.probation_region_id = pr.id
+    LEFT JOIN ap_areas apa
+    ON pr.ap_area_id = apa.id
+    LEFT JOIN beds b
+    ON oosb.bed_id = b.id
+    LEFT JOIN rooms r
+    ON b.room_id = r.id
+    LEFT JOIN cas1_out_of_service_bed_reasons oosr
+    ON d.out_of_service_bed_reason_id = oosr.id
     WHERE
-      (CAST(:premisesId as org.hibernate.type.UUIDCharType) IS NULL OR oosb.premises.id = :premisesId) AND
-      (CAST(:apAreaId as org.hibernate.type.UUIDCharType) IS NULL OR oosb.premises.probationRegion.apArea.id = :apAreaId) AND
-      ((FALSE = :excludePast) OR (oosb.endDate >= CURRENT_DATE)) AND
-      ((FALSE = :excludeCurrent) OR (CURRENT_DATE NOT BETWEEN oosb.startDate AND oosb.endDate)) AND
-      ((FALSE = :excludeFuture) OR (oosb.startDate <= CURRENT_DATE))
+      (CAST(:premisesId AS UUID) IS NULL OR oosb.premises_id = :premisesId) AND
+      (CAST(:apAreaId AS UUID) IS NULL OR apa.id = :apAreaId)
     """,
+    nativeQuery = true,
   )
   fun findOutOfServiceBeds(
     premisesId: UUID?,
@@ -36,24 +63,39 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
     excludeCurrent: Boolean,
     excludeFuture: Boolean,
     pageable: Pageable?,
-  ): Page<Cas1OutOfServiceBedEntity>
+  ): Page<String>
 
   @Query("SELECT oosb FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE oosb.premises.id = :premisesId AND c is NULL")
   fun findAllActiveForPremisesId(premisesId: UUID): List<Cas1OutOfServiceBedEntity>
 
   @Query(
     """
-    SELECT oosb 
-    FROM Cas1OutOfServiceBedEntity oosb 
-    LEFT JOIN oosb.cancellation c 
-    WHERE oosb.bed.id = :bedId AND 
-          oosb.startDate <= :endDate AND 
-          oosb.endDate >= :startDate AND 
-          (CAST(:thisEntityId as org.hibernate.type.UUIDCharType) IS NULL OR oosb.id != :thisEntityId) AND 
-          c is NULL
+    SELECT
+      CAST(oosb.id AS TEXT)
+    FROM cas1_out_of_service_beds oosb
+    INNER JOIN (
+      SELECT
+        out_of_service_bed_id,
+        MAX(created_at) AS max_created_at
+      FROM cas1_out_of_service_bed_revisions
+      WHERE
+        start_date <= :endDate AND
+        end_date >= :startDate
+      GROUP BY out_of_service_bed_id
+    ) d
+    ON oosb.id = d.out_of_service_bed_id
+    LEFT JOIN cas1_out_of_service_bed_cancellations c
+    ON oosb.id = c.out_of_service_bed_id
+    LEFT JOIN beds b
+    ON oosb.bed_id = b.id
+    WHERE
+      b.id = :bedId AND
+      (CAST(:thisEntityId AS UUID) IS NULL OR oosb.id != :thisEntityId) AND
+      c IS NULL
     """,
+    nativeQuery = true,
   )
-  fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<Cas1OutOfServiceBedEntity>
+  fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<String>
 }
 
 @Entity
@@ -65,16 +107,29 @@ data class Cas1OutOfServiceBedEntity(
   @JoinColumn(name = "premises_id")
   val premises: ApprovedPremisesEntity,
   @ManyToOne
-  @JoinColumn(name = "out_of_service_bed_reason_id")
-  var reason: Cas1OutOfServiceBedReasonEntity,
-  @ManyToOne
   @JoinColumn(name = "bed_id")
   val bed: BedEntity,
   val createdAt: OffsetDateTime,
-  var startDate: LocalDate,
-  var endDate: LocalDate,
-  var referenceNumber: String?,
-  var notes: String?,
   @OneToOne(mappedBy = "outOfServiceBed")
   var cancellation: Cas1OutOfServiceBedCancellationEntity?,
-)
+  @OneToMany(mappedBy = "outOfServiceBed")
+  var revisionHistory: MutableList<Cas1OutOfServiceBedRevisionEntity>,
+) {
+  val latestRevision: Cas1OutOfServiceBedRevisionEntity
+    get() = revisionHistory.maxBy { it.createdAt }
+
+  val reason: Cas1OutOfServiceBedReasonEntity
+    get() = latestRevision.reason
+
+  val startDate
+    get() = latestRevision.startDate
+
+  val endDate
+    get() = latestRevision.endDate
+
+  val referenceNumber
+    get() = latestRevision.referenceNumber
+
+  val notes
+    get() = latestRevision.notes
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedRevisionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedRevisionEntity.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.EnumSet
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType as DomainRevisionType
+
+@Repository
+interface Cas1OutOfServiceBedRevisionRepository : JpaRepository<Cas1OutOfServiceBedRevisionEntity, UUID>
+
+@Entity
+@Table(name = "cas1_out_of_service_bed_revisions")
+data class Cas1OutOfServiceBedRevisionEntity(
+  @Id
+  val id: UUID,
+  val createdAt: OffsetDateTime,
+  @Enumerated(EnumType.STRING)
+  val revisionType: DomainRevisionType,
+  var startDate: LocalDate,
+  var endDate: LocalDate,
+  var referenceNumber: String?,
+  var notes: String?,
+  @ManyToOne
+  @JoinColumn(name = "out_of_service_bed_reason_id")
+  var reason: Cas1OutOfServiceBedReasonEntity,
+  @ManyToOne
+  @JoinColumn(name = "out_of_service_bed_id")
+  val outOfServiceBed: Cas1OutOfServiceBedEntity,
+  @ManyToOne
+  @JoinColumn(name = "created_by_user_id")
+  val createdBy: UserEntity,
+  @Column(name = "change_type")
+  val changeTypePacked: Long,
+)
+
+enum class Cas1OutOfServiceBedRevisionType {
+  INITIAL,
+  UPDATE,
+}
+
+@Suppress("detekt:MagicNumber")
+enum class Cas1OutOfServiceBedRevisionChangeType(private val value: Long) {
+  START_DATE(0b0000_0001),
+  END_DATE(0b0000_0010),
+  REFERENCE_NUMBER(0b0000_0100),
+  REASON(0b0000_1000),
+  NOTES(0b0001_0000),
+  ;
+
+  companion object {
+    const val NO_CHANGE: Long = 0
+
+    fun pack(values: EnumSet<Cas1OutOfServiceBedRevisionChangeType>): Long = values
+      .fold(0L) { acc, changeType -> acc or changeType.value }
+
+    fun unpack(value: Long): EnumSet<Cas1OutOfServiceBedRevisionChangeType> {
+      val result = Cas1OutOfServiceBedRevisionChangeType.entries.filter { (it.value and value) != 0L }
+
+      return EnumSet
+        .noneOf(Cas1OutOfServiceBedRevisionChangeType::class.java)
+        .apply { addAll(result) }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedRevisionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedRevisionEntity.kt
@@ -14,6 +14,7 @@ import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.Table
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType as ApiRevisionType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType as DomainRevisionType
 
 @Repository
@@ -50,12 +51,12 @@ enum class Cas1OutOfServiceBedRevisionType {
 }
 
 @Suppress("detekt:MagicNumber")
-enum class Cas1OutOfServiceBedRevisionChangeType(private val value: Long) {
-  START_DATE(0b0000_0001),
-  END_DATE(0b0000_0010),
-  REFERENCE_NUMBER(0b0000_0100),
-  REASON(0b0000_1000),
-  NOTES(0b0001_0000),
+enum class Cas1OutOfServiceBedRevisionChangeType(private val value: Long, val apiValue: ApiRevisionType) {
+  START_DATE(0b0000_0001, ApiRevisionType.updatedStartDate),
+  END_DATE(0b0000_0010, ApiRevisionType.updatedEndDate),
+  REFERENCE_NUMBER(0b0000_0100, ApiRevisionType.updatedReferenceNumber),
+  REASON(0b0000_1000, ApiRevisionType.updatedReason),
+  NOTES(0b0001_0000, ApiRevisionType.updatedNotes),
   ;
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedRevisionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedRevisionTransformer.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionChangeType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.containsAny
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType as ApiRevisionType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType as DomainRevisionType
+
+@Component
+class Cas1OutOfServiceBedRevisionTransformer(
+  private val cas1OutOfServiceBedReasonTransformer: Cas1OutOfServiceBedReasonTransformer,
+  private val userTransformer: UserTransformer,
+) {
+  fun transformJpaToApi(jpa: Cas1OutOfServiceBedRevisionEntity): Cas1OutOfServiceBedRevision {
+    val revisionType = jpa.deriveRevisionType()
+
+    return Cas1OutOfServiceBedRevision(
+      id = jpa.id,
+      updatedAt = jpa.createdAt.toInstant(),
+      updatedBy = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),
+      revisionType = revisionType,
+      outOfServiceFrom = if (shouldDisplayOutOfServiceFrom(revisionType)) jpa.startDate else null,
+      outOfServiceTo = if (shouldDisplayOutOfServiceTo(revisionType)) jpa.endDate else null,
+      reason = if (shouldDisplayReason(revisionType)) cas1OutOfServiceBedReasonTransformer.transformJpaToApi(jpa.reason) else null,
+      referenceNumber = if (shouldDisplayReferenceNumber(revisionType)) jpa.referenceNumber else null,
+      notes = if (shouldDisplayNotes(revisionType)) jpa.notes else null,
+    )
+  }
+
+  private fun Cas1OutOfServiceBedRevisionEntity.deriveRevisionType(): List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType> {
+    return when (this.revisionType) {
+      DomainRevisionType.INITIAL -> listOf(ApiRevisionType.created)
+      else -> Cas1OutOfServiceBedRevisionChangeType.unpack(this.changeTypePacked).map { it.apiValue }
+    }
+  }
+
+  private fun shouldDisplayOutOfServiceFrom(revisionType: List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType>): Boolean =
+    revisionType.containsAny(ApiRevisionType.created, ApiRevisionType.updatedStartDate)
+
+  private fun shouldDisplayOutOfServiceTo(revisionType: List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType>): Boolean =
+    revisionType.containsAny(ApiRevisionType.created, ApiRevisionType.updatedEndDate)
+
+  private fun shouldDisplayReason(revisionType: List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType>): Boolean =
+    revisionType.containsAny(ApiRevisionType.created, ApiRevisionType.updatedReason)
+
+  private fun shouldDisplayReferenceNumber(revisionType: List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType>): Boolean =
+    revisionType.containsAny(ApiRevisionType.created, ApiRevisionType.updatedReferenceNumber)
+
+  private fun shouldDisplayNotes(revisionType: List<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType>): Boolean =
+    revisionType.containsAny(ApiRevisionType.created, ApiRevisionType.updatedNotes)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedTransformer.kt
@@ -13,6 +13,7 @@ import java.time.LocalDate
 class Cas1OutOfServiceBedTransformer(
   private val cas1OutOfServiceBedReasonTransformer: Cas1OutOfServiceBedReasonTransformer,
   private val cas1OutOfServiceBedCancellationTransformer: Cas1OutOfServiceBedCancellationTransformer,
+  private val cas1OutOfServiceBedRevisionTransformer: Cas1OutOfServiceBedRevisionTransformer,
 ) {
   fun transformJpaToApi(jpa: Cas1OutOfServiceBedEntity) = Cas1OutOfServiceBed(
     id = jpa.id,
@@ -30,6 +31,7 @@ class Cas1OutOfServiceBedTransformer(
     referenceNumber = jpa.referenceNumber,
     notes = jpa.notes,
     cancellation = jpa.cancellation?.let { cas1OutOfServiceBedCancellationTransformer.transformJpaToApi(it) },
+    revisionHistory = jpa.revisionHistory.map(cas1OutOfServiceBedRevisionTransformer::transformJpaToApi),
   )
 
   private fun Cas1OutOfServiceBedEntity.deriveStatus() = when (this.cancellation) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/CollectionUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/CollectionUtils.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+fun<T> Collection<T>.containsAny(vararg values: T): Boolean = values.toSet().intersect(this.toSet()).isNotEmpty()

--- a/src/main/resources/db/migration/all/20240626154305__create_cas1_out_of_service_bed_revisions_table.sql
+++ b/src/main/resources/db/migration/all/20240626154305__create_cas1_out_of_service_bed_revisions_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE cas1_out_of_service_bed_revisions (
+    id UUID NOT NULL,
+    out_of_service_bed_id UUID NOT NULL,
+    out_of_service_bed_reason_id UUID NOT NULL,
+    created_by_user_id UUID NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    revision_type TEXT NOT NULL,
+    start_date DATE NULL,
+    end_date DATE NULL,
+    reference_number TEXT NULL,
+    notes TEXT NULL,
+    change_type BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (out_of_service_bed_id) REFERENCES cas1_out_of_service_beds(id),
+    FOREIGN KEY (out_of_service_bed_reason_id) REFERENCES cas1_out_of_service_bed_reasons(id),
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id)
+);

--- a/src/main/resources/db/migration/all/20240626154329__migrate_cas1_out_of_service_bed_details_to_new_revisions_table.sql
+++ b/src/main/resources/db/migration/all/20240626154329__migrate_cas1_out_of_service_bed_details_to_new_revisions_table.sql
@@ -1,0 +1,13 @@
+INSERT INTO cas1_out_of_service_bed_revisions
+SELECT
+    gen_random_uuid() AS id,
+    id AS out_of_service_bed_id,
+    out_of_service_bed_reason_id,
+    NULL AS created_by_user_id,
+    CURRENT_TIMESTAMP AS created_at,
+    'INITIAL' AS revision_type,
+    start_date,
+    end_date,
+    reference_number,
+    notes
+FROM cas1_out_of_service_beds;

--- a/src/main/resources/db/migration/all/20240626154404__drop_moved_columns_from_cas1_out_of_service_bed_table.sql
+++ b/src/main/resources/db/migration/all/20240626154404__drop_moved_columns_from_cas1_out_of_service_bed_table.sql
@@ -1,0 +1,6 @@
+ALTER TABLE cas1_out_of_service_beds
+DROP COLUMN out_of_service_bed_reason_id,
+DROP COLUMN start_date,
+DROP COLUMN end_date,
+DROP COLUMN reference_number,
+DROP COLUMN notes;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4811,6 +4811,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+        revisionHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevision'
       required:
         - id
         - createdAt
@@ -4824,6 +4828,7 @@ components:
         - daysLostCount
         - temporality
         - status
+        - revisionHistory
     NewCas1OutOfServiceBed:
       type: object
       properties:
@@ -4917,6 +4922,47 @@ components:
         - outOfServiceTo
         - reason
         - daysLost
+    Cas1OutOfServiceBedRevision:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedAt:
+          type: string
+          format: date-time
+        updatedBy:
+          $ref: '#/components/schemas/User'
+        revisionType:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevisionType'
+        outOfServiceFrom:
+          type: string
+          format: date
+        outOfServiceTo:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - id
+        - updatedAt
+        - updatedBy
+        - revisionType
+    Cas1OutOfServiceBedRevisionType:
+      type: string
+      enum:
+        - created
+        - updatedStartDate
+        - updatedEndDate
+        - updatedReferenceNumber
+        - updatedReason
+        - updatedNotes
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9387,6 +9387,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+        revisionHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevision'
       required:
         - id
         - createdAt
@@ -9400,6 +9404,7 @@ components:
         - daysLostCount
         - temporality
         - status
+        - revisionHistory
     NewCas1OutOfServiceBed:
       type: object
       properties:
@@ -9493,6 +9498,47 @@ components:
         - outOfServiceTo
         - reason
         - daysLost
+    Cas1OutOfServiceBedRevision:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedAt:
+          type: string
+          format: date-time
+        updatedBy:
+          $ref: '#/components/schemas/User'
+        revisionType:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevisionType'
+        outOfServiceFrom:
+          type: string
+          format: date
+        outOfServiceTo:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - id
+        - updatedAt
+        - updatedBy
+        - revisionType
+    Cas1OutOfServiceBedRevisionType:
+      type: string
+      enum:
+        - created
+        - updatedStartDate
+        - updatedEndDate
+        - updatedReferenceNumber
+        - updatedReason
+        - updatedNotes
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5368,6 +5368,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+        revisionHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevision'
       required:
         - id
         - createdAt
@@ -5381,6 +5385,7 @@ components:
         - daysLostCount
         - temporality
         - status
+        - revisionHistory
     NewCas1OutOfServiceBed:
       type: object
       properties:
@@ -5474,6 +5479,47 @@ components:
         - outOfServiceTo
         - reason
         - daysLost
+    Cas1OutOfServiceBedRevision:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedAt:
+          type: string
+          format: date-time
+        updatedBy:
+          $ref: '#/components/schemas/User'
+        revisionType:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevisionType'
+        outOfServiceFrom:
+          type: string
+          format: date
+        outOfServiceTo:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - id
+        - updatedAt
+        - updatedBy
+        - revisionType
+    Cas1OutOfServiceBedRevisionType:
+      type: string
+      enum:
+        - created
+        - updatedStartDate
+        - updatedEndDate
+        - updatedReferenceNumber
+        - updatedReason
+        - updatedNotes
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5402,6 +5402,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+        revisionHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevision'
       required:
         - id
         - createdAt
@@ -5415,6 +5419,7 @@ components:
         - daysLostCount
         - temporality
         - status
+        - revisionHistory
     NewCas1OutOfServiceBed:
       type: object
       properties:
@@ -5508,6 +5513,47 @@ components:
         - outOfServiceTo
         - reason
         - daysLost
+    Cas1OutOfServiceBedRevision:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedAt:
+          type: string
+          format: date-time
+        updatedBy:
+          $ref: '#/components/schemas/User'
+        revisionType:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevisionType'
+        outOfServiceFrom:
+          type: string
+          format: date
+        outOfServiceTo:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - id
+        - updatedAt
+        - updatedBy
+        - revisionType
+    Cas1OutOfServiceBedRevisionType:
+      type: string
+      enum:
+        - created
+        - updatedStartDate
+        - updatedEndDate
+        - updatedReferenceNumber
+        - updatedReason
+        - updatedNotes
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4902,6 +4902,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Cas1OutOfServiceBedCancellation'
+        revisionHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevision'
       required:
         - id
         - createdAt
@@ -4915,6 +4919,7 @@ components:
         - daysLostCount
         - temporality
         - status
+        - revisionHistory
     NewCas1OutOfServiceBed:
       type: object
       properties:
@@ -5008,6 +5013,47 @@ components:
         - outOfServiceTo
         - reason
         - daysLost
+    Cas1OutOfServiceBedRevision:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedAt:
+          type: string
+          format: date-time
+        updatedBy:
+          $ref: '#/components/schemas/User'
+        revisionType:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OutOfServiceBedRevisionType'
+        outOfServiceFrom:
+          type: string
+          format: date
+        outOfServiceTo:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - id
+        - updatedAt
+        - updatedBy
+        - revisionType
+    Cas1OutOfServiceBedRevisionType:
+      type: string
+      enum:
+        - created
+        - updatedStartDate
+        - updatedEndDate
+        - updatedReferenceNumber
+        - updatedReason
+        - updatedNotes
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedEntityFactory.kt
@@ -5,34 +5,16 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class Cas1OutOfServiceBedEntityFactory : Factory<Cas1OutOfServiceBedEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var reason: Yielded<Cas1OutOfServiceBedReasonEntity> = { Cas1OutOfServiceBedReasonEntityFactory().produce() }
   private var bed: Yielded<BedEntity> = { BedEntityFactory().produce() }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
-  private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
-  private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }
-  private var referenceNumber: Yielded<String?> = { UUID.randomUUID().toString() }
-  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
-  }
-
-  fun withReason(reason: Cas1OutOfServiceBedReasonEntity) = apply {
-    this.reason = { reason }
-  }
-
-  fun withReason(configuration: Cas1OutOfServiceBedReasonEntityFactory.() -> Unit) = apply {
-    this.reason = { Cas1OutOfServiceBedReasonEntityFactory().apply(configuration).produce() }
   }
 
   fun withBed(bed: BedEntity) = apply {
@@ -47,36 +29,16 @@ class Cas1OutOfServiceBedEntityFactory : Factory<Cas1OutOfServiceBedEntity> {
     this.createdAt = { createdAt }
   }
 
-  fun withStartDate(startDate: LocalDate) = apply {
-    this.startDate = { startDate }
-  }
-
-  fun withEndDate(endDate: LocalDate) = apply {
-    this.endDate = { endDate }
-  }
-
-  fun withReferenceNumber(referenceNumber: String?) = apply {
-    this.referenceNumber = { referenceNumber }
-  }
-
-  fun withNotes(notes: String?) = apply {
-    this.notes = { notes }
-  }
-
   override fun produce(): Cas1OutOfServiceBedEntity {
     val bed = this.bed()
 
     return Cas1OutOfServiceBedEntity(
       id = this.id(),
       premises = bed.room.premises as ApprovedPremisesEntity,
-      reason = this.reason(),
       bed = bed,
       createdAt = this.createdAt(),
-      startDate = this.startDate(),
-      endDate = this.endDate(),
-      referenceNumber = this.referenceNumber(),
-      notes = this.notes(),
       cancellation = null,
+      revisionHistory = mutableListOf(),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedRevisionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedRevisionEntityFactory.kt
@@ -1,0 +1,100 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionChangeType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.EnumSet
+import java.util.UUID
+
+class Cas1OutOfServiceBedRevisionEntityFactory : Factory<Cas1OutOfServiceBedRevisionEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
+  private var detailType: Yielded<Cas1OutOfServiceBedRevisionType> = { Cas1OutOfServiceBedRevisionType.INITIAL }
+  private var startDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var endDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var referenceNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(9) }
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var reason: Yielded<Cas1OutOfServiceBedReasonEntity> = { Cas1OutOfServiceBedReasonEntityFactory().produce() }
+  private var outOfServiceBed: Yielded<Cas1OutOfServiceBedEntity> = { Cas1OutOfServiceBedEntityFactory().produce() }
+  private var createdBy: Yielded<UserEntity> = { UserEntityFactory().withDefaults().produce() }
+  private var changeType: Yielded<EnumSet<Cas1OutOfServiceBedRevisionChangeType>> =
+    { EnumSet.noneOf(Cas1OutOfServiceBedRevisionChangeType::class.java) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withDetailType(detailType: Cas1OutOfServiceBedRevisionType) = apply {
+    this.detailType = { detailType }
+  }
+
+  fun withStartDate(startDate: LocalDate) = apply {
+    this.startDate = { startDate }
+  }
+
+  fun withEndDate(endDate: LocalDate) = apply {
+    this.endDate = { endDate }
+  }
+
+  fun withReferenceNumber(referenceNumber: String) = apply {
+    this.referenceNumber = { referenceNumber }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withReason(reason: Cas1OutOfServiceBedReasonEntity) = apply {
+    this.reason = { reason }
+  }
+
+  fun withReason(configuration: Cas1OutOfServiceBedReasonEntityFactory.() -> Unit) = apply {
+    this.reason = { Cas1OutOfServiceBedReasonEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withOutOfServiceBed(outOfServiceBed: Cas1OutOfServiceBedEntity) = apply {
+    this.outOfServiceBed = { outOfServiceBed }
+  }
+
+  fun withOutOfServiceBed(configuration: Cas1OutOfServiceBedEntityFactory.() -> Unit) = apply {
+    this.outOfServiceBed = { Cas1OutOfServiceBedEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withCreatedBy(createdBy: UserEntity) = apply {
+    this.createdBy = { createdBy }
+  }
+
+  fun withCreatedBy(configuration: UserEntityFactory.() -> Unit) = apply {
+    this.createdBy = { UserEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withChangeType(changeType: EnumSet<Cas1OutOfServiceBedRevisionChangeType>) = apply {
+    this.changeType = { changeType }
+  }
+
+  override fun produce() = Cas1OutOfServiceBedRevisionEntity(
+    id = this.id(),
+    createdAt = this.createdAt(),
+    revisionType = this.detailType(),
+    startDate = this.startDate(),
+    endDate = this.endDate(),
+    referenceNumber = this.referenceNumber(),
+    notes = this.notes(),
+    reason = this.reason(),
+    outOfServiceBed = this.outOfServiceBed(),
+    createdBy = this.createdBy(),
+    changeTypePacked = Cas1OutOfServiceBedRevisionChangeType.pack(this.changeType()),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -54,6 +54,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1ApplicationU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
@@ -126,6 +127,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
@@ -204,6 +206,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingTestRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedCancellationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedDetailsTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
@@ -500,6 +503,9 @@ abstract class IntegrationTestBase {
   lateinit var cas1OutOfServiceBedCancellationTestRepository: Cas1OutOfServiceBedCancellationTestRepository
 
   @Autowired
+  lateinit var cas1OutOfServiceBedDetailsTestRepository: Cas1OutOfServiceBedDetailsTestRepository
+
+  @Autowired
   lateinit var emailAsserter: EmailNotificationAsserter
 
   @Autowired
@@ -579,6 +585,7 @@ abstract class IntegrationTestBase {
   lateinit var cas1OutOfServiceBedEntityFactory: PersistedFactory<Cas1OutOfServiceBedEntity, UUID, Cas1OutOfServiceBedEntityFactory>
   lateinit var cas1OutOfServiceBedReasonEntityFactory: PersistedFactory<Cas1OutOfServiceBedReasonEntity, UUID, Cas1OutOfServiceBedReasonEntityFactory>
   lateinit var cas1OutOfServiceBedCancellationEntityFactory: PersistedFactory<Cas1OutOfServiceBedCancellationEntity, UUID, Cas1OutOfServiceBedCancellationEntityFactory>
+  lateinit var cas1OutOfServiceBedRevisionEntityFactory: PersistedFactory<Cas1OutOfServiceBedRevisionEntity, UUID, Cas1OutOfServiceBedRevisionEntityFactory>
 
   private var clientCredentialsCallMocked = false
 
@@ -683,6 +690,7 @@ abstract class IntegrationTestBase {
     cas1OutOfServiceBedEntityFactory = PersistedFactory({ Cas1OutOfServiceBedEntityFactory() }, cas1OutOfServiceBedTestRepository)
     cas1OutOfServiceBedReasonEntityFactory = PersistedFactory({ Cas1OutOfServiceBedReasonEntityFactory() }, cas1OutOfServiceBedReasonTestRepository)
     cas1OutOfServiceBedCancellationEntityFactory = PersistedFactory({ Cas1OutOfServiceBedCancellationEntityFactory() }, cas1OutOfServiceBedCancellationTestRepository)
+    cas1OutOfServiceBedRevisionEntityFactory = PersistedFactory({ Cas1OutOfServiceBedRevisionEntityFactory() }, cas1OutOfServiceBedDetailsTestRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
@@ -101,7 +101,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = [ "CAS1_WORKFLOW_MANAGER", "CAS1_FUTURE_MANAGER", "CAS1_CRU_MEMBER" ])
     fun `Get All Out-Of-Service Beds returns OK with correct body when user has the role WORKFLOW_MANAGER`(role: UserRole) {
-      `Given a User`(roles = listOf(role)) { _, jwt ->
+      `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -119,18 +119,30 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val cancelledOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(3))
-          withEndDate(LocalDate.now().plusDays(5))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(3))
+            withEndDate(LocalDate.now().plusDays(5))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val cancellation = cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
@@ -160,7 +172,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Get All Out-Of-Service Beds filters by premises ID correctly`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -193,19 +205,31 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         // otherPremisesOutOfServiceBed
         cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(3))
-          withEndDate(LocalDate.now().plusDays(5))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(otherBed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(3))
+            withEndDate(LocalDate.now().plusDays(5))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val expectedJson = objectMapper.writeValueAsString(
@@ -227,7 +251,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Get All Out-Of-Service Beds filters by AP area ID correctly`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -260,19 +284,31 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         // otherPremisesOutOfServiceBed
         cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(3))
-          withEndDate(LocalDate.now().plusDays(5))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(otherBed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(3))
+            withEndDate(LocalDate.now().plusDays(5))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val expectedJson = objectMapper.writeValueAsString(
@@ -295,7 +331,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.OutOfServiceBedTest#temporalityArgs")
     @ParameterizedTest
     fun `Get All Out-Of-Service Beds filters by temporality correctly`(temporality: List<Temporality>) {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -313,26 +349,44 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val pastOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().minusDays(4))
-          withEndDate(LocalDate.now().minusDays(2))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().minusDays(4))
+            withEndDate(LocalDate.now().minusDays(2))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val currentOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().minusDays(1))
-          withEndDate(LocalDate.now().plusDays(1))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().minusDays(1))
+            withEndDate(LocalDate.now().plusDays(1))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val futureOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val expectedOutOfServiceBeds = mutableListOf<Cas1OutOfServiceBedEntity>()
@@ -382,7 +436,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @Suppress("detekt:CyclomaticComplexMethod")
     fun `Get All Out-Of-Service Beds sorts correctly`(sortField: Cas1OutOfServiceBedSortField, sortDirection: SortDirection) {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -415,14 +469,22 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val expectedOutOfServiceBeds = cas1OutOfServiceBedEntityFactory.produceAndPersistMultipleIndexed(4) {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(it.toLong()))
-          withEndDate(LocalDate.now().plusDays(it.toLong() * 2))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
 
           when {
             it % 2 == 0 -> withBed(bed)
             else -> withBed(otherBed)
           }
+        }.mapIndexed { index, entity ->
+          entity.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(entity)
+            withStartDate(LocalDate.now().plusDays(index.toLong()))
+            withEndDate(LocalDate.now().plusDays(index.toLong() * 2))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
+
+          entity
         }
 
         val sortedOutOfServiceBeds = when (sortDirection) {
@@ -463,7 +525,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Get All Out-Of-Service Beds paginates correctly`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -481,10 +543,18 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val outOfServiceBeds = cas1OutOfServiceBedEntityFactory.produceAndPersistMultipleIndexed(15) {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(it.toLong()))
-          withEndDate(LocalDate.now().plusDays(it.toLong() + 2))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.mapIndexed { index, entity ->
+          entity.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(entity)
+            withStartDate(LocalDate.now().plusDays(index.toLong()))
+            withEndDate(LocalDate.now().plusDays(index.toLong() + 2))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
+
+          entity
         }
 
         val expectedOutOfServiceBeds = outOfServiceBeds.slice(5..9)
@@ -546,7 +616,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
     fun `Get All Out-Of-Service Beds On Premises returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
-      `Given a User`(roles = listOf(role)) { _, jwt ->
+      `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -564,17 +634,29 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val cancelledOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
@@ -599,33 +681,41 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
   inner class GetOutOfServiceBed {
     @Test
     fun `Get Out-Of-Service Bed without JWT returns 401`() {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      `Given a User` { user, _ ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
         }
-      }
 
-      val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-        withStartDate(LocalDate.now().plusDays(2))
-        withEndDate(LocalDate.now().plusDays(4))
-        withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
-        withBed(
-          bedEntityFactory.produceAndPersist {
-            withYieldedRoom {
-              roomEntityFactory.produceAndPersist {
-                withYieldedPremises { premises }
+        val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
               }
-            }
-          },
-        )
-      }
+            },
+          )
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
+        }
 
-      webTestClient.get()
-        .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+        webTestClient.get()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+          .exchange()
+          .expectStatus()
+          .isUnauthorized
+      }
     }
 
     @Test
@@ -663,7 +753,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
     fun `Get Out-Of-Service Bed returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
-      `Given a User`(roles = listOf(role)) { _, jwt ->
+      `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -673,9 +763,6 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(
             bedEntityFactory.produceAndPersist {
               withYieldedRoom {
@@ -685,6 +772,15 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
               }
             },
           )
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val expectedJson = objectMapper.writeValueAsString(outOfServiceBedTransformer.transformJpaToApi(outOfServiceBed))
@@ -907,7 +1003,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Create Out-Of-Service Beds for current day does not break GET all Premises endpoint`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -929,9 +1025,15 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
               }
             },
           )
-          withStartDate(LocalDate.now().minusDays(2))
-          withEndDate(LocalDate.now().plusDays(2))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().minusDays(2))
+            withEndDate(LocalDate.now().plusDays(2))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         bookingEntityFactory.produceAndPersist {
@@ -953,7 +1055,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Create Out-Of-Service Bed returns 409 Conflict when An out-of-service bed for the same bed overlaps`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -974,9 +1076,15 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
           val existingOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
             withBed(bed)
-            withStartDate(LocalDate.parse("2022-07-15"))
-            withEndDate(LocalDate.parse("2022-08-15"))
-            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(user)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.parse("2022-07-15"))
+              withEndDate(LocalDate.parse("2022-08-15"))
+              withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+            }
           }
 
           webTestClient.post()
@@ -1005,7 +1113,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Create Out-Of-Service Bed returns OK with correct body when only cancelled out-of-service beds for the same bed overlap`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1026,11 +1134,17 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
           val existingOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
             withBed(bed)
-            withStartDate(LocalDate.parse("2022-07-15"))
-            withEndDate(LocalDate.parse("2022-08-15"))
-            withReason(
-              cas1OutOfServiceBedReasonEntityFactory.produceAndPersist(),
-            )
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(user)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.parse("2022-07-15"))
+              withEndDate(LocalDate.parse("2022-08-15"))
+              withReason(
+                cas1OutOfServiceBedReasonEntityFactory.produceAndPersist(),
+              )
+            }
           }
 
           existingOutOfServiceBed.cancellation = cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
@@ -1083,50 +1197,58 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
   inner class UpdateOutOfServiceBed {
     @Test
     fun `Update Out-Of-Service Bed without JWT returns 401`() {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
-      }
-
-      val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-        withStartDate(LocalDate.now().plusDays(2))
-        withEndDate(LocalDate.now().plusDays(4))
-        withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
-        withBed(
-          bedEntityFactory.produceAndPersist {
-            withYieldedRoom {
-              roomEntityFactory.produceAndPersist {
-                withYieldedPremises { premises }
-              }
-            }
-          },
-        )
-      }
-
-      bedEntityFactory.produceAndPersist {
-        withYieldedRoom {
-          roomEntityFactory.produceAndPersist {
-            withYieldedPremises { premises }
+      `Given a User` { user, _ ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
           }
         }
-      }
 
-      webTestClient.put()
-        .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
-        .bodyValue(
-          UpdateCas1OutOfServiceBed(
-            startDate = LocalDate.parse("2022-08-15"),
-            endDate = LocalDate.parse("2022-08-18"),
-            reason = UUID.randomUUID(),
-            referenceNumber = "REF-123",
-            notes = null,
-          ),
-        )
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+        val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
+              }
+            },
+          )
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
+        }
+
+        bedEntityFactory.produceAndPersist {
+          withYieldedRoom {
+            roomEntityFactory.produceAndPersist {
+              withYieldedPremises { premises }
+            }
+          }
+        }
+
+        webTestClient.put()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}")
+          .bodyValue(
+            UpdateCas1OutOfServiceBed(
+              startDate = LocalDate.parse("2022-08-15"),
+              endDate = LocalDate.parse("2022-08-18"),
+              reason = UUID.randomUUID(),
+              referenceNumber = "REF-123",
+              notes = null,
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isUnauthorized
+      }
     }
 
     @Test
@@ -1181,7 +1303,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
     fun `Update Out-Of-Service Beds returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
-      `Given a User`(roles = listOf(role)) { _, jwt ->
+      `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -1202,10 +1324,15 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         }
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.detailsHistory += cas1OutOfServiceBedDetailsEntityFactory.produceAndPersist {
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
@@ -1250,7 +1377,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Update Out-Of-Service Beds returns 409 Conflict when a booking for the same bed overlaps`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -1271,10 +1398,16 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         }
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-          withStartDate(LocalDate.parse("2022-08-16"))
-          withEndDate(LocalDate.parse("2022-08-30"))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(bed)
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.parse("2022-08-16"))
+            withEndDate(LocalDate.parse("2022-08-30"))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
@@ -1314,7 +1447,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Update Out-Of-Service Beds returns OK with correct body when only cancelled bookings for the same bed overlap`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         `Given an Offender` { offenderDetails, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1336,10 +1469,15 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
           }
 
           val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-            withStartDate(LocalDate.parse("2022-08-16"))
-            withEndDate(LocalDate.parse("2022-08-30"))
-            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
             withBed(bed)
+          }.apply {
+            this.detailsHistory += cas1OutOfServiceBedDetailsEntityFactory.produceAndPersist {
+              withCreatedBy(user)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.parse("2022-08-16"))
+              withEndDate(LocalDate.parse("2022-08-30"))
+              withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+            }
           }
 
           val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
@@ -1400,7 +1538,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Update Out-Of-Service Beds returns 409 Conflict when An out-of-service bed for the same bed overlaps`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1420,17 +1558,29 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
           val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
 
           val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-            withStartDate(LocalDate.parse("2022-08-16"))
-            withEndDate(LocalDate.parse("2022-08-30"))
-            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
             withBed(bed)
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(user)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.parse("2022-08-16"))
+              withEndDate(LocalDate.parse("2022-08-30"))
+              withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+            }
           }
 
           val existingOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
             withBed(bed)
-            withStartDate(LocalDate.parse("2022-07-15"))
-            withEndDate(LocalDate.parse("2022-08-15"))
-            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(user)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.parse("2022-07-15"))
+              withEndDate(LocalDate.parse("2022-08-15"))
+              withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+            }
           }
 
           webTestClient.put()
@@ -1458,7 +1608,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Update Out-Of-Service Beds returns OK with correct body when only cancelled out-of-service beds for the same bed overlap`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1478,19 +1628,30 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
           val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
 
           val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-            withStartDate(LocalDate.parse("2022-08-16"))
-            withEndDate(LocalDate.parse("2022-08-30"))
-            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
             withBed(bed)
+          }.apply {
+            this.detailsHistory += cas1OutOfServiceBedDetailsEntityFactory.produceAndPersist {
+              withCreatedBy(user)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.parse("2022-08-16"))
+              withEndDate(LocalDate.parse("2022-08-30"))
+              withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+            }
           }
 
           val existingOutOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
             withBed(bed)
-            withStartDate(LocalDate.parse("2022-07-15"))
-            withEndDate(LocalDate.parse("2022-08-15"))
-            withReason(
-              cas1OutOfServiceBedReasonEntityFactory.produceAndPersist(),
-            )
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(user)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.parse("2022-07-15"))
+              withEndDate(LocalDate.parse("2022-08-15"))
+              withReason(
+                cas1OutOfServiceBedReasonEntityFactory.produceAndPersist(),
+              )
+            }
           }
 
           existingOutOfServiceBed.cancellation = cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
@@ -1542,38 +1703,46 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
   inner class CancelOutOfServiceBed {
     @Test
     fun `Cancel Out-Of-Service Bed without JWT returns 401`() {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      `Given a User` { user, _ ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
         }
-      }
 
-      val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-        withStartDate(LocalDate.now().plusDays(2))
-        withEndDate(LocalDate.now().plusDays(4))
-        withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
-        withBed(
-          bedEntityFactory.produceAndPersist {
-            withYieldedRoom {
-              roomEntityFactory.produceAndPersist {
-                withYieldedPremises { premises }
+        val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+          withBed(
+            bedEntityFactory.produceAndPersist {
+              withYieldedRoom {
+                roomEntityFactory.produceAndPersist {
+                  withYieldedPremises { premises }
+                }
               }
-            }
-          },
-        )
-      }
+            },
+          )
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
+        }
 
-      webTestClient.post()
-        .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}/cancellations")
-        .bodyValue(
-          NewCas1OutOfServiceBedCancellation(
-            notes = "Unauthorized",
-          ),
-        )
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+        webTestClient.post()
+          .uri("/cas1/premises/${premises.id}/out-of-service-beds/${outOfServiceBed.id}/cancellations")
+          .bodyValue(
+            NewCas1OutOfServiceBedCancellation(
+              notes = "Unauthorized",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isUnauthorized
+      }
     }
 
     @Test
@@ -1620,7 +1789,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
     fun `Cancel Out-Of-Service Bed returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
-      `Given a User`(roles = listOf(role)) { _, jwt ->
+      `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
@@ -1633,9 +1802,6 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         }
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
-          withStartDate(LocalDate.now().plusDays(2))
-          withEndDate(LocalDate.now().plusDays(4))
-          withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
           withBed(
             bedEntityFactory.produceAndPersist {
               withYieldedRoom {
@@ -1645,6 +1811,15 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
               }
             },
           )
+        }.apply {
+          this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withCreatedBy(user)
+            withOutOfServiceBed(this@apply)
+            withStartDate(LocalDate.now().plusDays(2))
+            withEndDate(LocalDate.now().plusDays(4))
+            withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+          }
         }
 
         cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas1OutOfServiceBedDetailsTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas1OutOfServiceBedDetailsTestRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionEntity
+import java.util.UUID
+
+interface Cas1OutOfServiceBedDetailsTestRepository : JpaRepository<Cas1OutOfServiceBedRevisionEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedRevisionTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedRevisionTransformerTest.kt
@@ -1,0 +1,220 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionChangeType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedRevisionTransformer
+import java.util.EnumSet
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType as ApiRevisionType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType as DomainRevisionType
+
+class Cas1OutOfServiceBedRevisionTransformerTest {
+  private val cas1OutOfServiceBedReasonTransformer = mockk<Cas1OutOfServiceBedReasonTransformer>()
+  private val userTransformer = mockk<UserTransformer>()
+
+  private val transformer = Cas1OutOfServiceBedRevisionTransformer(
+    cas1OutOfServiceBedReasonTransformer,
+    userTransformer,
+  )
+
+  private val detailsFactory = Cas1OutOfServiceBedRevisionEntityFactory()
+    .withOutOfServiceBed {
+      withBed {
+        withRoom {
+          withPremises(
+            ApprovedPremisesEntityFactory()
+              .withDefaults()
+              .produce(),
+          )
+        }
+      }
+    }
+
+  private val expectedReason = Cas1OutOfServiceBedReason(
+    id = UUID.randomUUID(),
+    name = "Some Reason",
+    isActive = true,
+  )
+
+  private val expectedUser = ApprovedPremisesUser(
+    qualifications = listOf(),
+    roles = listOf(),
+    apArea = ApArea(
+      id = UUID.randomUUID(),
+      identifier = "APA",
+      name = "AP Area",
+    ),
+    service = ServiceName.approvedPremises.value,
+    id = UUID.randomUUID(),
+    name = "Some User",
+    deliusUsername = "SOMEUSER",
+    region = ProbationRegion(
+      id = UUID.randomUUID(),
+      name = "Some Probation Region",
+    ),
+  )
+
+  @BeforeEach
+  fun setup() {
+    every { cas1OutOfServiceBedReasonTransformer.transformJpaToApi(any()) } returns expectedReason
+    every { userTransformer.transformJpaToApi(any(), any()) } returns expectedUser
+  }
+
+  @Test
+  fun `transformJpaToApi transforms correctly when the details are the INITIAL type`() {
+    val details = detailsFactory
+      .withDetailType(DomainRevisionType.INITIAL)
+      .produce()
+
+    val result = transformer.transformJpaToApi(details)
+
+    assertThat(result.id).isEqualTo(details.id)
+    assertThat(result.updatedAt).isEqualTo(details.createdAt.toInstant())
+    assertThat(result.updatedBy).isEqualTo(expectedUser)
+    assertThat(result.revisionType).isEqualTo(listOf(ApiRevisionType.created))
+    assertThat(result.outOfServiceFrom).isEqualTo(details.startDate)
+    assertThat(result.outOfServiceTo).isEqualTo(details.endDate)
+    assertThat(result.reason).isEqualTo(expectedReason)
+    assertThat(result.referenceNumber).isEqualTo(details.referenceNumber)
+    assertThat(result.notes).isEqualTo(details.notes)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms correctly when the details are the UPDATE type and the change type is START_DATE`() {
+    val details = detailsFactory
+      .withDetailType(DomainRevisionType.UPDATE)
+      .withChangeType(EnumSet.of(Cas1OutOfServiceBedRevisionChangeType.START_DATE))
+      .produce()
+
+    val result = transformer.transformJpaToApi(details)
+
+    assertThat(result.id).isEqualTo(details.id)
+    assertThat(result.updatedAt).isEqualTo(details.createdAt.toInstant())
+    assertThat(result.updatedBy).isEqualTo(expectedUser)
+    assertThat(result.revisionType).isEqualTo(listOf(ApiRevisionType.updatedStartDate))
+    assertThat(result.outOfServiceFrom).isEqualTo(details.startDate)
+    assertThat(result.outOfServiceTo).isNull()
+    assertThat(result.reason).isNull()
+    assertThat(result.referenceNumber).isNull()
+    assertThat(result.notes).isNull()
+  }
+
+  @Test
+  fun `transformJpaToApi transforms correctly when the details are the UPDATE type and the change type is END_DATE`() {
+    val details = detailsFactory
+      .withDetailType(DomainRevisionType.UPDATE)
+      .withChangeType(EnumSet.of(Cas1OutOfServiceBedRevisionChangeType.END_DATE))
+      .produce()
+
+    val result = transformer.transformJpaToApi(details)
+
+    assertThat(result.id).isEqualTo(details.id)
+    assertThat(result.updatedAt).isEqualTo(details.createdAt.toInstant())
+    assertThat(result.updatedBy).isEqualTo(expectedUser)
+    assertThat(result.revisionType).isEqualTo(listOf(ApiRevisionType.updatedEndDate))
+    assertThat(result.outOfServiceFrom).isNull()
+    assertThat(result.outOfServiceTo).isEqualTo(details.endDate)
+    assertThat(result.reason).isNull()
+    assertThat(result.referenceNumber).isNull()
+    assertThat(result.notes).isNull()
+  }
+
+  @Test
+  fun `transformJpaToApi transforms correctly when the details are the UPDATE type and the change type is REFERENCE_NUMBER`() {
+    val details = detailsFactory
+      .withDetailType(DomainRevisionType.UPDATE)
+      .withChangeType(EnumSet.of(Cas1OutOfServiceBedRevisionChangeType.REFERENCE_NUMBER))
+      .produce()
+
+    val result = transformer.transformJpaToApi(details)
+
+    assertThat(result.id).isEqualTo(details.id)
+    assertThat(result.updatedAt).isEqualTo(details.createdAt.toInstant())
+    assertThat(result.updatedBy).isEqualTo(expectedUser)
+    assertThat(result.revisionType).isEqualTo(listOf(ApiRevisionType.updatedReferenceNumber))
+    assertThat(result.outOfServiceFrom).isNull()
+    assertThat(result.outOfServiceTo).isNull()
+    assertThat(result.reason).isNull()
+    assertThat(result.referenceNumber).isEqualTo(details.referenceNumber)
+    assertThat(result.notes).isNull()
+  }
+
+  @Test
+  fun `transformJpaToApi transforms correctly when the details are the UPDATE type and the change type is REASON`() {
+    val details = detailsFactory
+      .withDetailType(DomainRevisionType.UPDATE)
+      .withChangeType(EnumSet.of(Cas1OutOfServiceBedRevisionChangeType.REASON))
+      .produce()
+
+    val result = transformer.transformJpaToApi(details)
+
+    assertThat(result.id).isEqualTo(details.id)
+    assertThat(result.updatedAt).isEqualTo(details.createdAt.toInstant())
+    assertThat(result.updatedBy).isEqualTo(expectedUser)
+    assertThat(result.revisionType).isEqualTo(listOf(ApiRevisionType.updatedReason))
+    assertThat(result.outOfServiceFrom).isNull()
+    assertThat(result.outOfServiceTo).isNull()
+    assertThat(result.reason).isEqualTo(expectedReason)
+    assertThat(result.referenceNumber).isNull()
+    assertThat(result.notes).isNull()
+  }
+
+  @Test
+  fun `transformJpaToApi transforms correctly when the details are the UPDATE type and the change type is NOTES`() {
+    val details = detailsFactory
+      .withDetailType(DomainRevisionType.UPDATE)
+      .withChangeType(EnumSet.of(Cas1OutOfServiceBedRevisionChangeType.NOTES))
+      .produce()
+
+    val result = transformer.transformJpaToApi(details)
+
+    assertThat(result.id).isEqualTo(details.id)
+    assertThat(result.updatedAt).isEqualTo(details.createdAt.toInstant())
+    assertThat(result.updatedBy).isEqualTo(expectedUser)
+    assertThat(result.revisionType).isEqualTo(listOf(ApiRevisionType.updatedNotes))
+    assertThat(result.outOfServiceFrom).isNull()
+    assertThat(result.outOfServiceTo).isNull()
+    assertThat(result.reason).isNull()
+    assertThat(result.referenceNumber).isNull()
+    assertThat(result.notes).isEqualTo(details.notes)
+  }
+
+  @Test
+  fun `transformJpaToApi transforms correctly when the details are the UPDATE type and the change type is multiple types`() {
+    val details = detailsFactory
+      .withDetailType(DomainRevisionType.UPDATE)
+      .withChangeType(EnumSet.allOf(Cas1OutOfServiceBedRevisionChangeType::class.java))
+      .produce()
+
+    val result = transformer.transformJpaToApi(details)
+
+    assertThat(result.id).isEqualTo(details.id)
+    assertThat(result.updatedAt).isEqualTo(details.createdAt.toInstant())
+    assertThat(result.updatedBy).isEqualTo(expectedUser)
+    assertThat(result.revisionType).containsExactlyInAnyOrder(
+      ApiRevisionType.updatedStartDate,
+      ApiRevisionType.updatedEndDate,
+      ApiRevisionType.updatedReferenceNumber,
+      ApiRevisionType.updatedReason,
+      ApiRevisionType.updatedNotes,
+    )
+    assertThat(result.outOfServiceFrom).isEqualTo(details.startDate)
+    assertThat(result.outOfServiceTo).isEqualTo(details.endDate)
+    assertThat(result.reason).isEqualTo(expectedReason)
+    assertThat(result.referenceNumber).isEqualTo(details.referenceNumber)
+    assertThat(result.notes).isEqualTo(details.notes)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Temporality
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedCancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedTransformer
@@ -62,10 +63,15 @@ class Cas1OutOfServiceBedTransformerTest {
           )
         }
       }
-      .withStartDate(today.plusDays(startDateOffsetDays))
-      .withEndDate(today.plusDays(endDateOffsetDays))
-      .withNotes("Some notes")
       .produce()
+      .apply {
+        this.revisionHistory += Cas1OutOfServiceBedRevisionEntityFactory()
+          .withOutOfServiceBed(this)
+          .withStartDate(today.plusDays(startDateOffsetDays))
+          .withEndDate(today.plusDays(endDateOffsetDays))
+          .withNotes("Some notes")
+          .produce()
+      }
 
     val reason = Cas1OutOfServiceBedReason(
       id = UUID.randomUUID(),
@@ -102,8 +108,6 @@ class Cas1OutOfServiceBedTransformerTest {
 
   @Test
   fun `transformJpaToApi transforms correctly when cancelled`() {
-    val today = LocalDate.now()
-
     val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
       .withBed {
         withRoom {
@@ -114,8 +118,13 @@ class Cas1OutOfServiceBedTransformerTest {
           )
         }
       }
-      .withNotes("Some notes")
       .produce()
+      .apply {
+        this.revisionHistory += Cas1OutOfServiceBedRevisionEntityFactory()
+          .withOutOfServiceBed(this)
+          .withNotes("Some notes")
+          .produce()
+      }
 
     val cancellationEntity = Cas1OutOfServiceBedCancellationEntityFactory()
       .withOutOfServiceBed(outOfServiceBed)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
@@ -8,9 +8,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Temporality
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
@@ -18,19 +24,24 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedCancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedRevisionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import java.time.Instant
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class Cas1OutOfServiceBedTransformerTest {
   private val cas1OutOfServiceBedReasonTransformer = mockk<Cas1OutOfServiceBedReasonTransformer>()
   private val cas1OutOfServiceBedCancellationTransformer = mockk<Cas1OutOfServiceBedCancellationTransformer>()
+  private val cas1OutOfServiceBedRevisionTransformer = mockk<Cas1OutOfServiceBedRevisionTransformer>()
   private val transformer = Cas1OutOfServiceBedTransformer(
     cas1OutOfServiceBedReasonTransformer,
     cas1OutOfServiceBedCancellationTransformer,
+    cas1OutOfServiceBedRevisionTransformer,
   )
 
   @CsvSource(
@@ -79,7 +90,31 @@ class Cas1OutOfServiceBedTransformerTest {
       isActive = true,
     )
 
+    val historyItem = Cas1OutOfServiceBedRevision(
+      id = UUID.randomUUID(),
+      updatedAt = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres().toInstant(),
+      updatedBy = ApprovedPremisesUser(
+        qualifications = listOf(),
+        roles = listOf(),
+        apArea = ApArea(
+          id = UUID.randomUUID(),
+          identifier = "APAREA",
+          name = "An AP Area",
+        ),
+        service = ServiceName.approvedPremises.value,
+        id = UUID.randomUUID(),
+        name = "Some User",
+        deliusUsername = "SOMEUSER",
+        region = ProbationRegion(
+          id = UUID.randomUUID(),
+          name = "A Probation Region",
+        ),
+      ),
+      revisionType = listOf(Cas1OutOfServiceBedRevisionType.created),
+    )
+
     every { cas1OutOfServiceBedReasonTransformer.transformJpaToApi(outOfServiceBed.reason) } returns reason
+    every { cas1OutOfServiceBedRevisionTransformer.transformJpaToApi(any()) } returns historyItem
 
     val result = transformer.transformJpaToApi(outOfServiceBed)
 
@@ -144,8 +179,32 @@ class Cas1OutOfServiceBedTransformerTest {
       notes = randomStringMultiCaseWithNumbers(20),
     )
 
+    val historyItem = Cas1OutOfServiceBedRevision(
+      id = UUID.randomUUID(),
+      updatedAt = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres().toInstant(),
+      updatedBy = ApprovedPremisesUser(
+        qualifications = listOf(),
+        roles = listOf(),
+        apArea = ApArea(
+          id = UUID.randomUUID(),
+          identifier = "APAREA",
+          name = "An AP Area",
+        ),
+        service = ServiceName.approvedPremises.value,
+        id = UUID.randomUUID(),
+        name = "Some User",
+        deliusUsername = "SOMEUSER",
+        region = ProbationRegion(
+          id = UUID.randomUUID(),
+          name = "A Probation Region",
+        ),
+      ),
+      revisionType = listOf(Cas1OutOfServiceBedRevisionType.created),
+    )
+
     every { cas1OutOfServiceBedReasonTransformer.transformJpaToApi(outOfServiceBed.reason) } returns reason
     every { cas1OutOfServiceBedCancellationTransformer.transformJpaToApi(cancellationEntity) } returns cancellation
+    every { cas1OutOfServiceBedRevisionTransformer.transformJpaToApi(any()) } returns historyItem
 
     val result = transformer.transformJpaToApi(outOfServiceBed)
 


### PR DESCRIPTION
> See [APS-901](https://dsdmoj.atlassian.net/browse/APS-901) on the Approved Premises Jira board.

This PR introduces a timeline for out-of-service beds such that a complete record of what information has changed, when, and by whom is provided:

```jsonc
{
  "id": "00000000-0000-0000-0000-000000000000",
  "createdAt": "2024-01-01T12:34:56.789Z",
  "outOfServiceFrom": "2024-01-02",
  "outOfServiceTo": "2024-01-03",
  "bed": { // NamedId
    // ...
  },
  "room": { // NamedId
    // ...
  },
  "premises": { // NamedId
    // ...
  },
  "apArea": { // NamedId
    // ...
  },
  "reason": { // Cas1OutOfServiceBedReason
    // ...
  },
  "referenceNumber": "AB123456",
  "notes": "Some notes",
  "daysLostCount": 2,
  "temporality": "past", // Temporality
  "status": "cancelled", // Cas1OutOfServiceBedStatus
  "cancellation": { // Cas1OutOfServiceBedCancellation
    // ...
  }
  "history": [
    { // Cas1OutOfServiceBedHistoryItem
      "id": "00000000-0000-0000-0000-000000000000",
      "updatedAt": "2024-01-01T12:34:56.789Z",
      "updatedBy": { // ApprovedPremisesUser
        // ...
      },
      "historyType": [
        "created", // Cas1OutOfServiceBedHistoryType
        // ...
      ],
      "outOfServiceFrom": "2024-01-02",
      "outOfServiceTo": "2024-01-03",
      "reason": { // Cas1OutOfServiceBedReason
        // ...
      },
      "referenceNumber": "AB123456",
      "notes": "Some notes"
    },
    // ...
  ]
}
```

To achieve this, a new `cas1_out_of_service_bed_details` table has been created, along with a corresponding JPA `Cas1OutOfServiceBedDetailsEntity`:

```sql
-- cas1_out_of_service_bed_details
id UUID NOT NULL
out_of_service_bed_id UUID NOT NULL
out_of_service_bed_reason_id UUID NOT NULL
created_by_user_id UUID NULL
created_at TIMESTAMP WITH TIME ZONE NOT NULL
detail_type TEXT NOT NULL
start_date DATE NULL
end_date DATE NULL
reference_number TEXT NULL
notes TEXT NULL
change_type BIGINT NOT NULL
```

To provide rich information about the scope of each update, when a new `Cas1OutOfServiceBedDetailsEntity` is created a comparison is done against the most recent existing one for the start date, end date, reason ID, reference number, and notes, which is then packed into the `change_type` column as bit flags. This is unpacked into a set of `Cas1OutOfServiceBedHistoryType` values when marshalling the API response. This approach avoids having to perform the comparison for each history item whenever an out-of-service bed record is requested.

[APS-901]: https://dsdmoj.atlassian.net/browse/APS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ