### PR TITLE
APS-1008 - Apply LAO Qualification to CAS1 ‘All Applications’

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
@@ -131,7 +132,11 @@ class ApplicationsController(
       metadata?.toHeaders(),
     ).body(
       applications.map {
-        getPersonDetailAndTransformToSummary(it, user)
+        getPersonDetailAndTransformToSummary(
+          application = it,
+          user = user,
+          ignoreLaoRestrictions = user.hasQualification(UserQualification.LAO),
+        )
       },
     )
   }
@@ -604,8 +609,9 @@ class ApplicationsController(
   private fun getPersonDetailAndTransformToSummary(
     application: JPAApplicationSummary,
     user: UserEntity,
+    ignoreLaoRestrictions: Boolean = false,
   ): ApplicationSummary {
-    val personInfo = offenderService.getInfoForPerson(application.getCrn(), user.deliusUsername, false)
+    val personInfo = offenderService.getInfoForPerson(application.getCrn(), user.deliusUsername, ignoreLaoRestrictions)
 
     return applicationsTransformer.transformDomainToApiSummary(application, personInfo)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2932,7 +2932,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get applications all LAO with LAO qualification returns 200 and restricted person`() {
+    fun `Get applications all LAO with LAO qualification returns 200 and full person`() {
       `Given a User`(qualifications = listOf(UserQualification.LAO)) { userEntity, jwt ->
         val (offenderDetails, _) = `Given an Offender`(
           offenderDetailsConfigBlock = {
@@ -2970,7 +2970,7 @@ class ApplicationTest : IntegrationTestBase() {
           .bodyAsListOfObjects<ApplicationSummary>()
 
         assertThat(response).hasSize(1)
-        assertThat(response[0].person).isInstanceOf(RestrictedPerson::class.java)
+        assertThat(response[0].person).isInstanceOf(FullPerson::class.java)
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -94,6 +94,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEve
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AssignedLivingUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsListOfObjects
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
@@ -232,21 +233,13 @@ class ApplicationTest : IntegrationTestBase() {
                 exclusion = false,
               )
 
-              val rawResponseBody = webTestClient.get()
+              val responseBody = webTestClient.get()
                 .uri("/applications")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()
                 .isOk
-                .returnResult<String>()
-                .responseBody
-                .blockFirst()
-
-              val responseBody =
-                objectMapper.readValue(
-                  rawResponseBody,
-                  object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-                )
+                .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
               assertThat(responseBody).anyMatch {
                 outdatedApplicationEntityManagedByTeam.id == it.id &&
@@ -315,22 +308,14 @@ class ApplicationTest : IntegrationTestBase() {
                 exclusion = false,
               )
 
-              val rawResponseBody = webTestClient.get()
+              val responseBody = webTestClient.get()
                 .uri("/applications")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
                 .exchange()
                 .expectStatus()
                 .isOk
-                .returnResult<String>()
-                .responseBody
-                .blockFirst()
-
-              val responseBody =
-                objectMapper.readValue(
-                  rawResponseBody,
-                  object : TypeReference<List<TemporaryAccommodationApplicationSummary>>() {},
-                )
+                .bodyAsListOfObjects<TemporaryAccommodationApplicationSummary>()
 
               assertThat(responseBody).anyMatch {
                 application.id == it.id && application.crn == it.person.crn &&
@@ -405,22 +390,14 @@ class ApplicationTest : IntegrationTestBase() {
                 exclusion = false,
               )
 
-              val rawResponseBody = webTestClient.get()
+              val responseBody = webTestClient.get()
                 .uri("/applications")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
                 .exchange()
                 .expectStatus()
                 .isOk
-                .returnResult<String>()
-                .responseBody
-                .blockFirst()
-
-              val responseBody =
-                objectMapper.readValue(
-                  rawResponseBody,
-                  object : TypeReference<List<TemporaryAccommodationApplicationSummary>>() {},
-                )
+                .bodyAsListOfObjects<TemporaryAccommodationApplicationSummary>()
 
               assertThat(responseBody).anyMatch {
                 application.id == it.id &&
@@ -522,21 +499,13 @@ class ApplicationTest : IntegrationTestBase() {
             exclusion = false,
           )
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
             .isOk
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
           assertThat(responseBody).matches {
             val person = it[0].person as FullPerson
@@ -568,21 +537,13 @@ class ApplicationTest : IntegrationTestBase() {
         ) { _, _ ->
           val application = produceAndPersistBasicApplication(crn, userEntity, "TEAM1")
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
             .isOk
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
           assertThat(responseBody).matches {
             val person = it[0].person as FullPerson
@@ -2948,22 +2909,14 @@ class ApplicationTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, _ ->
           createTwelveApplications(offenderDetails.otherIds.crn, userEntity)
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()
             .expectStatus()
             .isOk
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(12)
         }
@@ -2976,7 +2929,7 @@ class ApplicationTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, _ ->
           createTwelveApplications(offenderDetails.otherIds.crn, userEntity)
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?page=1&sortDirection=asc")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -2987,15 +2940,7 @@ class ApplicationTest : IntegrationTestBase() {
             .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
             .expectHeader().valueEquals("X-Pagination-TotalResults", 12)
             .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(10)
         }
@@ -3009,22 +2954,14 @@ class ApplicationTest : IntegrationTestBase() {
           val crn = offenderDetails.otherIds.crn
           createTwelveApplications(crn, userEntity)
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?crnOrName=$crn")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
             .exchange()
             .expectStatus()
             .isOk
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(12)
         }
@@ -3043,22 +2980,14 @@ class ApplicationTest : IntegrationTestBase() {
             val crn2 = offenderDetails2.otherIds.crn
             createTwelveApplications(crn2, userEntity)
 
-            val rawResponseBody = webTestClient.get()
+            val responseBody = webTestClient.get()
               .uri("/applications/all?crnOrName=$crn2")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.approvedPremises.value)
               .exchange()
               .expectStatus()
               .isOk
-              .returnResult<String>()
-              .responseBody
-              .blockFirst()
-
-            val responseBody =
-              objectMapper.readValue(
-                rawResponseBody,
-                object : TypeReference<List<ApplicationSummary>>() {},
-              )
+              .bodyAsListOfObjects<ApplicationSummary>()
 
             assertThat(responseBody.count()).isEqualTo(12)
           }
@@ -3078,7 +3007,7 @@ class ApplicationTest : IntegrationTestBase() {
             val crn2 = offenderDetails2.otherIds.crn
             createTwelveApplications(crn2, userEntity)
 
-            val rawResponseBody = webTestClient.get()
+            val responseBody = webTestClient.get()
               .uri("/applications/all?page=2&sortDirection=desc&crnOrName=$crn2")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3089,15 +3018,7 @@ class ApplicationTest : IntegrationTestBase() {
               .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
               .expectHeader().valueEquals("X-Pagination-TotalResults", 12)
               .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-              .returnResult<String>()
-              .responseBody
-              .blockFirst()
-
-            val responseBody =
-              objectMapper.readValue(
-                rawResponseBody,
-                object : TypeReference<List<ApplicationSummary>>() {},
-              )
+              .bodyAsListOfObjects<ApplicationSummary>()
 
             assertThat(responseBody.count()).isEqualTo(2)
           }
@@ -3137,7 +3058,7 @@ class ApplicationTest : IntegrationTestBase() {
             withCreatedAt(date3)
           }
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?page=1&sortDirection=desc&sortBy=createdAt")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3148,15 +3069,7 @@ class ApplicationTest : IntegrationTestBase() {
             .expectHeader().valueEquals("X-Pagination-TotalPages", 1)
             .expectHeader().valueEquals("X-Pagination-TotalResults", 3)
             .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(3)
           assertThat(responseBody[0].createdAt).isEqualTo(date3.toInstant())
@@ -3198,7 +3111,7 @@ class ApplicationTest : IntegrationTestBase() {
             withCreatedAt(date3)
           }
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?page=1&sortDirection=asc&sortBy=createdAt")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3209,15 +3122,7 @@ class ApplicationTest : IntegrationTestBase() {
             .expectHeader().valueEquals("X-Pagination-TotalPages", 1)
             .expectHeader().valueEquals("X-Pagination-TotalResults", 3)
             .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(3)
           assertThat(responseBody[0].createdAt).isEqualTo(date1.toInstant())
@@ -3259,7 +3164,7 @@ class ApplicationTest : IntegrationTestBase() {
             withArrivalDate(date3)
           }
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?page=1&sortDirection=desc&sortBy=arrivalDate")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3270,15 +3175,7 @@ class ApplicationTest : IntegrationTestBase() {
             .expectHeader().valueEquals("X-Pagination-TotalPages", 1)
             .expectHeader().valueEquals("X-Pagination-TotalResults", 3)
             .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(3)
           assertThat(responseBody[0].arrivalDate).isEqualTo(date3.toInstant())
@@ -3320,7 +3217,7 @@ class ApplicationTest : IntegrationTestBase() {
             withArrivalDate(date3)
           }
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?page=1&sortDirection=asc&sortBy=arrivalDate")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3331,15 +3228,7 @@ class ApplicationTest : IntegrationTestBase() {
             .expectHeader().valueEquals("X-Pagination-TotalPages", 1)
             .expectHeader().valueEquals("X-Pagination-TotalResults", 3)
             .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(3)
           assertThat(responseBody[0].arrivalDate).isEqualTo(date1.toInstant())
@@ -3418,7 +3307,7 @@ class ApplicationTest : IntegrationTestBase() {
             withRiskRatings(risk3)
           }
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?page=1&sortDirection=asc&sortBy=tier")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3429,15 +3318,7 @@ class ApplicationTest : IntegrationTestBase() {
             .expectHeader().valueEquals("X-Pagination-TotalPages", 1)
             .expectHeader().valueEquals("X-Pagination-TotalResults", 3)
             .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(3)
           assertThat(responseBody[0].tier).isEqualTo("M1")
@@ -3516,7 +3397,7 @@ class ApplicationTest : IntegrationTestBase() {
             withRiskRatings(risk3)
           }
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?page=1&sortDirection=desc&sortBy=tier")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3527,15 +3408,7 @@ class ApplicationTest : IntegrationTestBase() {
             .expectHeader().valueEquals("X-Pagination-TotalPages", 1)
             .expectHeader().valueEquals("X-Pagination-TotalResults", 3)
             .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(3)
           assertThat(responseBody[0].tier).isEqualTo("M3")
@@ -3568,7 +3441,7 @@ class ApplicationTest : IntegrationTestBase() {
             withStatus(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
           }
 
-          val rawResponseBody = webTestClient.get()
+          val responseBody = webTestClient.get()
             .uri("/applications/all?page=2&sortDirection=desc&status=assesmentInProgress")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3579,15 +3452,7 @@ class ApplicationTest : IntegrationTestBase() {
             .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
             .expectHeader().valueEquals("X-Pagination-TotalResults", 12)
             .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-            .returnResult<String>()
-            .responseBody
-            .blockFirst()
-
-          val responseBody =
-            objectMapper.readValue(
-              rawResponseBody,
-              object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-            )
+            .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(2)
           assertThat(responseBody[0].status).isEqualTo(ApiApprovedPremisesApplicationStatus.assesmentInProgress)
@@ -3625,7 +3490,7 @@ class ApplicationTest : IntegrationTestBase() {
               withStatus(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
             }
 
-            val rawResponseBody = webTestClient.get()
+            val responseBody = webTestClient.get()
               .uri("/applications/all?page=1&sortDirection=desc&crnOrName=Gareth")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.approvedPremises.value)
@@ -3636,15 +3501,7 @@ class ApplicationTest : IntegrationTestBase() {
               .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
               .expectHeader().valueEquals("X-Pagination-TotalResults", 12)
               .expectHeader().valueEquals("X-Pagination-PageSize", 10)
-              .returnResult<String>()
-              .responseBody
-              .blockFirst()
-
-            val responseBody =
-              objectMapper.readValue(
-                rawResponseBody,
-                object : TypeReference<List<ApprovedPremisesApplicationSummary>>() {},
-              )
+              .bodyAsListOfObjects<ApprovedPremisesApplicationSummary>()
 
             assertThat(responseBody.count()).isEqualTo(10)
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -120,7 +120,7 @@ class ApplicationTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class GetAllApplications {
+  inner class GetApplications {
 
     @Test
     fun `Get all applications without JWT returns 401`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -81,8 +81,8 @@ fun IntegrationTestBase.`Given an Offender`(
   mockServerErrorForCommunityApi: Boolean = false,
   mockServerErrorForPrisonApi: Boolean = false,
   mockNotFoundErrorForPrisonApi: Boolean = false,
-  block: (offenderDetails: OffenderDetailSummary, inmateDetails: InmateDetail) -> Unit,
-) {
+  block: ((offenderDetails: OffenderDetailSummary, inmateDetails: InmateDetail) -> Unit)? = null,
+): Pair<OffenderDetailSummary, InmateDetail> {
   val (offenderDetails, inmateDetails) = `Given an Offender`(
     offenderDetailsConfigBlock,
     inmateDetailsConfigBlock,
@@ -91,7 +91,9 @@ fun IntegrationTestBase.`Given an Offender`(
     mockNotFoundErrorForPrisonApi,
   )
 
-  block(offenderDetails, inmateDetails)
+  block?.invoke(offenderDetails, inmateDetails)
+
+  return Pair(offenderDetails, inmateDetails)
 }
 
 fun IntegrationTestBase.`Given Some Offenders`(


### PR DESCRIPTION
See https://dsdmoj.atlassian.net/browse/APS-1008 for test evidence

Before this change users with the LAO Qualification could not navigate to an LAO application when using the ‘all applications’ screen on the Apply tab.

This commit allows users with the LAO Qualification to view LAO offenders names on the ‘all applications’ screen, and provides a link to click through to the application, as they can do elsewhere in the application.

The previous behaviour was (presumably) in place because the LAO qualification is not sufficient to apply for a new application, and this logic continued to the ‘All Applications’ screen which is also on the Apply Tab. Despite being on the Apply Tab, the all application screen is really a general purpose application search so loosening of restrictions here is fine.

This addresses an issue where users could not create appeals for LAO applications as there was no straight forward path to view the application.