### PR TITLE
APS-978 - Add Update NOMS Number Seed Job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -152,6 +152,23 @@ AND (
   )
   fun findAllSubmittedApprovedPremisesApplicationsWithShortNotice(): List<UUID>
 
+  @Query(
+    value = """
+    SELECT 
+     CAST(id AS text) as id,
+     noms_number as nomsNumber
+    FROM applications 
+    WHERE UPPER(crn) = UPPER(:crn)
+    """,
+    nativeQuery = true,
+  )
+  fun findByCrn(crn: String): List<CrnSearchResult>
+
+  interface CrnSearchResult {
+    fun getId(): String
+    fun getNomsNumber(): String
+  }
+
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.crn = :crn")
   fun <T : ApplicationEntity> findByCrn(crn: String, type: Class<T>): List<ApplicationEntity>
 
@@ -261,6 +278,17 @@ WHERE taa.probation_region_id = :probationRegionId AND a.submitted_at IS NOT NUL
     """,
   )
   fun updateEventNumber(applicationId: UUID, eventNumber: String, offenceId: String, convictionId: Long)
+
+  @Modifying
+  @Query(
+    """
+    UPDATE applications set 
+    noms_number = :nomsNumber
+    where id = :applicationId
+    """,
+    nativeQuery = true,
+  )
+  fun updateNomsNumber(applicationId: UUID, nomsNumber: String)
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -92,6 +92,17 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   @Query("SELECT DISTINCT(b.crn) FROM BookingEntity b")
   fun getDistinctCrns(): List<String>
 
+  @Modifying
+  @Query(
+    """
+    UPDATE bookings SET 
+    noms_number = :nomsNumber
+    WHERE crn = :crn
+    """,
+    nativeQuery = true,
+  )
+  fun updateNomsByCrn(crn: String, nomsNumber: String): Int
+
   @Query("SELECT DISTINCT(b.nomsNumber) FROM BookingEntity b WHERE b.nomsNumber IS NOT NULL")
   fun getDistinctNomsNumbers(): List<String>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateNomsNumberSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateNomsNumberSeedJob.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
+import java.util.UUID
+
+class Cas1UpdateNomsNumberSeedJob(
+  fileName: String,
+  private val applicationRepository: ApplicationRepository,
+  private val applicationTimelineNoteService: ApplicationTimelineNoteService,
+  private val bookingRepository: BookingRepository,
+) : SeedJob<UpdateNomsNumberSeedRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "crn",
+    "newNomsNumber",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = UpdateNomsNumberSeedRow(
+    crn = columns["crn"]!!.trim(),
+    newNomsNumber = columns["newNomsNumber"]!!.trim(),
+  )
+
+  override fun processRow(row: UpdateNomsNumberSeedRow) {
+    val crn = row.crn
+    val newNomsNumber = row.newNomsNumber
+    log.info("Updating NOMS number for all applications with CRN $crn to $newNomsNumber")
+
+    val applications = applicationRepository.findByCrn(crn)
+
+    applications.forEach { application ->
+      val applicationId = UUID.fromString(application.getId())
+      val previousNomsNumber = application.getNomsNumber()
+
+      log.info("Updating NOMS number on application $applicationId from $previousNomsNumber to $newNomsNumber")
+      applicationRepository.updateNomsNumber(applicationId, newNomsNumber)
+      applicationTimelineNoteService.saveApplicationTimelineNote(
+        applicationId = applicationId,
+        note = "NOMS Number for application updated from '$previousNomsNumber' to '$newNomsNumber' by Application Support",
+        user = null,
+      )
+    }
+    log.info("Have updated ${applications.size} applications")
+
+    log.info("Updating NOMS number for all bookings with CRN $crn to $newNomsNumber")
+    val bookingUpdatedCount = bookingRepository.updateNomsByCrn(crn, newNomsNumber)
+    log.info("Have updated $bookingUpdatedCount bookings")
+  }
+}
+
+data class UpdateNomsNumberSeedRow(
+  val crn: String,
+  val newNomsNumber: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.Cas1UpdateNomsNumberSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CharacteristicsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
@@ -209,6 +210,12 @@ class SeedService(
         SeedFileType.characteristics -> CharacteristicsSeedJob(
           filename,
           applicationContext.getBean(CharacteristicRepository::class.java),
+        )
+        SeedFileType.updateNomsNumber -> Cas1UpdateNomsNumberSeedJob(
+          filename,
+          applicationContext.getBean(ApplicationRepository::class.java),
+          applicationContext.getBean(ApplicationTimelineNoteService::class.java),
+          applicationContext.getBean(BookingRepository::class.java),
         )
         SeedFileType.temporaryAccommodationPremises -> TemporaryAccommodationPremisesSeedJob(
           filename,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3668,6 +3668,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - update_noms_number
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8244,6 +8244,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - update_noms_number
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4225,6 +4225,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - update_noms_number
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4259,6 +4259,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - update_noms_number
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3759,6 +3759,7 @@ components:
         - temporary_accommodation_users
         - approved_premises_users
         - characteristics
+        - update_noms_number
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUpdateNomsNumberSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedUpdateNomsNumberSeedJobTest.kt
@@ -1,0 +1,127 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UpdateNomsNumberSeedRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
+
+  @Autowired
+  lateinit var domainEventService: DomainEventService
+
+  companion object CONSTANTS {
+    const val CRN = "CRN123"
+    const val NEW_NOMS = "NOMS456"
+    const val OTHER_CRN = "OTHERCRN"
+    const val OTHER_NOMS = "OTHERNOMS"
+  }
+
+  @Test
+  fun `Update Application and Booking NOMS Numbers`() {
+    val (applicant, _) = `Given a User`()
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withDefaults()
+      withCreatedByUser(applicant)
+      withApplicationSchema(
+        approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        },
+      )
+      withApArea(apAreaEntityFactory.produceAndPersist())
+      withCrn(CRN)
+      withNomsNumber("OLDVALUE")
+    }
+
+    val otherUnaffectedApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withDefaults()
+      withCreatedByUser(applicant)
+      withApplicationSchema(
+        approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+          withPermissiveSchema()
+        },
+      )
+      withApArea(apAreaEntityFactory.produceAndPersist())
+      withCrn(OTHER_CRN)
+      withNomsNumber(OTHER_NOMS)
+    }
+
+    val booking = bookingEntityFactory.produceAndPersist {
+      withPremises(
+        approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        },
+      )
+      withCrn(CRN)
+      withNomsNumber("OLDVALUE")
+    }
+
+    val otherUnaffectedBooking = bookingEntityFactory.produceAndPersist {
+      withPremises(
+        approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          }
+        },
+      )
+      withCrn(OTHER_CRN)
+      withNomsNumber(OTHER_NOMS)
+    }
+
+    withCsv(
+      "valid-csv",
+      rowsToCsv(
+        listOf(
+          UpdateNomsNumberSeedRow(
+            CRN,
+            NEW_NOMS,
+          ),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.updateNomsNumber, "valid-csv")
+
+    val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(application.id)
+    assertThat(updatedApplication!!.nomsNumber).isEqualTo(NEW_NOMS)
+
+    val updatedOtherApplication = approvedPremisesApplicationRepository.findByIdOrNull(otherUnaffectedApplication.id)
+    assertThat(updatedOtherApplication!!.nomsNumber).isEqualTo(OTHER_NOMS)
+
+    val updatedBooking = bookingRepository.findByIdOrNull(booking.id)
+    assertThat(updatedBooking!!.nomsNumber).isEqualTo(NEW_NOMS)
+
+    val updatedOtherBooking = bookingRepository.findByIdOrNull(otherUnaffectedBooking.id)
+    assertThat(updatedOtherBooking!!.nomsNumber).isEqualTo(OTHER_NOMS)
+  }
+
+  private fun rowsToCsv(rows: List<UpdateNomsNumberSeedRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "crn",
+        "newNomsNumber",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.crn)
+        .withQuotedField(it.newNomsNumber)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}


### PR DESCRIPTION
This commit adds a seed job that allows us to update the NOMS number associated with a given CRN on applicationa and bookings. This is required when the NOMS number is updated in delius, which is rare, but can happen.

This helps reduce the number of 404 errors we see when the inmate cache is refreshed because we’re removing usage of invalid NOMS numbers.