### PR TITLE
APS-999 Send slack events to #cas-events

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: approved-premises-team-events
+    default: cas-events
   releases-slack-channel:
     type: string
-    default: approved-premises-team-events
+    default: cas-events
   run-security-workflow-on-branch:
     type: boolean
     default: false


### PR DESCRIPTION
This is replacing the CAS1 specific approved-premises-team-events