### PR TITLE
APS-953: Enforce presence of OutOfServiceBedRevision.notes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
@@ -62,6 +62,10 @@ class Cas1OutOfServiceBedService(
         "$.reason" hasValidationError "doesNotExist"
       }
 
+      if (notes.isNullOrEmpty()) {
+        "$.notes" hasValidationError "empty"
+      }
+
       if (validationErrors.any()) {
         return fieldValidationError
       }
@@ -118,6 +122,10 @@ class Cas1OutOfServiceBedService(
         val reason = outOfServiceBedReasonRepository.findByIdOrNull(reasonId)
         if (reason == null) {
           "$.reason" hasValidationError "doesNotExist"
+        }
+
+        if (notes.isNullOrEmpty()) {
+          "$.notes" hasValidationError "empty"
         }
 
         if (validationErrors.any()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
@@ -127,7 +127,7 @@ class Cas1OutOfServiceBedServiceTest {
         endDate = LocalDate.parse("2022-08-25"),
         reasonId = reasonId,
         referenceNumber = "12345",
-        notes = "notes",
+        notes = "",
         bedId = UUID.randomUUID(),
       )
 
@@ -135,6 +135,7 @@ class Cas1OutOfServiceBedServiceTest {
       assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
         entry("$.endDate", "beforeStartDate"),
         entry("$.reason", "doesNotExist"),
+        entry("$.notes", "empty"),
       )
     }
 
@@ -213,7 +214,7 @@ class Cas1OutOfServiceBedServiceTest {
         endDate = LocalDate.parse("2022-08-25"),
         reasonId = reasonId,
         referenceNumber = "12345",
-        notes = "notes",
+        notes = "",
       )
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
@@ -222,6 +223,7 @@ class Cas1OutOfServiceBedServiceTest {
       assertThat((resultEntity as ValidatableActionResult.FieldValidationError).validationMessages).contains(
         entry("$.endDate", "beforeStartDate"),
         entry("$.reason", "doesNotExist"),
+        entry("$.notes", "empty"),
       )
     }
 


### PR DESCRIPTION
We will be migrating existing LostBed records to the new OutOfServiceBed models. As `LostBed.notes` are nullable we won't enforce the presence of notes on the `OutOfServiceBedRevision` entity yet. Instead we use a validation step within the `OutOfServiceBedService`.

Once the new OOSB system is released and the `LostBed` data has been migrated we can make `OutOfServiceBedRevision.notes` non-nullable