### PR TITLE
Use incrementing num for integration test db name

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TestPropertiesInitializer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TestPropertiesInitializer.kt
@@ -58,7 +58,7 @@ class TestPropertiesInitializer : ApplicationContextInitializer<ConfigurableAppl
 
     val jdbcTemplate = JdbcTemplate(driver)
 
-    val databaseName = "approved_premises_integration_test_${randomStringLowerCase(6)}"
+    val databaseName = "ap_api_it_${System.currentTimeMillis()}"
 
     jdbcTemplate.execute("CREATE DATABASE $databaseName")
 


### PR DESCRIPTION
Before this commit a random name was given to the database generated for an integration test. This made it difficult to find the database created for the most recent execution of the integration tests.

This commit shortens the fixed part of the database name and suffixes it with an epoch milli, a number that will always increment. This ensures that the database used for the latest execution of tests will always appear last in the list of the available databases

![Screenshot 2024-07-05 at 15 24 32](https://github.com/ministryofjustice/hmpps-approved-premises-api/assets/22135634/c3ca9435-d6c2-4e97-911b-7cd28a6a2cb2)
