### PR TITLE
APS-948 Repoint all CAS1 report tests to use /cas1/reports

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -215,7 +215,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
   fun `Get application report returns 403 Forbidden if user does not have all regions access`() {
     `Given a User` { _, jwt ->
       webTestClient.get()
-        .uri("/reports/applications?year=2023&month=4")
+        .uri("/cas1/reports/applications?year=2023&month=4")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -228,7 +228,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
   fun `Get application report returns 400 if month is provided and not within 1-12`() {
     `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
-        .uri("/reports/applications?year=2023&month=-1")
+        .uri("/cas1/reports/applications?year=2023&month=-1")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -247,7 +247,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
       val month = now.monthValue.toString()
 
       webTestClient.get()
-        .uri("/reports/applications?year=$year&month=$month")
+        .uri("/cas1/reports/applications?year=$year&month=$month")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
@@ -37,7 +37,7 @@ class DailyMetricsReportTest : IntegrationTestBase() {
   fun `Get daily metrics report for returns 403 Forbidden if user does not have access`() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
       webTestClient.get()
-        .uri("/reports/daily-metrics?year=2023&month=4")
+        .uri("/cas1/reports/dailyMetrics?year=2023&month=4")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -51,7 +51,7 @@ class DailyMetricsReportTest : IntegrationTestBase() {
   fun `Get daily metrics report for returns not allowed if the service is not Approved Premises`(serviceName: ServiceName) {
     `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
-        .uri("/reports/daily-metrics?year=2023&month=4")
+        .uri("/cas1/reports/dailyMetrics?year=2023&month=4")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", serviceName.value)
         .exchange()
@@ -236,7 +236,7 @@ class DailyMetricsReportTest : IntegrationTestBase() {
         )
 
       webTestClient.get()
-        .uri("/reports/daily-metrics?year=$year&month=$month")
+        .uri("/cas1/reports/dailyMetrics?year=$year&month=$month")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -168,7 +168,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
   fun `Get placement application report returns 403 Forbidden if user does not have all regions access`() {
     `Given a User` { _, jwt ->
       webTestClient.get()
-        .uri("/reports/placement-applications?year=2023&month=4")
+        .uri("/cas1/reports/placementApplications?year=2023&month=4")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -181,7 +181,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
   fun `Get placement application report returns 400 if month is provided and not within 1-12`() {
     `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
-        .uri("/reports/placement-applications?year=2023&month=-1")
+        .uri("/cas1/reports/placementApplications?year=2023&month=-1")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -321,7 +321,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
       val month = now.monthValue.toString()
 
       webTestClient.get()
-        .uri("/reports/placement-applications?year=$year&month=$month")
+        .uri("/cas1/reports/placementApplications?year=$year&month=$month")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesReportTest.kt
@@ -41,7 +41,7 @@ class Cas1PlacementMatchingOutcomesReportTest : IntegrationTestBase() {
   fun `Get placement matching outcomes report returns 403 Forbidden if user does not have correct role`() {
     `Given a User` { _, jwt ->
       webTestClient.get()
-        .uri("/reports/placement-applications?year=2023&month=4")
+        .uri("/cas1/reports/placementMatchingOutcomes?year=2023&month=4")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -54,7 +54,7 @@ class Cas1PlacementMatchingOutcomesReportTest : IntegrationTestBase() {
   fun `Get placement matching outcomes report returns 400 if month is provided and not within 1-12`() {
     `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
-        .uri("/reports/placement-applications?year=2023&month=-1")
+        .uri("/cas1/reports/placementMatchingOutcomes?year=2023&month=-1")
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.approvedPremises.value)
         .exchange()
@@ -442,7 +442,7 @@ class Cas1PlacementMatchingOutcomesReportTest : IntegrationTestBase() {
 
   private fun getReport(jwt: String, inlineAssertion: (input: List<ExpectedRows>) -> Unit) {
     webTestClient.get()
-      .uri("/reports/placement-matching-outcomes?year=$REPORT_YEAR&month=$REPORT_MONTH")
+      .uri("/cas1/reports/placementMatchingOutcomes?year=$REPORT_YEAR&month=$REPORT_MONTH")
       .header("Authorization", "Bearer $jwt")
       .header("X-Service-Name", ServiceName.approvedPremises.value)
       .exchange()


### PR DESCRIPTION
The /reports endpoint is deprecated and should no longer be used.

The UI is using the /cas1/reports so this update ensures the tests better reflect usage of the API in prod