### PR TITLE
CAS-441 add releaseDate and accommodationRequiredFromDate to referral report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
@@ -61,7 +61,9 @@ class TransitionalAccommodationReferralReportGenerator : ReportGenerator<
           prisonReleaseType = referralData.prisonReleaseTypes,
           prisonAtReferral = referralData.prisonNameOnCreation,
           releaseDate = referralData.personReleaseDate,
+          updatedReleaseDate = referralData.updatedReleaseDate,
           accommodationRequiredDate = referralData.accommodationRequiredDate?.toLocalDateTime()?.toLocalDate(),
+          updatedAccommodationRequiredFromDate = referralData.updatedAccommodationRequiredFromDate,
           bookingOffered = (referralData.bookingId != null).toYesNo(),
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/TransitionalAccommodationReferralReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/TransitionalAccommodationReferralReportRow.kt
@@ -36,6 +36,8 @@ data class TransitionalAccommodationReferralReportRow(
   val prisonReleaseType: String?,
   val prisonAtReferral: String?,
   val releaseDate: LocalDate?,
+  val updatedReleaseDate: LocalDate?,
   val accommodationRequiredDate: LocalDate?,
+  val updatedAccommodationRequiredFromDate: LocalDate?,
   val bookingOffered: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TransitionalAccommodationReferralReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/TransitionalAccommodationReferralReportRepository.kt
@@ -41,11 +41,14 @@ interface TransitionalAccommodationReferralReportRepository : JpaRepository<Book
       premises.town as town,
       premises.postcode as postCode,
       taa.pdu as pdu,
-      taa.prison_release_types as prisonReleaseTypes
+      taa.prison_release_types as prisonReleaseTypes,
+      tass.release_date as updatedReleaseDate,
+      tass.accommodation_required_from_date as updatedAccommodationRequiredFromDate
     FROM temporary_accommodation_assessments aa
     JOIN assessments a on aa.assessment_id = a.id AND a.service='temporary-accommodation' AND a.reallocated_at IS NULL
+    JOIN temporary_accommodation_assessments tass on tass.assessment_id = a.id
     JOIN applications ap on a.application_id = ap.id AND ap.service='temporary-accommodation'
-    LEFT OUTER JOIN temporary_accommodation_applications taa on ap.id = taa.id
+    LEFT JOIN temporary_accommodation_applications taa on ap.id = taa.id
     LEFT JOIN probation_regions probation_region ON probation_region.id = taa.probation_region_id
     LEFT JOIN bookings b on b.application_id = ap.id AND b.service='temporary-accommodation'
     LEFT JOIN premises premises ON premises.id = b.premises_id and premises.service='temporary-accommodation'
@@ -97,4 +100,6 @@ interface TransitionalAccommodationReferralReportData {
   val town: String?
   val postCode: String?
   val prisonReleaseTypes: String?
+  val updatedReleaseDate: LocalDate?
+  val updatedAccommodationRequiredFromDate: LocalDate?
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -2353,8 +2353,10 @@ class Cas3ReportsTest : IntegrationTestBase() {
     assertThat(actualReferralReportRow.rejectionReason).isEqualTo(expectedAssessment.referralRejectionReason?.name)
     assertThat(actualReferralReportRow.rejectionReasonExplained).isEqualTo(expectedAssessment.referralRejectionReasonDetail)
     assertThat(actualReferralReportRow.accommodationRequiredDate).isEqualTo(application.arrivalDate?.toLocalDate())
+    assertThat(actualReferralReportRow.updatedAccommodationRequiredFromDate).isEqualTo(LocalDate.now().plusDays(20).toString())
     assertThat(actualReferralReportRow.prisonAtReferral).isEqualTo(application.prisonNameOnCreation)
     assertThat(actualReferralReportRow.releaseDate).isEqualTo(application.personReleaseDate)
+    assertThat(actualReferralReportRow.updatedReleaseDate).isEqualTo(LocalDate.now().plusDays(20).toString())
     assertThat(actualReferralReportRow.pdu).isEqualTo(application.pdu)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
@@ -317,6 +317,8 @@ class Cas3ReportServiceTest {
     postCode = null,
     pdu = null,
     prisonReleaseTypes = null,
+    updatedReleaseDate = null,
+    updatedAccommodationRequiredFromDate = null,
   )
 
   private fun createBookingReportData(crn: String) = TestBookingsReportData(
@@ -383,6 +385,8 @@ class Cas3ReportServiceTest {
     override val postCode: String?,
     override val pdu: String?,
     override val prisonReleaseTypes: String?,
+    override val updatedReleaseDate: LocalDate?,
+    override val updatedAccommodationRequiredFromDate: LocalDate?,
   ) : TransitionalAccommodationReferralReportData
 
   @Suppress("LongParameterList")


### PR DESCRIPTION
This PR adds 2 fields to the referral report, the updatedReleaseDate and the updatedAccommodationRequiredFromDate, as per [CAS-441](https://dsdmoj.atlassian.net/browse/CAS-441)


[CAS-441]: https://dsdmoj.atlassian.net/browse/CAS-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ