### PR TITLE
Stop renovate constantly rebasing branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,5 +28,6 @@
         "org.testcontainers"
       ]
     }
-  ]
+  ],
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
Before this commit renovate woud rebase any branch it has created whenever it was behind main by > 1 commit. This leads to many circleci jobs being executed, using up circle resources.

Renovates default configuration for rebasing is:

“It will use behind-base-branch if configured to automerge or repository has been set to require PRs to be up to date”

Where base-branch is

“Renovate will rebase whenever the branch falls 1 or more commit behind its base branch”

This commit changes the rebase strategy to only rebase renovate branches where there is a confluct (i.e. the gradle config has been updated on the main)

For more information, see https://docs.renovatebot.com/configuration-options/#rebasewhen