### PR TITLE
Fix performance issue when generate CAS3 utilisation report for all regions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUtilisationReportGenerator.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
@@ -11,18 +8,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayServic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.earliestDateOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.latestDateOf
+import java.util.UUID
 
 class BedUtilisationReportGenerator(
-  private val bookingRepository: BookingRepository,
-  private val lostBedsRepository: LostBedsRepository,
   private val workingDayService: WorkingDayService,
-) : ReportGenerator<BedEntity, BedUtilisationReportRow, BedUtilisationReportProperties>(BedUtilisationReportRow::class) {
-  override fun filter(properties: BedUtilisationReportProperties): (BedEntity) -> Boolean = {
-    checkServiceType(properties.serviceName, it.room.premises) &&
-      (properties.probationRegionId == null || it.room.premises.probationRegion.id == properties.probationRegionId)
+) : ReportGenerator<BedUtilisationReportData, BedUtilisationReportRow, BedUtilisationReportProperties>(BedUtilisationReportRow::class) {
+  override fun filter(properties: BedUtilisationReportProperties): (BedUtilisationReportData) -> Boolean = {
+    true
   }
 
-  override val convert: BedEntity.(properties: BedUtilisationReportProperties) -> List<BedUtilisationReportRow> = { properties ->
+  override val convert: BedUtilisationReportData.(properties: BedUtilisationReportProperties) -> List<BedUtilisationReportRow> = { properties ->
     var bookedDaysActiveAndClosed = 0
     var confirmedDays = 0
     var provisionalDays = 0
@@ -30,13 +25,9 @@ class BedUtilisationReportGenerator(
     var effectiveTurnaroundDays = 0
     var voidDays = 0
 
-    val nonCancelledBookings = bookingRepository.findAllByOverlappingDateForBed(properties.startDate, properties.endDate, this)
-      .filter { it.cancellation == null }
-
-    val nonCancelledVoids = lostBedsRepository.findAllByOverlappingDateForBed(properties.startDate, properties.endDate, this)
-      .filter { it.cancellation == null }
-
-    val premises = this.room.premises
+    val bedspace = this.bedspaceReportData
+    val nonCancelledBookings = this.bookingsReportData.filter { it.cancellationId == null }
+    val nonCancelledVoids = this.lostBedReportData.filter { it.cancellationId == null }
 
     nonCancelledBookings
       .forEach { booking ->
@@ -45,14 +36,14 @@ class BedUtilisationReportGenerator(
           .count()
 
         when {
-          booking.arrival != null -> bookedDaysActiveAndClosed += daysOfBookingInMonth
-          booking.confirmation != null && booking.arrival == null -> confirmedDays += daysOfBookingInMonth
-          booking.confirmation == null -> provisionalDays += daysOfBookingInMonth
+          booking.arrivalId != null -> bookedDaysActiveAndClosed += daysOfBookingInMonth
+          booking.confirmationId != null && booking.arrivalId == null -> confirmedDays += daysOfBookingInMonth
+          booking.confirmationId == null -> provisionalDays += daysOfBookingInMonth
         }
 
-        if (booking.turnaround != null) {
+        if (booking.turnaroundId != null) {
           val turnaroundStartDate = booking.departureDate.plusDays(1)
-          val turnaroundEndDate = workingDayService.addWorkingDays(booking.departureDate, booking.turnaround!!.workingDayCount)
+          val turnaroundEndDate = workingDayService.addWorkingDays(booking.departureDate, booking.workingDayCount!!)
           val firstDayOfTurnaroundInMonth = latestDateOf(turnaroundStartDate, properties.startDate)
           val lastDayOfTurnaroundInMonth = earliestDateOf(turnaroundEndDate, properties.endDate)
 
@@ -73,26 +64,25 @@ class BedUtilisationReportGenerator(
 
     val totalBookedDays = bookedDaysActiveAndClosed
     val bedspaceOnlineDaysStartDate =
-      if (this.createdAt == null) properties.startDate else latestDateOf(this.createdAt!!.toLocalDate(), properties.startDate)
+      if (bedspace.bedspaceStartDate == null) properties.startDate else latestDateOf(bedspace.bedspaceStartDate!!, properties.startDate)
 
     val bedspaceOnlineDaysEndDate =
-      if (this.endDate == null) properties.endDate else earliestDateOf(this.endDate!!, properties.endDate)
+      if (bedspace.bedspaceEndDate == null) properties.endDate else earliestDateOf(bedspace.bedspaceEndDate!!, properties.endDate)
 
     val bedspaceOnlineDays = bedspaceOnlineDaysStartDate
       .getDaysUntilInclusive(bedspaceOnlineDaysEndDate)
       .count()
 
-    val temporaryAccommodationPremisesEntity = premises as? TemporaryAccommodationPremisesEntity
     listOf(
       BedUtilisationReportRow(
-        probationRegion = temporaryAccommodationPremisesEntity?.probationRegion?.name,
-        pdu = temporaryAccommodationPremisesEntity?.probationDeliveryUnit?.name,
-        localAuthority = temporaryAccommodationPremisesEntity?.localAuthorityArea?.name,
-        propertyRef = premises.name,
-        addressLine1 = premises.addressLine1,
-        town = premises.town,
-        postCode = premises.postcode,
-        bedspaceRef = this.room.name,
+        probationRegion = bedspace.probationRegionName,
+        pdu = bedspace.probationDeliveryUnitName,
+        localAuthority = bedspace.localAuthorityName,
+        propertyRef = bedspace.premisesName,
+        addressLine1 = bedspace.addressLine1,
+        town = bedspace.town,
+        postCode = bedspace.postCode,
+        bedspaceRef = bedspace.roomName,
         bookedDaysActiveAndClosed = bookedDaysActiveAndClosed,
         confirmedDays = confirmedDays,
         provisionalDays = provisionalDays,
@@ -100,12 +90,12 @@ class BedUtilisationReportGenerator(
         effectiveTurnaroundDays = effectiveTurnaroundDays,
         voidDays = voidDays,
         totalBookedDays = totalBookedDays,
-        bedspaceStartDate = if (this.createdAt == null) null else this.createdAt!!.toLocalDate(),
-        bedspaceEndDate = this.endDate,
+        bedspaceStartDate = if (bedspace.bedspaceStartDate == null) null else bedspace.bedspaceStartDate!!,
+        bedspaceEndDate = bedspace.bedspaceEndDate,
         bedspaceOnlineDays = bedspaceOnlineDays,
         occupancyRate = totalBookedDays.toDouble() / bedspaceOnlineDays,
-        uniquePropertyRef = premises.id.toShortBase58(),
-        uniqueBedspaceRef = this.room.id.toShortBase58(),
+        uniquePropertyRef = UUID.fromString(bedspace.premisesId).toShortBase58(),
+        uniqueBedspaceRef = UUID.fromString(bedspace.roomId).toShortBase58(),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportData.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationLostBedReportData
+
+data class BedUtilisationReportData(
+  val bedspaceReportData: BedUtilisationBedspaceReportData,
+  val bookingsReportData: List<BedUtilisationBookingReportData>,
+  val lostBedReportData: List<BedUtilisationLostBedReportData>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import java.time.LocalDate
+import java.util.UUID
+
+interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
+  @Query(
+    """
+    SELECT
+        CAST(b.id AS VARCHAR) AS bedId,
+        CAST(r.id AS VARCHAR) AS roomId,
+        CAST(p.id AS VARCHAR) AS premisesId,
+        pr.name AS probationRegionName,
+        pdu.name AS probationDeliveryUnitName,
+        laa.name AS localAuthorityName,
+        p.name AS premisesName,
+        p.address_line1 AS addressLine1,
+        p.town AS town,
+        p.postcode AS postCode,
+        r.name AS roomName,
+        b.created_at AS bedspaceStartDate,
+        b.end_date AS bedspaceEndDate
+    FROM beds b
+    INNER JOIN rooms r ON b.room_id = r.id
+    LEFT JOIN premises p ON r.premises_id = p.id
+    LEFT JOIN probation_regions pr ON p.probation_region_id = pr.id
+    INNER JOIN temporary_accommodation_premises tap ON p.id = tap.premises_id
+    LEFT JOIN probation_delivery_units pdu ON tap.probation_delivery_unit_id = pdu.id
+    LEFT JOIN local_authority_areas laa ON p.local_authority_area_id = laa.id
+    WHERE
+      p.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
+    ORDER BY b.name      
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBedspaces(
+    probationRegionId: UUID?,
+  ): List<BedUtilisationBedspaceReportData>
+
+  @Query(
+    """
+    SELECT
+      booking.arrival_date AS arrivalDate,
+      booking.departure_date AS departureDate,
+      CAST(bed.id AS VARCHAR) AS bedId,
+      CAST(cancellation.id AS VARCHAR) AS cancellationId,
+      CAST(arrival.id AS VARCHAR) AS arrivalId,
+      CAST(confirmation.id AS VARCHAR) AS confirmationId,
+      CAST(turnaround.Id AS VARCHAR) AS turnaroundId,
+      turnaround.working_day_count AS workingDayCount
+    From bookings booking
+    LEFT JOIN cancellations cancellation ON cancellation.booking_id = booking.id
+    LEFT JOIN beds bed ON bed.id = booking.bed_id
+    LEFT JOIN premises premises ON booking.premises_id = premises.id
+    LEFT JOIN probation_regions probation_region ON probation_region.id = premises.probation_region_id
+    LEFT JOIN arrivals arrival ON booking.id = arrival.booking_id
+    LEFT JOIN confirmations confirmation ON booking.id = confirmation.booking_id
+    LEFT JOIN turnarounds turnaround ON booking.id = turnaround.booking_id   
+    WHERE
+        premises.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR premises.probation_region_id = :probationRegionId)
+      AND booking.arrival_date <= :endDate AND booking.departure_date >= :startDate
+    ORDER BY booking.id
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBookingsByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedUtilisationBookingReportData>
+
+  @Query(
+    """
+    SELECT
+        CAST(b.id AS VARCHAR) AS bedId,
+        lb.start_date AS startDate,
+        lb.end_date AS endDate,
+        CAST(lbc.id AS VARCHAR) AS cancellationId
+    From lost_beds lb
+    LEFT JOIN beds b ON lb.bed_id = b.id
+    LEFT JOIN rooms r ON b.room_id = r.id
+    LEFT JOIN premises p ON r.premises_id = p.id
+    LEFT JOIN lost_bed_cancellations lbc ON lb.id = lbc.lost_bed_id
+    WHERE
+        p.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
+      AND lb.start_date <= :endDate AND lb.end_date >= :startDate
+      AND lbc.id is NULL
+    ORDER BY lb.id     
+    """,
+    nativeQuery = true,
+  )
+  fun findAllLostBedByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedUtilisationLostBedReportData>
+}
+interface BedUtilisationBedspaceReportData {
+  val bedId: String
+  val probationRegionName: String?
+  val probationDeliveryUnitName: String?
+  val localAuthorityName: String?
+  val premisesName: String
+  val addressLine1: String
+  val town: String?
+  val postCode: String
+  val roomName: String
+  val bedspaceStartDate: LocalDate?
+  val bedspaceEndDate: LocalDate?
+  val premisesId: String
+  val roomId: String
+}
+
+interface BedUtilisationBookingReportData {
+  val arrivalDate: LocalDate
+  val departureDate: LocalDate
+  val bedId: String
+  val cancellationId: String?
+  val arrivalId: String?
+  val confirmationId: String?
+  val turnaroundId: String?
+  val workingDayCount: Int?
+}
+
+interface BedUtilisationLostBedReportData {
+  val bedId: String
+  val startDate: LocalDate
+  val endDate: LocalDate
+  val cancellationId: String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ReportService.kt
@@ -14,12 +14,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.TransitionalAccommodationReferralReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportDataAndPersonInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.TransitionalAccommodationReferralReportDataAndPersonInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.TransitionalAccommodationReferralReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TransitionalAccommodationReferralReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -40,6 +42,7 @@ class Cas3ReportService(
   private val workingDayService: WorkingDayService,
   private val bookingRepository: BookingRepository,
   private val bedRepository: BedRepository,
+  private val bedUtilisationReportRepository: BedUtilisationReportRepository,
   @Value("\${cas3-report.crn-search-limit:400}") private val numberOfCrn: Int,
 ) {
   fun createCas3ApplicationReferralsReport(
@@ -98,8 +101,31 @@ class Cas3ReportService(
   }
 
   fun createBedUtilisationReport(properties: BedUtilisationReportProperties, outputStream: OutputStream) {
-    BedUtilisationReportGenerator(bookingRepository, lostBedsRepository, workingDayService)
-      .createReport(bedRepository.findAll(), properties)
+    val bedspacesInScope = bedUtilisationReportRepository.findAllBedspaces(
+      probationRegionId = properties.probationRegionId,
+    )
+
+    val bedspaceBookingsInScope = bedUtilisationReportRepository.findAllBookingsByOverlappingDate(
+      probationRegionId = properties.probationRegionId,
+      properties.startDate,
+      properties.endDate,
+    )
+
+    val lostBedspaceInScope = bedUtilisationReportRepository.findAllLostBedByOverlappingDate(
+      probationRegionId = properties.probationRegionId,
+      properties.startDate,
+      properties.endDate,
+    )
+
+    val reportData = bedspacesInScope.map {
+      val bedId = it.bedId
+      val bedspaceBookings = bedspaceBookingsInScope.filter { it.bedId == bedId }
+      val lostBedspace = lostBedspaceInScope.filter { it.bedId == bedId }
+      BedUtilisationReportData(it, bedspaceBookings, lostBedspace)
+    }
+
+    BedUtilisationReportGenerator(workingDayService)
+      .createReport(reportData, properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -5,10 +5,12 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
 import org.jetbrains.kotlinx.dataframe.api.convertTo
 import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
@@ -18,26 +20,22 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.LostBedsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.LostBedReportRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.LostBedReportProperties
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -51,13 +49,7 @@ class ReportsTest : IntegrationTestBase() {
   lateinit var bookingTransformer: BookingTransformer
 
   @Autowired
-  lateinit var realBookingRepository: BookingRepository
-
-  @Autowired
   lateinit var realLostBedsRepository: LostBedsRepository
-
-  @Autowired
-  lateinit var realWorkingDayService: WorkingDayService
 
   @Nested
   inner class GetBookingReport {
@@ -910,8 +902,6 @@ class ReportsTest : IntegrationTestBase() {
     fun `Get bed usage report returns OK with correct body`() {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withProbationRegion(userEntity.probationRegion)
@@ -936,13 +926,30 @@ class ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUsageReportGenerator(
-            bookingTransformer,
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayService,
+          val expectedReportRows = listOf(
+            BedUsageReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = userEntity.probationDeliveryUnit?.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              crn = offenderDetails.otherIds.crn,
+              type = BedUsageType.Booking,
+              startDate = LocalDate.parse("2023-04-05"),
+              endDate = LocalDate.parse("2023-04-15"),
+              durationOfBookingDays = 10,
+              bookingStatus = BookingStatus.provisional,
+              voidCategory = null,
+              voidNotes = null,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(listOf(bed), BedUsageReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate))
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/reports/bed-usage?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")
@@ -966,8 +973,6 @@ class ReportsTest : IntegrationTestBase() {
     fun `Get bed usage report returns OK with correct body with pdu and local authority`() {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
           val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
@@ -998,13 +1003,30 @@ class ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUsageReportGenerator(
-            bookingTransformer,
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayService,
+          val expectedReportRows = listOf(
+            BedUsageReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              crn = offenderDetails.otherIds.crn,
+              type = BedUsageType.Booking,
+              startDate = LocalDate.parse("2023-04-05"),
+              endDate = LocalDate.parse("2023-04-15"),
+              durationOfBookingDays = 10,
+              bookingStatus = BookingStatus.provisional,
+              voidCategory = null,
+              voidNotes = null,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(listOf(bed), BedUsageReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate))
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/reports/bed-usage?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")
@@ -1085,8 +1107,6 @@ class ReportsTest : IntegrationTestBase() {
     fun `Get bed utilisation report returns OK with correct body`() {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withProbationRegion(userEntity.probationRegion)
@@ -1114,12 +1134,33 @@ class ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUtilisationReportGenerator(
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayService,
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = userEntity.probationDeliveryUnit?.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 11,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(listOf(bed), BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate))
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/reports/bed-utilisation?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")
@@ -1143,14 +1184,11 @@ class ReportsTest : IntegrationTestBase() {
     fun `Get bed utilisation report returns OK with correct body with pdu and local authority`() {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
           val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
           }
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withProbationRegion(userEntity.probationRegion)
             withProbationDeliveryUnit(probationDeliveryUnit)
             withLocalAuthorityArea(localAuthorityArea)
@@ -1178,12 +1216,33 @@ class ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUtilisationReportGenerator(
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayService,
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 11,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(listOf(bed), BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate))
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/reports/bed-utilisation?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns.Remove
 import org.jetbrains.kotlinx.dataframe.api.convertTo
 import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.api.toList
 import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Nested
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus.cas3InReview
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus.cas3ReadyToPlace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus.cas3Unallocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3ReportType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
@@ -34,9 +36,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.Go
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision.ACCEPTED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision.REJECTED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
@@ -49,18 +54,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.TransitionalAccommodationReferralReportRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toYesNo
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
@@ -76,15 +78,6 @@ import java.util.UUID
 class Cas3ReportsTest : IntegrationTestBase() {
   @Autowired
   lateinit var bookingTransformer: BookingTransformer
-
-  @Autowired
-  lateinit var realBookingRepository: BookingRepository
-
-  @Autowired
-  lateinit var realLostBedsRepository: LostBedsRepository
-
-  @Autowired
-  lateinit var realWorkingDayCountService: WorkingDayService
 
   @ParameterizedTest
   @EnumSource(value = Cas3ReportType::class)
@@ -2053,42 +2046,46 @@ class Cas3ReportsTest : IntegrationTestBase() {
     fun `Get bed usage report returns OK with correct body`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
-          val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
           }
-
-          val room = roomEntityFactory.produceAndPersist {
-            withPremises(premises)
-          }
-
-          val bed = bedEntityFactory.produceAndPersist {
-            withRoom(room)
-          }
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
 
           GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 
-          bookingEntityFactory.produceAndPersist {
-            withPremises(premises)
-            withBed(bed)
-            withServiceName(ServiceName.temporaryAccommodation)
-            withCrn(offenderDetails.otherIds.crn)
-            withArrivalDate(LocalDate.parse("2023-04-05"))
-            withDepartureDate(LocalDate.parse("2023-04-15"))
-          }
-
-          val expectedDataFrame = BedUsageReportGenerator(
-            bookingTransformer,
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayCountService,
+          createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-04-05"),
+            LocalDate.parse("2023-04-15"),
           )
-            .createReport(
-              listOf(bed),
-              BedUsageReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
-            )
+
+          val expectedReportRows = listOf(
+            BedUsageReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              crn = offenderDetails.otherIds.crn,
+              type = BedUsageType.Booking,
+              startDate = LocalDate.parse("2023-04-05"),
+              endDate = LocalDate.parse("2023-04-15"),
+              durationOfBookingDays = 10,
+              bookingStatus = BookingStatus.provisional,
+              voidCategory = null,
+              voidNotes = null,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/cas3/reports/bedUsage?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
@@ -2112,48 +2109,47 @@ class Cas3ReportsTest : IntegrationTestBase() {
     fun `Get bed usage report returns OK with correct body with pdu and local authority`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
-          val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
           val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
           }
-          val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withProbationRegion(userEntity.probationRegion)
-            withProbationDeliveryUnit(probationDeliveryUnit)
-            withLocalAuthorityArea(localAuthorityArea)
-          }
 
-          val room = roomEntityFactory.produceAndPersist {
-            withPremises(premises)
-          }
-
-          val bed = bedEntityFactory.produceAndPersist {
-            withRoom(room)
-          }
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
 
           GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 
-          bookingEntityFactory.produceAndPersist {
-            withPremises(premises)
-            withBed(bed)
-            withServiceName(ServiceName.temporaryAccommodation)
-            withCrn(offenderDetails.otherIds.crn)
-            withArrivalDate(LocalDate.parse("2023-04-05"))
-            withDepartureDate(LocalDate.parse("2023-04-15"))
-          }
-
-          val expectedDataFrame = BedUsageReportGenerator(
-            bookingTransformer,
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayCountService,
+          createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-04-05"),
+            LocalDate.parse("2023-04-15"),
           )
-            .createReport(
-              listOf(bed),
-              BedUsageReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
-            )
+
+          val expectedReportRows = listOf(
+            BedUsageReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              crn = offenderDetails.otherIds.crn,
+              type = BedUsageType.Booking,
+              startDate = LocalDate.parse("2023-04-05"),
+              endDate = LocalDate.parse("2023-04-15"),
+              durationOfBookingDays = 10,
+              bookingStatus = BookingStatus.provisional,
+              voidCategory = null,
+              voidNotes = null,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/cas3/reports/bedUsage?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
@@ -2180,44 +2176,53 @@ class Cas3ReportsTest : IntegrationTestBase() {
     fun `Get bed utilisation report returns OK with correct body`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
-          val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
           }
 
-          val room = roomEntityFactory.produceAndPersist {
-            withPremises(premises)
-          }
-
-          val bed = bedEntityFactory.produceAndPersist {
-            withRoom(room)
-          }
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
 
           bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
           bedRepository.save(bed)
 
           GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 
-          bookingEntityFactory.produceAndPersist {
-            withPremises(premises)
-            withBed(bed)
-            withServiceName(ServiceName.temporaryAccommodation)
-            withCrn(offenderDetails.otherIds.crn)
-            withArrivalDate(LocalDate.parse("2023-04-05"))
-            withDepartureDate(LocalDate.parse("2023-04-15"))
-          }
-
-          val expectedDataFrame = BedUtilisationReportGenerator(
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayCountService,
+          createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-03-25"),
+            LocalDate.parse("2023-04-17"),
           )
-            .createReport(
-              listOf(bed),
-              BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
-            )
+
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 17,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
@@ -2241,50 +2246,517 @@ class Cas3ReportsTest : IntegrationTestBase() {
     fun `Get bed utilisation report returns OK with correct body with pdu and local authority`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
-          val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
           val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
           }
-          val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withProbationRegion(userEntity.probationRegion)
-            withProbationDeliveryUnit(probationDeliveryUnit)
-            withLocalAuthorityArea(localAuthorityArea)
-          }
 
-          val room = roomEntityFactory.produceAndPersist {
-            withPremises(premises)
-          }
-
-          val bed = bedEntityFactory.produceAndPersist {
-            withRoom(room)
-          }
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
 
           bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
           bedRepository.save(bed)
 
           GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 
-          bookingEntityFactory.produceAndPersist {
-            withPremises(premises)
-            withBed(bed)
-            withServiceName(ServiceName.temporaryAccommodation)
-            withCrn(offenderDetails.otherIds.crn)
-            withArrivalDate(LocalDate.parse("2023-04-05"))
-            withDepartureDate(LocalDate.parse("2023-04-15"))
+          createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-04-05"),
+            LocalDate.parse("2023-04-15"),
+          )
+
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 11,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
+
+          webTestClient.get()
+            .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith {
+              val actual = DataFrame
+                .readExcel(it.responseBody!!.inputStream())
+                .convertTo<BedUtilisationReportRow>(Remove)
+              assertThat(actual).isEqualTo(expectedDataFrame)
+            }
+        }
+      }
+    }
+
+    @Test
+    fun `Get bed utilisation report returns OK and shows correctly bookedDaysActiveAndClosed the total number of days for Bookings that are marked as arrived`() {
+      `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
+        `Given an Offender` { offenderDetails, inmateDetails ->
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(userEntity.probationRegion)
           }
 
-          val expectedDataFrame = BedUtilisationReportGenerator(
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayCountService,
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
+
+          bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+          bedRepository.save(bed)
+
+          GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+          val booking = createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-03-25"),
+            LocalDate.parse("2023-04-17"),
           )
-            .createReport(
-              listOf(bed),
-              BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate),
-            )
+
+          arrivalEntityFactory.produceAndPersist {
+            withBooking(booking)
+            withArrivalDate(LocalDate.parse("2023-03-25"))
+          }
+
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit?.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 17,
+              confirmedDays = 0,
+              provisionalDays = 0,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 17,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.5666666666666667,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
+
+          webTestClient.get()
+            .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith {
+              val actual = DataFrame
+                .readExcel(it.responseBody!!.inputStream())
+                .convertTo<BedUtilisationReportRow>(Remove)
+              assertThat(actual).isEqualTo(expectedDataFrame)
+            }
+        }
+      }
+    }
+
+    @Test
+    fun `Get bed utilisation report returns OK and shows correctly confirmedDays the total number of days for Bookings that are marked as confirmed but not arrived`() {
+      `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
+        `Given an Offender` { offenderDetails, inmateDetails ->
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(userEntity.probationRegion)
+          }
+
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
+
+          bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+          bedRepository.save(bed)
+
+          GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+          val booking = createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-03-25"),
+            LocalDate.parse("2023-04-10"),
+          )
+
+          confirmationEntityFactory.produceAndPersist {
+            withBooking(booking)
+          }
+
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 10,
+              provisionalDays = 0,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
+
+          webTestClient.get()
+            .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith {
+              val actual = DataFrame
+                .readExcel(it.responseBody!!.inputStream())
+                .convertTo<BedUtilisationReportRow>(Remove)
+              assertThat(actual).isEqualTo(expectedDataFrame)
+            }
+        }
+      }
+    }
+
+    @Test
+    fun `Get bed utilisation report returns OK and shows correctly scheduledTurnaroundDays the number of working days in the report period for the turnaround`() {
+      `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
+        `Given an Offender` { offenderDetails, inmateDetails ->
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(userEntity.probationRegion)
+          }
+
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
+
+          bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+          bedRepository.save(bed)
+
+          GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+          val booking = createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-04-07"),
+            LocalDate.parse("2023-04-21"),
+          )
+
+          turnaroundFactory.produceAndPersist {
+            withBooking(booking)
+            withWorkingDayCount(5)
+          }
+
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 15,
+              scheduledTurnaroundDays = 5,
+              effectiveTurnaroundDays = 7,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
+
+          webTestClient.get()
+            .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith {
+              val actual = DataFrame
+                .readExcel(it.responseBody!!.inputStream())
+                .convertTo<BedUtilisationReportRow>(Remove)
+              assertThat(actual).isEqualTo(expectedDataFrame)
+            }
+        }
+      }
+    }
+
+    @Test
+    fun `Get bed utilisation report returns OK and shows correctly effectiveTurnaroundDays the total number of days in the report period for the turnaround`() {
+      `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
+        `Given an Offender` { offenderDetails, inmateDetails ->
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(userEntity.probationRegion)
+          }
+
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
+
+          bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+          bedRepository.save(bed)
+
+          GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+          val booking = createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-03-25"),
+            LocalDate.parse("2023-04-17"),
+          )
+
+          turnaroundFactory.produceAndPersist {
+            withBooking(booking)
+            withWorkingDayCount(5)
+          }
+
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 17,
+              scheduledTurnaroundDays = 5,
+              effectiveTurnaroundDays = 7,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
+
+          webTestClient.get()
+            .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith {
+              val actual = DataFrame
+                .readExcel(it.responseBody!!.inputStream())
+                .convertTo<BedUtilisationReportRow>(Remove)
+              assertThat(actual).isEqualTo(expectedDataFrame)
+            }
+        }
+      }
+    }
+
+    @Test
+    fun `Get bed utilisation report returns OK and shows correctly voidDays the total number of days in the month for voids`() {
+      `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
+        `Given an Offender` { offenderDetails, inmateDetails ->
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(userEntity.probationRegion)
+          }
+
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
+
+          bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+          bedRepository.save(bed)
+
+          GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+          lostBedsEntityFactory.produceAndPersist {
+            withBed(bed)
+            withPremises(premises)
+            withStartDate(LocalDate.parse("2023-03-28"))
+            withEndDate(LocalDate.parse("2023-04-04"))
+            withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          }
+
+          lostBedsEntityFactory.produceAndPersist {
+            withBed(bed)
+            withPremises(premises)
+            withStartDate(LocalDate.parse("2023-04-25"))
+            withEndDate(LocalDate.parse("2023-05-03"))
+            withYieldedReason { lostBedReasonEntityFactory.produceAndPersist() }
+          }
+
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 0,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 10,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
+
+          webTestClient.get()
+            .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith {
+              val actual = DataFrame
+                .readExcel(it.responseBody!!.inputStream())
+                .convertTo<BedUtilisationReportRow>(Remove)
+              assertThat(actual).isEqualTo(expectedDataFrame)
+            }
+        }
+      }
+    }
+
+    @Test
+    fun `Get bed utilisation report returns OK and shows correctly totalBookedDays`() {
+      `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
+        `Given an Offender` { offenderDetails, inmateDetails ->
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(userEntity.probationRegion)
+          }
+
+          val (premises, room) = createPremisesAndRoom(userEntity.probationRegion, probationDeliveryUnit)
+          val bed = createBed(room)
+
+          bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+          bedRepository.save(bed)
+
+          GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
+
+          val booking = createBooking(
+            premises,
+            bed,
+            offenderDetails.otherIds.crn,
+            LocalDate.parse("2023-03-28"),
+            LocalDate.parse("2023-04-04"),
+          )
+
+          turnaroundFactory.produceAndPersist {
+            withBooking(booking)
+            withWorkingDayCount(5)
+          }
+
+          arrivalEntityFactory.produceAndPersist {
+            withBooking(booking)
+            withArrivalDate(LocalDate.parse("2023-03-28"))
+          }
+
+          departureEntityFactory.produceAndPersist {
+            withBooking(booking)
+            withDateTime(OffsetDateTime.parse("2023-04-04T12:00:00.000Z"))
+            withReason(departureReasonEntityFactory.produceAndPersist())
+            withMoveOnCategory(moveOnCategoryEntityFactory.produceAndPersist())
+          }
+
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 4,
+              confirmedDays = 0,
+              provisionalDays = 0,
+              scheduledTurnaroundDays = 5,
+              effectiveTurnaroundDays = 7,
+              voidDays = 0,
+              totalBookedDays = 4,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.13333333333333333,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
+          )
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${userEntity.probationRegion.id}")
@@ -2491,6 +2963,47 @@ class Cas3ReportsTest : IntegrationTestBase() {
       withProbationRegion(userEntity.probationRegion)
       withApplicationSchema(applicationSchema)
       withDutyToReferLocalAuthorityAreaName("London")
+    }
+  }
+
+  private fun createPremisesAndRoom(
+    probationRegion: ProbationRegionEntity,
+    probationDeliveryUnit: ProbationDeliveryUnitEntity,
+  ): Pair<PremisesEntity, RoomEntity> {
+    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+    val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+      withProbationDeliveryUnit(probationDeliveryUnit)
+      withLocalAuthorityArea(localAuthorityArea)
+    }
+
+    val room = roomEntityFactory.produceAndPersist {
+      withPremises(premises)
+    }
+
+    return Pair(premises, room)
+  }
+
+  private fun createBed(room: RoomEntity): BedEntity {
+    return bedEntityFactory.produceAndPersist {
+      withRoom(room)
+    }
+  }
+
+  private fun createBooking(
+    premises: PremisesEntity,
+    bed: BedEntity,
+    crn: String,
+    arrivalDate: LocalDate,
+    departureDate: LocalDate,
+  ): BookingEntity {
+    return bookingEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withBed(bed)
+      withServiceName(ServiceName.temporaryAccommodation)
+      withCrn(crn)
+      withArrivalDate(arrivalDate)
+      withDepartureDate(departureDate)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
@@ -193,7 +194,7 @@ class BedUsageReportGeneratorTest {
     assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())
 
     verify {
-      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-07-01"), any())
+      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-07-01"), any<BedEntity>())
     }
   }
 
@@ -263,7 +264,7 @@ class BedUsageReportGeneratorTest {
     assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(approvedPremises.id.toShortBase58())
 
     verify {
-      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), any())
+      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), any<BedEntity>())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/Cas3ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/Cas3ReportsTestHelper.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.util
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationLostBedReportData
+import java.time.LocalDate
+
+fun convertToCas3BedUtilisationBedspaceReportData(bed: BedEntity): Cas3BedUtilisationBedspaceReportData {
+  val room = bed.room
+  var probationDeliveryUnitName: String? = null
+  val premises = room.premises
+
+  if (room.premises is TemporaryAccommodationPremisesEntity) {
+    probationDeliveryUnitName = (room.premises as TemporaryAccommodationPremisesEntity).probationDeliveryUnit?.name
+  }
+
+  return Cas3BedUtilisationBedspaceReportData(
+    bedId = bed.id.toString(),
+    probationRegionName = premises.probationRegion.name,
+    probationDeliveryUnitName = probationDeliveryUnitName,
+    localAuthorityName = premises.localAuthorityArea?.name,
+    premisesName = premises.name,
+    addressLine1 = premises.addressLine1,
+    town = premises.town,
+    postCode = premises.postcode,
+    roomName = room.name,
+    bedspaceStartDate = bed.createdAt?.toLocalDate(),
+    bedspaceEndDate = bed.endDate,
+    premisesId = premises.id.toString(),
+    roomId = room.id.toString(),
+  )
+}
+
+fun convertToCas3BedUtilisationBookingReportData(booking: BookingEntity): Cas3BedUtilisationBookingReportData {
+  return Cas3BedUtilisationBookingReportData(
+    arrivalDate = booking.arrivalDate,
+    departureDate = booking.departureDate,
+    bedId = booking.bed?.id.toString(),
+    cancellationId = booking.cancellation?.id?.toString(),
+    arrivalId = booking.arrival?.id?.toString(),
+    confirmationId = booking.confirmation?.id?.toString(),
+    turnaroundId = booking.turnaround?.id?.toString(),
+    workingDayCount = booking.turnaround?.workingDayCount,
+  )
+}
+
+fun convertToCas3BedUtilisationLostBedReportData(lostBed: LostBedsEntity): Cas3BedUtilisationLostBedReportData {
+  return Cas3BedUtilisationLostBedReportData(
+    bedId = lostBed.bed.id.toString(),
+    startDate = lostBed.startDate,
+    endDate = lostBed.endDate,
+    cancellationId = lostBed.cancellation?.id?.toString(),
+  )
+}
+
+@Suppress("LongParameterList")
+class Cas3BedUtilisationBedspaceReportData(
+  override val bedId: String,
+  override val probationRegionName: String?,
+  override val probationDeliveryUnitName: String?,
+  override val localAuthorityName: String?,
+  override val premisesName: String,
+  override val addressLine1: String,
+  override val town: String?,
+  override val postCode: String,
+  override val roomName: String,
+  override val bedspaceStartDate: LocalDate?,
+  override val bedspaceEndDate: LocalDate?,
+  override val premisesId: String,
+  override val roomId: String,
+) : BedUtilisationBedspaceReportData
+
+@Suppress("LongParameterList")
+class Cas3BedUtilisationBookingReportData(
+  override val arrivalDate: LocalDate,
+  override val departureDate: LocalDate,
+  override val bedId: String,
+  override val cancellationId: String?,
+  override val arrivalId: String?,
+  override val confirmationId: String?,
+  override val turnaroundId: String?,
+  override val workingDayCount: Int?,
+) : BedUtilisationBookingReportData
+
+class Cas3BedUtilisationLostBedReportData(
+  override val bedId: String,
+  override val startDate: LocalDate,
+  override val endDate: LocalDate,
+  override val cancellationId: String?,
+) : BedUtilisationLostBedReportData

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.TransitionalAccommodationReferralReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TransitionalAccommodationReferralReportData
@@ -40,6 +41,7 @@ class Cas3ReportServiceTest {
   private val mockWorkingDayService = mockk<WorkingDayService>()
   private val mockBookingRepository = mockk<BookingRepository>()
   private val mockBedRepository = mockk<BedRepository>()
+  private val mockBedUtilisationReportRepository = mockk<BedUtilisationReportRepository>()
 
   private val cas3ReportService = Cas3ReportService(
     mockOffenderService,
@@ -51,6 +53,7 @@ class Cas3ReportServiceTest {
     mockWorkingDayService,
     mockBookingRepository,
     mockBedRepository,
+    mockBedUtilisationReportRepository,
     2,
   )
 
@@ -105,6 +108,7 @@ class Cas3ReportServiceTest {
       mockWorkingDayService,
       mockBookingRepository,
       mockBedRepository,
+      mockBedUtilisationReportRepository,
       3,
     )
 


### PR DESCRIPTION
This [PR CAS-414](https://dsdmoj.atlassian.net/browse/CAS-414) is to fix a performance issue when generate utilisation report in CAS3 for all regions. Which includes:
- Reduce the amount of data retrieved in the report queries by changing it to sql queries 
- Get all the information needed for bedspace, bookings and lost bed space in one query instead of calling the database for each row in the report
- Return only the data related to temporary accommodation which is needed in the report 
- Add integration tests to check the new report queries