### PR TITLE
CAS 365, = null changed to IS null, required for Spring 3.2.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/NoticeTypeMigrationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/NoticeTypeMigrationJob.kt
@@ -30,7 +30,7 @@ interface NoticeTypeMigrationJobApplicationRepository : JpaRepository<Applicatio
 
   @Query(
     "SELECT ap FROM ApprovedPremisesApplicationEntity ap where " +
-      "ap.noticeType = null AND ap.isEmergencyApplication = false ",
+      "ap.noticeType IS null AND ap.isEmergencyApplication = false ",
   )
   fun getApplicationsThatRequireNoticeTypeUpdating(pageable: Pageable): Slice<ApprovedPremisesApplicationEntity>
 }


### PR DESCRIPTION
CAS 365, = null changed to IS null, required for Spring 3.2.