### PR TITLE
CAS-367 Return null in message details when the rejection reason is not specified

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
@@ -51,7 +51,7 @@ class AssessmentReferralHistoryNoteTransformer {
   }
 
   private fun getMessageDetails(systemNoteType: ReferralHistorySystemNoteType, assessmentEntity: TemporaryAccommodationAssessmentEntity): ReferralHistoryNoteMessageDetails? {
-    if (systemNoteType == ReferralHistorySystemNoteType.REJECTED) {
+    if (systemNoteType == ReferralHistorySystemNoteType.REJECTED && assessmentEntity.referralRejectionReason != null) {
       return ReferralHistoryNoteMessageDetails(
         assessmentEntity.referralRejectionReason?.name,
         assessmentEntity.referralRejectionReasonDetail,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentReferralHistoryNoteTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentReferralHistoryNoteTransformerTest.kt
@@ -156,6 +156,7 @@ class AssessmentReferralHistoryNoteTransformerTest {
       "UNALLOCATED",
       "IN_REVIEW",
       "READY_TO_PLACE",
+      "REJECTED",
       "COMPLETED",
     ],
   )
@@ -173,15 +174,8 @@ class AssessmentReferralHistoryNoteTransformerTest {
       .withProbationRegion(probationRegion)
       .produce()
 
-    var rejectionReason = ReferralRejectionReasonEntityFactory()
-      .produce()
-
-    val rejectionReasonDetail = randomNumberChars(10)
     val assessment = TemporaryAccommodationAssessmentEntityFactory()
       .withApplication(application)
-      .withReferralRejectionReason(rejectionReason)
-      .withReferralRejectionReasonDetail(rejectionReasonDetail)
-      .withIsWithdrawn(true)
       .produce()
 
     val note = AssessmentReferralHistorySystemNoteEntityFactory()
@@ -209,8 +203,6 @@ class AssessmentReferralHistoryNoteTransformerTest {
         ReferralHistorySystemNoteType.COMPLETED -> ReferralHistorySystemNote.Category.completed
       },
     )
-    assertThat(result.messageDetails?.rejectionReason).isNull()
-    assertThat(result.messageDetails?.rejectionReasonDetails).isNull()
-    assertThat(result.messageDetails?.isWithdrawn).isNull()
+    assertThat(result.messageDetails).isNull()
   }
 }


### PR DESCRIPTION
This [PR CAS-367](https://dsdmoj.atlassian.net/browse/CAS-367) is to return null in message details when the rejection reason is not specified. To cover the scenario for the previous assessments rejected and not show message details for them