### PR TITLE
APS-1000: Provide cancelled booking information on Timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -14,6 +14,7 @@ interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity,
     val CAS1_RELATED_PLACEMENT_APP_WITHDRAWN_ID: UUID = UUID.fromString("0e068767-c62e-43b5-866d-f0fb1d02ad83")
     val CAS1_RELATED_PLACEMENT_REQ_WITHDRAWN_ID: UUID = UUID.fromString("0a115fa4-6fd0-4b23-8e31-e6d1769c3985")
     val CAS1_RELATED_APP_WITHDRAWN_ID: UUID = UUID.fromString("bcb90030-b2d3-47d1-b289-a8b8c8898576")
+    val CAS1_RELATED_OTHER_ID: UUID = UUID.fromString("1d6f3c6e-3a86-49b4-bfca-2513a078aba3")
   }
 
   @Query("SELECT c FROM CancellationReasonEntity c WHERE c.serviceScope = :serviceName OR c.serviceScope = '*' ORDER by c.sortOrder ASC, c.name ASC")


### PR DESCRIPTION
Added original booking information to the description which includes detail about the booked premises and booking start and end dates. 
Added user inputted information text to timeline when reason for cancelling is 'Other' and a text narrative has been added.