### PR TITLE
[APS-936] Introduce `CAS1_JANITOR` user role as prerequisite for out-of-service bed cancellation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRolesAndQualifications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -54,7 +55,7 @@ class UsersController(
       throw ForbiddenProblem()
     }
 
-    var roles = roles?.map(::transformApiRole)
+    var roles = roles?.map(UserRole::valueOf)
     var qualifications = qualifications?.map(::transformApiQualification)
 
     val (users, metadata) = userService.getUsersWithQualificationsAndRoles(
@@ -141,24 +142,6 @@ class UsersController(
     if (!userEntity.staffRecordFound) throw NotFoundProblem(name, "user", "username")
     val userTransformed = userTransformer.transformJpaToApi(userEntity.user!!, xServiceName)
     return ResponseEntity.ok(userTransformed)
-  }
-
-  @SuppressWarnings("CyclomaticComplexMethod")
-  private fun transformApiRole(apiRole: ApprovedPremisesUserRole): JpaUserRole = when (apiRole) {
-    ApprovedPremisesUserRole.roleAdmin -> JpaUserRole.CAS1_ADMIN
-    ApprovedPremisesUserRole.applicant -> JpaUserRole.CAS1_APPLICANT
-    ApprovedPremisesUserRole.assessor -> JpaUserRole.CAS1_ASSESSOR
-    ApprovedPremisesUserRole.manager -> JpaUserRole.CAS1_MANAGER
-    ApprovedPremisesUserRole.legacyManager -> JpaUserRole.CAS1_LEGACY_MANAGER
-    ApprovedPremisesUserRole.futureManager -> JpaUserRole.CAS1_FUTURE_MANAGER
-    ApprovedPremisesUserRole.matcher -> JpaUserRole.CAS1_MATCHER
-    ApprovedPremisesUserRole.workflowManager -> JpaUserRole.CAS1_WORKFLOW_MANAGER
-    ApprovedPremisesUserRole.cruMember -> JpaUserRole.CAS1_CRU_MEMBER
-    ApprovedPremisesUserRole.reportViewer -> JpaUserRole.CAS1_REPORT_VIEWER
-    ApprovedPremisesUserRole.excludedFromAssessAllocation -> JpaUserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION
-    ApprovedPremisesUserRole.excludedFromMatchAllocation -> JpaUserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION
-    ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation -> JpaUserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION
-    ApprovedPremisesUserRole.appealsManager -> JpaUserRole.CAS1_APPEALS_MANAGER
   }
 
   private fun transformApiQualification(apiQualification: UserQualification): uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/OutOfServiceBedsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/OutOfServiceBedsController.kt
@@ -93,7 +93,7 @@ class OutOfServiceBedsController(
       .firstOrNull { it.id == outOfServiceBedId }
       ?: throw NotFoundProblem(outOfServiceBedId, "OutOfServiceBed")
 
-    if (!userAccessService.currentUserCanManagePremisesOutOfServiceBed(premises)) {
+    if (!userAccessService.currentUserCanCancelOutOfServiceBed()) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.converter.StringListConverter
 import java.time.OffsetDateTime
@@ -301,28 +302,30 @@ data class UserRoleAssignmentEntity(
   override fun hashCode() = Objects.hash(id, role)
 }
 
-enum class UserRole(val service: ServiceName) {
-  CAS1_ASSESSOR(ServiceName.approvedPremises),
-  CAS1_MATCHER(ServiceName.approvedPremises),
-  CAS1_MANAGER(ServiceName.approvedPremises),
-  CAS1_LEGACY_MANAGER(ServiceName.approvedPremises),
-  CAS1_FUTURE_MANAGER(ServiceName.approvedPremises),
-  CAS1_WORKFLOW_MANAGER(ServiceName.approvedPremises),
-  CAS1_CRU_MEMBER(ServiceName.approvedPremises),
-  CAS1_APPLICANT(ServiceName.approvedPremises),
-  CAS1_ADMIN(ServiceName.approvedPremises),
-  CAS1_REPORT_VIEWER(ServiceName.approvedPremises),
-  CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION(ServiceName.approvedPremises),
-  CAS1_EXCLUDED_FROM_MATCH_ALLOCATION(ServiceName.approvedPremises),
-  CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION(ServiceName.approvedPremises),
-  CAS1_APPEALS_MANAGER(ServiceName.approvedPremises),
-  CAS3_ASSESSOR(ServiceName.temporaryAccommodation),
-  CAS3_REFERRER(ServiceName.temporaryAccommodation),
-  CAS3_REPORTER(ServiceName.temporaryAccommodation),
+enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremisesUserRole?) {
+  CAS1_ASSESSOR(ServiceName.approvedPremises, ApprovedPremisesUserRole.assessor),
+  CAS1_MATCHER(ServiceName.approvedPremises, ApprovedPremisesUserRole.matcher),
+  CAS1_MANAGER(ServiceName.approvedPremises, ApprovedPremisesUserRole.manager),
+  CAS1_LEGACY_MANAGER(ServiceName.approvedPremises, ApprovedPremisesUserRole.legacyManager),
+  CAS1_FUTURE_MANAGER(ServiceName.approvedPremises, ApprovedPremisesUserRole.futureManager),
+  CAS1_WORKFLOW_MANAGER(ServiceName.approvedPremises, ApprovedPremisesUserRole.workflowManager),
+  CAS1_CRU_MEMBER(ServiceName.approvedPremises, ApprovedPremisesUserRole.cruMember),
+  CAS1_APPLICANT(ServiceName.approvedPremises, ApprovedPremisesUserRole.applicant),
+  CAS1_ADMIN(ServiceName.approvedPremises, ApprovedPremisesUserRole.roleAdmin),
+  CAS1_REPORT_VIEWER(ServiceName.approvedPremises, ApprovedPremisesUserRole.reportViewer),
+  CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION(ServiceName.approvedPremises, ApprovedPremisesUserRole.excludedFromAssessAllocation),
+  CAS1_EXCLUDED_FROM_MATCH_ALLOCATION(ServiceName.approvedPremises, ApprovedPremisesUserRole.excludedFromMatchAllocation),
+  CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION(ServiceName.approvedPremises, ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation),
+  CAS1_APPEALS_MANAGER(ServiceName.approvedPremises, ApprovedPremisesUserRole.appealsManager),
+  CAS3_ASSESSOR(ServiceName.temporaryAccommodation, null),
+  CAS3_REFERRER(ServiceName.temporaryAccommodation, null),
+  CAS3_REPORTER(ServiceName.temporaryAccommodation, null),
   ;
 
   companion object {
     fun getAllRolesForService(service: ServiceName) = UserRole.values().filter { it.service == service }
+
+    fun valueOf(apiValue: ApprovedPremisesUserRole) = UserRole.entries.first { it.cas1ApiValue == apiValue }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -317,6 +317,7 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
   CAS1_EXCLUDED_FROM_MATCH_ALLOCATION(ServiceName.approvedPremises, ApprovedPremisesUserRole.excludedFromMatchAllocation),
   CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION(ServiceName.approvedPremises, ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation),
   CAS1_APPEALS_MANAGER(ServiceName.approvedPremises, ApprovedPremisesUserRole.appealsManager),
+  CAS1_JANITOR(ServiceName.approvedPremises, ApprovedPremisesUserRole.janitor),
   CAS3_ASSESSOR(ServiceName.temporaryAccommodation, null),
   CAS3_REFERRER(ServiceName.temporaryAccommodation, null),
   CAS3_REPORTER(ServiceName.temporaryAccommodation, null),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -99,6 +99,12 @@ class UserAccessService(
   fun userCanManagePremisesOutOfServiceBed(user: UserEntity, premises: PremisesEntity) =
     userCanManagePremisesLostBeds(user, premises)
 
+  fun currentUserCanCancelOutOfServiceBed() =
+    userCanCancelOutOfServiceBed(userService.getUserForRequest())
+
+  fun userCanCancelOutOfServiceBed(user: UserEntity) =
+    user.hasRole(UserRole.CAS1_JANITOR)
+
   fun currentUserCanViewOutOfServiceBeds() =
     userCanViewOutOfServiceBeds(userService.getUserForRequest())
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -40,7 +40,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.AllocationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.transformQualifications
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.transformUserRoles
 import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as APIUserQualification
@@ -193,7 +192,7 @@ class UserService(
     clearRolesForService(user, ServiceName.approvedPremises)
 
     roles.forEach {
-      this.addRoleToUser(user, transformUserRoles(it))
+      this.addRoleToUser(user, UserRole.valueOf(it))
     }
 
     qualifications.forEach {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -80,23 +80,11 @@ class UserTransformer(
     return ProfileResponse(userName, loadError = null, transformJpaToApi(userResponse.user!!, xServiceName))
   }
 
-  private fun transformApprovedPremisesRoleToApi(userRole: UserRoleAssignmentEntity): ApprovedPremisesUserRole? = when (userRole.role) {
-    UserRole.CAS1_ADMIN -> ApprovedPremisesUserRole.roleAdmin
-    UserRole.CAS1_ASSESSOR -> ApprovedPremisesUserRole.assessor
-    UserRole.CAS1_MATCHER -> ApprovedPremisesUserRole.matcher
-    UserRole.CAS1_MANAGER -> ApprovedPremisesUserRole.manager
-    UserRole.CAS1_LEGACY_MANAGER -> ApprovedPremisesUserRole.legacyManager
-    UserRole.CAS1_FUTURE_MANAGER -> ApprovedPremisesUserRole.futureManager
-    UserRole.CAS1_WORKFLOW_MANAGER -> ApprovedPremisesUserRole.workflowManager
-    UserRole.CAS1_CRU_MEMBER -> ApprovedPremisesUserRole.cruMember
-    UserRole.CAS1_APPLICANT -> ApprovedPremisesUserRole.applicant
-    UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION -> ApprovedPremisesUserRole.excludedFromMatchAllocation
-    UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION -> ApprovedPremisesUserRole.excludedFromAssessAllocation
-    UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION -> ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation
-    UserRole.CAS1_REPORT_VIEWER -> ApprovedPremisesUserRole.reportViewer
-    UserRole.CAS1_APPEALS_MANAGER -> ApprovedPremisesUserRole.appealsManager
-    UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER, UserRole.CAS3_REPORTER -> null
-  }
+  private fun transformApprovedPremisesRoleToApi(userRole: UserRoleAssignmentEntity): ApprovedPremisesUserRole? =
+    when (userRole.role.service) {
+      ServiceName.approvedPremises -> userRole.role.cas1ApiValue!!
+      else -> null
+    }
 
   private fun transformTemporaryAccommodationRoleToApi(userRole: UserRoleAssignmentEntity): TemporaryAccommodationUserRole? = when (userRole.role) {
     UserRole.CAS3_ASSESSOR -> TemporaryAccommodationUserRole.assessor

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserServiceUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/UserServiceUtils.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as ApiUserQualification
 
 fun transformQualifications(qualification: ApiUserQualification): UserQualification = when (qualification) {
@@ -13,22 +11,4 @@ fun transformQualifications(qualification: ApiUserQualification): UserQualificat
   ApiUserQualification.womens -> UserQualification.WOMENS
   ApiUserQualification.mentalHealthSpecialist -> UserQualification.MENTAL_HEALTH_SPECIALIST
   ApiUserQualification.recoveryFocused -> UserQualification.RECOVERY_FOCUSED
-}
-
-@SuppressWarnings("CyclomaticComplexMethod")
-fun transformUserRoles(approvedPremisesUserRole: ApprovedPremisesUserRole): UserRole = when (approvedPremisesUserRole) {
-  ApprovedPremisesUserRole.assessor -> UserRole.CAS1_ASSESSOR
-  ApprovedPremisesUserRole.matcher -> UserRole.CAS1_MATCHER
-  ApprovedPremisesUserRole.manager -> UserRole.CAS1_MANAGER
-  ApprovedPremisesUserRole.legacyManager -> UserRole.CAS1_LEGACY_MANAGER
-  ApprovedPremisesUserRole.futureManager -> UserRole.CAS1_FUTURE_MANAGER
-  ApprovedPremisesUserRole.workflowManager -> UserRole.CAS1_WORKFLOW_MANAGER
-  ApprovedPremisesUserRole.cruMember -> UserRole.CAS1_CRU_MEMBER
-  ApprovedPremisesUserRole.applicant -> UserRole.CAS1_APPLICANT
-  ApprovedPremisesUserRole.roleAdmin -> UserRole.CAS1_ADMIN
-  ApprovedPremisesUserRole.reportViewer -> UserRole.CAS1_REPORT_VIEWER
-  ApprovedPremisesUserRole.excludedFromAssessAllocation -> UserRole.CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION
-  ApprovedPremisesUserRole.excludedFromMatchAllocation -> UserRole.CAS1_EXCLUDED_FROM_MATCH_ALLOCATION
-  ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation -> UserRole.CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION
-  ApprovedPremisesUserRole.appealsManager -> UserRole.CAS1_APPEALS_MANAGER
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3070,6 +3070,7 @@ components:
         - excluded_from_match_allocation
         - excluded_from_placement_application_allocation
         - appeals_manager
+        - janitor
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7646,6 +7646,7 @@ components:
         - excluded_from_match_allocation
         - excluded_from_placement_application_allocation
         - appeals_manager
+        - janitor
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3647,6 +3647,7 @@ components:
         - excluded_from_match_allocation
         - excluded_from_placement_application_allocation
         - appeals_manager
+        - janitor
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3661,6 +3661,7 @@ components:
         - excluded_from_match_allocation
         - excluded_from_placement_application_allocation
         - appeals_manager
+        - janitor
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3161,6 +3161,7 @@ components:
         - excluded_from_match_allocation
         - excluded_from_placement_application_allocation
         - appeals_manager
+        - janitor
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
@@ -1958,8 +1958,8 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Cancel Out-Of-Service Bed returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_JANITOR" ])
+    fun `Cancel Out-Of-Service Bed returns OK with correct body when user has the JANITOR role`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -733,6 +733,38 @@ class UserAccessServiceTest {
     assertThat(userAccessService.currentUserCanManagePremisesOutOfServiceBed(temporaryAccommodationPremisesNotInUserRegion)).isFalse
   }
 
+  @Test
+  fun `userCanCancelOutOfServiceBed returns true if the user has the JANITOR user role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(UserRole.CAS1_JANITOR)
+
+    assertThat(userAccessService.userCanCancelOutOfServiceBed(user)).isTrue
+  }
+
+  @Test
+  fun `userCanCancelOutOfServiceBed returns false if the user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.userCanCancelOutOfServiceBed(user)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanCancelOutOfServiceBed returns true if the current user has the JANITOR user role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    user.addRoleForUnitTest(UserRole.CAS1_JANITOR)
+
+    assertThat(userAccessService.currentUserCanCancelOutOfServiceBed()).isTrue
+  }
+
+  @Test
+  fun `currentUserCanCancelOutOfServiceBed returns false if the current user has no suitable role`() {
+    currentRequestIsFor(ServiceName.approvedPremises)
+
+    assertThat(userAccessService.currentUserCanCancelOutOfServiceBed()).isFalse
+  }
+
   @ParameterizedTest
   @EnumSource(value = UserRole::class, names = [ "CAS1_WORKFLOW_MANAGER", "CAS1_FUTURE_MANAGER", "CAS1_CRU_MEMBER" ])
   fun `userCanViewOutOfServiceBeds returns true if the user has the WORKFLOW_MANAGER user role`(role: UserRole) {


### PR DESCRIPTION
> See [APS-936 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-936).

This PR introduces the `CAS1_JANITOR` user role and applies it as a prerequisite for a user to access the `POST /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}/cancellations` endpoint.

This new role is intended to be expanded in future to allow a small number of users various permissions to modify or remove data beyond the capabilities of regular users.