### PR TITLE
APS-998 - Add event number to CAS1 placement made timline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -85,7 +85,8 @@ class DomainEventDescriber(
     val event = domainEventService.getBookingMadeEvent(domainEventSummary.id())
     return event.describe {
       "A placement at ${it.eventDetails.premises.name} was booked for " +
-        "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()}"
+        "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()} " +
+        "against Delius Event Number ${it.eventDetails.deliusEventNumber}"
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -123,13 +123,14 @@ class DomainEventDescriberTest {
               .withName("The Premises Name")
               .produce(),
           )
+          .withDeliusEventNumber("989")
           .produce(),
       )
     }
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("A placement at The Premises Name was booked for Monday 1 January 2024 to Monday 1 April 2024")
+    assertThat(result).isEqualTo("A placement at The Premises Name was booked for Monday 1 January 2024 to Monday 1 April 2024 against Delius Event Number 989")
   }
 
   @ParameterizedTest


### PR DESCRIPTION
When a placement is made it is created using the Delius Event Number selected when the corresponding application was first created. At the point of the placement being created this event number may no longer be active. This has led to some user confusion becuase they’re used to seeing contact logs for new referrals in delius against the latest event.

This commit adds the event number a placement was created against to the ‘booking made’ timeline entry, making it easier for users to determine against which event number the placement was created.

![Screenshot 2024-07-03 at 11 25 55](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/047462e4-0395-4f67-8bcf-07cbcafb3c9c)

