### PR TITLE
APS-956: Expose CAS1 out-of-service bed reasons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/ReferenceDataController.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.ReferenceDataCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
+
+@Service("Cas1ReferenceDataController")
+class ReferenceDataController(
+  private val reasonTransformer: Cas1OutOfServiceBedReasonTransformer,
+  private val repository: Cas1OutOfServiceBedReasonRepository,
+) : ReferenceDataCas1Delegate {
+
+  override fun referenceDataOutOfServiceBedReasonsGet(): ResponseEntity<List<Cas1OutOfServiceBedReason>> {
+    return ResponseEntity.ok(transformedOutOfServiceBedReasons())
+  }
+
+  private fun transformedOutOfServiceBedReasons(): List<Cas1OutOfServiceBedReason> {
+    return repository.findActive().map { reason -> reasonTransformer.transformJpaToApi(reason) }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedReasonEntity.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -9,7 +10,10 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Repository
-interface Cas1OutOfServiceBedReasonRepository : JpaRepository<Cas1OutOfServiceBedReasonEntity, UUID>
+interface Cas1OutOfServiceBedReasonRepository : JpaRepository<Cas1OutOfServiceBedReasonEntity, UUID> {
+  @Query("SELECT r FROM Cas1OutOfServiceBedReasonEntity r WHERE r.isActive = true")
+  fun findActive(): List<Cas1OutOfServiceBedReasonEntity>
+}
 
 @Entity
 @Table(name = "cas1_out_of_service_bed_reasons")

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -439,6 +439,26 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /reference-data/out-of-service-bed-reasons:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all reasons for beds going out of service
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/Cas1OutOfServiceBedReason'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /reports/{reportName}:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -441,6 +441,26 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+  /reference-data/out-of-service-bed-reasons:
+    get:
+      tags:
+        - Reference Data
+      summary: Lists all reasons for beds going out of service
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /reports/{reportName}:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
+
+class Cas1ReferenceDataTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var reasonTransformer: Cas1OutOfServiceBedReasonTransformer
+
+  @Test
+  fun `All available out-of-service bed reasons are returned`() {
+    val activeReason1 = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist {
+      withIsActive(true)
+      withName("Active reason 1")
+    }
+
+    val activeReason2 = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist {
+      withIsActive(true)
+      withName("Active reason 2")
+    }
+
+    cas1OutOfServiceBedReasonEntityFactory.produceAndPersist {
+      withIsActive(false)
+      withName("Inactive reason")
+    }
+
+    val expectedReasons = objectMapper.writeValueAsString(
+      listOf(activeReason1, activeReason2).map { reason -> reasonTransformer.transformJpaToApi(reason) },
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/cas1/reference-data/out-of-service-bed-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedReasons)
+  }
+}


### PR DESCRIPTION
### A new CAS1 reference endpoint

In this PR we implement a new (and first) reference data endpoint within the `/cas1/` namespace:

```
GET /cas1/reference-data/out-of-service-bed-reasons
```

![ref_data_oosb_reasons](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/20245/9d00ea4e-78a8-48fa-915a-9342a4bfb565)

This will allow us to develop and expose our new `OutOfServiceBedReason`s away from the legacy `LostBedReason`s.

However, we do need to retain our imported legacy `LostBedReason`s to support our data migration. Read on:

### Migrating and managing our OOSB reasons

We will be migrating `LostBed` records to `OutOfService` bed records. To support this our `OutOfServiceBedReason` entities are seeded from the original `LostBedReason` entities. Importantly this includes the UUIDs to preserve the foreign key relationships (`LostBed.lost_bed_reason_id` == `OutOfServiceBed.out_of_service_bed_reason_id`).

See our [update_cas1_out_of_service_bed_reasons][] "migration_job" which has been run now in `dev` environment with:

`run_migration_job update_cas1_out_of_service_bed_reasons`

[update_cas1_out_of_service_bed_reasons]:
https://github.com/ministryofjustice/approved-premises-api/blob/f9a84328ad34b99486fbb17834330621ccfe2b16/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1OutOfServiceBedReasonMigrationJob.kt#L10-L29

Our `cas1_out_of_service_bed_reasons` table now looks like this:


| name                                       | is_active |
| ------------------------------------------ | --------- |
| Planned Refurbishment                      | true      |
| Damage by Resident                         | true      |
| Accident/Flood/Fire                        | true      |
| Staff Shortage/Illness                     | true      |
| Double Room with Single occupancy - risk   | true      |
| Double room with single occupancy - health | true      |
| Planned FM works required                  | true      |

As we go forward we **can**:

- create new reasons
- make existing (including legacy) reasons inactive or active

What we **can't** do:

- delete a reason (this is enforced by the db to preserve data integrity)
- rename a reason as this would be rewriting history as we don't record the displayed value at the time of use separately