### PR TITLE
Show if entity withdrawn in CAS1WithdrawableTree

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -644,6 +644,7 @@ class ApplicationService(
   fun getWithdrawableState(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableState {
     return WithdrawableState(
       withdrawable = !application.isWithdrawn,
+      withdrawn = application.isWithdrawn,
       userMayDirectlyWithdraw = userAccessService.userMayWithdrawApplication(user, application),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1038,6 +1038,7 @@ class BookingService(
   fun getWithdrawableState(booking: BookingEntity, user: UserEntity): WithdrawableState {
     return WithdrawableState(
       withdrawable = booking.isInCancellableStateCas1(),
+      withdrawn = booking.isCancelled,
       userMayDirectlyWithdraw = userAccessService.userMayCancelBooking(user, booking),
       blockingReason = if (booking.hasArrivals()) {
         BlockingReason.ArrivalRecordedInCas1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -204,6 +204,7 @@ class PlacementApplicationService(
   fun getWithdrawableState(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableState {
     return WithdrawableState(
       withdrawable = placementApplication.isInWithdrawableState(),
+      withdrawn = placementApplication.isWithdrawn,
       userMayDirectlyWithdraw = userAccessService.userMayWithdrawPlacementApplication(user, placementApplication),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -302,12 +302,13 @@ class PlacementRequestService(
   fun getWithdrawableState(placementRequest: PlacementRequestEntity, user: UserEntity): WithdrawableState {
     return WithdrawableState(
       withdrawable = placementRequest.isInWithdrawableState(),
+      withdrawn = placementRequest.isWithdrawn,
       userMayDirectlyWithdraw = placementRequest.isForApplicationsArrivalDate() && userAccessService.userMayWithdrawPlacementRequest(user, placementRequest),
     )
   }
 
   /**
-   * This function should not be called directly. Instead, use [WithdrawableService.withdrawPlacementRequest] that
+   * This function should not be called directly. Instead, use [Cas1WithdrawableService.withdrawPlacementRequest] that
    * will indirectly invoke this function. It will also ensure that:
    *
    * 1. The entity is withdrawable, and error if not

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -271,6 +271,7 @@ data class WithdrawableState(
    * placement and application
    */
   val blockingReason: BlockingReason? = null,
+  val withdrawn: Boolean,
 )
 
 data class WithdrawableDatePeriod(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -188,6 +188,7 @@ data class WithdrawableTreeNode(
     val abbreviatedId = if (includeIds) { entityId.toString().substring(0, 3) } else ""
     val description = "" +
       "$entityType($abbreviatedId), " +
+      "withdrawn:${yesOrNo(status.withdrawn)}, " +
       "withdrawable:${yesOrNo(status.withdrawable)}, " +
       "mayDirectlyWithdraw:${yesOrNo(status.userMayDirectlyWithdraw)}" +
       blockingDescription()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -2879,6 +2879,7 @@ class ApplicationServiceTest {
 
       val result = applicationService.getWithdrawableState(application, user)
 
+      assertThat(result.withdrawn).isFalse()
       assertThat(result.withdrawable).isTrue()
     }
 
@@ -2893,6 +2894,7 @@ class ApplicationServiceTest {
 
       val result = applicationService.getWithdrawableState(application, user)
 
+      assertThat(result.withdrawn).isTrue()
       assertThat(result.withdrawable).isFalse()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -6793,6 +6793,7 @@ class BookingServiceTest {
 
       val result = bookingService.getWithdrawableState(booking, user)
 
+      assertThat(result.withdrawn).isTrue()
       assertThat(result.withdrawable).isFalse()
     }
 
@@ -6807,6 +6808,7 @@ class BookingServiceTest {
 
       val result = bookingService.getWithdrawableState(booking, user)
 
+      assertThat(result.withdrawn).isFalse()
       assertThat(result.withdrawable).isTrue()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -717,6 +717,7 @@ class PlacementApplicationServiceTest {
 
       val result = placementApplicationService.getWithdrawableState(placementApplication, user)
 
+      assertThat(result.withdrawn).isTrue()
       assertThat(result.withdrawable).isFalse()
     }
 
@@ -753,6 +754,7 @@ class PlacementApplicationServiceTest {
 
       val result = placementApplicationService.getWithdrawableState(placementApplication, user)
 
+      assertThat(result.withdrawn).isFalse()
       assertThat(result.withdrawable).isTrue()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementRequestServiceTest.kt
@@ -555,6 +555,7 @@ class PlacementRequestServiceTest {
 
       val result = placementRequestService.getWithdrawableState(placementRequest, user)
 
+      assertThat(result.withdrawn).isTrue()
       assertThat(result.withdrawable).isFalse()
     }
 
@@ -568,6 +569,7 @@ class PlacementRequestServiceTest {
 
       val result = placementRequestService.getWithdrawableState(placementRequest, user)
 
+      assertThat(result.withdrawn).isFalse()
       assertThat(result.withdrawable).isTrue()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableServiceTest.kt
@@ -79,7 +79,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = appId,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           dates = listOf(
             WithdrawableDatePeriod(LocalDate.of(2021, 1, 2), LocalDate.of(2021, 2, 3)),
             WithdrawableDatePeriod(LocalDate.of(2021, 3, 4), LocalDate.of(2021, 4, 5)),
@@ -121,19 +121,19 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           entityType = WithdrawableEntityType.Application,
           entityId = appWithdrawableId,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequest1WithdrawableId,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = placementWithdrawableId,
-                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+                  status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
                 ),
               ),
             ),
@@ -141,19 +141,19 @@ class Cas1WithdrawableServiceTest {
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawableButNotPermittedId,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
             ),
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementApplication,
               entityId = placementApplication1WithdrawableId,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.PlacementRequest,
                   entityId = placementRequest2WithdrawableId,
-                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+                  status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
                 ),
               ),
             ),
@@ -161,13 +161,13 @@ class Cas1WithdrawableServiceTest {
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementApplication,
               entityId = placementApplication2NotWithdrawableId,
-              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
             ),
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.Booking,
               entityId = placementNotWithdrawableId,
-              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
             ),
           ),
         ),
@@ -202,19 +202,19 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           entityType = WithdrawableEntityType.Application,
           entityId = appWithdrawableButBlockedId,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequest1WithdrawableButBlockedId,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = placementWithdrawableButBlockingId,
-                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
+                  status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
                 ),
               ),
             ),
@@ -222,19 +222,19 @@ class Cas1WithdrawableServiceTest {
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawableButNotPermittedId,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
             ),
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementApplication,
               entityId = placementApplication1WithdrawableId,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.PlacementRequest,
                   entityId = placementRequest2WithdrawableId,
-                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = null),
+                  status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = null),
                 ),
               ),
             ),
@@ -242,13 +242,13 @@ class Cas1WithdrawableServiceTest {
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementApplication,
               entityId = placementApplication2NotWithdrawableId,
-              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
             ),
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.Booking,
               entityId = placementNotWithdrawableId,
-              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
             ),
           ),
         ),
@@ -279,7 +279,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.Application,
           application.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
         ),
       )
 
@@ -339,7 +339,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.Application,
           application.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
         ),
       )
 
@@ -359,7 +359,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.Application,
           application.id,
-          WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
         ),
       )
 
@@ -380,13 +380,13 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.Application,
           application.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               WithdrawableEntityType.Booking,
               UUID.randomUUID(),
-              WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
+              WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
             ),
           ),
         ),
@@ -430,7 +430,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.PlacementRequest,
           placementRequest.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
         ),
       )
 
@@ -477,7 +477,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.PlacementRequest,
           placementRequest.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
         ),
       )
 
@@ -497,7 +497,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.PlacementRequest,
           placementRequest.id,
-          WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
         ),
       )
 
@@ -518,13 +518,13 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.PlacementRequest,
           placementRequest.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               WithdrawableEntityType.Booking,
               UUID.randomUUID(),
-              WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
+              WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
             ),
           ),
         ),
@@ -559,7 +559,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.PlacementApplication,
           placementApplication.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
         ),
       )
 
@@ -601,7 +601,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.PlacementApplication,
           placementApplication.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
         ),
       )
 
@@ -621,7 +621,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.PlacementApplication,
           placementApplication.id,
-          WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
         ),
       )
 
@@ -642,13 +642,13 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.PlacementApplication,
           placementApplication.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               WithdrawableEntityType.PlacementApplication,
               placementApplication.id,
-              WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
+              WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
             ),
           ),
         ),
@@ -683,7 +683,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.Booking,
           booking.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
         ),
       )
 
@@ -726,7 +726,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.Booking,
           booking.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
         ),
       )
 
@@ -744,7 +744,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.Booking,
           booking.id,
-          WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+          WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
         ),
       )
 
@@ -763,7 +763,7 @@ class Cas1WithdrawableServiceTest {
           applicationId = application.id,
           WithdrawableEntityType.Booking,
           booking.id,
-          WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
+          WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true, blockingReason = BlockingReason.ArrivalRecordedInCas1),
         ),
       )
 
@@ -797,7 +797,7 @@ class Cas1WithdrawableServiceTest {
             applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementApplication,
             entityId = placementApplication.id,
-            status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+            status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
             dates = emptyList(),
           ),
         )
@@ -817,7 +817,7 @@ class Cas1WithdrawableServiceTest {
             applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementApplication,
             entityId = placementApplication.id,
-            status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+            status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
             dates = emptyList(),
           ),
         )
@@ -860,7 +860,7 @@ class Cas1WithdrawableServiceTest {
             applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementRequest,
             entityId = placementRequest.id,
-            status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+            status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
             dates = emptyList(),
           ),
         )
@@ -880,7 +880,7 @@ class Cas1WithdrawableServiceTest {
             applicationId = application.id,
             entityType = WithdrawableEntityType.PlacementApplication,
             entityId = placementRequest.id,
-            status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+            status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
             dates = emptyList(),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
@@ -75,14 +75,14 @@ class Cas1WithdrawableTreeBuilderTest {
   fun `tree for app returns all potential elements`() {
     every {
       applicationService.getWithdrawableState(application, user)
-    } returns WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true)
+    } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     val initialPlacementRequest = createPlacementRequest()
-    setupWithdrawableState(initialPlacementRequest, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(initialPlacementRequest, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
 
     val initialPlacementRequestBooking = createBooking(adhoc = false)
     initialPlacementRequest.booking = initialPlacementRequestBooking
-    setupWithdrawableState(initialPlacementRequestBooking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(initialPlacementRequestBooking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false))
 
     every {
       placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)
@@ -91,23 +91,23 @@ class Cas1WithdrawableTreeBuilderTest {
     )
 
     val placementApp1 = createPlacementApplication()
-    setupWithdrawableState(placementApp1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1 = createPlacementRequest()
     placementApp1.placementRequests.add(placementApp1PlacementRequest1)
-    setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawn = true, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1Booking = createBooking(adhoc = false)
     placementApp1PlacementRequest1.booking = placementApp1PlacementRequest1Booking
-    setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false))
 
     val placementApplication2 = createPlacementApplication()
-    setupWithdrawableState(placementApplication2, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true))
+    setupWithdrawableState(placementApplication2, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true))
 
     every {
       placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
     } returns listOf(placementApp1, placementApplication2)
 
     val adhocBooking1 = createBooking(adhoc = true)
-    setupWithdrawableState(adhocBooking1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(adhocBooking1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
 
     every {
       bookingService.getAllAdhocOrUnknownForApplication(application)
@@ -117,14 +117,14 @@ class Cas1WithdrawableTreeBuilderTest {
 
     assertThat(result.render(includeIds = false).trim()).isEqualTo(
       """
-Application(), withdrawable:Y, mayDirectlyWithdraw:Y
----> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N
-------> Booking(), withdrawable:Y, mayDirectlyWithdraw:N
----> PlacementApplication(), withdrawable:N, mayDirectlyWithdraw:N
-------> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N
----------> Booking(), withdrawable:Y, mayDirectlyWithdraw:N
----> PlacementApplication(), withdrawable:Y, mayDirectlyWithdraw:Y
----> Booking(), withdrawable:N, mayDirectlyWithdraw:N
+Application(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:Y
+---> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:N
+---> PlacementApplication(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+------> PlacementRequest(), withdrawn:Y, withdrawable:N, mayDirectlyWithdraw:N
+---------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:N
+---> PlacementApplication(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:Y
+---> Booking(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
 
 Notes: []
       """
@@ -136,14 +136,14 @@ Notes: []
   fun `tree for app excludes placement request's bookings if bookings are adhoc or potentially adhoc`() {
     every {
       applicationService.getWithdrawableState(application, user)
-    } returns WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true)
+    } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     val initialPlacementRequest = createPlacementRequest()
-    setupWithdrawableState(initialPlacementRequest, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(initialPlacementRequest, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
 
     val initialPlacementRequestBooking = createBooking(adhoc = true)
     initialPlacementRequest.booking = initialPlacementRequestBooking
-    setupWithdrawableState(initialPlacementRequestBooking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(initialPlacementRequestBooking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false))
 
     every {
       placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)
@@ -152,22 +152,22 @@ Notes: []
     )
 
     val placementApp1 = createPlacementApplication()
-    setupWithdrawableState(placementApp1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1 = createPlacementRequest()
     placementApp1.placementRequests.add(placementApp1PlacementRequest1)
-    setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1Booking = createBooking(adhoc = false)
     placementApp1PlacementRequest1.booking = placementApp1PlacementRequest1Booking
-    setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false))
 
     val placementApp2 = createPlacementApplication()
-    setupWithdrawableState(placementApp2, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp2, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp2PlacementRequest1 = createPlacementRequest()
     placementApp2.placementRequests.add(placementApp2PlacementRequest1)
-    setupWithdrawableState(placementApp2PlacementRequest1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp2PlacementRequest1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp2PlacementRequest1Booking = createBooking(adhoc = null)
     placementApp2PlacementRequest1.booking = placementApp2PlacementRequest1Booking
-    setupWithdrawableState(placementApp2PlacementRequest1Booking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp2PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false))
 
     every {
       placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
@@ -179,13 +179,13 @@ Notes: []
 
     assertThat(result.render(includeIds = false).trim()).isEqualTo(
       """
-Application(), withdrawable:Y, mayDirectlyWithdraw:Y
----> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N
----> PlacementApplication(), withdrawable:N, mayDirectlyWithdraw:N
-------> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N
----------> Booking(), withdrawable:Y, mayDirectlyWithdraw:N
----> PlacementApplication(), withdrawable:N, mayDirectlyWithdraw:N
-------> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N
+Application(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:Y
+---> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+---> PlacementApplication(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+------> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+---------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:N
+---> PlacementApplication(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+------> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
 
 Notes: []
       """
@@ -197,14 +197,14 @@ Notes: []
   fun `tree for app blocks withdrawal if booking has arrival in CAS1`() {
     every {
       applicationService.getWithdrawableState(application, user)
-    } returns WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true)
+    } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     val initialPlacementRequest = createPlacementRequest()
-    setupWithdrawableState(initialPlacementRequest, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(initialPlacementRequest, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
 
     val initialPlacementRequestBooking = createBooking(adhoc = false)
     initialPlacementRequest.booking = initialPlacementRequestBooking
-    setupWithdrawableState(initialPlacementRequestBooking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(initialPlacementRequestBooking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false))
 
     every {
       placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)
@@ -213,22 +213,22 @@ Notes: []
     )
 
     val placementApp1 = createPlacementApplication()
-    setupWithdrawableState(placementApp1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1 = createPlacementRequest()
     placementApp1.placementRequests.add(placementApp1PlacementRequest1)
-    setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1Booking = createBooking(adhoc = false)
     placementApp1PlacementRequest1.booking = placementApp1PlacementRequest1Booking
-    setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInCas1))
+    setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInCas1))
 
     val placementApp2 = createPlacementApplication()
-    setupWithdrawableState(placementApp2, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp2, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp2PlacementRequest1 = createPlacementRequest()
     placementApp2.placementRequests.add(placementApp2PlacementRequest1)
-    setupWithdrawableState(placementApp2PlacementRequest1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp2PlacementRequest1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp2PlacementRequest1Booking = createBooking(adhoc = false)
     placementApp2PlacementRequest1.booking = placementApp2PlacementRequest1Booking
-    setupWithdrawableState(placementApp2PlacementRequest1Booking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true))
+    setupWithdrawableState(placementApp2PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true))
 
     every {
       placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
@@ -240,15 +240,15 @@ Notes: []
 
     assertThat(result.render(includeIds = false).trim()).isEqualTo(
       """
-Application(), withdrawable:Y, mayDirectlyWithdraw:Y, BLOCKED
----> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N
-------> Booking(), withdrawable:Y, mayDirectlyWithdraw:N
----> PlacementApplication(), withdrawable:N, mayDirectlyWithdraw:N, BLOCKED
-------> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N, BLOCKED
----------> Booking(), withdrawable:Y, mayDirectlyWithdraw:N, BLOCKING - ArrivalRecordedInCas1
----> PlacementApplication(), withdrawable:N, mayDirectlyWithdraw:N
-------> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N
----------> Booking(), withdrawable:Y, mayDirectlyWithdraw:Y
+Application(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:Y, BLOCKED
+---> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:N
+---> PlacementApplication(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N, BLOCKED
+------> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N, BLOCKED
+---------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:N, BLOCKING - ArrivalRecordedInCas1
+---> PlacementApplication(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+------> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
+---------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:Y
 
 Notes: [1 or more placements cannot be withdrawn as they have an arrival]
       """
@@ -260,20 +260,20 @@ Notes: [1 or more placements cannot be withdrawn as they have an arrival]
   fun `tree for app blocks withdrawal if booking has arrival in Delius`() {
     every {
       applicationService.getWithdrawableState(application, user)
-    } returns WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true)
+    } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     every {
       placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)
     } returns emptyList()
 
     val placementApp1 = createPlacementApplication()
-    setupWithdrawableState(placementApp1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1 = createPlacementRequest()
     placementApp1.placementRequests.add(placementApp1PlacementRequest1)
-    setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false))
+    setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1Booking = createBooking(adhoc = false)
     placementApp1PlacementRequest1.booking = placementApp1PlacementRequest1Booking
-    setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInDelius))
+    setupWithdrawableState(placementApp1PlacementRequest1Booking, WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInDelius))
 
     every {
       placementApplicationService.getAllActivePlacementApplicationsForApplicationId(application.id)
@@ -285,10 +285,10 @@ Notes: [1 or more placements cannot be withdrawn as they have an arrival]
 
     assertThat(result.render(includeIds = false).trim()).isEqualTo(
       """
-Application(), withdrawable:Y, mayDirectlyWithdraw:Y, BLOCKED
----> PlacementApplication(), withdrawable:N, mayDirectlyWithdraw:N, BLOCKED
-------> PlacementRequest(), withdrawable:N, mayDirectlyWithdraw:N, BLOCKED
----------> Booking(), withdrawable:Y, mayDirectlyWithdraw:N, BLOCKING - ArrivalRecordedInDelius
+Application(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:Y, BLOCKED
+---> PlacementApplication(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N, BLOCKED
+------> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N, BLOCKED
+---------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:N, BLOCKING - ArrivalRecordedInDelius
 
 Notes: [1 or more placements cannot be withdrawn as they have an arrival recorded in Delius]
       """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeOperationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeOperationsTest.kt
@@ -110,31 +110,31 @@ class Cas1WithdrawableTreeOperationsTest {
       applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
-      status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+      status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
       children = listOf(
         WithdrawableTreeNode(
           applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplication.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawable.id,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingWithdrawable.id,
-                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+                  status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
                 ),
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingNotWithdrawable.id,
-                  status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
+                  status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false),
                 ),
               ),
             ),
@@ -142,7 +142,7 @@ class Cas1WithdrawableTreeOperationsTest {
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestNotWithdrawable.id,
-              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
             ),
           ),
         ),
@@ -150,13 +150,13 @@ class Cas1WithdrawableTreeOperationsTest {
           applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawable.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
         ),
         WithdrawableTreeNode(
           applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingNotWithdrawable.id,
-          status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
+          status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false),
         ),
       ),
     )
@@ -270,19 +270,19 @@ class Cas1WithdrawableTreeOperationsTest {
       applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
-      status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+      status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
       children = listOf(
         WithdrawableTreeNode(
           applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplicationWithdrawable.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawable.id,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
             ),
           ),
         ),
@@ -290,25 +290,25 @@ class Cas1WithdrawableTreeOperationsTest {
           applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplicationWithdrawableButBlocked.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawableButBlocked.id,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingWithdrawableButBlocking.id,
-                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInCas1),
+                  status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInCas1),
                 ),
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingNotWithdrawable.id,
-                  status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false, blockingReason = null),
+                  status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false, blockingReason = null),
                 ),
               ),
             ),
@@ -316,7 +316,7 @@ class Cas1WithdrawableTreeOperationsTest {
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestNotWithdrawable.id,
-              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
             ),
           ),
         ),
@@ -324,13 +324,13 @@ class Cas1WithdrawableTreeOperationsTest {
           applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawable.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = null),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = null),
         ),
         WithdrawableTreeNode(
           applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawableButBlocked.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInCas1),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false, blockingReason = ArrivalRecordedInCas1),
         ),
       ),
     )
@@ -428,31 +428,31 @@ class Cas1WithdrawableTreeOperationsTest {
       applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
-      status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+      status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
       children = listOf(
         WithdrawableTreeNode(
           applicationId = application.id,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplication.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawable.id,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
                   applicationId = application.id,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingWithdrawable.id,
-                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+                  status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
                 ),
                 WithdrawableTreeNode(
                   applicationId = UUID.randomUUID(),
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingNotWithdrawable.id,
-                  status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
+                  status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false),
                 ),
               ),
             ),
@@ -460,7 +460,7 @@ class Cas1WithdrawableTreeOperationsTest {
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestNotWithdrawable.id,
-              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
             ),
           ),
         ),
@@ -468,13 +468,13 @@ class Cas1WithdrawableTreeOperationsTest {
           applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawable.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
         ),
         WithdrawableTreeNode(
           applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingNotWithdrawable.id,
-          status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
+          status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false),
         ),
       ),
     )
@@ -575,31 +575,31 @@ class Cas1WithdrawableTreeOperationsTest {
       applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
-      status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+      status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
       children = listOf(
         WithdrawableTreeNode(
           applicationId = otherApplicationId,
           entityType = WithdrawableEntityType.PlacementApplication,
           entityId = placementApplicationOtherApp.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
           children = listOf(
             WithdrawableTreeNode(
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestWithdrawable.id,
-              status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
               children = listOf(
                 WithdrawableTreeNode(
                   applicationId = otherApplicationId,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingWithdrawableOtherApp.id,
-                  status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+                  status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
                 ),
                 WithdrawableTreeNode(
                   applicationId = otherApplicationId,
                   entityType = WithdrawableEntityType.Booking,
                   entityId = bookingNotWithdrawable.id,
-                  status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
+                  status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false),
                 ),
               ),
             ),
@@ -607,7 +607,7 @@ class Cas1WithdrawableTreeOperationsTest {
               applicationId = application.id,
               entityType = WithdrawableEntityType.PlacementRequest,
               entityId = placementRequestNotWithdrawable.id,
-              status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = true),
+              status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = true),
             ),
           ),
         ),
@@ -615,13 +615,13 @@ class Cas1WithdrawableTreeOperationsTest {
           applicationId = otherApplicationId,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingWithdrawableOtherApp.id,
-          status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = false),
+          status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = false),
         ),
         WithdrawableTreeNode(
           applicationId = application.id,
           entityType = WithdrawableEntityType.Booking,
           entityId = adhocBookingNotWithdrawable.id,
-          status = WithdrawableState(withdrawable = false, userMayDirectlyWithdraw = false),
+          status = WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false),
         ),
       ),
     )
@@ -650,7 +650,7 @@ class Cas1WithdrawableTreeOperationsTest {
         applicationId = application.id,
         entityType = WithdrawableEntityType.PlacementRequest,
         entityId = UUID.randomUUID(),
-        status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+        status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
       )
     }
 
@@ -658,7 +658,7 @@ class Cas1WithdrawableTreeOperationsTest {
       applicationId = application.id,
       entityType = WithdrawableEntityType.Application,
       entityId = application.id,
-      status = WithdrawableState(withdrawable = true, userMayDirectlyWithdraw = true),
+      status = WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true),
       children = childenNodes,
     )
 


### PR DESCRIPTION
During investigation of production issues related to withdrawals we’ve noted that it would be very helpful if when showing the CAS1WithdrawableTree in the log we included whether each element in the tree is already withdrawn. This commit captures that information and shows it when rendering the tree to the logs

```
Application(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:Y
---> PlacementRequest(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:N
---> PlacementApplication(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
------> PlacementRequest(), withdrawn:Y, withdrawable:N, mayDirectlyWithdraw:N
---------> Booking(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:N
---> PlacementApplication(), withdrawn:N, withdrawable:Y, mayDirectlyWithdraw:Y
---> Booking(), withdrawn:N, withdrawable:N, mayDirectlyWithdraw:N
```