### PR TITLE
CAS2-506 Add new sub status under Referral Cancelled.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
@@ -230,6 +230,11 @@ object Cas2ApplicationStatusSeeding {
             name = "hdcNotEligible",
             label = "HDC not eligible",
           ),
+          Cas2PersistedApplicationStatusDetail(
+            id = UUID.fromString("4f1033ab-2dea-47ce-8a86-7c47b3ccadd8"),
+            name = "personTransferredToAnotherPrison",
+            label = "Person transferred to another prison",
+          ),
         ),
       ),
       Cas2PersistedApplicationStatus(


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/CAS2-506

New sub status required to cover scenario when prisoners are transferred to another prison and the referral has to be cancelled titled: "Person transferred to another prison".