### PR TITLE
Remove unused ‘forceApDeliusContextApi’ variable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -330,7 +330,6 @@ class TasksController(
       crns.toSet(),
       user.deliusUsername,
       user.hasQualification(UserQualification.LAO),
-      false,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -333,13 +333,6 @@ class TasksController(
     )
   }
 
-  private fun toTaskEntityType(type: String): TaskEntityType = when (toTaskType(type)) {
-    TaskType.assessment -> TaskEntityType.ASSESSMENT
-    TaskType.placementRequest -> TaskEntityType.PLACEMENT_REQUEST
-    TaskType.placementApplication -> TaskEntityType.PLACEMENT_APPLICATION
-    TaskType.bookingAppeal -> throw BadRequestProblem()
-  }
-
   private fun toTaskType(type: String) = enumConverterFactory.getConverter(TaskType::class.java).convert(
     type.kebabCaseToPascalCase(),
   ) ?: throw NotFoundProblem(type, "TaskType")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
@@ -72,7 +72,6 @@ class BookingSearchService(
       bookingSearchResultDtos.map { it.personCrn }.toSet(),
       user.deliusUsername,
       ignoreLaoRestrictions = false,
-      forceApDeliusContextApi = false,
     )
 
     return bookingSearchResultDtos

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CalendarService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CalendarService.kt
@@ -22,7 +22,7 @@ class CalendarService(
     val crns = calendarInfo.values.flatMap {
       it.filterIsInstance<CalendarBookingInfo>().map { it.crn }
     }.toSet()
-    val offenderSummaries = offenderService.getOffenderSummariesByCrns(crns, user.deliusUsername, user.hasQualification(UserQualification.LAO), forceApDeliusContextApi = false)
+    val offenderSummaries = offenderService.getOffenderSummariesByCrns(crns, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
     calendarInfo.values.forEach { bedList ->
       bedList.filterIsInstance<CalendarBookingInfo>().forEach { bed ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -83,10 +83,7 @@ class OffenderService(
     crns: Set<String>,
     deliusUsername: String,
     ignoreLaoRestrictions: Boolean = false,
-    forceApDeliusContextApi: Boolean = false,
   ): List<PersonSummaryInfoResult> {
-    if (forceApDeliusContextApi) return getOffenderSummariesByCrns(crns.toList(), deliusUsername, ignoreLaoRestrictions)
-
     if (crns.isEmpty()) return emptyList()
 
     val offenderDetailsList = offenderDetailsDataSource.getOffenderDetailSummaries(crns.toList())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingSearchServiceTest.kt
@@ -69,7 +69,7 @@ class BookingSearchServiceTest {
       crns.map { TestBookingSearchResult().withPersonCrn(it) },
     )
 
-    every { mockOffenderService.getOffenderSummariesByCrns(crns, any(), any(), any()) } returns
+    every { mockOffenderService.getOffenderSummariesByCrns(crns, any(), any()) } returns
       crns.map { PersonSummaryInfoResult.Success.Full(it, CaseSummaryFactory().produce()) }
 
     val (results, metaData) = bookingSearchService.findBookings(
@@ -112,7 +112,7 @@ class BookingSearchServiceTest {
           .withBookingCreatedAt(OffsetDateTime.now().minusDays(1)),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any(), any()) } returns
+    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().withName(NameFactory().withForename("Gregor").withSurname("Samsa").produce()).produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().withName(NameFactory().withForename("Franz").withSurname("Kafka").produce()).produce()),
@@ -161,7 +161,7 @@ class BookingSearchServiceTest {
           .withBookingCreatedAt(OffsetDateTime.now().minusDays(1)),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any(), any()) } returns
+    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -218,7 +218,7 @@ class BookingSearchServiceTest {
         TestBookingSearchResult().withPersonCrn("crn3"),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any(), any()) } returns
+    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -271,7 +271,7 @@ class BookingSearchServiceTest {
         TestBookingSearchResult().withPersonCrn("crn3"),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any(), any()) } returns
+    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -324,7 +324,7 @@ class BookingSearchServiceTest {
         TestBookingSearchResult().withPersonCrn("crn3"),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any(), any()) } returns
+    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -377,7 +377,7 @@ class BookingSearchServiceTest {
         TestBookingSearchResult().withPersonCrn("crn3"),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any(), any()) } returns
+    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -412,7 +412,7 @@ class BookingSearchServiceTest {
       }
       .produce()
     every { mockBookingRepository.findBookings(any(), any(), any(), any(), any()) } returns PageImpl(emptyList())
-    every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any(), any()) } returns emptyList()
+    every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any()) } returns emptyList()
 
     val (results, metaData) = bookingSearchService.findBookings(
       ServiceName.temporaryAccommodation,
@@ -442,7 +442,7 @@ class BookingSearchServiceTest {
       }
       .produce()
     every { mockBookingRepository.findBookings(any(), any(), any(), any(), any()) } returns PageImpl(emptyList())
-    every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any(), any()) } returns emptyList()
+    every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any()) } returns emptyList()
 
     val (results, metaData) = bookingSearchService.findBookings(
       ServiceName.temporaryAccommodation,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CalendarServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CalendarServiceTest.kt
@@ -71,7 +71,7 @@ class CalendarServiceTest {
     )
 
     every { calendarRepositoryMock.getCalendarInfo(premisesId, startDate, endDate) } returns repositoryResults
-    every { offenderServiceMock.getOffenderSummariesByCrns(emptySet(), user.deliusUsername, ignoreLaoRestrictions = false, forceApDeliusContextApi = false) } returns emptyList()
+    every { offenderServiceMock.getOffenderSummariesByCrns(emptySet(), user.deliusUsername, ignoreLaoRestrictions = false) } returns emptyList()
 
     val result = calendarService.getCalendarInfo(user, premisesId, startDate, endDate)
 
@@ -119,7 +119,7 @@ class CalendarServiceTest {
       )
     }
 
-    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false, forceApDeliusContextApi = false) } returns
+    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false) } returns
       listOf(PersonSummaryInfoResult.NotFound(crn))
 
     every { offenderServiceMock.getOffenderByCrn(crn, user.deliusUsername) } returns AuthorisableActionResult.NotFound()
@@ -182,7 +182,7 @@ class CalendarServiceTest {
       )
     }
 
-    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false, forceApDeliusContextApi = false) } returns
+    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false) } returns
       listOf(PersonSummaryInfoResult.Success.Restricted(crn, "noms"))
 
     val result = calendarService.getCalendarInfo(user, premisesId, startDate, endDate)
@@ -243,7 +243,7 @@ class CalendarServiceTest {
       )
     }
 
-    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false, forceApDeliusContextApi = false) } returns
+    every { offenderServiceMock.getOffenderSummariesByCrns(setOf(crn), user.deliusUsername, ignoreLaoRestrictions = false) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full(
           crn,


### PR DESCRIPTION
This is no longer used, as we no longer have the option of using Community API instead of the AP Delius Context when get calling getOffenderSummariesByCrns