### PR TITLE
APS-978 - Update Noms Number Seed Job Improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -158,11 +158,11 @@ AND (
      CAST(id AS text) as id,
      noms_number as nomsNumber
     FROM applications 
-    WHERE UPPER(crn) = UPPER(:crn)
+    WHERE UPPER(crn) = UPPER(:crn) AND UPPER(noms_number) = UPPER(:nomsNumber)
     """,
     nativeQuery = true,
   )
-  fun findByCrn(crn: String): List<CrnSearchResult>
+  fun findByCrnAndNoms(crn: String, nomsNumber: String): List<CrnSearchResult>
 
   interface CrnSearchResult {
     fun getId(): String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -97,11 +97,11 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     """
     UPDATE bookings SET 
     noms_number = :nomsNumber
-    WHERE crn = :crn
+    WHERE UPPER(crn) = UPPER(:crn) AND UPPER(noms_number) = UPPER(:oldNomsNumber)
     """,
     nativeQuery = true,
   )
-  fun updateNomsByCrn(crn: String, nomsNumber: String): Int
+  fun updateNomsByCrn(crn: String, oldNomsNumber: String, nomsNumber: String): Int
 
   @Query("SELECT DISTINCT(b.nomsNumber) FROM BookingEntity b WHERE b.nomsNumber IS NOT NULL")
   fun getDistinctNomsNumbers(): List<String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateNomsNumberSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateNomsNumberSeedJob.kt
@@ -16,6 +16,7 @@ class Cas1UpdateNomsNumberSeedJob(
   fileName = fileName,
   requiredHeaders = setOf(
     "crn",
+    "oldNomsNumber",
     "newNomsNumber",
   ),
 ) {
@@ -23,15 +24,17 @@ class Cas1UpdateNomsNumberSeedJob(
 
   override fun deserializeRow(columns: Map<String, String>) = UpdateNomsNumberSeedRow(
     crn = columns["crn"]!!.trim(),
+    oldNomsNumber = columns["oldNomsNumber"]!!.trim(),
     newNomsNumber = columns["newNomsNumber"]!!.trim(),
   )
 
   override fun processRow(row: UpdateNomsNumberSeedRow) {
     val crn = row.crn
+    val oldNomsNumber = row.oldNomsNumber
     val newNomsNumber = row.newNomsNumber
-    log.info("Updating NOMS number for all applications with CRN $crn to $newNomsNumber")
+    log.info("Updating NOMS number for all applications with CRN $crn and NOMS $oldNomsNumber to $newNomsNumber")
 
-    val applications = applicationRepository.findByCrn(crn)
+    val applications = applicationRepository.findByCrnAndNoms(crn, oldNomsNumber)
 
     applications.forEach { application ->
       val applicationId = UUID.fromString(application.getId())
@@ -47,13 +50,14 @@ class Cas1UpdateNomsNumberSeedJob(
     }
     log.info("Have updated ${applications.size} applications")
 
-    log.info("Updating NOMS number for all bookings with CRN $crn to $newNomsNumber")
-    val bookingUpdatedCount = bookingRepository.updateNomsByCrn(crn, newNomsNumber)
+    log.info("Updating NOMS number for all bookings with CRN $crn and NOMS $oldNomsNumber to $newNomsNumber")
+    val bookingUpdatedCount = bookingRepository.updateNomsByCrn(crn, oldNomsNumber, newNomsNumber)
     log.info("Have updated $bookingUpdatedCount bookings")
   }
 }
 
 data class UpdateNomsNumberSeedRow(
   val crn: String,
+  val oldNomsNumber: String,
   val newNomsNumber: String,
 )


### PR DESCRIPTION
This commit updates the seed job to only update applications that have a specified ‘old’ noms number. This can be used to ensure we don’t update applications/bookings that already use the new noms number. Generally updating such applications wouldn’t be an issue, but it would lead to a redundant and confusing application note being added to the application.