### PR TITLE
Fix performance issue when generate CAS3 utilisation report for all regions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/BedUtilisationReportData.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingCancellationReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingTurnaroundReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationLostBedReportData
+
+data class BedUtilisationReportData(
+  val bedspaceReportData: BedUtilisationBedspaceReportData,
+  val bookingsReportData: List<BedUtilisationBookingReportData>,
+  val bookingCancellationReportData: List<BedUtilisationBookingCancellationReportData>,
+  val bookingTurnaroundReportData: List<BedUtilisationBookingTurnaroundReportData>,
+  val lostBedReportData: List<BedUtilisationLostBedReportData>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -1,0 +1,179 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import java.time.LocalDate
+import java.util.UUID
+
+interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
+  @Query(
+    """
+    SELECT
+        CAST(b.id AS VARCHAR) AS bedId,
+        CAST(r.id AS VARCHAR) AS roomId,
+        CAST(p.id AS VARCHAR) AS premisesId,
+        pr.name AS probationRegionName,
+        pdu.name AS probationDeliveryUnitName,
+        laa.name AS localAuthorityName,
+        p.name AS premisesName,
+        p.address_line1 AS addressLine1,
+        p.town AS town,
+        p.postcode AS postCode,
+        r.name AS roomName,
+        b.created_at AS bedspaceStartDate,
+        b.end_date AS bedspaceEndDate
+    FROM beds b
+    INNER JOIN rooms r ON b.room_id = r.id
+    LEFT JOIN premises p ON r.premises_id = p.id
+    LEFT JOIN probation_regions pr ON p.probation_region_id = pr.id
+    INNER JOIN temporary_accommodation_premises tap ON p.id = tap.premises_id
+    LEFT JOIN probation_delivery_units pdu ON tap.probation_delivery_unit_id = pdu.id
+    LEFT JOIN local_authority_areas laa ON p.local_authority_area_id = laa.id
+    WHERE
+      p.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
+    ORDER BY b.name      
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBedspaces(
+    probationRegionId: UUID?,
+  ): List<BedUtilisationBedspaceReportData>
+
+  @Query(
+    """
+    SELECT
+      CAST(booking.id AS VARCHAR) AS bookingId,
+      booking.arrival_date AS arrivalDate,
+      booking.departure_date AS departureDate,
+      CAST(bed.id AS VARCHAR) AS bedId,
+      CAST(arrival.id AS VARCHAR) AS arrivalId,
+      CAST(confirmation.id AS VARCHAR) AS confirmationId
+    From bookings booking
+    INNER JOIN beds bed ON bed.id = booking.bed_id
+    INNER JOIN premises premises ON booking.premises_id = premises.id
+    INNER JOIN probation_regions probation_region ON probation_region.id = premises.probation_region_id
+    LEFT JOIN arrivals arrival ON booking.id = arrival.booking_id
+    LEFT JOIN confirmations confirmation ON booking.id = confirmation.booking_id
+    WHERE
+        premises.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR premises.probation_region_id = :probationRegionId)
+      AND booking.arrival_date <= :endDate AND booking.departure_date >= :startDate
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBookingsByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedUtilisationBookingReportData>
+
+  @Query(
+    """
+    SELECT
+      CAST(cancellation.id AS VARCHAR) AS cancellationId,
+      CAST(bed.id AS VARCHAR) AS bedId,
+      CAST(booking.id AS VARCHAR) AS bookingId,
+      cancellation.created_at AS createdAt
+    From cancellations cancellation
+    INNER JOIN bookings booking ON cancellation.booking_id = booking.id
+    INNER JOIN beds bed ON bed.id = booking.bed_id
+    INNER JOIN premises premises ON booking.premises_id = premises.id
+    INNER JOIN probation_regions probation_region ON probation_region.id = premises.probation_region_id
+    WHERE
+        premises.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR premises.probation_region_id = :probationRegionId)
+      AND booking.arrival_date <= :endDate AND booking.departure_date >= :startDate
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBookingCancellationsByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedUtilisationBookingCancellationReportData>
+
+  @Query(
+    """
+    SELECT
+      CAST(turnaround.Id AS VARCHAR) AS turnaroundId,
+      CAST(bed.id AS VARCHAR) AS bedId,
+      CAST(booking.id AS VARCHAR) AS bookingId,
+      turnaround.created_at AS CreatedAt,
+      working_day_count AS workingDayCount
+    From turnarounds turnaround
+    INNER JOIN bookings booking ON booking.id = turnaround.booking_id
+    INNER JOIN beds bed ON bed.id = booking.bed_id
+    INNER JOIN premises premises ON booking.premises_id = premises.id
+    INNER JOIN probation_regions probation_region ON probation_region.id = premises.probation_region_id
+    WHERE
+        premises.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR premises.probation_region_id = :probationRegionId)
+      AND booking.arrival_date <= :endDate AND booking.departure_date >= :startDate
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBookingTurnaroundByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedUtilisationBookingTurnaroundReportData>
+
+  @Query(
+    """
+    SELECT
+        CAST(b.id AS VARCHAR) AS bedId,
+        lb.start_date AS startDate,
+        lb.end_date AS endDate,
+        CAST(lbc.id AS VARCHAR) AS cancellationId
+    From lost_beds lb
+    LEFT JOIN beds b ON lb.bed_id = b.id
+    LEFT JOIN rooms r ON b.room_id = r.id
+    LEFT JOIN premises p ON r.premises_id = p.id
+    LEFT JOIN lost_bed_cancellations lbc ON lb.id = lbc.lost_bed_id
+    WHERE
+        p.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
+      AND lb.start_date <= :endDate AND lb.end_date >= :startDate
+      AND lbc.id is NULL
+    ORDER BY lb.id     
+    """,
+    nativeQuery = true,
+  )
+  fun findAllLostBedByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedUtilisationLostBedReportData>
+}
+interface BedUtilisationBedspaceReportData {
+  val bedId: String
+  val probationRegionName: String?
+  val probationDeliveryUnitName: String?
+  val localAuthorityName: String?
+  val premisesName: String
+  val addressLine1: String
+  val town: String?
+  val postCode: String
+  val roomName: String
+  val bedspaceStartDate: LocalDate?
+  val bedspaceEndDate: LocalDate?
+  val premisesId: String
+  val roomId: String
+}
+
+interface BedUtilisationBookingReportData {
+  val bookingId: String
+  val arrivalDate: LocalDate
+  val departureDate: LocalDate
+  val bedId: String
+  val arrivalId: String?
+  val confirmationId: String?
+}
+
+interface BedUtilisationBookingCancellationReportData {
+  val cancellationId: String
+  val bedId: String
+  val bookingId: String
+  val createdAt: LocalDate
+}
+
+interface BedUtilisationBookingTurnaroundReportData {
+  val turnaroundId: String
+  val bedId: String
+  val bookingId: String
+  val workingDayCount: Int
+  val createdAt: LocalDate
+}
+
+interface BedUtilisationLostBedReportData {
+  val bedId: String
+  val startDate: LocalDate
+  val endDate: LocalDate
+  val cancellationId: String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ReportService.kt
@@ -14,12 +14,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.TransitionalAccommodationReferralReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportDataAndPersonInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.TransitionalAccommodationReferralReportDataAndPersonInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.TransitionalAccommodationReferralReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TransitionalAccommodationReferralReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -40,6 +42,7 @@ class Cas3ReportService(
   private val workingDayService: WorkingDayService,
   private val bookingRepository: BookingRepository,
   private val bedRepository: BedRepository,
+  private val bedUtilisationReportRepository: BedUtilisationReportRepository,
   @Value("\${cas3-report.crn-search-limit:400}") private val numberOfCrn: Int,
 ) {
   fun createCas3ApplicationReferralsReport(
@@ -98,8 +101,45 @@ class Cas3ReportService(
   }
 
   fun createBedUtilisationReport(properties: BedUtilisationReportProperties, outputStream: OutputStream) {
-    BedUtilisationReportGenerator(bookingRepository, lostBedsRepository, workingDayService)
-      .createReport(bedRepository.findAll(), properties)
+    val bedspacesInScope = bedUtilisationReportRepository.findAllBedspaces(
+      probationRegionId = properties.probationRegionId,
+    )
+
+    val bedspaceBookingsInScope = bedUtilisationReportRepository.findAllBookingsByOverlappingDate(
+      probationRegionId = properties.probationRegionId,
+      properties.startDate,
+      properties.endDate,
+    )
+
+    val bedspaceBookingsCancellationInScope = bedUtilisationReportRepository.findAllBookingCancellationsByOverlappingDate(
+      probationRegionId = properties.probationRegionId,
+      properties.startDate,
+      properties.endDate,
+    )
+
+    val bedspaceBookingsTurnaroundInScope = bedUtilisationReportRepository.findAllBookingTurnaroundByOverlappingDate(
+      probationRegionId = properties.probationRegionId,
+      properties.startDate,
+      properties.endDate,
+    )
+
+    val lostBedspaceInScope = bedUtilisationReportRepository.findAllLostBedByOverlappingDate(
+      probationRegionId = properties.probationRegionId,
+      properties.startDate,
+      properties.endDate,
+    )
+
+    val reportData = bedspacesInScope.map {
+      val bedId = it.bedId
+      val bedspaceBookings = bedspaceBookingsInScope.filter { it.bedId == bedId }
+      val bedspaceBookingsCancellation = bedspaceBookingsCancellationInScope.filter { it.bedId == bedId }
+      val bedspaceBookingsTurnaround = bedspaceBookingsTurnaroundInScope.filter { it.bedId == bedId }
+      val lostBedspace = lostBedspaceInScope.filter { it.bedId == bedId }
+      BedUtilisationReportData(it, bedspaceBookings, bedspaceBookingsCancellation, bedspaceBookingsTurnaround, lostBedspace)
+    }
+
+    BedUtilisationReportGenerator(workingDayService)
+      .createReport(reportData, properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -5,10 +5,12 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
 import org.jetbrains.kotlinx.dataframe.api.convertTo
 import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
@@ -18,26 +20,22 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.LostBedsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUsageType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.LostBedReportRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUsageReportProperties
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BedUtilisationReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.LostBedReportProperties
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -51,13 +49,7 @@ class ReportsTest : IntegrationTestBase() {
   lateinit var bookingTransformer: BookingTransformer
 
   @Autowired
-  lateinit var realBookingRepository: BookingRepository
-
-  @Autowired
   lateinit var realLostBedsRepository: LostBedsRepository
-
-  @Autowired
-  lateinit var realWorkingDayService: WorkingDayService
 
   @Nested
   inner class GetBookingReport {
@@ -910,8 +902,6 @@ class ReportsTest : IntegrationTestBase() {
     fun `Get bed usage report returns OK with correct body`() {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withProbationRegion(userEntity.probationRegion)
@@ -936,13 +926,30 @@ class ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUsageReportGenerator(
-            bookingTransformer,
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayService,
+          val expectedReportRows = listOf(
+            BedUsageReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = userEntity.probationDeliveryUnit?.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              crn = offenderDetails.otherIds.crn,
+              type = BedUsageType.Booking,
+              startDate = LocalDate.parse("2023-04-05"),
+              endDate = LocalDate.parse("2023-04-15"),
+              durationOfBookingDays = 10,
+              bookingStatus = BookingStatus.provisional,
+              voidCategory = null,
+              voidNotes = null,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(listOf(bed), BedUsageReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate))
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/reports/bed-usage?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")
@@ -966,8 +973,6 @@ class ReportsTest : IntegrationTestBase() {
     fun `Get bed usage report returns OK with correct body with pdu and local authority`() {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
           val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
@@ -998,13 +1003,30 @@ class ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUsageReportGenerator(
-            bookingTransformer,
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayService,
+          val expectedReportRows = listOf(
+            BedUsageReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              crn = offenderDetails.otherIds.crn,
+              type = BedUsageType.Booking,
+              startDate = LocalDate.parse("2023-04-05"),
+              endDate = LocalDate.parse("2023-04-15"),
+              durationOfBookingDays = 10,
+              bookingStatus = BookingStatus.provisional,
+              voidCategory = null,
+              voidNotes = null,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(listOf(bed), BedUsageReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate))
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/reports/bed-usage?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")
@@ -1085,8 +1107,6 @@ class ReportsTest : IntegrationTestBase() {
     fun `Get bed utilisation report returns OK with correct body`() {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withProbationRegion(userEntity.probationRegion)
@@ -1114,12 +1134,33 @@ class ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUtilisationReportGenerator(
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayService,
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = userEntity.probationDeliveryUnit?.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 11,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(listOf(bed), BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate))
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/reports/bed-utilisation?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")
@@ -1143,14 +1184,11 @@ class ReportsTest : IntegrationTestBase() {
     fun `Get bed utilisation report returns OK with correct body with pdu and local authority`() {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
-          val startDate = LocalDate.of(2023, 4, 1)
-          val endDate = LocalDate.of(2023, 4, 30)
           val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
           val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
             withProbationRegion(userEntity.probationRegion)
           }
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withProbationRegion(userEntity.probationRegion)
             withProbationDeliveryUnit(probationDeliveryUnit)
             withLocalAuthorityArea(localAuthorityArea)
@@ -1178,12 +1216,33 @@ class ReportsTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2023-04-15"))
           }
 
-          val expectedDataFrame = BedUtilisationReportGenerator(
-            realBookingRepository,
-            realLostBedsRepository,
-            realWorkingDayService,
+          val expectedReportRows = listOf(
+            BedUtilisationReportRow(
+              probationRegion = userEntity.probationRegion.name,
+              pdu = probationDeliveryUnit.name,
+              localAuthority = premises.localAuthorityArea?.name,
+              propertyRef = premises.name,
+              addressLine1 = premises.addressLine1,
+              town = premises.town,
+              postCode = premises.postcode,
+              bedspaceRef = room.name,
+              bookedDaysActiveAndClosed = 0,
+              confirmedDays = 0,
+              provisionalDays = 11,
+              scheduledTurnaroundDays = 0,
+              effectiveTurnaroundDays = 0,
+              voidDays = 0,
+              totalBookedDays = 0,
+              bedspaceStartDate = bed.createdAt?.toLocalDate(),
+              bedspaceEndDate = bed.endDate,
+              bedspaceOnlineDays = 30,
+              occupancyRate = 0.0,
+              uniquePropertyRef = premises.id.toShortBase58(),
+              uniqueBedspaceRef = room.id.toShortBase58(),
+            ),
           )
-            .createReport(listOf(bed), BedUtilisationReportProperties(ServiceName.temporaryAccommodation, null, startDate, endDate))
+
+          val expectedDataFrame = expectedReportRows.toDataFrame()
 
           webTestClient.get()
             .uri("/reports/bed-utilisation?year=2023&month=4&probationRegionId=${userEntity.probationRegion.id}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
@@ -193,7 +194,7 @@ class BedUsageReportGeneratorTest {
     assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(temporaryAccommodationPremises.id.toShortBase58())
 
     verify {
-      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-07-01"), any())
+      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-07-01"), any<BedEntity>())
     }
   }
 
@@ -263,7 +264,7 @@ class BedUsageReportGeneratorTest {
     assertThat(result[0][BedUsageReportRow::uniquePropertyRef]).isEqualTo(approvedPremises.id.toShortBase58())
 
     verify {
-      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), any())
+      mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), any<BedEntity>())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/Cas3ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/Cas3ReportsTestHelper.kt
@@ -1,0 +1,126 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.util
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingCancellationReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingTurnaroundReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationLostBedReportData
+import java.time.LocalDate
+
+fun convertToCas3BedUtilisationBedspaceReportData(bed: BedEntity): Cas3BedUtilisationBedspaceReportData {
+  val room = bed.room
+  var probationDeliveryUnitName: String? = null
+  val premises = room.premises
+
+  if (room.premises is TemporaryAccommodationPremisesEntity) {
+    probationDeliveryUnitName = (room.premises as TemporaryAccommodationPremisesEntity).probationDeliveryUnit?.name
+  }
+
+  return Cas3BedUtilisationBedspaceReportData(
+    bedId = bed.id.toString(),
+    probationRegionName = premises.probationRegion.name,
+    probationDeliveryUnitName = probationDeliveryUnitName,
+    localAuthorityName = premises.localAuthorityArea?.name,
+    premisesName = premises.name,
+    addressLine1 = premises.addressLine1,
+    town = premises.town,
+    postCode = premises.postcode,
+    roomName = room.name,
+    bedspaceStartDate = bed.createdAt?.toLocalDate(),
+    bedspaceEndDate = bed.endDate,
+    premisesId = premises.id.toString(),
+    roomId = room.id.toString(),
+  )
+}
+
+fun convertToCas3BedUtilisationBookingReportData(booking: BookingEntity): Cas3BedUtilisationBookingReportData {
+  return Cas3BedUtilisationBookingReportData(
+    bookingId = booking.id.toString(),
+    arrivalDate = booking.arrivalDate,
+    departureDate = booking.departureDate,
+    bedId = booking.bed?.id.toString(),
+    arrivalId = booking.arrival?.id?.toString(),
+    confirmationId = booking.confirmation?.id?.toString(),
+  )
+}
+
+fun convertToCas3BedUtilisationBookingCancellationReportData(booking: BookingEntity): Cas3BedUtilisationBookingCancellationReportData {
+  return Cas3BedUtilisationBookingCancellationReportData(
+    cancellationId = booking.cancellation?.id.toString(),
+    bedId = booking.bed?.id.toString(),
+    bookingId = booking.id.toString(),
+    createdAt = booking.cancellation?.createdAt?.toLocalDate()!!,
+  )
+}
+
+fun convertToCas3BedUtilisationBookingTurnaroundReportData(booking: BookingEntity): Cas3BedUtilisationBookingTurnaroundReportData {
+  return Cas3BedUtilisationBookingTurnaroundReportData(
+    turnaroundId = booking.turnaround?.id.toString(),
+    bedId = booking.bed?.id.toString(),
+    bookingId = booking.id.toString(),
+    workingDayCount = booking.turnaround?.workingDayCount!!,
+    createdAt = booking.turnaround?.createdAt?.toLocalDate()!!,
+  )
+}
+
+fun convertToCas3BedUtilisationLostBedReportData(lostBed: LostBedsEntity): Cas3BedUtilisationLostBedReportData {
+  return Cas3BedUtilisationLostBedReportData(
+    bedId = lostBed.bed.id.toString(),
+    startDate = lostBed.startDate,
+    endDate = lostBed.endDate,
+    cancellationId = lostBed.cancellation?.id?.toString(),
+  )
+}
+
+@Suppress("LongParameterList")
+class Cas3BedUtilisationBedspaceReportData(
+  override val bedId: String,
+  override val probationRegionName: String?,
+  override val probationDeliveryUnitName: String?,
+  override val localAuthorityName: String?,
+  override val premisesName: String,
+  override val addressLine1: String,
+  override val town: String?,
+  override val postCode: String,
+  override val roomName: String,
+  override val bedspaceStartDate: LocalDate?,
+  override val bedspaceEndDate: LocalDate?,
+  override val premisesId: String,
+  override val roomId: String,
+) : BedUtilisationBedspaceReportData
+
+@Suppress("LongParameterList")
+class Cas3BedUtilisationBookingReportData(
+  override val bookingId: String,
+  override val arrivalDate: LocalDate,
+  override val departureDate: LocalDate,
+  override val bedId: String,
+  override val arrivalId: String?,
+  override val confirmationId: String?,
+) : BedUtilisationBookingReportData
+
+class Cas3BedUtilisationBookingCancellationReportData(
+  override val cancellationId: String,
+  override val bedId: String,
+  override val bookingId: String,
+  override val createdAt: LocalDate,
+) : BedUtilisationBookingCancellationReportData
+
+class Cas3BedUtilisationBookingTurnaroundReportData(
+  override val turnaroundId: String,
+  override val bedId: String,
+  override val bookingId: String,
+  override val createdAt: LocalDate,
+  override val workingDayCount: Int,
+) : BedUtilisationBookingTurnaroundReportData
+
+class Cas3BedUtilisationLostBedReportData(
+  override val bedId: String,
+  override val startDate: LocalDate,
+  override val endDate: LocalDate,
+  override val cancellationId: String?,
+) : BedUtilisationLostBedReportData

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepos
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.TransitionalAccommodationReferralReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TransitionalAccommodationReferralReportData
@@ -40,6 +41,7 @@ class Cas3ReportServiceTest {
   private val mockWorkingDayService = mockk<WorkingDayService>()
   private val mockBookingRepository = mockk<BookingRepository>()
   private val mockBedRepository = mockk<BedRepository>()
+  private val mockBedUtilisationReportRepository = mockk<BedUtilisationReportRepository>()
 
   private val cas3ReportService = Cas3ReportService(
     mockOffenderService,
@@ -51,6 +53,7 @@ class Cas3ReportServiceTest {
     mockWorkingDayService,
     mockBookingRepository,
     mockBedRepository,
+    mockBedUtilisationReportRepository,
     2,
   )
 
@@ -105,6 +108,7 @@ class Cas3ReportServiceTest {
       mockWorkingDayService,
       mockBookingRepository,
       mockBedRepository,
+      mockBedUtilisationReportRepository,
       3,
     )
 


### PR DESCRIPTION
This [PR CAS-414](https://dsdmoj.atlassian.net/browse/CAS-414) is to fix a performance issue when generate utilisation report in CAS3 for all regions. Which includes:
- Reduce the amount of data retrieved in the report queries by changing it to sql queries 
- Get all the information needed for bedspace, bookings and lost bed space in one query instead of calling the database for each row in the report
- Return only the data related to temporary accommodation which is needed in the report 
- Add integration tests to check the new report queries

This PR is different from previous one:
- Move the Booking cancellations and turnaround in separate sql queries.
- Add new integration tests to cover the scenarios when there are  multiple booking cancellations and turnarounds for the same bedspace during the report period