### PR TITLE
CAS-365 Upgrade Java from 17 to 21.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ executors:
   integration-test-gradle:
     resource_class: medium+
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0.2
       - image: "postgis/postgis"
         environment:
           - POSTGRES_USER=integration_test
@@ -41,13 +41,13 @@ executors:
   unit-test-gradle:
     resource_class: medium+
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0.2
 
 jobs:
   generate_trivyignore:
     # Needed to get Trivy to respect the .trivyignore file, as it doesn't use the one that's inside the Docker image.
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0.2
     resource_class: small
     steps:
       - checkout
@@ -127,7 +127,7 @@ jobs:
       _JAVA_OPTIONS: "-Xmx3g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0.2
     steps:
       - checkout
       - restore_cache:
@@ -153,7 +153,7 @@ jobs:
       _JAVA_OPTIONS: "-Xmx3g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0.2
     steps:
       - attach_workspace:
           at: ~/
@@ -165,7 +165,7 @@ jobs:
       _JAVA_OPTIONS: "-Xmx3g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0.2
     steps:
       - attach_workspace:
           at: ~/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jre-jammy AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jre-jammy AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
@@ -7,7 +7,7 @@ WORKDIR /app
 ADD . .
 RUN ./gradlew --no-daemon assemble
 
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
 }
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
 // The `buildDir` built-in property has been deprecated in favour of `layout.buildDirectory`
@@ -102,7 +102,7 @@ val buildDir = layout.buildDirectory.asFile.get()
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-      jvmTarget = "17"
+      jvmTarget = "21"
     }
 
     kotlin.sourceSets["main"].kotlin.srcDir("$buildDir/generated/src/main")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
 
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.13.9")
+  testImplementation("net.bytebuddy:byte-buddy:1.14.17")
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")
   testImplementation("com.github.tomakehurst:wiremock-standalone:3.0.1")
   testRuntimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")


### PR DESCRIPTION
A PR to upgrade Java to version 21.  Changes to `build.gradle.kts` and CircleCI `config.yml` file.

Requires an upgrade to bytebuddy to be compatible with Java 21.