### PR TITLE
APS-987 - Add config to exclude NOMS from cache refresh

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/PreemptiveCacheRefresher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/PreemptiveCacheRefresher.kt
@@ -12,12 +12,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClien
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CacheRefreshExclusionsInmateDetailsRepository
 
 @Component
 class PreemptiveCacheRefresher(
   private val flyway: Flyway,
   private val applicationRepository: ApplicationRepository,
   private val bookingRepository: BookingRepository,
+  private val cacheRefreshExclusionsInmateDetailsRepository: CacheRefreshExclusionsInmateDetailsRepository,
   private val communityApiClient: CommunityApiClient,
   private val prisonsApiClient: PrisonsApiClient,
   @Value("\${preemptive-cache-logging-enabled}") private val loggingEnabled: Boolean,
@@ -51,6 +53,7 @@ class PreemptiveCacheRefresher(
       preemptiveCacheThreads += InmateDetailsCacheRefreshWorker(
         applicationRepository,
         bookingRepository,
+        cacheRefreshExclusionsInmateDetailsRepository,
         prisonsApiClient,
         loggingEnabled,
         delayMs,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CacheRefreshExclusionsInmateDetailsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CacheRefreshExclusionsInmateDetailsEntity.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Repository
+interface CacheRefreshExclusionsInmateDetailsRepository : JpaRepository<ExternalUserEntity, UUID> {
+  @Query("SELECT DISTINCT(nomsNumber) FROM CacheRefreshExclusionsInmateDetailsEntity")
+  fun getDistinctNomsNumbers(): List<String>
+}
+
+@Entity
+@Table(name = "cache_refresh_exclusions_inmate_details")
+data class CacheRefreshExclusionsInmateDetailsEntity(
+  @Id
+  val nomsNumber: String,
+  val description: String,
+)

--- a/src/main/resources/db/migration/all/20240702113929__create_cache_refresh_exclusions_inmate_details.sql
+++ b/src/main/resources/db/migration/all/20240702113929__create_cache_refresh_exclusions_inmate_details.sql
@@ -1,0 +1,5 @@
+CREATE TABLE cache_refresh_exclusions_inmate_details (
+   noms_number TEXT NOT NULL,
+   description TEXT NOT NULL,
+   PRIMARY KEY (noms_number)
+);


### PR DESCRIPTION
When a NOMS number can’t be found in the prisons-api, we receive a 404. If this occurs multiple times when refreshing inmate details in the cache (via InmateDetailsCacheRefreshWorker), we start to receive Sentry errors that this has occurred.

It’s possible that the resolution to the issue (typically Delius or NOMIS having the wrong NOMS number for the CRN) may take days or weeks. In the meantime we no longer need to see the cache refresh warnings, and we should stop attempting to refresh the inmate details as it will fail.

This commit provides a mechanism to exclude NOMS from inmate details cache refresh. Entries can be added to the cache_refresh_exclusions_inmate_details table using SQL