### PR TITLE
CAS-365 cast updatedData as jsonb and change to SQL.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -83,10 +83,12 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
   @Modifying
   @Query(
     """
-    UPDATE DomainEventEntity d set 
-    d.data = :updatedData
-    where d.id = :id
+    UPDATE domain_events 
+    SET
+        data = CAST(:updatedData as jsonb)
+    WHERE id = :id
     """,
+    nativeQuery = true,
   )
   fun updateData(id: UUID, updatedData: String)
 }


### PR DESCRIPTION
Without this change upgrading spring and hibernate to later versions causes a SQL exception since we are attempting to update a jsonb field with string data.  Casting to jsonb will resolve this error.  Casting also requires a change to use SQL rather than JPQL.