### PR TITLE
CAS1 Provide FullPerson info if can view app

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -154,7 +154,13 @@ class ApplicationsController(
     }
 
     if (application != null) {
-      return ResponseEntity.ok(getPersonDetailAndTransform(application, user))
+      return ResponseEntity.ok(
+        getPersonDetailAndTransform(
+          application = application,
+          user = user,
+          ignoreLaoRestrictions = application is ApprovedPremisesApplicationEntity && user.hasQualification(UserQualification.LAO),
+        ),
+      )
     }
 
     val offlineApplication = when (
@@ -166,7 +172,13 @@ class ApplicationsController(
       is AuthorisableActionResult.Success -> offlineApplicationResult.entity
     }
 
-    return ResponseEntity.ok(getPersonDetailAndTransform(offlineApplication, user))
+    return ResponseEntity.ok(
+      getPersonDetailAndTransform(
+        offlineApplication = offlineApplication,
+        user = user,
+        ignoreLaoRestrictions = user.hasQualification(UserQualification.LAO),
+      ),
+    )
   }
 
   @Transactional
@@ -600,8 +612,12 @@ class ApplicationsController(
     return cas1WithdrawableService.allDirectlyWithdrawables(application, user)
   }
 
-  private fun getPersonDetailAndTransform(application: ApplicationEntity, user: UserEntity): Application {
-    val personInfo = offenderService.getInfoForPerson(application.crn, user.deliusUsername, false)
+  private fun getPersonDetailAndTransform(
+    application: ApplicationEntity,
+    user: UserEntity,
+    ignoreLaoRestrictions: Boolean = false,
+  ): Application {
+    val personInfo = offenderService.getInfoForPerson(application.crn, user.deliusUsername, ignoreLaoRestrictions)
 
     return applicationsTransformer.transformJpaToApi(application, personInfo)
   }
@@ -616,8 +632,12 @@ class ApplicationsController(
     return applicationsTransformer.transformDomainToApiSummary(application, personInfo)
   }
 
-  private fun getPersonDetailAndTransform(offlineApplication: OfflineApplicationEntity, user: UserEntity): Application {
-    val personInfo = offenderService.getInfoForPerson(offlineApplication.crn, user.deliusUsername, false)
+  private fun getPersonDetailAndTransform(
+    offlineApplication: OfflineApplicationEntity,
+    user: UserEntity,
+    ignoreLaoRestrictions: Boolean = false,
+  ): Application {
+    val personInfo = offenderService.getInfoForPerson(offlineApplication.crn, user.deliusUsername, ignoreLaoRestrictions)
 
     return applicationsTransformer.transformJpaToApi(offlineApplication, personInfo)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -9,8 +9,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -158,12 +156,6 @@ class ApplicationsTransformer(
     person = personTransformer.transformModelToPersonApi(personInfo),
     createdAt = jpa.createdAt.toInstant(),
     type = "Offline",
-  )
-
-  fun transformToWithdrawable(jpa: ApplicationEntity) = Withdrawable(
-    id = jpa.id,
-    type = WithdrawableType.application,
-    dates = emptyList(),
   )
 
   private fun getStatus(entity: ApplicationEntity, latestAssessment: AssessmentEntity?): ApplicationStatus {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -700,7 +700,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get single LAO application for user who is not creator but has LAO Qualification returns RestrictedPerson`() {
+    fun `Get single LAO application for user who is not creator but has LAO Qualification returns FullPerson`() {
       `Given a User` { applicationCreator, _ ->
         `Given a User`(qualifications = listOf(UserQualification.LAO)) { _, otherUserJwt ->
           `Given an Offender`(
@@ -737,7 +737,7 @@ class ApplicationTest : IntegrationTestBase() {
 
             val responseBody = objectMapper.readValue(rawResponseBody, ApprovedPremisesApplication::class.java)
 
-            assertThat(responseBody.person).isInstanceOf(RestrictedPerson::class.java)
+            assertThat(responseBody.person).isInstanceOf(FullPerson::class.java)
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
 import com.fasterxml.jackson.core.type.TypeReference
 import com.github.tomakehurst.wiremock.client.WireMock
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummaries
@@ -35,12 +34,6 @@ fun IntegrationTestBase.APDeliusContext_mockSuccessfulCaseDetailCall(crn: String
   mockSuccessfulGetCallWithJsonResponse(
     url = "/probation-cases/$crn/details",
     responseBody = response,
-  )
-
-fun IntegrationTestBase.APDeliusContext_mockSuccessfulStaffDetailsCall(staffCode: String, staffUserDetails: StaffUserDetails) =
-  mockSuccessfulGetCallWithJsonResponse(
-    url = "/secure/staff/staffCode/$staffCode",
-    responseBody = staffUserDetails,
   )
 
 fun IntegrationTestBase.APDeliusContext_mockSuccessfulTeamsManagingCaseCall(crn: String, response: ManagingTeamsResponse) =


### PR DESCRIPTION
This commit fixes a bug where a ‘RestrictedPerson’ type was returned for an applicaiton’s ‘person’ information when

1. The application related to an LAO offender
2. The user requesting the information had the LAO Qualification (i.e. they had adequate permissions to view the application)

This didn’t make sense because the rest of the application information _was_ being returned, and only the name was being redacted.

Test evidence from local testing is on the ticket - https://dsdmoj.atlassian.net/browse/APS-1052