### PR TITLE
[APS-954] Introduce out-of-service beds report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
@@ -79,6 +79,12 @@ class Cas1ReportsController(
       ) { outputStream ->
         cas1ReportService.createLostBedReport(LostBedReportProperties(xServiceName, null, year, month), outputStream)
       }
+      Cas1ReportName.outOfServiceBeds -> return generateStreamingResponse(
+        contentType = ContentType.XLSX,
+        fileName = createCas1ReportName("out-of-service-beds", year, month, ContentType.XLSX),
+      ) { outputStream ->
+        cas1ReportService.createOutOfServiceBedReport(monthSpecificReportParams, outputStream)
+      }
       Cas1ReportName.placementApplications -> return generateStreamingResponse(
         contentType = ContentType.XLSX,
         fileName = createCas1ReportName("placement-applications", year, month, ContentType.XLSX),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/Cas1OutOfServiceBedsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/Cas1OutOfServiceBedsReportGenerator.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas1OutOfServiceBedReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.earliestDateOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.latestDateOf
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas1OutOfServiceBedsReportGenerator(
+  private val outOfServiceBedRepository: Cas1OutOfServiceBedRepository,
+) : ReportGenerator<BedEntity, Cas1OutOfServiceBedReportRow, Cas1ReportService.MonthSpecificReportParams>(
+  Cas1OutOfServiceBedReportRow::class,
+) {
+  override fun filter(properties: Cas1ReportService.MonthSpecificReportParams): (BedEntity) -> Boolean = {
+    checkServiceType(ServiceName.approvedPremises, it.room.premises)
+  }
+
+  override val convert: BedEntity.(properties: Cas1ReportService.MonthSpecificReportParams) -> List<Cas1OutOfServiceBedReportRow> = { properties ->
+    val startOfMonth = LocalDate.of(properties.year, properties.month, 1)
+    val endOfMonth = LocalDate.of(properties.year, properties.month, startOfMonth.month.length(startOfMonth.isLeapYear))
+
+    val outOfServiceBedIds = outOfServiceBedRepository.findByBedIdAndOverlappingDate(this.id, startOfMonth, endOfMonth, null)
+
+    val outOfServiceBeds = outOfServiceBedRepository.findAllById(outOfServiceBedIds.map(UUID::fromString))
+
+    outOfServiceBeds.map {
+      val bed = it.bed
+      val room = bed.room
+      val premises = room.premises
+
+      Cas1OutOfServiceBedReportRow(
+        roomName = room.name,
+        bedName = bed.name,
+        id = it.id.toString(),
+        workOrderId = it.referenceNumber,
+        region = premises.probationRegion.name,
+        ap = premises.name,
+        reason = it.reason.name,
+        startDate = it.startDate,
+        endDate = it.endDate,
+        lengthDays = latestDateOf(startOfMonth, it.startDate).getDaysUntilInclusive(earliestDateOf(endOfMonth, it.endDate)).size,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/Cas1OutOfServiceBedReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/Cas1OutOfServiceBedReportRow.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import java.time.LocalDate
+
+data class Cas1OutOfServiceBedReportRow(
+  val roomName: String,
+  val bedName: String,
+  val id: String,
+  val workOrderId: String?,
+  val region: String,
+  val ap: String,
+  val reason: String,
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+  val lengthDays: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntityReportRowRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntityReportRowRepository
@@ -15,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Plac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1PlacementMatchingOutcomesV2ReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1RequestForPlacementReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ApplicationReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.DailyMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.LostBedsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.PlacementApplicationReportGenerator
@@ -38,6 +40,7 @@ class Cas1ReportService(
   private val cas1PlacementRequestReportRepository: Cas1RequestForPlacementReportRepository,
   private val domainEventRepository: DomainEventRepository,
   private val lostBedsRepository: LostBedsRepository,
+  private val cas1OutOfServiceBedRepository: Cas1OutOfServiceBedRepository,
   private val objectMapper: ObjectMapper,
   private val placementApplicationEntityReportRowRepository: PlacementApplicationEntityReportRowRepository,
 ) {
@@ -101,6 +104,14 @@ class Cas1ReportService(
 
   fun createLostBedReport(properties: LostBedReportProperties, outputStream: OutputStream) {
     LostBedsReportGenerator(lostBedsRepository)
+      .createReport(bedRepository.findAll(), properties)
+      .writeExcel(outputStream) {
+        WorkbookFactory.create(true)
+      }
+  }
+
+  fun createOutOfServiceBedReport(properties: MonthSpecificReportParams, outputStream: OutputStream) {
+    Cas1OutOfServiceBedsReportGenerator(cas1OutOfServiceBedRepository)
       .createReport(bedRepository.findAll(), properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4816,6 +4816,7 @@ components:
         - applicationsV2
         - dailyMetrics
         - lostBeds
+        - outOfServiceBeds
         - placementApplications
         - placementMatchingOutcomes
         - placementMatchingOutcomesV2

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9398,6 +9398,7 @@ components:
         - applicationsV2
         - dailyMetrics
         - lostBeds
+        - outOfServiceBeds
         - placementApplications
         - placementMatchingOutcomes
         - placementMatchingOutcomesV2

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5393,6 +5393,7 @@ components:
         - applicationsV2
         - dailyMetrics
         - lostBeds
+        - outOfServiceBeds
         - placementApplications
         - placementMatchingOutcomes
         - placementMatchingOutcomesV2

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5407,6 +5407,7 @@ components:
         - applicationsV2
         - dailyMetrics
         - lostBeds
+        - outOfServiceBeds
         - placementApplications
         - placementMatchingOutcomes
         - placementMatchingOutcomesV2

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4907,6 +4907,7 @@ components:
         - applicationsV2
         - dailyMetrics
         - lostBeds
+        - outOfServiceBeds
         - placementApplications
         - placementMatchingOutcomes
         - placementMatchingOutcomesV2

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedRevisionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedRevisionEntityFactory.kt
@@ -64,6 +64,10 @@ class Cas1OutOfServiceBedRevisionEntityFactory : Factory<Cas1OutOfServiceBedRevi
     this.reason = { Cas1OutOfServiceBedReasonEntityFactory().apply(configuration).produce() }
   }
 
+  fun withYieldedReason(reason: Yielded<Cas1OutOfServiceBedReasonEntity>) = apply {
+    this.reason = reason
+  }
+
   fun withOutOfServiceBed(outOfServiceBed: Cas1OutOfServiceBedEntity) = apply {
     this.outOfServiceBed = { outOfServiceBed }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReportsTest.kt
@@ -1,15 +1,31 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
 
+import org.assertj.core.api.Assertions
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
+import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.io.readExcel
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ADMIN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_ASSESSOR
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas1OutOfServiceBedReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
+import java.time.LocalDate
+import java.time.OffsetDateTime
 
 class Cas1ReportsTest : IntegrationTestBase() {
   val cas1Report: String = Cas1ReportName.lostBeds.value
@@ -98,6 +114,124 @@ class Cas1ReportsTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
+    }
+  }
+
+  @Nested
+  inner class GetOutOfServiceBedsReport {
+    private val outOfServiceBedsEndpoint = "/cas1/reports/${Cas1ReportName.outOfServiceBeds.value}"
+
+    @Autowired
+    lateinit var realOutOfServiceBedRepository: Cas1OutOfServiceBedRepository
+
+    @Test
+    fun `Get out-of-service beds report returns OK with correct body`() {
+      `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { userEntity, jwt ->
+        `Given an Offender` { _, _ ->
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withProbationRegion(userEntity.probationRegion)
+          }
+
+          val bed1 = bedEntityFactory.produceAndPersist {
+            withRoom(
+              roomEntityFactory.produceAndPersist {
+                withPremises(premises)
+              },
+            )
+          }
+
+          val bed2 = bedEntityFactory.produceAndPersist {
+            withRoom(
+              roomEntityFactory.produceAndPersist {
+                withPremises(premises)
+              },
+            )
+          }
+
+          val bed3 = bedEntityFactory.produceAndPersist {
+            withRoom(
+              roomEntityFactory.produceAndPersist {
+                withPremises(premises)
+              },
+            )
+          }
+
+          cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withBed(bed1)
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(userEntity)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.of(2023, 4, 5))
+              withEndDate(LocalDate.of(2023, 7, 8))
+              withYieldedReason {
+                cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+              }
+            }
+          }
+
+          cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withBed(bed2)
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(userEntity)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.of(2023, 4, 12))
+              withEndDate(LocalDate.of(2023, 7, 5))
+              withYieldedReason {
+                cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+              }
+            }
+          }
+
+          cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withBed(bed3)
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(userEntity)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.of(2023, 4, 1))
+              withEndDate(LocalDate.of(2023, 7, 5))
+              withYieldedReason {
+                cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+              }
+            }
+
+            this.cancellation = cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withOutOfServiceBed(this@apply)
+            }
+          }
+
+          val expectedDataFrame = Cas1OutOfServiceBedsReportGenerator(realOutOfServiceBedRepository)
+            .createReport(
+              listOf(bed1, bed2),
+              Cas1ReportService.MonthSpecificReportParams(2023, 4),
+            )
+
+          webTestClient.get()
+            .uri("$outOfServiceBedsEndpoint?year=2023&month=4")
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.approvedPremises.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith {
+              val actual = DataFrame
+                .readExcel(it.responseBody!!.inputStream())
+                .convertTo<Cas1OutOfServiceBedReportRow>(ExcessiveColumns.Remove)
+              Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
+            }
+        }
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/Cas1OutOfServiceBedReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/Cas1OutOfServiceBedReportGeneratorTest.kt
@@ -1,0 +1,241 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.generator
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlinx.dataframe.api.count
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.LostBedReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService
+import java.time.LocalDate
+
+class Cas1OutOfServiceBedReportGeneratorTest {
+  private val outOfServiceBedRepository = mockk<Cas1OutOfServiceBedRepository>()
+
+  private val reportGenerator = Cas1OutOfServiceBedsReportGenerator(
+    outOfServiceBedRepository,
+  )
+
+  @Test
+  fun `Results for out-of-service beds from all probation regions are returned in the report`() {
+    val apArea = ApAreaEntityFactory()
+      .produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory()
+      .withApArea(apArea)
+      .produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val probationRegion2 = ProbationRegionEntityFactory()
+      .withApArea(apArea)
+      .produce()
+
+    val localAuthorityArea2 = LocalAuthorityEntityFactory().produce()
+
+    val premisesInProbationRegion = ApprovedPremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationRegion(probationRegion1)
+      .produce()
+
+    val roomInProbationRegion = RoomEntityFactory()
+      .withPremises(premisesInProbationRegion)
+      .produce()
+
+    val bedInProbationRegion = BedEntityFactory()
+      .withRoom(roomInProbationRegion)
+      .produce()
+
+    val outOfServiceBedInProbationArea = Cas1OutOfServiceBedEntityFactory()
+      .withBed(bedInProbationRegion)
+      .produce()
+      .apply {
+        this.revisionHistory += Cas1OutOfServiceBedRevisionEntityFactory()
+          .withOutOfServiceBed(this)
+          .withStartDate(LocalDate.parse("2023-04-05"))
+          .withEndDate(LocalDate.parse("2023-04-07"))
+          .produce()
+      }
+
+    val premisesOutsideProbationRegion = ApprovedPremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea2)
+      .withProbationRegion(probationRegion2)
+      .produce()
+
+    val roomOutsideProbationRegion = RoomEntityFactory()
+      .withPremises(premisesOutsideProbationRegion)
+      .produce()
+
+    val bedOutsideProbationRegion = BedEntityFactory()
+      .withRoom(roomOutsideProbationRegion)
+      .produce()
+
+    val outOfServiceBedOutsideProbationArea = Cas1OutOfServiceBedEntityFactory()
+      .withBed(bedOutsideProbationRegion)
+      .produce()
+      .apply {
+        this.revisionHistory += Cas1OutOfServiceBedRevisionEntityFactory()
+          .withOutOfServiceBed(this)
+          .withStartDate(LocalDate.parse("2023-04-05"))
+          .withEndDate(LocalDate.parse("2023-04-07"))
+          .produce()
+      }
+
+    every {
+      outOfServiceBedRepository.findByBedIdAndOverlappingDate(
+        bedInProbationRegion.id,
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        null,
+      )
+    } returns listOf(outOfServiceBedInProbationArea.id.toString())
+
+    every {
+      outOfServiceBedRepository.findAllById(listOf(outOfServiceBedInProbationArea.id))
+    } returns listOf(outOfServiceBedInProbationArea)
+
+    every {
+      outOfServiceBedRepository.findByBedIdAndOverlappingDate(
+        bedOutsideProbationRegion.id,
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        null,
+      )
+    } returns listOf(outOfServiceBedOutsideProbationArea.id.toString())
+
+    every {
+      outOfServiceBedRepository.findAllById(listOf(outOfServiceBedOutsideProbationArea.id))
+    } returns listOf(outOfServiceBedOutsideProbationArea)
+
+    val result = reportGenerator.createReport(
+      listOf(bedInProbationRegion, bedOutsideProbationRegion),
+      Cas1ReportService.MonthSpecificReportParams(2023, 4),
+    )
+
+    assertThat(result.count()).isEqualTo(2)
+    assertThat(result[0][LostBedReportRow::ap]).isEqualTo(premisesInProbationRegion.name)
+    assertThat(result[1][LostBedReportRow::ap]).isEqualTo(premisesOutsideProbationRegion.name)
+  }
+
+  @Test
+  fun `Out-of-service bed rows are correctly generated`() {
+    val premises = ApprovedPremisesEntityFactory()
+      .withUnitTestControlTestProbationAreaAndLocalAuthority()
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val bed = BedEntityFactory()
+      .withRoom(room)
+      .produce()
+
+    val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+      .withBed(bed)
+      .produce()
+      .apply {
+        this.revisionHistory += Cas1OutOfServiceBedRevisionEntityFactory()
+          .withOutOfServiceBed(this)
+          .withStartDate(LocalDate.parse("2023-04-05"))
+          .withEndDate(LocalDate.parse("2023-04-07"))
+          .produce()
+      }
+
+    every {
+      outOfServiceBedRepository.findByBedIdAndOverlappingDate(
+        bed.id,
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        null,
+      )
+    } returns listOf(outOfServiceBed.id.toString())
+
+    every {
+      outOfServiceBedRepository.findAllById(listOf(outOfServiceBed.id))
+    } returns listOf(outOfServiceBed)
+
+    val result = reportGenerator.createReport(
+      listOf(bed),
+      Cas1ReportService.MonthSpecificReportParams(2023, 4),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][LostBedReportRow::roomName]).isEqualTo(room.name)
+    assertThat(result[0][LostBedReportRow::bedName]).isEqualTo(bed.name)
+    assertThat(result[0][LostBedReportRow::id]).isEqualTo(outOfServiceBed.id.toString())
+    assertThat(result[0][LostBedReportRow::workOrderId]).isEqualTo(outOfServiceBed.referenceNumber)
+    assertThat(result[0][LostBedReportRow::region]).isEqualTo(premises.probationRegion.name)
+    assertThat(result[0][LostBedReportRow::ap]).isEqualTo(premises.name)
+    assertThat(result[0][LostBedReportRow::reason]).isEqualTo(outOfServiceBed.reason.name)
+    assertThat(result[0][LostBedReportRow::startDate]).isEqualTo(outOfServiceBed.startDate)
+    assertThat(result[0][LostBedReportRow::endDate]).isEqualTo(outOfServiceBed.endDate)
+    assertThat(result[0][LostBedReportRow::lengthDays]).isEqualTo(3)
+  }
+
+  @Test
+  fun `Length Days only includes days in month requested where out-of-service bed spans more than 1 calendar month`() {
+    val premises = ApprovedPremisesEntityFactory()
+      .withUnitTestControlTestProbationAreaAndLocalAuthority()
+      .produce()
+
+    val room = RoomEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val bed = BedEntityFactory()
+      .withRoom(room)
+      .produce()
+
+    val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+      .withBed(bed)
+      .produce()
+      .apply {
+        this.revisionHistory += Cas1OutOfServiceBedRevisionEntityFactory()
+          .withOutOfServiceBed(this)
+          .withStartDate(LocalDate.parse("2023-03-28"))
+          .withEndDate(LocalDate.parse("2023-04-07"))
+          .produce()
+      }
+
+    every {
+      outOfServiceBedRepository.findByBedIdAndOverlappingDate(
+        bed.id,
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        null,
+      )
+    } returns listOf(outOfServiceBed.id.toString())
+
+    every {
+      outOfServiceBedRepository.findAllById(listOf(outOfServiceBed.id))
+    } returns listOf(outOfServiceBed)
+
+    val result = reportGenerator.createReport(
+      listOf(bed),
+      Cas1ReportService.MonthSpecificReportParams(2023, 4),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][LostBedReportRow::roomName]).isEqualTo(room.name)
+    assertThat(result[0][LostBedReportRow::bedName]).isEqualTo(bed.name)
+    assertThat(result[0][LostBedReportRow::id]).isEqualTo(outOfServiceBed.id.toString())
+    assertThat(result[0][LostBedReportRow::workOrderId]).isEqualTo(outOfServiceBed.referenceNumber)
+    assertThat(result[0][LostBedReportRow::region]).isEqualTo(premises.probationRegion.name)
+    assertThat(result[0][LostBedReportRow::ap]).isEqualTo(premises.name)
+    assertThat(result[0][LostBedReportRow::reason]).isEqualTo(outOfServiceBed.reason.name)
+    assertThat(result[0][LostBedReportRow::startDate]).isEqualTo(outOfServiceBed.startDate)
+    assertThat(result[0][LostBedReportRow::endDate]).isEqualTo(outOfServiceBed.endDate)
+    assertThat(result[0][LostBedReportRow::lengthDays]).isEqualTo(7)
+  }
+}


### PR DESCRIPTION
> See [APS-954 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-954).

This PR introduces a new report for out-of-service beds, accessible using the `GET /cas1/reports/outOfServiceBeds` endpoint. This report is functionally almost identical to the existing lost beds report and is intended as a drop-in replacement for the CAS1 use case.