### PR TITLE
APS-922 : API - Domain Event for Placement Application Decisions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -206,13 +206,14 @@ class DomainEventDescriber(
 
     return event.describe { data ->
       val details = data.eventDetails
+      val summary = details.decisionSummary?.let { " The reason was: $it." } ?: ""
 
-      val description = when (details.decision) {
-        RequestForPlacementAssessed.Decision.accepted -> "A request for placement assessment was accepted."
-        RequestForPlacementAssessed.Decision.rejected -> "A request for placement assessment was rejected."
+      when (details.decision) {
+        RequestForPlacementAssessed.Decision.accepted ->
+          "A request for placement assessment was accepted. ${buildRequestForPlacementDescription(details.expectedArrival, details.duration)}.$summary"
+        RequestForPlacementAssessed.Decision.rejected ->
+          "A request for placement assessment was rejected. ${buildRequestForPlacementDescription(details.expectedArrival, details.duration, true)}.$summary"
       }
-      val summary = details.decisionSummary?.let { " The reason was: $it" } ?: ""
-      "$description$summary"
     }
   }
 
@@ -228,9 +229,9 @@ class DomainEventDescriber(
     return "$prelude $allocatedToDescription $allocatedByDescription".trim()
   }
 
-  private fun buildRequestForPlacementDescription(expectedArrival: LocalDate, duration: Int): String {
+  private fun buildRequestForPlacementDescription(expectedArrival: LocalDate, duration: Int, rejected: Boolean = false): String {
     val endDate = expectedArrival.plusDays(duration.toLong())
-    return "The placement request is for ${expectedArrival.toUiFormat()} to ${endDate.toUiFormat()} (${toWeekAndDayDurationString(duration)})"
+    return "The placement request ${if (rejected) "was" else "is"} for ${expectedArrival.toUiFormat()} to ${endDate.toUiFormat()} (${toWeekAndDayDurationString(duration)})"
   }
 
   private fun DomainEventSummary.id(): UUID = UUID.fromString(this.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -194,6 +194,7 @@ class Cas1PlacementApplicationDomainEventService(
     val domainEventId = UUID.randomUUID()
     val eventOccurredAt = Instant.now()
     val application = placementApplication.application
+    val dates = placementApplication.placementDates[0]
 
     val assessor = assessedByUser.let { domainEventTransformer.toStaffMember(it) }
 
@@ -213,6 +214,8 @@ class Cas1PlacementApplicationDomainEventService(
       assessedBy = assessor,
       decision = assessmentDecision,
       decisionSummary = placementApplicationDecision.decisionSummary,
+      expectedArrival = dates.expectedArrival,
+      duration = dates.duration,
     )
 
     domainEventService.saveRequestForPlacementAssessedEvent(

--- a/src/main/resources/db/migration/all/20240704135216__delete_assessed_request_for_placements_domain_events.sql
+++ b/src/main/resources/db/migration/all/20240704135216__delete_assessed_request_for_placements_domain_events.sql
@@ -1,0 +1,10 @@
+DELETE FROM domain_events_metadata
+WHERE
+    domain_event_id IN (
+        SELECT ID FROM domain_events
+        WHERE domain_events.type = 'APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED'
+     );
+
+DELETE FROM domain_events
+WHERE
+    domain_events.type = 'APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED';

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1777,12 +1777,21 @@ components:
         decisionSummary:
           type: string
           example: the decision was to accept
+        expectedArrival:
+          type: string
+          example: '2023-01-30'
+          format: date
+        duration:
+          type: integer
+          example: 7
       required:
         - applicationId
         - applicationUrl
         - placementApplicationId
         - assessedBy
         - decision
+        - expectedArrival
+        - duration
     AppealDecision:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/RequestForPlacementAssessedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/RequestForPlacementAssessedFactory.kt
@@ -4,7 +4,9 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
 import java.util.UUID
 
 class RequestForPlacementAssessedFactory : Factory<RequestForPlacementAssessed> {
@@ -14,6 +16,8 @@ class RequestForPlacementAssessedFactory : Factory<RequestForPlacementAssessed> 
   private var assessedBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
   private var decision: Yielded<RequestForPlacementAssessed.Decision> = { RequestForPlacementAssessed.Decision.accepted }
   private var decisionSummary: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
+  private var expectedArrival: Yielded<LocalDate> = { LocalDate.now() }
+  private var duration: Yielded<Int> = { randomInt(0, 1000) }
 
   fun withApplicationId(applicationId: UUID) = apply {
     this.applicationId = { applicationId }
@@ -39,6 +43,14 @@ class RequestForPlacementAssessedFactory : Factory<RequestForPlacementAssessed> 
     this.decisionSummary = { decisionSummary }
   }
 
+  fun withExpectedArrival(expectedArrival: LocalDate) = apply {
+    this.expectedArrival = { expectedArrival }
+  }
+
+  fun withDuration(duration: Int) = apply {
+    this.duration = { duration }
+  }
+
   override fun produce() = RequestForPlacementAssessed(
     applicationId = this.applicationId(),
     applicationUrl = this.applicationUrl(),
@@ -46,5 +58,7 @@ class RequestForPlacementAssessedFactory : Factory<RequestForPlacementAssessed> 
     assessedBy = this.assessedBy(),
     decision = this.decision(),
     decisionSummary = this.decisionSummary(),
+    expectedArrival = this.expectedArrival(),
+    duration = this.duration(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -528,6 +528,7 @@ class DomainEventDescriberTest {
   @EnumSource(value = RequestForPlacementAssessed.Decision::class)
   fun `Returns expected description for request for placement assessed event with summary`(decision: RequestForPlacementAssessed.Decision) {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED)
+    val expectedTermUsed = if (decision == RequestForPlacementAssessed.Decision.rejected) "was" else "is"
 
     every { mockDomainEventService.getRequestForPlacementAssessedEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
       RequestForPlacementAssessedEnvelope(
@@ -536,7 +537,9 @@ class DomainEventDescriberTest {
         eventType = EventType.requestForPlacementCreated,
         eventDetails = RequestForPlacementAssessedFactory()
           .withDecision(decision)
-          .withDecisionSummary(decision.toString())
+          .withDecisionSummary("Request was $decision")
+          .withExpectedArrival(LocalDate.of(2024, 5, 3))
+          .withDuration(7)
           .produce(),
       )
     }
@@ -544,7 +547,7 @@ class DomainEventDescriberTest {
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
     assertThat(result).isEqualTo(
-      "A request for placement assessment was $decision. The reason was: $decision",
+      "A request for placement assessment was $decision. The placement request $expectedTermUsed for Friday 3 May 2024 to Friday 10 May 2024 (1 week). The reason was: Request was $decision.",
     )
   }
 
@@ -552,6 +555,7 @@ class DomainEventDescriberTest {
   @EnumSource(value = RequestForPlacementAssessed.Decision::class)
   fun `Returns expected description for request for placement assessed event without summary`(decision: RequestForPlacementAssessed.Decision) {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED)
+    val expectedTermUsed = if (decision == RequestForPlacementAssessed.Decision.rejected) "was" else "is"
 
     every { mockDomainEventService.getRequestForPlacementAssessedEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
       RequestForPlacementAssessedEnvelope(
@@ -561,6 +565,8 @@ class DomainEventDescriberTest {
         eventDetails = RequestForPlacementAssessedFactory()
           .withDecision(decision)
           .withDecisionSummary(null)
+          .withExpectedArrival(LocalDate.of(2024, 5, 3))
+          .withDuration(7)
           .produce(),
       )
     }
@@ -568,7 +574,7 @@ class DomainEventDescriberTest {
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
     assertThat(result).isEqualTo(
-      "A request for placement assessment was $decision.",
+      "A request for placement assessment was $decision. The placement request $expectedTermUsed for Friday 3 May 2024 to Friday 10 May 2024 (1 week).",
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
@@ -416,6 +416,8 @@ class Cas1PlacementApplicationDomainEventServiceTest {
             assertThat(eventDetails.assessedBy).isEqualTo(assessedByStaffMember)
             assertThat(eventDetails.decision.value).isEqualTo(decisionMade.value)
             assertThat(eventDetails.decisionSummary).isEqualTo(decisionSummary)
+            assertThat(eventDetails.expectedArrival).isEqualTo(LocalDate.of(2024, 5, 3))
+            assertThat(eventDetails.duration).isEqualTo(7)
           },
         )
       }
@@ -462,12 +464,20 @@ class Cas1PlacementApplicationDomainEventServiceTest {
     }
 
     private fun getPlacementApplicationWithDecision(decision: PlacementApplicationDecision?): PlacementApplicationEntity {
-      return PlacementApplicationEntityFactory()
+      val placementApplication = PlacementApplicationEntityFactory()
         .withApplication(application)
         .withAllocatedToUser(UserEntityFactory().withDefaultProbationRegion().produce())
         .withDecision(decision)
         .withCreatedByUser(user)
         .produce()
+      placementApplication.placementDates = mutableListOf(
+        PlacementDateEntityFactory()
+          .withPlacementApplication(placementApplication)
+          .withExpectedArrival(LocalDate.of(2024, 5, 3))
+          .withDuration(7)
+          .produce(),
+      )
+      return placementApplication
     }
   }
 }


### PR DESCRIPTION
Added arrival date and duration to the domain event to clarify which request the decision is for.
Existing Request For Placement decision (assessed) domain events are cleared from the DB.
Recording this domain event isn't actually live yet so clearing them out is not a problem. 