### PR TITLE
APS-964 - Remove unused person types

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4565,8 +4565,6 @@ components:
         - FullPerson
         - RestrictedPerson
         - UnknownPerson
-        - FullPersonInfo
-        - RestrictedPersonInfo
     Withdrawables:
       type: object
       properties:


### PR DESCRIPTION
The FullPersonInfo and RestrictedPersonInfo types are not used in the API or any UI code.

These are being removed to avoid confusion with new types that we’re going to add to differentiate Person Summary responses