### PR TITLE
CAS-434 Fix issue with existing person departure updated domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -79,6 +79,8 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 
   fun findByApplicationId(applicationId: UUID): List<DomainEventEntity>
 
+  fun findByType(type: DomainEventType): List<DomainEventEntity>
+
   fun getByApplicationIdAndType(applicationId: UUID, type: DomainEventType): DomainEventEntity
 
   @Modifying

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3PersonDepartedEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+
+class Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob(
+  private val domainEventRepository: DomainEventRepository,
+  private val objectMapper: ObjectMapper,
+  private val migrationLogger: MigrationLogger,
+) : MigrationJob() {
+  override val shouldRunInTransaction = true
+
+  @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught", "NestedBlockDepth")
+  override fun process() {
+    val domainEvents = domainEventRepository.findByType(DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED)
+    domainEvents.forEach {
+      migrationLogger.info("Updating person departure updated domain event. Event id ${it.id}")
+      try {
+        val domainEvent = domainEventRepository.findById(it.id)
+        val domainEventData = domainEvent.get().data
+        if (!domainEventData.contains("accommodation.cas3.person.departed.updated")) {
+          val departureEvent = objectMapper.readValue<CAS3PersonDepartedEvent>(domainEventData)
+          if (departureEvent.eventType == EventType.personDeparted) {
+            val updatedDepartureEvent = departureEvent.copy(
+              eventType = EventType.personDepartureUpdated,
+            )
+            domainEventRepository.updateData(it.id, objectMapper.writeValueAsString(updatedDepartureEvent))
+          }
+        }
+      } catch (exception: Exception) {
+        migrationLogger.error("Unable to update person departure updated domain event ${it.id}", exception)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/MigrationJobService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.sentry.Sentry
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationContext
@@ -33,6 +34,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2NoteMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas2StatusUpdateMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas3UpdateApplicationOffenderNameJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.Cas3UpdateUsersPduFromCommunityApiJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.LostBedMigrationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
@@ -179,6 +181,12 @@ class MigrationJobService(
           applicationContext.getBean(DomainEventRepository::class.java),
           applicationContext.getBean(TransactionTemplate::class.java),
           applicationContext.getBean(JdbcTemplate::class.java),
+        )
+
+        MigrationJobType.cas3DomainEventTypeForPersonDepartedUpdated -> Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob(
+          applicationContext.getBean(DomainEventRepository::class.java),
+          applicationContext.getBean(ObjectMapper::class.java),
+          applicationContext.getBean(MigrationLogger::class.java),
         )
       }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3709,6 +3709,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
         - update_cas1_populate_app_reason_for_short_notice_metadata
+        - update_cas3_domain_event_type_for_person_departed_updated
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8285,6 +8285,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
         - update_cas1_populate_app_reason_for_short_notice_metadata
+        - update_cas3_domain_event_type_for_person_departed_updated
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4266,6 +4266,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
         - update_cas1_populate_app_reason_for_short_notice_metadata
+        - update_cas3_domain_event_type_for_person_departed_updated
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4300,6 +4300,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
         - update_cas1_populate_app_reason_for_short_notice_metadata
+        - update_cas3_domain_event_type_for_person_departed_updated
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3800,6 +3800,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_users_pdu_from_community_api
         - update_cas1_populate_app_reason_for_short_notice_metadata
+        - update_cas3_domain_event_type_for_person_departed_updated
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest.kt
@@ -1,0 +1,96 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3PersonDepartureUpdatedEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType.bookingChanged
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingChangedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas3.CAS3PersonDepartedEventDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.Instant
+import java.util.UUID
+
+class Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest : MigrationJobTestBase() {
+
+  @Test
+  fun `update all person departure updated domain events when event type is person departure`() {
+    val personDepartureUpdatedInvalidDomainEvents = generateSequence {
+      domainEventFactory.produceAndPersist {
+        withType(DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED)
+        withData(
+          objectMapper.writeValueAsString(
+            CAS3PersonDepartureUpdatedEvent(
+              id = UUID.randomUUID(),
+              timestamp = Instant.now().randomDateTimeBefore(),
+              eventType = EventType.personDeparted,
+              eventDetails = CAS3PersonDepartedEventDetailsFactory().produce(),
+            ),
+          ),
+        )
+      }
+    }.take(5).toList()
+
+    val personDepartureUpdatedValidDomainEvents = generateSequence {
+      domainEventFactory.produceAndPersist {
+        withType(DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED)
+        withData(
+          objectMapper.writeValueAsString(
+            CAS3PersonDepartureUpdatedEvent(
+              id = UUID.randomUUID(),
+              timestamp = Instant.now().randomDateTimeBefore(),
+              eventType = EventType.personDepartureUpdated,
+              eventDetails = CAS3PersonDepartedEventDetailsFactory().produce(),
+            ),
+          ),
+        )
+      }
+    }.take(3).toList()
+
+    val approvedPremisesBookingChangedDomainEvents = generateSequence {
+      domainEventFactory.produceAndPersist {
+        withType(DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED)
+        withData(
+          objectMapper.writeValueAsString(
+            BookingChangedEnvelope(
+              id = UUID.randomUUID(),
+              timestamp = Instant.now().randomDateTimeBefore(),
+              eventType = bookingChanged,
+              eventDetails = BookingChangedFactory().produce(),
+            ),
+          ),
+        )
+      }
+    }.take(3).toList()
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas3DomainEventTypeForPersonDepartedUpdated)
+
+    personDepartureUpdatedInvalidDomainEvents.forEach {
+      val domainEvent = domainEventRepository.findById(it.id)
+      Assertions.assertThat(domainEvent).isNotNull()
+      val departureUpdatedEvent = objectMapper.readValue<CAS3PersonDepartureUpdatedEvent>(domainEvent.get().data!!)
+      Assertions.assertThat(departureUpdatedEvent.id == it.id)
+      Assertions.assertThat(departureUpdatedEvent.eventType == EventType.personDepartureUpdated)
+    }
+
+    personDepartureUpdatedValidDomainEvents.forEach {
+      val domainEvent = domainEventRepository.findById(it.id)
+      Assertions.assertThat(domainEvent).isNotNull()
+      val departureUpdatedEvent = objectMapper.readValue<CAS3PersonDepartureUpdatedEvent>(domainEvent.get().data!!)
+      Assertions.assertThat(departureUpdatedEvent.id == it.id)
+      Assertions.assertThat(departureUpdatedEvent.eventType == EventType.personDepartureUpdated)
+    }
+
+    approvedPremisesBookingChangedDomainEvents.forEach {
+      val domainEvent = domainEventRepository.findById(it.id)
+      Assertions.assertThat(domainEvent).isNotNull()
+      val bookingChangedEnvelope = objectMapper.readValue<BookingChangedEnvelope>(domainEvent.get().data!!)
+      Assertions.assertThat(bookingChangedEnvelope.id == it.id)
+      Assertions.assertThat(bookingChangedEnvelope.eventType == bookingChanged)
+    }
+  }
+}


### PR DESCRIPTION
This [PR CAS-434](https://dsdmoj.atlassian.net/browse/CAS-434) is to create a job to fix the current person departure domain events with incorrect event type. 

This job will update the event type in the data field for the current domain events from  **accommodation.cas3.person.departed** to **accommodation.cas3.person.departed.updated**