### PR TITLE
APS-1011 - Remove /applications/{id}/placement-applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -37,21 +37,6 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
   )
   fun findAllSubmittedNonReallocatedApplicationsForApplicationId(applicationId: UUID): List<PlacementApplicationEntity>
 
-  @Query(
-    """
-      SELECT a from PlacementApplicationEntity a where a.application.id = :applicationId
-      AND a.submittedAt is not null
-      AND a.reallocatedAt is null
-      AND 
-        (
-            a.decision != uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision.WITHDRAWN_BY_PP
-            OR
-            a.decision is null
-        )
-    """,
-  )
-  fun findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(applicationId: UUID): List<PlacementApplicationEntity>
-
   fun findByApplication(application: ApplicationEntity): List<PlacementApplicationEntity>
 
   @Query("SELECT p from PlacementApplicationEntity p WHERE p.dueAt IS NULL AND p.submittedAt IS NOT NULL")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -61,12 +61,6 @@ class PlacementApplicationService(
     return placementApplicationRepository.findAllSubmittedNonReallocatedApplicationsForApplicationId(applicationId)
   }
 
-  fun getAllActivePlacementApplicationsForApplicationId(applicationId: UUID): List<PlacementApplicationEntity> {
-    return placementApplicationRepository.findAllSubmittedNonReallocatedAndNonWithdrawnApplicationsForApplicationId(
-      applicationId,
-    )
-  }
-
   fun createPlacementApplication(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -41,7 +41,7 @@ class Cas1WithdrawableTreeBuilder(
       children.add(treeForPlacementReq(it, user).rootNode)
     }
 
-    placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id).forEach {
+    placementApplicationService.getAllSubmittedNonReallocatedApplications(application.id).forEach {
       children.add(treeForPlacementApp(it, user).rootNode)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -9,17 +9,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 
 @Component
 class PlacementApplicationTransformer(
   private val objectMapper: ObjectMapper,
-  private val jsonSchemaService: JsonSchemaService,
-  private val placementRequestTransformer: PlacementRequestTransformer,
 ) {
   fun transformJpaToApi(jpa: PlacementApplicationEntity): PlacementApplication {
     val assessment = jpa.application.getLatestAssessment()!!
@@ -43,31 +38,6 @@ class PlacementApplicationTransformer(
       withdrawalReason = getWithdrawalReason(jpa.withdrawalReason),
       type = PlacementApplicationType.additional,
       placementDates = jpa.placementDates.map { PlacementDates(it.expectedArrival, it.duration) },
-    )
-  }
-
-  fun transformPlacementRequestJpaToApi(jpa: PlacementRequestEntity): PlacementApplication {
-    val application = jpa.application
-    val assessment = jpa.assessment
-
-    return PlacementApplication(
-      id = jpa.id,
-      applicationId = application.id,
-      applicationCompletedAt = application.submittedAt!!.toInstant(),
-      assessmentId = assessment.id,
-      assessmentCompletedAt = assessment.submittedAt!!.toInstant(),
-      createdByUserId = application.createdByUser.id,
-      schemaVersion = jsonSchemaService.getNewestSchema(ApprovedPremisesPlacementApplicationJsonSchemaEntity::class.java).id,
-      createdAt = jpa.createdAt.toInstant(),
-      data = "{}",
-      document = "{}",
-      outdatedSchema = false,
-      submittedAt = application.submittedAt?.toInstant(),
-      canBeWithdrawn = jpa.isInWithdrawableState(),
-      isWithdrawn = jpa.isWithdrawn,
-      withdrawalReason = placementRequestTransformer.getWithdrawalReason(jpa.withdrawalReason),
-      type = PlacementApplicationType.initial,
-      placementDates = listOf(PlacementDates(jpa.expectedArrival, jpa.duration)),
     )
   }
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2063,52 +2063,6 @@ paths:
                 $ref: '_shared.yml#/components/schemas/Problem'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
-  /applications/{applicationId}/placement-applications:
-    get:
-      tags:
-        - Application data timeline
-      summary: Returns domain event summary
-      parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: includeInitialRequestForPlacement
-          in: query
-          description: If true, will return a PlacementApplication of type 'Initial' representing the placement requests as part of the original application submission (i.e. when arrival date is known).
-          required: false
-          schema:
-            type: boolean
-        - name: X-Service-Name
-          in: header
-          required: true
-          description: If given, only users for this service will be returned
-          schema:
-            $ref: '_shared.yml#/components/schemas/ServiceName'
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                type: array
-                items:
-                  $ref: '_shared.yml#/components/schemas/PlacementApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        404:
-          description: invalid CRN
-          content:
-            'application/json':
-              schema:
-                $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /applications/{applicationId}/documents:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
@@ -103,7 +103,7 @@ class Cas1WithdrawableTreeBuilderTest {
     setupWithdrawableState(placementApplication2, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true))
 
     every {
-      placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
+      placementApplicationService.getAllSubmittedNonReallocatedApplications(application.id)
     } returns listOf(placementApp1, placementApplication2)
 
     val adhocBooking1 = createBooking(adhoc = true)
@@ -170,7 +170,7 @@ Notes: []
     setupWithdrawableState(placementApp2PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false))
 
     every {
-      placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
+      placementApplicationService.getAllSubmittedNonReallocatedApplications(application.id)
     } returns listOf(placementApp1, placementApp2)
 
     every { bookingService.getAllAdhocOrUnknownForApplication(application) } returns emptyList()
@@ -231,7 +231,7 @@ Notes: []
     setupWithdrawableState(placementApp2PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true))
 
     every {
-      placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
+      placementApplicationService.getAllSubmittedNonReallocatedApplications(application.id)
     } returns listOf(placementApp1, placementApp2)
 
     every { bookingService.getAllAdhocOrUnknownForApplication(application) } returns emptyList()
@@ -276,7 +276,7 @@ Notes: [1 or more placements cannot be withdrawn as they have an arrival]
     setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInDelius))
 
     every {
-      placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
+      placementApplicationService.getAllSubmittedNonReallocatedApplications(application.id)
     } returns listOf(placementApp1)
 
     every { bookingService.getAllAdhocOrUnknownForApplication(application) } returns emptyList()


### PR DESCRIPTION
This has been superseded by the /applications/{applicationId}/requests-for-placement endpoint