### PR TITLE
CAS-414 Fix performance issue when generate CAS3 utilisation report for all regions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
@@ -11,18 +8,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayServic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.earliestDateOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.latestDateOf
+import java.util.UUID
 
 class BedUtilisationReportGenerator(
-  private val bookingRepository: BookingRepository,
-  private val lostBedsRepository: LostBedsRepository,
   private val workingDayService: WorkingDayService,
-) : ReportGenerator<BedEntity, BedUtilisationReportRow, BedUtilisationReportProperties>(BedUtilisationReportRow::class) {
-  override fun filter(properties: BedUtilisationReportProperties): (BedEntity) -> Boolean = {
-    checkServiceType(properties.serviceName, it.room.premises) &&
-      (properties.probationRegionId == null || it.room.premises.probationRegion.id == properties.probationRegionId)
+) : ReportGenerator<BedUtilisationReportData, BedUtilisationReportRow, BedUtilisationReportProperties>(BedUtilisationReportRow::class) {
+  override fun filter(properties: BedUtilisationReportProperties): (BedUtilisationReportData) -> Boolean = {
+    true
   }
 
-  override val convert: BedEntity.(properties: BedUtilisationReportProperties) -> List<BedUtilisationReportRow> = { properties ->
+  override val convert: BedUtilisationReportData.(properties: BedUtilisationReportProperties) -> List<BedUtilisationReportRow> = { properties ->
     var bookedDaysActiveAndClosed = 0
     var confirmedDays = 0
     var provisionalDays = 0
@@ -30,13 +25,9 @@ class BedUtilisationReportGenerator(
     var effectiveTurnaroundDays = 0
     var voidDays = 0
 
-    val nonCancelledBookings = bookingRepository.findAllByOverlappingDateForBed(properties.startDate, properties.endDate, this)
-      .filter { it.cancellation == null }
-
-    val nonCancelledVoids = lostBedsRepository.findAllByOverlappingDateForBed(properties.startDate, properties.endDate, this)
-      .filter { it.cancellation == null }
-
-    val premises = this.room.premises
+    val bedspace = this.bedspaceReportData
+    val nonCancelledBookings = this.bookingsReportData.filter { it.cancellationId == null }
+    val nonCancelledVoids = this.lostBedReportData.filter { it.cancellationId == null }
 
     nonCancelledBookings
       .forEach { booking ->
@@ -45,14 +36,14 @@ class BedUtilisationReportGenerator(
           .count()
 
         when {
-          booking.arrival != null -> bookedDaysActiveAndClosed += daysOfBookingInMonth
-          booking.confirmation != null && booking.arrival == null -> confirmedDays += daysOfBookingInMonth
-          booking.confirmation == null -> provisionalDays += daysOfBookingInMonth
+          booking.arrivalId != null -> bookedDaysActiveAndClosed += daysOfBookingInMonth
+          booking.confirmationId != null && booking.arrivalId == null -> confirmedDays += daysOfBookingInMonth
+          booking.confirmationId == null -> provisionalDays += daysOfBookingInMonth
         }
 
-        if (booking.turnaround != null) {
+        if (booking.turnaroundId != null) {
           val turnaroundStartDate = booking.departureDate.plusDays(1)
-          val turnaroundEndDate = workingDayService.addWorkingDays(booking.departureDate, booking.turnaround!!.workingDayCount)
+          val turnaroundEndDate = workingDayService.addWorkingDays(booking.departureDate, booking.workingDayCount!!)
           val firstDayOfTurnaroundInMonth = latestDateOf(turnaroundStartDate, properties.startDate)
           val lastDayOfTurnaroundInMonth = earliestDateOf(turnaroundEndDate, properties.endDate)
 
@@ -73,26 +64,25 @@ class BedUtilisationReportGenerator(
 
     val totalBookedDays = bookedDaysActiveAndClosed
     val bedspaceOnlineDaysStartDate =
-      if (this.createdAt == null) properties.startDate else latestDateOf(this.createdAt!!.toLocalDate(), properties.startDate)
+      if (bedspace.bedspaceStartDate == null) properties.startDate else latestDateOf(bedspace.bedspaceStartDate!!, properties.startDate)
 
     val bedspaceOnlineDaysEndDate =
-      if (this.endDate == null) properties.endDate else earliestDateOf(this.endDate!!, properties.endDate)
+      if (bedspace.bedspaceEndDate == null) properties.endDate else earliestDateOf(bedspace.bedspaceEndDate!!, properties.endDate)
 
     val bedspaceOnlineDays = bedspaceOnlineDaysStartDate
       .getDaysUntilInclusive(bedspaceOnlineDaysEndDate)
       .count()
 
-    val temporaryAccommodationPremisesEntity = premises as? TemporaryAccommodationPremisesEntity
     listOf(
       BedUtilisationReportRow(
-        probationRegion = temporaryAccommodationPremisesEntity?.probationRegion?.name,
-        pdu = temporaryAccommodationPremisesEntity?.probationDeliveryUnit?.name,
-        localAuthority = temporaryAccommodationPremisesEntity?.localAuthorityArea?.name,
-        propertyRef = premises.name,
-        addressLine1 = premises.addressLine1,
-        town = premises.town,
-        postCode = premises.postcode,
-        bedspaceRef = this.room.name,
+        probationRegion = bedspace.probationRegionName,
+        pdu = bedspace.probationDeliveryUnitName,
+        localAuthority = bedspace.localAuthorityName,
+        propertyRef = bedspace.premisesName,
+        addressLine1 = bedspace.addressLine1,
+        town = bedspace.town,
+        postCode = bedspace.postCode,
+        bedspaceRef = bedspace.roomName,
         bookedDaysActiveAndClosed = bookedDaysActiveAndClosed,
         confirmedDays = confirmedDays,
         provisionalDays = provisionalDays,
@@ -100,12 +90,12 @@ class BedUtilisationReportGenerator(
         effectiveTurnaroundDays = effectiveTurnaroundDays,
         voidDays = voidDays,
         totalBookedDays = totalBookedDays,
-        bedspaceStartDate = if (this.createdAt == null) null else this.createdAt!!.toLocalDate(),
-        bedspaceEndDate = this.endDate,
+        bedspaceStartDate = if (bedspace.bedspaceStartDate == null) null else bedspace.bedspaceStartDate!!,
+        bedspaceEndDate = bedspace.bedspaceEndDate,
         bedspaceOnlineDays = bedspaceOnlineDays,
         occupancyRate = totalBookedDays.toDouble() / bedspaceOnlineDays,
-        uniquePropertyRef = premises.id.toShortBase58(),
-        uniqueBedspaceRef = this.room.id.toShortBase58(),
+        uniquePropertyRef = UUID.fromString(bedspace.premisesId).toShortBase58(),
+        uniqueBedspaceRef = UUID.fromString(bedspace.roomId).toShortBase58(),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportData.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationLostBedReportData
+
+data class BedUtilisationReportData(
+  val bedspaceReportData: BedUtilisationBedspaceReportData,
+  val bookingsReportData: List<BedUtilisationBookingReportData>,
+  val lostBedReportData: List<BedUtilisationLostBedReportData>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import java.time.LocalDate
+import java.util.UUID
+
+interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
+  @Query(
+    """
+    SELECT
+        CAST(b.id AS VARCHAR) AS bedId,
+        CAST(r.id AS VARCHAR) AS roomId,
+        CAST(p.id AS VARCHAR) AS premisesId,
+        pr.name AS probationRegionName,
+        pdu.name AS probationDeliveryUnitName,
+        laa.name AS localAuthorityName,
+        p.name AS premisesName,
+        p.address_line1 AS addressLine1,
+        p.town AS town,
+        p.postcode AS postCode,
+        r.name AS roomName,
+        b.created_at AS bedspaceStartDate,
+        b.end_date AS bedspaceEndDate
+    FROM beds b
+    INNER JOIN rooms r ON b.room_id = r.id
+    LEFT JOIN premises p ON r.premises_id = p.id
+    LEFT JOIN probation_regions pr ON p.probation_region_id = pr.id
+    INNER JOIN temporary_accommodation_premises tap ON p.id = tap.premises_id
+    LEFT JOIN probation_delivery_units pdu ON pr.id = pdu.probation_region_id
+    LEFT JOIN local_authority_areas laa ON p.local_authority_area_id = laa.id
+    WHERE
+      p.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
+    ORDER BY b.name      
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBedspaces(
+    probationRegionId: UUID?,
+  ): List<BedUtilisationBedspaceReportData>
+
+  @Query(
+    """
+    SELECT
+      booking.arrival_date AS arrivalDate,
+      booking.departure_date AS departureDate,
+      CAST(bed.id AS VARCHAR) AS bedId,
+      CAST(cancellation.id AS VARCHAR) AS cancellationId,
+      CAST(arrival.id AS VARCHAR) AS arrivalId,
+      CAST(confirmation.id AS VARCHAR) AS confirmationId,
+      CAST(turnaround.Id AS VARCHAR) AS turnaroundId,
+      turnaround.working_day_count AS workingDayCount
+    From bookings booking
+    LEFT JOIN cancellations cancellation ON cancellation.booking_id = booking.id
+    LEFT JOIN beds bed ON bed.id = booking.premises_id
+    LEFT JOIN premises premises ON booking.premises_id = premises.id
+    LEFT JOIN probation_regions probation_region ON probation_region.id = premises.probation_region_id
+    LEFT JOIN arrivals arrival ON booking.id = arrival.booking_id
+    LEFT JOIN confirmations confirmation ON booking.id = confirmation.booking_id
+    LEFT JOIN turnarounds turnaround ON booking.id = turnaround.booking_id   
+    WHERE
+        premises.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR premises.id = :probationRegionId)
+      AND booking.arrival_date <= :endDate AND booking.departure_date >= :startDate
+    ORDER BY booking.id
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBookingsByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedUtilisationBookingReportData>
+
+  @Query(
+    """
+    SELECT
+        CAST(b.id AS VARCHAR) AS bedId,
+        lb.start_date AS startDate,
+        lb.end_date AS endDate,
+        CAST(lbc.id AS VARCHAR) AS cancellationId
+    From lost_beds lb
+    LEFT JOIN beds b ON lb.bed_id = b.id
+    LEFT JOIN rooms r ON b.room_id = r.id
+    LEFT JOIN premises p ON r.premises_id = p.id
+    LEFT JOIN lost_bed_cancellations lbc ON lb.id = lbc.lost_bed_id
+    WHERE
+        p.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR p.id = :probationRegionId)
+      AND lb.start_date <= :endDate AND lb.end_date >= :startDate
+      AND lbc.id is NULL
+    ORDER BY lb.id     
+    """,
+    nativeQuery = true,
+  )
+  fun findAllLostBedByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedUtilisationLostBedReportData>
+}
+interface BedUtilisationBedspaceReportData {
+  val bedId: String
+  val probationRegionName: String?
+  val probationDeliveryUnitName: String?
+  val localAuthorityName: String?
+  val premisesName: String
+  val addressLine1: String
+  val town: String?
+  val postCode: String
+  val roomName: String
+  val bedspaceStartDate: LocalDate?
+  val bedspaceEndDate: LocalDate?
+  val premisesId: String
+  val roomId: String
+}
+
+interface BedUtilisationBookingReportData {
+  val arrivalDate: LocalDate
+  val departureDate: LocalDate
+  val bedId: String
+  val cancellationId: String?
+  val arrivalId: String?
+  val confirmationId: String?
+  val turnaroundId: String?
+  val workingDayCount: Int?
+}
+
+interface BedUtilisationLostBedReportData {
+  val bedId: String
+  val startDate: LocalDate
+  val endDate: LocalDate
+  val cancellationId: String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ReportService.kt
@@ -14,12 +14,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.TransitionalAccommodationReferralReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportDataAndPersonInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.TransitionalAccommodationReferralReportDataAndPersonInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.TransitionalAccommodationReferralReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TransitionalAccommodationReferralReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -40,6 +42,7 @@ class Cas3ReportService(
   private val workingDayService: WorkingDayService,
   private val bookingRepository: BookingRepository,
   private val bedRepository: BedRepository,
+  private val bedUtilisationReportRepository: BedUtilisationReportRepository,
   @Value("\${cas3-report.crn-search-limit:400}") private val numberOfCrn: Int,
 ) {
   fun createCas3ApplicationReferralsReport(
@@ -98,8 +101,31 @@ class Cas3ReportService(
   }
 
   fun createBedUtilisationReport(properties: BedUtilisationReportProperties, outputStream: OutputStream) {
-    BedUtilisationReportGenerator(bookingRepository, lostBedsRepository, workingDayService)
-      .createReport(bedRepository.findAll(), properties)
+    val bedspacesInScope = bedUtilisationReportRepository.findAllBedspaces(
+      probationRegionId = properties.probationRegionId,
+    )
+
+    val bedspaceBookingsInScope = bedUtilisationReportRepository.findAllBookingsByOverlappingDate(
+      probationRegionId = properties.probationRegionId,
+      properties.startDate,
+      properties.endDate,
+    )
+
+    val lostBedspaceInScope = bedUtilisationReportRepository.findAllLostBedByOverlappingDate(
+      probationRegionId = properties.probationRegionId,
+      properties.startDate,
+      properties.endDate,
+    )
+
+    val reportData = bedspacesInScope.map {
+      val bedId = it.bedId
+      val bedspaceBookings = bedspaceBookingsInScope.filter { it.bedId == bedId }
+      val lostBedspace = lostBedspaceInScope.filter { it.bedId == bedId }
+      BedUtilisationReportData(it, bedspaceBookings, lostBedspace)
+    }
+
+    BedUtilisationReportGenerator(workingDayService)
+      .createReport(reportData, properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns.Remove
 import org.jetbrains.kotlinx.dataframe.api.convertTo
 import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.api.toList
 import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Nested
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus.cas3InReview
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus.cas3ReadyToPlace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus.cas3Unallocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3ReportType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
@@ -35,8 +37,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDec
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision.ACCEPTED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision.REJECTED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
@@ -49,18 +49,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.TransitionalAccommodationReferralReportRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toYesNo
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
@@ -76,15 +73,6 @@ import java.util.UUID
 class Cas3ReportsTest : IntegrationTestBase() {
   @Autowired
   lateinit var bookingTransformer: BookingTransformer
-
-  @Autowired
-  lateinit var realBookingRepository: BookingRepository
-
-  @Autowired
-  lateinit var realLostBedsRepository: LostBedsRepository
-
-  @Autowired
-  lateinit var realWorkingDayCountService: WorkingDayService
 
   @ParameterizedTest
   @EnumSource(value = Cas3ReportType::class)
@@ -2053,8 +2041,6 @@ class Cas3ReportsTest : IntegrationTestBase() {
     fun `Get bed usage report returns OK with correct body`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withProbationRegion(userEntity.probationRegion)
@@ -2079,16 +2065,30 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUsageReportGenerator(
-            bookingTransformer,
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayCountService,
+          val expectedReportRows = listOf(
+            BedUsageReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = userEntity.probationDeliveryUnit?.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              crn = offenderDetails.otherIds.crn,
+              type = BedUsageType.Booking,
+              startDate = LocalDate.parse("2023-04-05"),
+              endDate = LocalDate.parse("2023-04-15"),
+              durationOfBookingDays = 10,
+              bookingStatus = BookingStatus.provisional,
+              voidCategory = null,
+              voidNotes = null,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(
-              listOf(bed),
-              BedUsageReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
-            )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/cas3/reports/bedUsage?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
@@ -2112,8 +2112,6 @@ class Cas3ReportsTest : IntegrationTestBase() {
     fun `Get bed usage report returns OK with correct body with pdu and local authority`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
           val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
@@ -2144,16 +2142,30 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUsageReportGenerator(
-            bookingTransformer,
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayCountService,
+          val expectedReportRows = listOf(
+            BedUsageReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              crn = offenderDetails.otherIds.crn,
+              type = BedUsageType.Booking,
+              startDate = LocalDate.parse("2023-04-05"),
+              endDate = LocalDate.parse("2023-04-15"),
+              durationOfBookingDays = 10,
+              bookingStatus = BookingStatus.provisional,
+              voidCategory = null,
+              voidNotes = null,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(
-              listOf(bed),
-              BedUsageReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
-            )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/cas3/reports/bedUsage?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
@@ -2180,8 +2192,6 @@ class Cas3ReportsTest : IntegrationTestBase() {
     fun `Get bed utilisation report returns OK with correct body`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withProbationRegion(userEntity.probationRegion)
@@ -2209,15 +2219,33 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUtilisationReportGenerator(
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayCountService,
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = userEntity.probationDeliveryUnit?.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 0,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(
-              listOf(bed),
-              BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
-            )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
@@ -2241,8 +2269,6 @@ class Cas3ReportsTest : IntegrationTestBase() {
     fun `Get bed utilisation report returns OK with correct body with pdu and local authority`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
           val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
@@ -2276,15 +2302,33 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUtilisationReportGenerator(
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayCountService,
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 0,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(
-              listOf(bed),
-              BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
-            )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
@@ -193,7 +194,7 @@ class BedUsageReportGeneratorTest {
     assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())
 
     verify {
-      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-07-01"), any())
+      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-07-01"), any<BedEntity>())
     }
   }
 
@@ -263,7 +264,7 @@ class BedUsageReportGeneratorTest {
     assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(approvedPremises.id.toShortBase58())
 
     verify {
-      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), any())
+      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), any<BedEntity>())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
@@ -22,13 +22,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.util.convertToBedUtilisationBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.util.convertToBedUtilisationBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.util.convertToBedUtilisationLostBedReportData
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -36,15 +38,9 @@ import java.time.OffsetDateTime
 class BedUtilisationReportGeneratorTest {
   private val startDate = LocalDate.of(2023, 4, 1)
   private val endDate = LocalDate.of(2023, 4, 30)
-  private val mockBookingRepository = mockk<BookingRepository>()
-  private val mockLostBedsRepository = mockk<LostBedsRepository>()
   private val mockWorkingDayService = mockk<WorkingDayService>()
 
-  private val bedUtilisationReportGenerator = BedUtilisationReportGenerator(
-    mockBookingRepository,
-    mockLostBedsRepository,
-    mockWorkingDayService,
-  )
+  private val bedUtilisationReportGenerator = BedUtilisationReportGenerator(mockWorkingDayService)
 
   @Test
   fun `Only results for beds from the specified service are returned in the report`() {
@@ -80,21 +76,21 @@ class BedUtilisationReportGeneratorTest {
       .withRoom(approvedPremisesRoom)
       .produce()
 
-    val approvedPremisesLostBed = LostBedsEntityFactory()
+    LostBedsEntityFactory()
       .withBed(approvedPremisesBed)
-      .withStartDate(LocalDate.parse("2023-04-05"))
-      .withEndDate(LocalDate.parse("2023-04-07"))
+      .withStartDate(LocalDate.parse("2023-04-10"))
+      .withEndDate(LocalDate.parse("2023-04-17"))
       .withYieldedReason { LostBedReasonEntityFactory().produce() }
       .withPremises(approvedPremises)
       .produce()
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationLostBed)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(temporaryAccommodationBed)
+    val bedUtilisationLostBedReportData = convertToBedUtilisationLostBedReportData(temporaryAccommodationLostBed)
+    val bedUtilisationReportData =
+      BedUtilisationReportData(bedUtilisationBedspaceReportData, listOf(), listOf(bedUtilisationLostBedReportData))
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(approvedPremisesBed, temporaryAccommodationBed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -139,7 +135,7 @@ class BedUtilisationReportGeneratorTest {
       .withRoom(approvedPremisesRoom)
       .produce()
 
-    val approvedPremisesLostBed = LostBedsEntityFactory()
+    LostBedsEntityFactory()
       .withBed(approvedPremisesBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -147,43 +143,15 @@ class BedUtilisationReportGeneratorTest {
       .withPremises(approvedPremises)
       .produce()
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2023-04-01"),
-        LocalDate.parse("2023-07-01"),
-        temporaryAccommodationBed,
-      )
-    } returns emptyList()
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2023-04-01"),
-        LocalDate.parse("2023-07-01"),
-        approvedPremisesBed,
-      )
-    } returns emptyList()
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2023-04-01"),
-        LocalDate.parse("2023-07-01"),
-        temporaryAccommodationBed,
-      )
-    } returns listOf(temporaryAccommodationLostBed)
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2023-04-01"),
-        LocalDate.parse("2023-07-01"),
-        approvedPremisesBed,
-      )
-    } returns listOf(approvedPremisesLostBed)
+    val bedUtilisationReportGeneratorForThreeMonths = BedUtilisationReportGenerator(mockWorkingDayService)
 
-    val bedUtilisationReportGeneratorForThreeMonths = BedUtilisationReportGenerator(
-      mockBookingRepository,
-      mockLostBedsRepository,
-      mockWorkingDayService,
-    )
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(temporaryAccommodationBed)
+    val bedUtilisationLostBedReportData = convertToBedUtilisationLostBedReportData(temporaryAccommodationLostBed)
+    val bedUtilisationReportData =
+      BedUtilisationReportData(bedUtilisationBedspaceReportData, listOf(), listOf(bedUtilisationLostBedReportData))
 
     val result = bedUtilisationReportGeneratorForThreeMonths.createReport(
-      listOf(approvedPremisesBed, temporaryAccommodationBed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -206,7 +174,7 @@ class BedUtilisationReportGeneratorTest {
       .withRoom(temporaryAccommodationRoom)
       .produce()
 
-    val temporaryAccommodationLostBed = LostBedsEntityFactory()
+    LostBedsEntityFactory()
       .withBed(temporaryAccommodationBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -234,19 +202,15 @@ class BedUtilisationReportGeneratorTest {
       .withPremises(approvedPremises)
       .produce()
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationLostBed)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)
+    val bedUtilisationReportGeneratorForThreeMonths = BedUtilisationReportGenerator(mockWorkingDayService)
 
-    val bedUtilisationReportGeneratorForThreeMonths = BedUtilisationReportGenerator(
-      mockBookingRepository,
-      mockLostBedsRepository,
-      mockWorkingDayService,
-    )
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(approvedPremisesBed)
+    val bedUtilisationLostBedReportData = convertToBedUtilisationLostBedReportData(approvedPremisesLostBed)
+    val bedUtilisationReportData =
+      BedUtilisationReportData(bedUtilisationBedspaceReportData, listOf(), listOf(bedUtilisationLostBedReportData))
 
     val result = bedUtilisationReportGeneratorForThreeMonths.createReport(
-      listOf(approvedPremisesBed, temporaryAccommodationBed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.approvedPremises, null, startDate, endDate),
     )
 
@@ -314,19 +278,25 @@ class BedUtilisationReportGeneratorTest {
       .withPremises(temporaryAccommodationPremisesOutsideProbationRegion)
       .produce()
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns listOf(temporaryAccommodationLostBedInProbationArea)
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)
+    val bedUtilisationBedspaceReportData =
+      convertToBedUtilisationBedspaceReportData(temporaryAccommodationBedInProbationRegion)
+    val bedUtilisationLostBedReportData =
+      convertToBedUtilisationLostBedReportData(temporaryAccommodationLostBedInProbationArea)
+    val bedUtilisationReportData =
+      BedUtilisationReportData(bedUtilisationBedspaceReportData, listOf(), listOf(bedUtilisationLostBedReportData))
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(temporaryAccommodationBedInProbationRegion, temporaryAccommodationBedOutsideProbationRegion),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, probationRegion1.id, startDate, endDate),
     )
 
     assertThat(result.count()).isEqualTo(1)
-    assertThat(result[0][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.name)
-    assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.id.toShortBase58())
+    assertThat(result[0][BedUtilisationReportRow::propertyRef]).isEqualTo(
+      temporaryAccommodationPremisesInProbationRegion.name,
+    )
+    assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(
+      temporaryAccommodationPremisesInProbationRegion.id.toShortBase58(),
+    )
   }
 
   @Test
@@ -388,21 +358,43 @@ class BedUtilisationReportGeneratorTest {
       .withPremises(temporaryAccommodationPremisesOutsideProbationRegion)
       .produce()
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns listOf(temporaryAccommodationLostBedInProbationArea)
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)
+    val bedUtilisationBedInProbationRegionReportData =
+      convertToBedUtilisationBedspaceReportData(temporaryAccommodationBedInProbationRegion)
+    val bedUtilisationLostBedInProbationRegionReportData =
+      convertToBedUtilisationLostBedReportData(temporaryAccommodationLostBedInProbationArea)
+    val bedUtilisationInProbationRegionReportData = BedUtilisationReportData(
+      bedUtilisationBedInProbationRegionReportData,
+      listOf(),
+      listOf(bedUtilisationLostBedInProbationRegionReportData),
+    )
+    val bedUtilisationBedOutsideProbationRegionReportData =
+      convertToBedUtilisationBedspaceReportData(temporaryAccommodationBedOutsideProbationRegion)
+    val bedUtilisationLostBedOutsideProbationRegionReportData =
+      convertToBedUtilisationLostBedReportData(temporaryAccommodationLostBedOutsideProbationArea)
+    val bedUtilisationOutsideProbationRegionReportData = BedUtilisationReportData(
+      bedUtilisationBedOutsideProbationRegionReportData,
+      listOf(),
+      listOf(bedUtilisationLostBedOutsideProbationRegionReportData),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(temporaryAccommodationBedInProbationRegion, temporaryAccommodationBedOutsideProbationRegion),
+      listOf(bedUtilisationInProbationRegionReportData, bedUtilisationOutsideProbationRegionReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
     assertThat(result.count()).isEqualTo(2)
-    assertThat(result[0][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.name)
-    assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesInProbationRegion.id.toShortBase58())
-    assertThat(result[1][BedUtilisationReportRow::propertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.name)
-    assertThat(result[1][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremisesOutsideProbationRegion.id.toShortBase58())
+    assertThat(result[0][BedUtilisationReportRow::propertyRef]).isEqualTo(
+      temporaryAccommodationPremisesInProbationRegion.name,
+    )
+    assertThat(result[0][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(
+      temporaryAccommodationPremisesInProbationRegion.id.toShortBase58(),
+    )
+    assertThat(result[1][BedUtilisationReportRow::propertyRef]).isEqualTo(
+      temporaryAccommodationPremisesOutsideProbationRegion.name,
+    )
+    assertThat(result[1][BedUtilisationReportRow::uniquePropertyRef]).isEqualTo(
+      temporaryAccommodationPremisesOutsideProbationRegion.id.toShortBase58(),
+    )
   }
 
   @Test
@@ -461,11 +453,19 @@ class BedUtilisationReportGeneratorTest {
           .produce()
       }
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -529,11 +529,19 @@ class BedUtilisationReportGeneratorTest {
           .produce()
       }
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -585,7 +593,12 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns LocalDate.parse("2023-04-10")
 
-    every { mockWorkingDayService.getWorkingDaysCount(LocalDate.parse("2023-04-05"), LocalDate.parse("2023-04-10")) } returns 5
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-05"),
+        LocalDate.parse("2023-04-10"),
+      )
+    } returns 5
 
     val relevantBookingStraddlingEndOfMonth = BookingEntityFactory()
       .withBed(bed)
@@ -607,13 +620,26 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns LocalDate.parse("2023-05-01")
 
-    every { mockWorkingDayService.getWorkingDaysCount(LocalDate.parse("2023-04-28"), LocalDate.parse("2023-04-30")) } returns 1
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-28"),
+        LocalDate.parse("2023-04-30"),
+      )
+    } returns 1
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -665,7 +691,12 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns LocalDate.parse("2023-04-10")
 
-    every { mockWorkingDayService.getWorkingDaysCount(LocalDate.parse("2023-04-05"), LocalDate.parse("2023-04-10")) } returns 4
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-05"),
+        LocalDate.parse("2023-04-10"),
+      )
+    } returns 4
 
     val relevantBookingStraddlingEndOfMonth = BookingEntityFactory()
       .withBed(bed)
@@ -687,13 +718,26 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns LocalDate.parse("2023-05-01")
 
-    every { mockWorkingDayService.getWorkingDaysCount(LocalDate.parse("2023-04-28"), LocalDate.parse("2023-04-30")) } returns 1
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-28"),
+        LocalDate.parse("2023-04-30"),
+      )
+    } returns 1
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -741,11 +785,19 @@ class BedUtilisationReportGeneratorTest {
       .withYieldedReason { LostBedReasonEntityFactory().produce() }
       .produce()
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantVoidStraddlingStartOfMonth, relevantVoidStraddlingEndOfMonth)
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantVoidStraddlingStartOfMonthReportData =
+      convertToBedUtilisationLostBedReportData(relevantVoidStraddlingStartOfMonth)
+    val relevantVoidStraddlingEndOfMonthReportData =
+      convertToBedUtilisationLostBedReportData(relevantVoidStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(),
+      listOf(relevantVoidStraddlingStartOfMonthReportData, relevantVoidStraddlingEndOfMonthReportData),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -811,7 +863,12 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns LocalDate.parse("2023-04-09")
 
-    every { mockWorkingDayService.getWorkingDaysCount(LocalDate.parse("2023-04-05"), LocalDate.parse("2023-04-09")) } returns 4
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-05"),
+        LocalDate.parse("2023-04-09"),
+      )
+    } returns 4
 
     val relevantBookingStraddlingEndOfMonth = BookingEntityFactory()
       .withBed(bed)
@@ -843,7 +900,12 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns LocalDate.parse("2023-05-01")
 
-    every { mockWorkingDayService.getWorkingDaysCount(LocalDate.parse("2023-04-28"), LocalDate.parse("2023-04-30")) } returns 1
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-28"),
+        LocalDate.parse("2023-04-30"),
+      )
+    } returns 1
 
     val relevantVoidStraddlingStartOfMonth = LostBedsEntityFactory()
       .withBed(bed)
@@ -861,11 +923,23 @@ class BedUtilisationReportGeneratorTest {
       .withYieldedReason { LostBedReasonEntityFactory().produce() }
       .produce()
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), bed) } returns listOf(relevantVoidStraddlingStartOfMonth, relevantVoidStraddlingEndOfMonth)
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val relevantVoidStraddlingStartOfMonthReportData =
+      convertToBedUtilisationLostBedReportData(relevantVoidStraddlingStartOfMonth)
+    val relevantVoidStraddlingEndOfMonthReportData =
+      convertToBedUtilisationLostBedReportData(relevantVoidStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(relevantVoidStraddlingStartOfMonthReportData, relevantVoidStraddlingEndOfMonthReportData),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -911,23 +985,11 @@ class BedUtilisationReportGeneratorTest {
       .withCreatedAt { OffsetDateTime.parse("2024-01-16T14:03:00+00:00") }
       .produce()
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val bedUtilisationReportData = BedUtilisationReportData(bedUtilisationBedspaceReportData, listOf(), listOf())
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -963,23 +1025,11 @@ class BedUtilisationReportGeneratorTest {
       .withEndDate { LocalDate.parse("2024-05-12") }
       .produce()
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val bedUtilisationReportData = BedUtilisationReportData(bedUtilisationBedspaceReportData, listOf(), listOf())
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -1014,23 +1064,11 @@ class BedUtilisationReportGeneratorTest {
       .withCreatedAt(null)
       .produce()
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val bedUtilisationReportData = BedUtilisationReportData(bedUtilisationBedspaceReportData, listOf(), listOf())
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -1065,23 +1103,11 @@ class BedUtilisationReportGeneratorTest {
       .withCreatedAt { OffsetDateTime.parse("2024-02-16T14:03:00+00:00") }
       .produce()
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val bedUtilisationReportData = BedUtilisationReportData(bedUtilisationBedspaceReportData, listOf(), listOf())
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -1193,23 +1219,19 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns 3
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -1326,23 +1348,19 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns 3
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -1459,23 +1477,19 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns 3
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 
@@ -1592,23 +1606,19 @@ class BedUtilisationReportGeneratorTest {
       )
     } returns 3
 
-    every {
-      mockBookingRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns listOf(relevantBookingStraddlingStartOfMonth, relevantBookingStraddlingEndOfMonth)
-    every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
-        LocalDate.parse("2024-02-01"),
-        LocalDate.parse("2024-02-29"),
-        bed,
-      )
-    } returns emptyList()
+    val bedUtilisationBedspaceReportData = convertToBedUtilisationBedspaceReportData(bed)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToBedUtilisationBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedUtilisationReportData = BedUtilisationReportData(
+      bedUtilisationBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+    )
 
     val result = bedUtilisationReportGenerator.createReport(
-      listOf(bed),
+      listOf(bedUtilisationReportData),
       BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/Cas3ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/Cas3ReportsTestHelper.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.util
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationLostBedReportData
+import java.time.LocalDate
+
+fun convertToBedUtilisationBedspaceReportData(bed: BedEntity): Cas3BedUtilisationBedspaceReportData {
+  val room = bed.room
+  var probationDeliveryUnitName: String? = null
+  val premises = room.premises
+
+  if (room.premises is TemporaryAccommodationPremisesEntity) {
+    probationDeliveryUnitName = (room.premises as TemporaryAccommodationPremisesEntity).probationDeliveryUnit?.name
+  }
+
+  return Cas3BedUtilisationBedspaceReportData(
+    bedId = bed.id.toString(),
+    probationRegionName = premises.probationRegion.name,
+    probationDeliveryUnitName = probationDeliveryUnitName,
+    localAuthorityName = premises.localAuthorityArea?.name,
+    premisesName = premises.name,
+    addressLine1 = premises.addressLine1,
+    town = premises.town,
+    postCode = premises.postcode,
+    roomName = room.name,
+    bedspaceStartDate = bed.createdAt?.toLocalDate(),
+    bedspaceEndDate = bed.endDate,
+    premisesId = premises.id.toString(),
+    roomId = room.id.toString(),
+  )
+}
+
+fun convertToBedUtilisationBookingReportData(booking: BookingEntity): Cas3BedUtilisationBookingReportData {
+  return Cas3BedUtilisationBookingReportData(
+    arrivalDate = booking.arrivalDate,
+    departureDate = booking.departureDate,
+    bedId = booking.bed?.id.toString(),
+    cancellationId = booking.cancellation?.id?.toString(),
+    arrivalId = booking.arrival?.id?.toString(),
+    confirmationId = booking.confirmation?.id?.toString(),
+    turnaroundId = booking.turnaround?.id?.toString(),
+    workingDayCount = booking.turnaround?.workingDayCount,
+  )
+}
+
+fun convertToBedUtilisationLostBedReportData(lostBed: LostBedsEntity): Cas3BedUtilisationLostBedReportData {
+  return Cas3BedUtilisationLostBedReportData(
+    bedId = lostBed.bed.id.toString(),
+    startDate = lostBed.startDate,
+    endDate = lostBed.endDate,
+    cancellationId = lostBed.cancellation?.id?.toString(),
+  )
+}
+
+@Suppress("LongParameterList")
+class Cas3BedUtilisationBedspaceReportData(
+  override val bedId: String,
+  override val probationRegionName: String?,
+  override val probationDeliveryUnitName: String?,
+  override val localAuthorityName: String?,
+  override val premisesName: String,
+  override val addressLine1: String,
+  override val town: String?,
+  override val postCode: String,
+  override val roomName: String,
+  override val bedspaceStartDate: LocalDate?,
+  override val bedspaceEndDate: LocalDate?,
+  override val premisesId: String,
+  override val roomId: String,
+) : BedUtilisationBedspaceReportData
+
+@Suppress("LongParameterList")
+class Cas3BedUtilisationBookingReportData(
+  override val arrivalDate: LocalDate,
+  override val departureDate: LocalDate,
+  override val bedId: String,
+  override val cancellationId: String?,
+  override val arrivalId: String?,
+  override val confirmationId: String?,
+  override val turnaroundId: String?,
+  override val workingDayCount: Int?,
+) : BedUtilisationBookingReportData
+
+class Cas3BedUtilisationLostBedReportData(
+  override val bedId: String,
+  override val startDate: LocalDate,
+  override val endDate: LocalDate,
+  override val cancellationId: String?,
+) : BedUtilisationLostBedReportData

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.TransitionalAccommodationReferralReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TransitionalAccommodationReferralReportData
@@ -40,6 +41,7 @@ class Cas3ReportServiceTest {
   private val mockWorkingDayService = mockk<WorkingDayService>()
   private val mockBookingRepository = mockk<BookingRepository>()
   private val mockBedRepository = mockk<BedRepository>()
+  private val mockBedUtilisationReportRepository = mockk<BedUtilisationReportRepository>()
 
   private val cas3ReportService = Cas3ReportService(
     mockOffenderService,
@@ -51,6 +53,7 @@ class Cas3ReportServiceTest {
     mockWorkingDayService,
     mockBookingRepository,
     mockBedRepository,
+    mockBedUtilisationReportRepository,
     2,
   )
 
@@ -105,6 +108,7 @@ class Cas3ReportServiceTest {
       mockWorkingDayService,
       mockBookingRepository,
       mockBedRepository,
+      mockBedUtilisationReportRepository,
       3,
     )
 


### PR DESCRIPTION
This [PR CAS-414](https://dsdmoj.atlassian.net/browse/CAS-414) is to fix a performance issue when generate utilisation report in CAS3 for all regions. Which includes:
- Reduce the amount of data retrieved in the report queries by changing it to sql queries 
- Get all the information needed for bedspace, bookings and lost bed space in one query instead of calling the database for each row in the report
- Return only the data related to temporary accommodation which is needed in the report 