### PR TITLE
APS-972 - Add Placement Request ID Metadata to Booking Made/Not Made Domain Events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -183,6 +183,7 @@ enum class MetaDataName {
   CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER,
   CAS1_PLACEMENT_APPLICATION_ID,
   CAS1_REQUESTED_AP_TYPE,
+  CAS1_PLACEMENT_REQUEST_ID,
 }
 
 enum class DomainEventType(val typeName: String, val typeDescription: String, val timelineEventType: TimelineEventType?) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -304,7 +304,6 @@ class BookingService(
         application = application,
         booking = booking,
         user = user,
-        bookingCreatedAt = bookingCreatedAt,
       )
       cas1BookingEmailService.bookingMade(placementRequest.application, booking)
 
@@ -454,7 +453,6 @@ class BookingService(
           eventNumber,
           booking,
           user!!,
-          bookingCreatedAt,
         )
 
         if (onlineApplication != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -304,6 +304,7 @@ class BookingService(
         application = application,
         booking = booking,
         user = user,
+        placementRequest = placementRequest,
       )
       cas1BookingEmailService.bookingMade(placementRequest.application, booking)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClien
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapOfNonNullValues
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -40,6 +42,7 @@ class Cas1BookingDomainEventService(
     application: ApprovedPremisesApplicationEntity,
     booking: BookingEntity,
     user: UserEntity,
+    placementRequest: PlacementRequestEntity,
   ) {
     bookingMade(
       applicationId = application.id,
@@ -50,6 +53,7 @@ class Cas1BookingDomainEventService(
       releaseType = application.releaseType,
       sentenceType = application.sentenceType,
       situation = application.situation,
+      placementRequestId = placementRequest.id,
     )
   }
 
@@ -73,6 +77,7 @@ class Cas1BookingDomainEventService(
       releaseType = onlineApplication?.releaseType,
       sentenceType = onlineApplication?.sentenceType,
       situation = onlineApplication?.situation,
+      placementRequestId = null,
     )
   }
 
@@ -151,6 +156,7 @@ class Cas1BookingDomainEventService(
     sentenceType: String?,
     releaseType: String?,
     situation: String?,
+    placementRequestId: UUID?,
   ) {
     val domainEventId = UUID.randomUUID()
 
@@ -207,6 +213,9 @@ class Cas1BookingDomainEventService(
             sentenceType = sentenceType,
             situation = situation,
           ),
+        ),
+        metadata = mapOfNonNullValues(
+          MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequestId?.toString(),
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -128,6 +128,9 @@ class Cas1BookingDomainEventService(
             failureDescription = notes,
           ),
         ),
+        metadata = mapOfNonNullValues(
+          MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequest.id.toString(),
+        ),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -40,14 +40,12 @@ class Cas1BookingDomainEventService(
     application: ApprovedPremisesApplicationEntity,
     booking: BookingEntity,
     user: UserEntity,
-    bookingCreatedAt: OffsetDateTime,
   ) {
     bookingMade(
       applicationId = application.id,
       eventNumber = application.eventNumber,
       booking = booking,
       user = user,
-      bookingCreatedAt = bookingCreatedAt,
       applicationSubmittedOn = application.submittedAt,
       releaseType = application.releaseType,
       sentenceType = application.sentenceType,
@@ -61,7 +59,6 @@ class Cas1BookingDomainEventService(
     eventNumber: String?,
     booking: BookingEntity,
     user: UserEntity,
-    bookingCreatedAt: OffsetDateTime,
   ) {
     val applicationId = (onlineApplication?.id ?: offlineApplication?.id)
     val eventNumberForDomainEvent =
@@ -72,7 +69,6 @@ class Cas1BookingDomainEventService(
       eventNumber = eventNumberForDomainEvent!!,
       booking = booking,
       user = user,
-      bookingCreatedAt = bookingCreatedAt,
       applicationSubmittedOn = onlineApplication?.submittedAt,
       releaseType = onlineApplication?.releaseType,
       sentenceType = onlineApplication?.sentenceType,
@@ -151,7 +147,6 @@ class Cas1BookingDomainEventService(
     eventNumber: String,
     booking: BookingEntity,
     user: UserEntity,
-    bookingCreatedAt: OffsetDateTime,
     applicationSubmittedOn: OffsetDateTime?,
     sentenceType: String?,
     releaseType: String?,
@@ -168,6 +163,7 @@ class Cas1BookingDomainEventService(
     val staffDetails = getStaffDetails(user.deliusUsername)
 
     val approvedPremises = booking.premises as ApprovedPremisesEntity
+    val bookingCreatedAt = booking.createdAt
 
     domainEventService.saveBookingMadeDomainEvent(
       DomainEvent(

--- a/src/main/resources/db/migration/all/20240703153901__backfill_cas1_booking_made_event_placement_request_id.sql
+++ b/src/main/resources/db/migration/all/20240703153901__backfill_cas1_booking_made_event_placement_request_id.sql
@@ -1,0 +1,10 @@
+-- This will only backfill the most recent booking made for a placement
+-- request, but for reporting purposes this is adequate
+INSERT INTO domain_events_metadata (domain_event_id, name, value)
+SELECT
+    evt.id as id,
+    'CAS1_PLACEMENT_REQUEST_ID',
+    cast(pr.id as TEXT)
+FROM domain_events evt
+         INNER JOIN placement_requests pr on pr.booking_id = evt.booking_id
+WHERE evt.type = 'APPROVED_PREMISES_BOOKING_MADE';

--- a/src/main/resources/db/migration/all/20240705104459__backfill_cas1_booking_not_made_event_placement_request_id.sql
+++ b/src/main/resources/db/migration/all/20240705104459__backfill_cas1_booking_not_made_event_placement_request_id.sql
@@ -1,0 +1,8 @@
+INSERT INTO domain_events_metadata (domain_event_id, name, value)
+SELECT
+    evt.id as id,
+    'CAS1_PLACEMENT_REQUEST_ID',
+    cast(bnm.placement_request_id as TEXT)
+FROM domain_events evt
+INNER JOIN booking_not_mades bnm on bnm.created_at = evt.occurred_at
+WHERE evt.type = 'APPROVED_PREMISES_BOOKING_NOT_MADE';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -4315,7 +4315,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { bookingEntity }
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
-      every { mockCas1BookingDomainEventService.adhocBookingMade(any(), any(), any(), any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.adhocBookingMade(any(), any(), any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
     }
 
@@ -4492,7 +4492,6 @@ class BookingServiceTest {
           eventNumber = "eventNumber",
           booking = booking,
           user = user,
-          bookingCreatedAt = any(),
         )
       }
 
@@ -4540,7 +4539,6 @@ class BookingServiceTest {
           eventNumber = "eventNumber",
           booking = booking,
           user = user,
-          bookingCreatedAt = any(),
         )
       }
 
@@ -4588,7 +4586,6 @@ class BookingServiceTest {
           eventNumber = "eventNumber",
           booking = booking,
           user = user,
-          bookingCreatedAt = any(),
         )
       }
 
@@ -4634,7 +4631,6 @@ class BookingServiceTest {
           eventNumber = "eventNumber",
           booking = booking,
           user = user,
-          bookingCreatedAt = any(),
         )
       }
     }
@@ -4679,7 +4675,6 @@ class BookingServiceTest {
           eventNumber = "eventNumber",
           booking = booking,
           user = user,
-          bookingCreatedAt = any(),
         )
       }
     }
@@ -6394,7 +6389,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -6413,7 +6408,6 @@ class BookingServiceTest {
           application,
           booking,
           user,
-          any(),
         )
       }
 
@@ -6448,7 +6442,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -6467,7 +6461,6 @@ class BookingServiceTest {
           application,
           booking,
           user,
-          any(),
         )
       }
 
@@ -6527,7 +6520,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -6546,7 +6539,6 @@ class BookingServiceTest {
           application,
           booking,
           user,
-          any(),
         )
       }
 
@@ -6592,7 +6584,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -6611,7 +6603,6 @@ class BookingServiceTest {
           application,
           booking,
           workflowManager,
-          any(),
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -6389,7 +6389,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -6408,6 +6408,7 @@ class BookingServiceTest {
           application,
           booking,
           user,
+          placementRequest,
         )
       }
 
@@ -6442,7 +6443,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -6461,6 +6462,7 @@ class BookingServiceTest {
           application,
           booking,
           user,
+          placementRequest,
         )
       }
 
@@ -6520,7 +6522,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -6539,6 +6541,7 @@ class BookingServiceTest {
           application,
           booking,
           user,
+          placementRequest,
         )
       }
 
@@ -6584,7 +6587,7 @@ class BookingServiceTest {
       every { mockBookingListener.prePersist(any()) } returns Unit
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
-      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
       every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
@@ -6603,6 +6606,7 @@ class BookingServiceTest {
           application,
           booking,
           workflowManager,
+          placementRequest,
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
@@ -89,6 +90,10 @@ class Cas1BookingDomainEventServiceTest {
       .withCreatedAt(createdAt)
       .produce()
 
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .produce()
+
     @BeforeEach
     fun before() {
       every { domainEventService.saveBookingMadeDomainEvent(any()) } just Runs
@@ -117,7 +122,7 @@ class Cas1BookingDomainEventServiceTest {
 
     @Test
     fun `bookingMade saves domain event`() {
-      service.bookingMade(application, booking, user)
+      service.bookingMade(application, booking, user, placementRequest)
 
       val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()
 
@@ -154,6 +159,8 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(data.releaseType).isEqualTo(application.releaseType)
       assertThat(data.sentenceType).isEqualTo(application.sentenceType)
       assertThat(data.situation).isEqualTo(application.situation)
+
+      assertThat(domainEvent.metadata).isEqualTo(mapOf(MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequest.id.toString()))
     }
 
     @Test
@@ -201,6 +208,8 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(data.releaseType).isEqualTo(application.releaseType)
       assertThat(data.sentenceType).isEqualTo(application.sentenceType)
       assertThat(data.situation).isEqualTo(application.situation)
+
+      assertThat(domainEvent.metadata).isEmpty()
     }
 
     @Test
@@ -249,6 +258,8 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(data.releaseType).isNull()
       assertThat(data.sentenceType).isNull()
       assertThat(data.situation).isNull()
+
+      assertThat(domainEvent.metadata).isEmpty()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
@@ -79,14 +79,15 @@ class Cas1BookingDomainEventServiceTest {
       .withLocalAuthorityArea(LocalAuthorityAreaEntityFactory().withName("authority name").produce())
       .produce()
 
+    val createdAt = OffsetDateTime.now()
+
     val booking = BookingEntityFactory()
       .withDefaults()
       .withCrn("THEBOOKINGCRN")
       .withArrivalDate(LocalDate.of(2025, 12, 11))
       .withPremises(premises)
+      .withCreatedAt(createdAt)
       .produce()
-
-    val createdAt = OffsetDateTime.now()
 
     @BeforeEach
     fun before() {
@@ -116,7 +117,7 @@ class Cas1BookingDomainEventServiceTest {
 
     @Test
     fun `bookingMade saves domain event`() {
-      service.bookingMade(application, booking, user, createdAt)
+      service.bookingMade(application, booking, user)
 
       val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()
 
@@ -131,9 +132,12 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(domainEvent.applicationId).isEqualTo(application.id)
       assertThat(domainEvent.crn).isEqualTo("THEBOOKINGCRN")
       assertThat(domainEvent.bookingId).isEqualTo(booking.id)
+      assertThat(domainEvent.occurredAt).isEqualTo(createdAt.toInstant())
       assertThat(domainEvent.data.eventType).isEqualTo(EventType.bookingMade)
+      assertThat(domainEvent.data.timestamp).isEqualTo(createdAt.toInstant())
 
       val data = domainEvent.data.eventDetails
+      assertThat(data.createdAt).isEqualTo(createdAt.toInstant())
       assertThat(data.applicationId).isEqualTo(application.id)
       assertThat(data.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")
       assertThat(data.bookingId).isEqualTo(booking.id)
@@ -160,7 +164,6 @@ class Cas1BookingDomainEventServiceTest {
         eventNumber = "adhoc event number",
         booking = booking,
         user = user,
-        bookingCreatedAt = createdAt,
       )
 
       val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()
@@ -176,9 +179,12 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(domainEvent.applicationId).isEqualTo(application.id)
       assertThat(domainEvent.crn).isEqualTo("THEBOOKINGCRN")
       assertThat(domainEvent.bookingId).isEqualTo(booking.id)
+      assertThat(domainEvent.occurredAt).isEqualTo(createdAt.toInstant())
       assertThat(domainEvent.data.eventType).isEqualTo(EventType.bookingMade)
+      assertThat(domainEvent.data.timestamp).isEqualTo(createdAt.toInstant())
 
       val data = domainEvent.data.eventDetails
+      assertThat(data.createdAt).isEqualTo(createdAt.toInstant())
       assertThat(data.applicationId).isEqualTo(application.id)
       assertThat(data.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")
       assertThat(data.bookingId).isEqualTo(booking.id)
@@ -209,7 +215,6 @@ class Cas1BookingDomainEventServiceTest {
         eventNumber = "adhoc event number",
         booking = booking,
         user = user,
-        bookingCreatedAt = createdAt,
       )
 
       val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()
@@ -258,7 +263,6 @@ class Cas1BookingDomainEventServiceTest {
         eventNumber = "adhoc event number",
         booking = booking,
         user = user,
-        bookingCreatedAt = createdAt,
       )
 
       val domainEventArgument = slot<DomainEvent<BookingMadeEnvelope>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
@@ -374,6 +374,8 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(data.attemptedAt).isNotNull()
       assertThat(data.attemptedBy.staffMember!!.staffCode).isEqualTo("the staff code")
       assertThat(data.failureDescription).isEqualTo("the notes")
+
+      assertThat(domainEvent.metadata).isEqualTo(mapOf(MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequest.id.toString()))
     }
   }
 }


### PR DESCRIPTION
Add Placement Request ID Metadata to Booking Made/Not Made Domain Events, including backfilling existing entries, where possible (see notes in migration files)