### PR TITLE
APS-969 Allow ASSESSORs to assess placement_applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -37,7 +37,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
   fun findActiveUsersWithRole(role: UserRole): List<UserEntity>
 
   @Query("SELECT DISTINCT u FROM UserEntity u join u.roles r where r.role in (:roles) and u.isActive = true")
-  fun findActiveUsersWithRoles(roles: List<UserRole>): List<UserEntity>
+  fun findActiveUsersWithAtLeastOneRole(roles: List<UserRole>): List<UserEntity>
 
   @Query("SELECT DISTINCT u FROM UserEntity u join u.qualifications q where q.qualification = :qualification and u.isActive = true")
   fun findActiveUsersWithQualification(qualification: UserQualification): List<UserEntity>
@@ -276,6 +276,7 @@ data class UserEntity(
 ) {
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
   fun hasAnyRole(vararg userRoles: UserRole) = userRoles.any(::hasRole)
+  fun hasAnyRole(userRoles: List<UserRole>) = userRoles.any(::hasRole)
   fun hasQualification(userQualification: UserQualification) =
     qualifications.any { it.qualification === userQualification }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateUsersPduFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateUsersPduFromCommunityApiJob.kt
@@ -14,7 +14,7 @@ class Cas3UpdateUsersPduFromCommunityApiJob(
   @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught")
   override fun process() {
     val cas3Roles = listOf(UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER, UserRole.CAS3_REPORTER)
-    userRepository.findActiveUsersWithRoles(cas3Roles).forEach {
+    userRepository.findActiveUsersWithAtLeastOneRole(cas3Roles).forEach {
       migrationLogger.info("Updating user PDU. User id ${it.id}")
       try {
         userService.updateUserPduFromCommunityApiById(it.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -57,6 +57,10 @@ class PlacementApplicationService(
 
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
+  companion object {
+    val ROLE_REQUIRED_TO_ASSESS = listOf(UserRole.CAS1_MATCHER, UserRole.CAS1_ASSESSOR)
+  }
+
   fun getAllSubmittedNonReallocatedApplications(applicationId: UUID): List<PlacementApplicationEntity> {
     return placementApplicationRepository.findAllSubmittedNonReallocatedApplicationsForApplicationId(applicationId)
   }
@@ -142,7 +146,7 @@ class PlacementApplicationService(
       )
     }
 
-    if (!assigneeUser.hasRole(UserRole.CAS1_MATCHER)) {
+    if (!assigneeUser.hasAnyRole(ROLE_REQUIRED_TO_ASSESS)) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.FieldValidationError(
           ValidationErrors().apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -148,13 +148,13 @@ class UserService(
       userQualifications.add(UserQualification.LAO)
     }
 
-    val requiredRole = when (allocationType) {
-      AllocationType.Assessment -> UserRole.CAS1_ASSESSOR
-      AllocationType.PlacementRequest -> UserRole.CAS1_MATCHER
-      AllocationType.PlacementApplication -> UserRole.CAS1_MATCHER
+    val requiredRoles = when (allocationType) {
+      AllocationType.Assessment -> listOf(UserRole.CAS1_ASSESSOR)
+      AllocationType.PlacementRequest -> listOf(UserRole.CAS1_MATCHER)
+      AllocationType.PlacementApplication -> PlacementApplicationService.ROLE_REQUIRED_TO_ASSESS
     }
 
-    var users = userRepository.findActiveUsersWithRole(requiredRole)
+    var users = userRepository.findActiveUsersWithAtLeastOneRole(requiredRoles)
 
     userQualifications.forEach { qualification ->
       users = users.filter { it.hasQualification(qualification) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -2043,101 +2043,96 @@ class TasksTest {
     }
 
     @Test
-    fun `Get an assessment task for an application returns 200 with correct body`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
-        `Given a User` { user, _ ->
-          `Given a User`(
-            roles = listOf(UserRole.CAS1_ASSESSOR),
-          ) { allocatableUser, _ ->
-            `Given a User`(
-              roles = listOf(UserRole.CAS1_MATCHER),
-              isActive = false,
-            ) { _, _ ->
-              `Given an Offender` { offenderDetails, inmateDetails ->
-                `Given an Assessment for Approved Premises`(
-                  allocatedToUser = user,
-                  createdByUser = user,
-                  crn = offenderDetails.otherIds.crn,
-                ) { assessment, _ ->
+    fun `Get an Assessment task for an application returns users with ASSESSOR role`() {
+      val (creator, _) = `Given a User`()
+      val (workflowManager, jwt) = `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER))
+      val (assessor, _) = `Given a User`(
+        roles = listOf(UserRole.CAS1_ASSESSOR),
+      )
+      val (inactiveMatcher, _) = `Given a User`(
+        roles = listOf(UserRole.CAS1_ASSESSOR),
+        isActive = false,
+      )
+      val (matcher, _) = `Given a User`(
+        roles = listOf(UserRole.CAS1_MATCHER),
+      )
 
-                  webTestClient.get()
-                    .uri("/tasks/assessment/${assessment.id}")
-                    .header("Authorization", "Bearer $jwt")
-                    .exchange()
-                    .expectStatus()
-                    .isOk
-                    .expectBody()
-                    .json(
-                      objectMapper.writeValueAsString(
-                        TaskWrapper(
-                          task = taskTransformer.transformAssessmentToTask(
-                            assessment,
-                            getOffenderSummaries(offenderDetails),
-                          ),
-                          users = listOf(
-                            userTransformer.transformJpaToAPIUserWithWorkload(
-                              allocatableUser,
-                              UserWorkload(
-                                0,
-                                0,
-                                0,
-                              ),
-                            ),
-                          ),
-                        ),
+      `Given an Offender` { offenderDetails, _ ->
+        `Given an Assessment for Approved Premises`(
+          allocatedToUser = null,
+          createdByUser = creator,
+          crn = offenderDetails.otherIds.crn,
+        ) { assessment, _ ->
+
+          webTestClient.get()
+            .uri("/tasks/assessment/${assessment.id}")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                TaskWrapper(
+                  task = taskTransformer.transformAssessmentToTask(
+                    assessment,
+                    getOffenderSummaries(offenderDetails),
+                  ),
+                  users = listOf(
+                    userTransformer.transformJpaToAPIUserWithWorkload(
+                      assessor,
+                      UserWorkload(
+                        0,
+                        0,
+                        0,
                       ),
-                    )
-                }
-              }
-            }
-          }
+                    ),
+                  ),
+                ),
+              ),
+            )
         }
       }
     }
 
     @Test
-    fun `Get a Placement Request Task for an application returns 200`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
-        `Given a User`(
-          roles = listOf(UserRole.CAS1_ASSESSOR),
-        ) { user, _ ->
-          `Given a User`(
-            roles = listOf(UserRole.CAS1_MATCHER),
-          ) { allocatableUser, _ ->
-            `Given an Offender` { offenderDetails, inmateDetails ->
-              `Given a Placement Request`(
-                placementRequestAllocatedTo = user,
-                assessmentAllocatedTo = user,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-              ) { placementRequest, _ ->
+    fun `Get a Placement Request Task for an application returns users with MATCHER role`() {
+      val (workflowManager, jwt) = `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER))
+      val (creator, _) = `Given a User`()
+      val (matcher, _) = `Given a User`(roles = listOf(UserRole.CAS1_MATCHER))
+      val (assessor, _) = `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR))
 
-                webTestClient.get()
-                  .uri("/tasks/placement-request/${placementRequest.id}")
-                  .header("Authorization", "Bearer $jwt")
-                  .exchange()
-                  .expectStatus()
-                  .isOk
-                  .expectBody()
-                  .json(
-                    objectMapper.writeValueAsString(
-                      TaskWrapper(
-                        task = taskTransformer.transformPlacementRequestToTask(
-                          placementRequest,
-                          getOffenderSummaries(offenderDetails),
-                        ),
-                        users = listOf(
-                          userTransformer.transformJpaToAPIUserWithWorkload(
-                            allocatableUser,
-                            UserWorkload(0, 0, 0),
-                          ),
-                        ),
-                      ),
+      `Given an Offender` { offenderDetails, _ ->
+        `Given a Placement Request`(
+          placementRequestAllocatedTo = creator,
+          assessmentAllocatedTo = creator,
+          createdByUser = creator,
+          crn = offenderDetails.otherIds.crn,
+        ) { placementRequest, _ ->
+
+          webTestClient.get()
+            .uri("/tasks/placement-request/${placementRequest.id}")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                TaskWrapper(
+                  task = taskTransformer.transformPlacementRequestToTask(
+                    placementRequest,
+                    getOffenderSummaries(offenderDetails),
+                  ),
+                  users = listOf(
+                    userTransformer.transformJpaToAPIUserWithWorkload(
+                      matcher,
+                      UserWorkload(0, 0, 0),
                     ),
-                  )
-              }
-            }
-          }
+                  ),
+                ),
+              ),
+            )
         }
       }
     }
@@ -2192,60 +2187,73 @@ class TasksTest {
     }
 
     @Test
-    fun `Get a Placement Application Task for an application returns 2 users with correct roles`() {
+    fun `Get a Placement Application Task for an application returns users with MATCHER roles`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
-        `Given a User`(
-          roles = listOf(UserRole.CAS1_MATCHER),
-        ) { user, _ ->
-          `Given a User`(
-            roles = listOf(UserRole.CAS1_MATCHER),
-          ) { allocatableUser, _ ->
-            `Given an Offender` { offenderDetails, inmateDetails ->
-              `Given a Placement Application`(
-                createdByUser = user,
-                allocatedToUser = user,
-                schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
-                  withPermissiveSchema()
-                },
-                crn = offenderDetails.otherIds.crn,
-              ) { placementApplication ->
 
-                webTestClient.get()
-                  .uri("/tasks/placement-application/${placementApplication.id}")
-                  .header("Authorization", "Bearer $jwt")
-                  .exchange()
-                  .expectStatus()
-                  .isOk
-                  .expectBody()
-                  .json(
-                    objectMapper.writeValueAsString(
-                      TaskWrapper(
-                        task = taskTransformer.transformPlacementApplicationToTask(
-                          placementApplication,
-                          getOffenderSummaries(offenderDetails),
-                        ),
-                        users = listOf(
-                          userTransformer.transformJpaToAPIUserWithWorkload(
-                            user,
-                            UserWorkload(1, 0, 0),
-                          ),
-                          userTransformer.transformJpaToAPIUserWithWorkload(
-                            allocatableUser,
-                            UserWorkload(0, 0, 0),
-                          ),
-                        ),
+        val (matcherUser1, _) = `Given a User`(
+          roles = listOf(UserRole.CAS1_MATCHER),
+        )
+
+        val (matcherUser2, _) = `Given a User`(
+          roles = listOf(UserRole.CAS1_MATCHER),
+        )
+
+        val (assessorUser, _) = `Given a User`(
+          roles = listOf(UserRole.CAS1_ASSESSOR),
+        )
+
+        val (assessorAndMatcherUser, _) = `Given a User`(
+          roles = listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS1_MATCHER),
+        )
+
+        `Given an Offender` { offenderDetails, _ ->
+          `Given a Placement Application`(
+            createdByUser = matcherUser1,
+            allocatedToUser = matcherUser1,
+            schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+              withPermissiveSchema()
+            },
+            crn = offenderDetails.otherIds.crn,
+          ) { placementApplication ->
+
+            webTestClient.get()
+              .uri("/tasks/placement-application/${placementApplication.id}")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody()
+              .json(
+                objectMapper.writeValueAsString(
+                  TaskWrapper(
+                    task = taskTransformer.transformPlacementApplicationToTask(
+                      placementApplication,
+                      getOffenderSummaries(offenderDetails),
+                    ),
+                    users = listOf(
+                      userTransformer.transformJpaToAPIUserWithWorkload(
+                        matcherUser1,
+                        UserWorkload(1, 0, 0),
+                      ),
+                      userTransformer.transformJpaToAPIUserWithWorkload(
+                        matcherUser2,
+                        UserWorkload(0, 0, 0),
+                      ),
+                      userTransformer.transformJpaToAPIUserWithWorkload(
+                        assessorAndMatcherUser,
+                        UserWorkload(0, 0, 0),
                       ),
                     ),
-                  )
-              }
-            }
+                  ),
+                ),
+              )
           }
         }
       }
     }
 
     @Test
-    fun `Get a PlacementApplication Task for an application gets UserWithWorkload, ignores inactive users and returns 200`() {
+    fun `Get a Placement Application Task for an application gets UserWithWorkload, ignores inactive users and returns 200`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
         `Given a User` { user, _ ->
           `Given a User`(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -2240,6 +2240,10 @@ class TasksTest {
                         UserWorkload(0, 0, 0),
                       ),
                       userTransformer.transformJpaToAPIUserWithWorkload(
+                        assessorUser,
+                        UserWorkload(0, 0, 0),
+                      ),
+                      userTransformer.transformJpaToAPIUserWithWorkload(
                         assessorAndMatcherUser,
                         UserWorkload(0, 0, 0),
                       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -464,12 +464,13 @@ class PlacementApplicationServiceTest {
       ),
     )
 
-    @Test
-    fun `Reallocating an allocated application returns successfully`() {
+    @CsvSource("CAS1_MATCHER,CAS1_ASSESSOR")
+    @ParameterizedTest
+    fun `Reallocating an allocated application returns successfully`(role: UserRole) {
       assigneeUser.apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.CAS1_MATCHER)
+          .withRole(role)
           .produce()
       }
 
@@ -658,7 +659,7 @@ class PlacementApplicationServiceTest {
     }
 
     @Test
-    fun `Reallocating a placement application when user to assign to is not a MATCHER returns a field validation error`() {
+    fun `Reallocating a placement application when user to assign to is not a MATCHER or ASSESSOR returns a field validation error`() {
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
       val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)


### PR DESCRIPTION
Switched back to draft as want to merge rob's change first that uses permissions in this area and then update this to use permissions

DO NOT MERGE. This relies on an equivalent UI change going live first. Otherwise assessors will be assigned placement applications that they then can't assess/see

This commit allows users with the role ASSESSOR to be considered when allocating/reallocating assessments of placement applications by including them in the task’s users list.

This commit also changes permissions on various endpoints required to complete the assessment of a placement application, ensuring users with the ASSESSOR role can access them.