### PR TITLE
Move CAS1 BookingMade and NotMade events into DomainEventService

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -1,0 +1,152 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeBookedBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service
+class Cas1BookingDomainEventService(
+  val domainEventService: DomainEventService,
+  val offenderService: OffenderService,
+  val communityApiClient: CommunityApiClient,
+  @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+) {
+
+  fun bookingMade(
+    application: ApprovedPremisesApplicationEntity,
+    booking: BookingEntity,
+    user: UserEntity,
+    bookingCreatedAt: OffsetDateTime,
+  ) {
+    bookingMade(
+      applicationId = application.id,
+      eventNumber = application.eventNumber,
+      booking = booking,
+      user = user,
+      bookingCreatedAt = bookingCreatedAt,
+      applicationSubmittedOn = application.submittedAt,
+      releaseType = application.releaseType,
+      sentenceType = application.sentenceType,
+      situation = application.situation,
+    )
+  }
+
+  fun adhocBookingMade(
+    onlineApplication: ApprovedPremisesApplicationEntity?,
+    offlineApplication: OfflineApplicationEntity?,
+    eventNumber: String?,
+    booking: BookingEntity,
+    user: UserEntity,
+    bookingCreatedAt: OffsetDateTime,
+  ) {
+    val applicationId = (onlineApplication?.id ?: offlineApplication?.id)
+    val eventNumberForDomainEvent =
+      (onlineApplication?.eventNumber ?: offlineApplication?.eventNumber ?: eventNumber)
+
+    bookingMade(
+      applicationId = applicationId!!,
+      eventNumber = eventNumberForDomainEvent!!,
+      booking = booking,
+      user = user,
+      bookingCreatedAt = bookingCreatedAt,
+      applicationSubmittedOn = onlineApplication?.submittedAt,
+      releaseType = onlineApplication?.releaseType,
+      sentenceType = onlineApplication?.sentenceType,
+      situation = onlineApplication?.situation,
+    )
+  }
+
+  private fun bookingMade(
+    applicationId: UUID,
+    eventNumber: String,
+    booking: BookingEntity,
+    user: UserEntity,
+    bookingCreatedAt: OffsetDateTime,
+    applicationSubmittedOn: OffsetDateTime?,
+    sentenceType: String?,
+    releaseType: String?,
+    situation: String?,
+  ) {
+    val domainEventId = UUID.randomUUID()
+
+    val offenderDetails =
+      when (val offenderDetailsResult = offenderService.getOffenderByCrn(booking.crn, user.deliusUsername, true)) {
+        is AuthorisableActionResult.Success -> offenderDetailsResult.entity
+        else -> null
+      }
+
+    val staffDetailsResult = communityApiClient.getStaffUserDetails(user.deliusUsername)
+    val staffDetails = when (staffDetailsResult) {
+      is ClientResult.Success -> staffDetailsResult.body
+      is ClientResult.Failure -> staffDetailsResult.throwException()
+    }
+
+    val approvedPremises = booking.premises as ApprovedPremisesEntity
+
+    domainEventService.saveBookingMadeDomainEvent(
+      DomainEvent(
+        id = domainEventId,
+        applicationId = applicationId,
+        crn = booking.crn,
+        nomsNumber = offenderDetails?.otherIds?.nomsNumber,
+        occurredAt = bookingCreatedAt.toInstant(),
+        bookingId = booking.id,
+        data = BookingMadeEnvelope(
+          id = domainEventId,
+          timestamp = bookingCreatedAt.toInstant(),
+          eventType = EventType.bookingMade,
+          eventDetails = BookingMade(
+            applicationId = applicationId,
+            applicationUrl = applicationUrlTemplate.resolve("id", applicationId.toString()),
+            bookingId = booking.id,
+            personReference = PersonReference(
+              crn = booking.crn,
+              noms = offenderDetails?.otherIds?.nomsNumber ?: "Unknown NOMS Number",
+            ),
+            deliusEventNumber = eventNumber,
+            createdAt = bookingCreatedAt.toInstant(),
+            bookedBy = BookingMadeBookedBy(
+              staffMember = staffDetails.toStaffMember(),
+              cru = Cru(
+                name = user.apArea?.name ?: "Unknown CRU",
+              ),
+            ),
+            premises = Premises(
+              id = approvedPremises.id,
+              name = approvedPremises.name,
+              apCode = approvedPremises.apCode,
+              legacyApCode = approvedPremises.qCode,
+              localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
+            ),
+            arrivalOn = booking.arrivalDate,
+            departureOn = booking.departureDate,
+            applicationSubmittedOn = applicationSubmittedOn?.toInstant(),
+            releaseType = releaseType,
+            sentenceType = sentenceType,
+            situation = situation,
+          ),
+        ),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityAreaEntityFactory.kt
@@ -11,6 +11,10 @@ class LocalAuthorityAreaEntityFactory : Factory<LocalAuthorityAreaEntity> {
   private var identifier: Yielded<String> = { randomStringUpperCase(5) }
   private var name: Yielded<String> = { randomStringUpperCase(5) }
 
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
   override fun produce(): LocalAuthorityAreaEntity = LocalAuthorityAreaEntity(
     id = this.id(),
     identifier = this.identifier(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1604,10 +1604,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Create a Booking Not Made from a Placement Request returns 200`() {
+    fun `Create a Booking Not Made from a Placement Request returns 200 and creates a domain event`() {
       `Given a User` { _, jwt ->
         `Given a User` { otherUser, _ ->
-          `Given an Offender` { offenderDetails, inmateDetails ->
+          `Given an Offender` { offenderDetails, _ ->
             `Given an Application`(createdByUser = otherUser) {
               `Given a Placement Request`(
                 placementRequestAllocatedTo = otherUser,
@@ -1629,6 +1629,11 @@ class PlacementRequestsTest : IntegrationTestBase() {
                   .expectBody()
                   .jsonPath("$.placementRequestId").isEqualTo(placementRequest.id.toString())
                   .jsonPath("$.notes").isEqualTo("some notes")
+
+                domainEventAsserter.assertDomainEventOfTypeStored(
+                  placementRequest.application.id,
+                  DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE,
+                )
               }
             }
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1366,6 +1366,68 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `Creating a Booking from a Placement Request creates a domain event and sends booking made emails`() {
+      `Given a User` { user, jwt ->
+        `Given a User` { applicant, _ ->
+          `Given an Offender` { offenderDetails, _ ->
+            `Given an Application`(createdByUser = applicant) {
+              `Given a Placement Request`(
+                placementRequestAllocatedTo = user,
+                assessmentAllocatedTo = applicant,
+                createdByUser = applicant,
+                crn = offenderDetails.otherIds.crn,
+              ) { placementRequest, _ ->
+                val premises = approvedPremisesEntityFactory.produceAndPersist {
+                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+                  withYieldedProbationRegion {
+                    probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+                  }
+                }
+
+                val room = roomEntityFactory.produceAndPersist {
+                  withPremises(premises)
+                }
+
+                val bed = bedEntityFactory.produceAndPersist {
+                  withRoom(room)
+                }
+
+                webTestClient.post()
+                  .uri("/placement-requests/${placementRequest.id}/booking")
+                  .header("Authorization", "Bearer $jwt")
+                  .bodyValue(
+                    NewPlacementRequestBooking(
+                      arrivalDate = LocalDate.parse("2023-03-29"),
+                      departureDate = LocalDate.parse("2023-04-01"),
+                      bedId = bed.id,
+                    ),
+                  )
+                  .exchange()
+                  .expectStatus()
+                  .isOk
+
+                domainEventAsserter.assertDomainEventOfTypeStored(
+                  placementRequest.application.id,
+                  DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
+                )
+
+                emailAsserter.assertEmailsRequestedCount(2)
+                emailAsserter.assertEmailRequested(
+                  applicant.email!!,
+                  notifyConfig.templates.bookingMade,
+                )
+                emailAsserter.assertEmailRequested(
+                  premises.emailAddress!!,
+                  notifyConfig.templates.bookingMadePremises,
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @Test
     fun `Creating a Booking from a Placement Request that is not allocated to the User returns a 403`() {
       `Given a User` { user, jwt ->
         `Given a User` { otherUser, _ ->
@@ -1437,16 +1499,6 @@ class PlacementRequestsTest : IntegrationTestBase() {
                   .exchange()
                   .expectStatus()
                   .isOk
-
-                emailAsserter.assertEmailsRequestedCount(2)
-                emailAsserter.assertEmailRequested(
-                  applicant.email!!,
-                  notifyConfig.templates.bookingMade,
-                )
-                emailAsserter.assertEmailRequested(
-                  premises.emailAddress!!,
-                  notifyConfig.templates.bookingMadePremises,
-                )
               }
             }
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
@@ -1,0 +1,275 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+class Cas1BookingDomainEventServiceTest {
+
+  private val domainEventService = mockk<DomainEventService>()
+  private val offenderService = mockk<OffenderService>()
+  private val communityApiClient = mockk<CommunityApiClient>()
+
+  val service = Cas1BookingDomainEventService(
+    domainEventService,
+    offenderService,
+    communityApiClient,
+    UrlTemplate("http://frontend/applications/#id"),
+  )
+
+  @Nested
+  inner class BookingMade {
+
+    val user = UserEntityFactory()
+      .withDefaults()
+      .withDeliusUsername("THEDELIUSUSERNAME")
+      .produce()
+
+    private val otherUser = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withEventNumber("online app event number")
+      .withCreatedByUser(otherUser)
+      .withSubmittedAt(OffsetDateTime.now())
+      .withReleaseType(ReleaseTypeOption.licence.toString())
+      .withSentenceType(SentenceTypeOption.nonStatutory.toString())
+      .withSituation(SituationOption.bailSentence.toString())
+      .produce()
+
+    val premises = ApprovedPremisesEntityFactory()
+      .withDefaults()
+      .withName("the premises name")
+      .withApCode("the premises ap code")
+      .withQCode("the premises qcode")
+      .withLocalAuthorityArea(LocalAuthorityAreaEntityFactory().withName("authority name").produce())
+      .produce()
+
+    val booking = BookingEntityFactory()
+      .withDefaults()
+      .withCrn("THEBOOKINGCRN")
+      .withArrivalDate(LocalDate.of(2025, 12, 11))
+      .withPremises(premises)
+      .produce()
+
+    val createdAt = OffsetDateTime.now()
+
+    @BeforeEach
+    fun before() {
+      every { domainEventService.saveBookingMadeDomainEvent(any()) } just Runs
+
+      val assigneeUserStaffDetails = StaffUserDetailsFactory().produce()
+      every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+        HttpStatus.OK,
+        assigneeUserStaffDetails,
+      )
+
+      every {
+        offenderService.getOffenderByCrn(
+          "THEBOOKINGCRN",
+          "THEDELIUSUSERNAME",
+          true,
+        )
+      } returns AuthorisableActionResult.Success(
+        OffenderDetailsSummaryFactory()
+          .withGender("male")
+          .withCrn("THECRN")
+          .withNomsNumber("THENOMS")
+          .withDateOfBirth(LocalDate.of(1982, 3, 11))
+          .produce(),
+      )
+    }
+
+    @Test
+    fun `bookingMade saves domain event`() {
+      service.bookingMade(application, booking, user, createdAt)
+
+      val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()
+
+      verify(exactly = 1) {
+        domainEventService.saveBookingMadeDomainEvent(
+          capture(domainEventArgument),
+        )
+      }
+
+      val domainEvent = domainEventArgument.captured
+
+      assertThat(domainEvent.applicationId).isEqualTo(application.id)
+      assertThat(domainEvent.crn).isEqualTo("THEBOOKINGCRN")
+      assertThat(domainEvent.bookingId).isEqualTo(booking.id)
+      assertThat(domainEvent.data.eventType).isEqualTo(EventType.bookingMade)
+
+      val data = domainEvent.data.eventDetails
+      assertThat(data.applicationId).isEqualTo(application.id)
+      assertThat(data.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")
+      assertThat(data.bookingId).isEqualTo(booking.id)
+      assertThat(data.personReference.crn).isEqualTo("THEBOOKINGCRN")
+      assertThat(data.personReference.noms).isEqualTo("THENOMS")
+      assertThat(data.deliusEventNumber).isEqualTo("online app event number")
+      assertThat(data.premises.id).isEqualTo(premises.id)
+      assertThat(data.premises.name).isEqualTo("the premises name")
+      assertThat(data.premises.apCode).isEqualTo("the premises ap code")
+      assertThat(data.premises.legacyApCode).isEqualTo("the premises qcode")
+      assertThat(data.premises.localAuthorityAreaName).isEqualTo("authority name")
+      assertThat(data.arrivalOn).isEqualTo(LocalDate.of(2025, 12, 11))
+      assertThat(data.applicationSubmittedOn).isEqualTo(application.submittedAt!!.toInstant())
+      assertThat(data.releaseType).isEqualTo(application.releaseType)
+      assertThat(data.sentenceType).isEqualTo(application.sentenceType)
+      assertThat(data.situation).isEqualTo(application.situation)
+    }
+
+    @Test
+    fun `adhocBookingMade for regular application saves domain event`() {
+      service.adhocBookingMade(
+        onlineApplication = application,
+        offlineApplication = null,
+        eventNumber = "adhoc event number",
+        booking = booking,
+        user = user,
+        bookingCreatedAt = createdAt,
+      )
+
+      val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()
+
+      verify(exactly = 1) {
+        domainEventService.saveBookingMadeDomainEvent(
+          capture(domainEventArgument),
+        )
+      }
+
+      val domainEvent = domainEventArgument.captured
+
+      assertThat(domainEvent.applicationId).isEqualTo(application.id)
+      assertThat(domainEvent.crn).isEqualTo("THEBOOKINGCRN")
+      assertThat(domainEvent.bookingId).isEqualTo(booking.id)
+      assertThat(domainEvent.data.eventType).isEqualTo(EventType.bookingMade)
+
+      val data = domainEvent.data.eventDetails
+      assertThat(data.applicationId).isEqualTo(application.id)
+      assertThat(data.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")
+      assertThat(data.bookingId).isEqualTo(booking.id)
+      assertThat(data.personReference.crn).isEqualTo("THEBOOKINGCRN")
+      assertThat(data.personReference.noms).isEqualTo("THENOMS")
+      assertThat(data.deliusEventNumber).isEqualTo("online app event number")
+      assertThat(data.premises.id).isEqualTo(premises.id)
+      assertThat(data.premises.name).isEqualTo("the premises name")
+      assertThat(data.premises.apCode).isEqualTo("the premises ap code")
+      assertThat(data.premises.legacyApCode).isEqualTo("the premises qcode")
+      assertThat(data.premises.localAuthorityAreaName).isEqualTo("authority name")
+      assertThat(data.arrivalOn).isEqualTo(LocalDate.of(2025, 12, 11))
+      assertThat(data.applicationSubmittedOn).isEqualTo(application.submittedAt!!.toInstant())
+      assertThat(data.releaseType).isEqualTo(application.releaseType)
+      assertThat(data.sentenceType).isEqualTo(application.sentenceType)
+      assertThat(data.situation).isEqualTo(application.situation)
+    }
+
+    @Test
+    fun `adhocBookingMade for offline application saves domain event`() {
+      val offlineApplication = OfflineApplicationEntityFactory()
+        .withEventNumber("offline app event number")
+        .produce()
+
+      service.adhocBookingMade(
+        onlineApplication = null,
+        offlineApplication = offlineApplication,
+        eventNumber = "adhoc event number",
+        booking = booking,
+        user = user,
+        bookingCreatedAt = createdAt,
+      )
+
+      val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()
+
+      verify(exactly = 1) {
+        domainEventService.saveBookingMadeDomainEvent(
+          capture(domainEventArgument),
+        )
+      }
+
+      val domainEvent = domainEventArgument.captured
+
+      assertThat(domainEvent.applicationId).isEqualTo(offlineApplication.id)
+      assertThat(domainEvent.crn).isEqualTo("THEBOOKINGCRN")
+      assertThat(domainEvent.bookingId).isEqualTo(booking.id)
+      assertThat(domainEvent.data.eventType).isEqualTo(EventType.bookingMade)
+
+      val data = domainEvent.data.eventDetails
+      assertThat(data.applicationId).isEqualTo(offlineApplication.id)
+      assertThat(data.applicationUrl).isEqualTo("http://frontend/applications/${offlineApplication.id}")
+      assertThat(data.bookingId).isEqualTo(booking.id)
+      assertThat(data.personReference.crn).isEqualTo("THEBOOKINGCRN")
+      assertThat(data.personReference.noms).isEqualTo("THENOMS")
+      assertThat(data.deliusEventNumber).isEqualTo("offline app event number")
+      assertThat(data.premises.id).isEqualTo(premises.id)
+      assertThat(data.premises.name).isEqualTo("the premises name")
+      assertThat(data.premises.apCode).isEqualTo("the premises ap code")
+      assertThat(data.premises.legacyApCode).isEqualTo("the premises qcode")
+      assertThat(data.premises.localAuthorityAreaName).isEqualTo("authority name")
+      assertThat(data.arrivalOn).isEqualTo(LocalDate.of(2025, 12, 11))
+      assertThat(data.applicationSubmittedOn).isNull()
+      assertThat(data.releaseType).isNull()
+      assertThat(data.sentenceType).isNull()
+      assertThat(data.situation).isNull()
+    }
+
+    @Test
+    fun `adhocBookingMade for offline app with no event number`() {
+      val offlineApplication = OfflineApplicationEntityFactory()
+        .withEventNumber(null)
+        .produce()
+
+      service.adhocBookingMade(
+        onlineApplication = null,
+        offlineApplication = offlineApplication,
+        eventNumber = "adhoc event number",
+        booking = booking,
+        user = user,
+        bookingCreatedAt = createdAt,
+      )
+
+      val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()
+
+      verify(exactly = 1) {
+        domainEventService.saveBookingMadeDomainEvent(
+          capture(domainEventArgument),
+        )
+      }
+
+      val domainEvent = domainEventArgument.captured
+      val data = domainEvent.data.eventDetails
+      assertThat(data.deliusEventNumber).isEqualTo("adhoc event number")
+    }
+  }
+}


### PR DESCRIPTION
This PR moves the code that creates a CAS1 Booking Made and Booking Not Made Domains Event into a new Cas1BookingDomainEventService, in preparation for adding metadata to the events.

See ticket for examples of domain events captured locally when testing change