### PR TITLE
Replace Spring HttpMethod with enum.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
@@ -214,4 +214,36 @@ class WebClientCache(
     val hasResponseBody: Boolean,
     val attempt: Int?,
   )
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  data class MarshallablePreemptiveCacheMetadata(
+    val httpStatus: HttpStatus,
+    val refreshableAfter: Instant,
+    val method: MarshallableHttpMethod?,
+    val path: String?,
+    val hasResponseBody: Boolean,
+    val attempt: Int?,
+  ) {
+    fun toPreemptiveCacheMetadata(): PreemptiveCacheMetadata {
+      return PreemptiveCacheMetadata(
+        httpStatus,
+        refreshableAfter,
+        if (method != null) HttpMethod.valueOf(method.name) else null,
+        path,
+        hasResponseBody,
+        attempt,
+      )
+    }
+  }
+
+  enum class MarshallableHttpMethod {
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    OPTIONS,
+    TRACE,
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
@@ -127,9 +127,9 @@ class PreemptiveCacheTest : IntegrationTestBase() {
     assertThat((firstResult as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
     wiremockServer.verify(exactly(1), getRequestedFor(urlEqualTo("/secure/offenders/crn/${offenderDetailsResponseOne.otherIds.crn}")))
 
-    val firstMetadata = objectMapper.readValue<WebClientCache.PreemptiveCacheMetadata>(
+    val firstMetadata = objectMapper.readValue<WebClientCache.MarshallablePreemptiveCacheMetadata>(
       redisTemplate.boundValueOps("$preemptiveCacheKeyPrefix-offenderDetailSummary-$crn-metadata").get()!!,
-    )
+    ).toPreemptiveCacheMetadata()
 
     assertThat(firstMetadata.attempt).isEqualTo(1)
 


### PR DESCRIPTION
Without this change and when Spring and Hibernate are upgraded Jackson is not able to unmarshall JSON into HttpMethod objects and the following error occurs:

`com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of org.springframework.http.HttpMethod (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)`

HttpMethod was previously an enum class (Spring v 4.14) which was serializable by Jackson but following the upgrade it is now neither an enum class nor serializable.

This PR adds in a serializable enum HTTP method class and uses it to construct a temporary `MarshallablePreemptiveCacheMetadata` from which the `PreemptiveCacheMetadata` object can be created.