### PR TITLE
[APS-924] Introduce seed job for CAS1 out-of-service beds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/CsvBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/CsvBuilder.kt
@@ -7,7 +7,7 @@ class CsvBuilder {
     csv.append("$field,")
   }
 
-  fun withHeader(vararg fields: Any) = withUnquotedFields(fields)
+  fun withHeader(vararg fields: Any) = withUnquotedFields(*fields)
   fun withUnquotedFields(vararg fields: Any) = apply {
     fields.forEach {
       csv.append("$it,")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
@@ -26,3 +26,5 @@ abstract class SeedJob<RowType> (
   abstract fun deserializeRow(columns: Map<String, String>): RowType
   abstract fun processRow(row: RowType)
 }
+
+class SeedException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1OutOfServiceBedSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1OutOfServiceBedSeedJob.kt
@@ -1,0 +1,109 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedException
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.trimToNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromNestedAuthorisableValidatableActionResultIsSuccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromValidatableActionResultIsSuccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas1OutOfServiceBedSeedJob(
+  filename: String,
+  private val cas1OutOfServiceBedService: Cas1OutOfServiceBedService,
+  private val premisesService: PremisesService,
+) : SeedJob<Cas1OutOfServiceBedSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = filename,
+  requiredHeaders = setOf(
+    "premisesId",
+    "bedId",
+    "startDate",
+    "endDate",
+    "reasonId",
+    "isCancelled",
+  ),
+) {
+  private val rowKeys = mutableMapOf<Cas1OutOfServiceBedSeedCsvRowKey, UUID>()
+
+  override fun deserializeRow(columns: Map<String, String>) = Cas1OutOfServiceBedSeedCsvRow(
+    key = Cas1OutOfServiceBedSeedCsvRowKey(
+      premisesId = UUID.fromString(columns["premisesId"]!!.trim()),
+      bedId = UUID.fromString(columns["bedId"]!!.trim()),
+    ),
+    startDate = LocalDate.parse(columns["startDate"]!!.trim()),
+    endDate = LocalDate.parse(columns["endDate"]!!.trim()),
+    reasonId = UUID.fromString(columns["reasonId"]!!.trim()),
+    referenceNumber = columns["referenceNumber"].trimToNull(),
+    notes = columns["notes"].trimToNull(),
+    isCancelled = columns["isCancelled"]!!.trim().equals("true", ignoreCase = true),
+    cancellationNotes = columns["cancellationNotes"].trimToNull(),
+  )
+
+  override fun processRow(row: Cas1OutOfServiceBedSeedCsvRow) {
+    when (val outOfServiceBedId = rowKeys[row.key]) {
+      null -> createOutOfServiceBed(row)
+      else -> updateOutOfServiceBed(outOfServiceBedId, row)
+    }
+  }
+
+  private fun createOutOfServiceBed(row: Cas1OutOfServiceBedSeedCsvRow) {
+    val premises = premisesService.getPremises(row.key.premisesId) as ApprovedPremisesEntity?
+      ?: throw SeedException("No Approved Premises with ID ${row.key.premisesId} exists.")
+
+    val creationResult = cas1OutOfServiceBedService.createOutOfServiceBed(
+      premises,
+      row.startDate,
+      row.endDate,
+      row.reasonId,
+      row.referenceNumber,
+      row.notes,
+      row.key.bedId,
+      createdBy = null,
+    )
+
+    val outOfServiceBed = extractEntityFromValidatableActionResult(creationResult)
+
+    if (row.isCancelled) {
+      val cancellationResult = cas1OutOfServiceBedService.cancelOutOfServiceBed(outOfServiceBed, row.cancellationNotes)
+
+      ensureEntityFromValidatableActionResultIsSuccess(cancellationResult)
+    }
+
+    rowKeys[row.key] = outOfServiceBed.id
+  }
+
+  private fun updateOutOfServiceBed(outOfServiceBedId: UUID, row: Cas1OutOfServiceBedSeedCsvRow) {
+    val result = cas1OutOfServiceBedService.updateOutOfServiceBed(
+      outOfServiceBedId,
+      row.startDate,
+      row.endDate,
+      row.reasonId,
+      row.referenceNumber,
+      row.notes,
+      createdBy = null,
+    )
+
+    ensureEntityFromNestedAuthorisableValidatableActionResultIsSuccess(result)
+  }
+}
+
+data class Cas1OutOfServiceBedSeedCsvRowKey(
+  val premisesId: UUID,
+  val bedId: UUID,
+)
+
+data class Cas1OutOfServiceBedSeedCsvRow(
+  val key: Cas1OutOfServiceBedSeedCsvRowKey,
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+  val reasonId: UUID,
+  val referenceNumber: String?,
+  val notes: String?,
+  val isCancelled: Boolean,
+  val cancellationNotes: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -58,6 +58,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DomainEven
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DuplicateApplicationSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1LinkedBookingToPlacementRequestSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServiceBedSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateEventNumberSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1WithdrawPlacementRequestSeedJob
@@ -65,6 +66,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2Applicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.ExternalUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.NomisUsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.findRootCause
 import java.io.File
@@ -308,6 +310,12 @@ class SeedService(
           applicationContext.getBean(PlacementRequestRepository::class.java),
           applicationContext.getBean(BookingRepository::class.java),
           applicationContext.getBean(ApplicationTimelineNoteService::class.java),
+        )
+
+        SeedFileType.approvedPremisesOutOfServiceBeds -> Cas1OutOfServiceBedSeedJob(
+          filename,
+          applicationContext.getBean(Cas1OutOfServiceBedService::class.java),
+          applicationContext.getBean(PremisesService::class.java),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -46,6 +47,26 @@ class Cas1OutOfServiceBedService(
     referenceNumber: String?,
     notes: String?,
     bedId: UUID,
+  ) = createOutOfServiceBed(
+    premises,
+    startDate,
+    endDate,
+    reasonId,
+    referenceNumber,
+    notes,
+    bedId,
+    userService.getUserForRequest(),
+  )
+
+  fun createOutOfServiceBed(
+    premises: ApprovedPremisesEntity,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    reasonId: UUID,
+    referenceNumber: String?,
+    notes: String?,
+    bedId: UUID,
+    createdBy: UserEntity?,
   ): ValidatableActionResult<Cas1OutOfServiceBedEntity> =
     validated {
       if (endDate.isBefore(startDate)) {
@@ -93,7 +114,7 @@ class Cas1OutOfServiceBedService(
             notes = notes,
             reason = reason!!,
             outOfServiceBed = this,
-            createdBy = userService.getUserForRequest(),
+            createdBy = createdBy,
             changeTypePacked = Cas1OutOfServiceBedRevisionChangeType.NO_CHANGE,
           ),
         )
@@ -109,6 +130,24 @@ class Cas1OutOfServiceBedService(
     reasonId: UUID,
     referenceNumber: String?,
     notes: String?,
+  ) = updateOutOfServiceBed(
+    outOfServiceBedId,
+    startDate,
+    endDate,
+    reasonId,
+    referenceNumber,
+    notes,
+    userService.getUserForRequest(),
+  )
+
+  fun updateOutOfServiceBed(
+    outOfServiceBedId: UUID,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    reasonId: UUID,
+    referenceNumber: String?,
+    notes: String?,
+    createdBy: UserEntity?,
   ): AuthorisableActionResult<ValidatableActionResult<Cas1OutOfServiceBedEntity>> {
     val outOfServiceBed = outOfServiceBedRepository.findByIdOrNull(outOfServiceBedId)
       ?: return AuthorisableActionResult.NotFound()
@@ -143,7 +182,7 @@ class Cas1OutOfServiceBedService(
             notes = notes,
             reason = reason!!,
             outOfServiceBed = outOfServiceBed,
-            createdBy = userService.getUserForRequest(),
+            createdBy = createdBy,
             changeTypePacked = getChangeType(outOfServiceBed.latestRevision, startDate, endDate, referenceNumber, notes, reason),
           ),
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/EntityUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/EntityUtils.kt
@@ -25,6 +25,14 @@ fun <EntityType> ensureEntityFromNestedAuthorisableValidatableActionResultIsSucc
   extractEntityFromNestedAuthorisableValidatableActionResult(result)
 }
 
+fun <EntityType> ensureEntityFromAuthorisableActionResultIsSuccess(result: AuthorisableActionResult<EntityType>) {
+  extractEntityFromAuthorisableActionResult(result)
+}
+
+fun <EntityType> ensureEntityFromValidatableActionResultIsSuccess(result: ValidatableActionResult<EntityType>) {
+  extractEntityFromValidatableActionResult(result)
+}
+
 fun <EntityType> extractEntityFromNestedAuthorisableValidatableActionResult(result: AuthorisableActionResult<ValidatableActionResult<EntityType>>): EntityType {
   val validatableResult = extractEntityFromAuthorisableActionResult(result)
   return extractEntityFromValidatableActionResult(validatableResult)

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3719,6 +3719,7 @@ components:
         - approved_premises_duplicate_application
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
+        - approved_premises_out_of_service_beds
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8132,6 +8132,7 @@ components:
         - approved_premises_duplicate_application
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
+        - approved_premises_out_of_service_beds
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4296,6 +4296,7 @@ components:
         - approved_premises_duplicate_application
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
+        - approved_premises_out_of_service_beds
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4310,6 +4310,7 @@ components:
         - approved_premises_duplicate_application
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
+        - approved_premises_out_of_service_beds
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3810,6 +3810,7 @@ components:
         - approved_premises_duplicate_application
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
+        - approved_premises_out_of_service_beds
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
@@ -1,0 +1,516 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Approved Premises Bed`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServiceBedSeedCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServiceBedSeedCsvRowKey
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+class SeedCas1OutOfServiceBedTest : SeedTestBase() {
+  @Test
+  fun `Logs an error if the premises ID is not provided`() {
+    seedWithCsv("no-premises-id") {
+      withRow(
+        bedId = UUID.randomUUID(),
+        startDate = LocalDate.now(),
+        endDate = LocalDate.now().plusDays(1),
+        reasonId = UUID.randomUUID(),
+        isCancelled = false,
+      )
+    }
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message != null &&
+        it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Invalid UUID string")
+    }
+  }
+
+  @Test
+  fun `Logs an error if no premises exists with the given ID`() {
+    val row = Cas1OutOfServiceBedSeedCsvRowFactory().produce()
+
+    seedWithCsv("no-premises") {
+      withRow(row)
+    }
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Error on row 1:" &&
+        it.throwable != null &&
+        it.throwable.message == "No Approved Premises with ID ${row.key.premisesId} exists."
+    }
+  }
+
+  @Test
+  fun `Logs an error if the bed ID is not provided`() {
+    seedWithCsv("no-bed-id") {
+      withRow(
+        premisesId = UUID.randomUUID(),
+        startDate = LocalDate.now(),
+        endDate = LocalDate.now().plusDays(1),
+        reasonId = UUID.randomUUID(),
+        isCancelled = false,
+      )
+    }
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message != null &&
+        it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Invalid UUID string")
+    }
+  }
+
+  @Test
+  fun `Logs an error if no bed exists with the given ID`() {
+    val premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea {
+            apAreaEntityFactory.produceAndPersist()
+          }
+        }
+      }
+      withYieldedLocalAuthorityArea {
+        localAuthorityEntityFactory.produceAndPersist()
+      }
+    }
+
+    val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+    val row = Cas1OutOfServiceBedSeedCsvRowFactory()
+      .withPremisesId(premises.id)
+      .withReasonId(reason.id)
+      .produce()
+
+    seedWithCsv("no-bed") {
+      withRow(row)
+    }
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Error on row 1:" &&
+        it.throwable is BadRequestProblem &&
+        it.throwable.invalidParams == ValidationErrors(mutableMapOf("$.bedId" to "doesNotExist"))
+    }
+  }
+
+  @Test
+  fun `Logs an error if the start date is not provided`() {
+    seedWithCsv("no-start-date") {
+      withRow(
+        premisesId = UUID.randomUUID(),
+        bedId = UUID.randomUUID(),
+        endDate = LocalDate.now().plusDays(1),
+        reasonId = UUID.randomUUID(),
+        isCancelled = false,
+      )
+    }
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message != null &&
+        it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Text '' could not be parsed at index 0")
+    }
+  }
+
+  @Test
+  fun `Logs an error if the end date is not provided`() {
+    seedWithCsv("no-end-date") {
+      withRow(
+        premisesId = UUID.randomUUID(),
+        bedId = UUID.randomUUID(),
+        startDate = LocalDate.now(),
+        reasonId = UUID.randomUUID(),
+        isCancelled = false,
+      )
+    }
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message != null &&
+        it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Text '' could not be parsed at index 0")
+    }
+  }
+
+  @Test
+  fun `Logs an error if the reason ID is not provided`() {
+    seedWithCsv("no-reason-id") {
+      withRow(
+        premisesId = UUID.randomUUID(),
+        bedId = UUID.randomUUID(),
+        startDate = LocalDate.now(),
+        endDate = LocalDate.now().plusDays(1),
+        isCancelled = false,
+      )
+    }
+
+    assertThat(logEntries).anyMatch {
+      it.level == "error" &&
+        it.message == "Unable to complete Seed Job" &&
+        it.throwable != null &&
+        it.throwable.message != null &&
+        it.throwable.message!!.contains("Unable to deserialize CSV at row: 1: Invalid UUID string")
+    }
+  }
+
+  @Test
+  fun `Logs an error if no reason exists with the given ID`() {
+    `Given an Approved Premises Bed` { bed ->
+      val row = Cas1OutOfServiceBedSeedCsvRowFactory()
+        .withPremisesId(bed.room.premises.id)
+        .withBedId(bed.id)
+        .produce()
+
+      seedWithCsv("no-reason") {
+        withRow(row)
+      }
+
+      assertThat(logEntries).anyMatch {
+        it.level == "error" &&
+          it.message == "Error on row 1:" &&
+          it.throwable is BadRequestProblem &&
+          it.throwable.invalidParams == ValidationErrors(mutableMapOf("$.reason" to "doesNotExist"))
+      }
+    }
+  }
+
+  @Test
+  fun `Creates an out-of-service bed with the correct data`() {
+    `Given an Approved Premises Bed` { bed ->
+      val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+      val row = Cas1OutOfServiceBedSeedCsvRowFactory()
+        .withPremisesId(bed.room.premises.id)
+        .withBedId(bed.id)
+        .withStartDate(LocalDate.of(2024, 7, 1))
+        .withEndDate(LocalDate.of(2024, 7, 3))
+        .withReasonId(reason.id)
+        .withReferenceNumber("ABC123")
+        .withNotes("Some notes")
+        .withIsCancelled(false)
+        .withCancellationNotes(null)
+        .produce()
+
+      seedWithCsv("valid-out-of-service-bed") {
+        withRow(row)
+      }
+
+      val outOfServiceBeds = cas1OutOfServiceBedTestRepository.findAll()
+
+      assertThat(outOfServiceBeds).hasSize(1)
+
+      val outOfServiceBed = outOfServiceBeds.first()
+      assertThat(outOfServiceBed.premises.id).isEqualTo(row.key.premisesId)
+      assertThat(outOfServiceBed.bed.id).isEqualTo(row.key.bedId)
+      assertThat(outOfServiceBed.revisionHistory).hasSize(1)
+      assertThat(outOfServiceBed.startDate).isEqualTo(row.startDate)
+      assertThat(outOfServiceBed.endDate).isEqualTo(row.endDate)
+      assertThat(outOfServiceBed.reason.id).isEqualTo(row.reasonId)
+      assertThat(outOfServiceBed.referenceNumber).isEqualTo(row.referenceNumber)
+      assertThat(outOfServiceBed.notes).isEqualTo(row.notes)
+      assertThat(outOfServiceBed.cancellation).isNull()
+    }
+  }
+
+  @Test
+  fun `Creates a cancelled out-of-service bed with the correct data`() {
+    `Given an Approved Premises Bed` { bed ->
+      val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+      val row = Cas1OutOfServiceBedSeedCsvRowFactory()
+        .withPremisesId(bed.room.premises.id)
+        .withBedId(bed.id)
+        .withStartDate(LocalDate.of(2024, 7, 1))
+        .withEndDate(LocalDate.of(2024, 7, 3))
+        .withReasonId(reason.id)
+        .withReferenceNumber("ABC123")
+        .withNotes("Some notes")
+        .withIsCancelled(true)
+        .withCancellationNotes("Some cancellation notes")
+        .produce()
+
+      seedWithCsv("cancelled-out-of-service-bed") {
+        withRow(row)
+      }
+
+      val outOfServiceBeds = cas1OutOfServiceBedTestRepository.findAll()
+
+      assertThat(outOfServiceBeds).hasSize(1)
+
+      val outOfServiceBed = outOfServiceBeds.first()
+      assertThat(outOfServiceBed.premises.id).isEqualTo(row.key.premisesId)
+      assertThat(outOfServiceBed.bed.id).isEqualTo(row.key.bedId)
+      assertThat(outOfServiceBed.revisionHistory).hasSize(1)
+      assertThat(outOfServiceBed.startDate).isEqualTo(row.startDate)
+      assertThat(outOfServiceBed.endDate).isEqualTo(row.endDate)
+      assertThat(outOfServiceBed.reason.id).isEqualTo(row.reasonId)
+      assertThat(outOfServiceBed.referenceNumber).isEqualTo(row.referenceNumber)
+      assertThat(outOfServiceBed.notes).isEqualTo(row.notes)
+      assertThat(outOfServiceBed.cancellation).isNotNull
+      assertThat(outOfServiceBed.cancellation!!.notes).isEqualTo(row.cancellationNotes)
+    }
+  }
+
+  @Test
+  fun `Creates an updated out-of-service bed with the correct data`() {
+    `Given an Approved Premises Bed` { bed ->
+      val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+      val factory = Cas1OutOfServiceBedSeedCsvRowFactory()
+        .withPremisesId(bed.room.premises.id)
+        .withBedId(bed.id)
+        .withStartDate(LocalDate.of(2024, 7, 1))
+        .withEndDate(LocalDate.of(2024, 7, 3))
+        .withReasonId(reason.id)
+        .withReferenceNumber("ABC123")
+        .withNotes("Some notes")
+        .withIsCancelled(false)
+        .withCancellationNotes(null)
+
+      val firstRow = factory.produce()
+
+      val secondRow = factory
+        .withEndDate(LocalDate.of(2024, 7, 4))
+        .withReferenceNumber("XYZ789")
+        .withNotes("Updated notes")
+        .produce()
+
+      seedWithCsv("updated-out-of-service-bed") {
+        withRow(firstRow)
+        withRow(secondRow)
+      }
+
+      val outOfServiceBeds = cas1OutOfServiceBedTestRepository.findAll()
+
+      assertThat(outOfServiceBeds).hasSize(1)
+
+      val outOfServiceBed = outOfServiceBeds.first()
+      assertThat(outOfServiceBed.premises.id).isEqualTo(firstRow.key.premisesId)
+      assertThat(outOfServiceBed.bed.id).isEqualTo(firstRow.key.bedId)
+      assertThat(outOfServiceBed.revisionHistory).hasSize(2)
+      assertThat(outOfServiceBed.startDate).isEqualTo(secondRow.startDate)
+      assertThat(outOfServiceBed.endDate).isEqualTo(secondRow.endDate)
+      assertThat(outOfServiceBed.reason.id).isEqualTo(secondRow.reasonId)
+      assertThat(outOfServiceBed.referenceNumber).isEqualTo(secondRow.referenceNumber)
+      assertThat(outOfServiceBed.notes).isEqualTo(secondRow.notes)
+      assertThat(outOfServiceBed.cancellation).isNull()
+    }
+  }
+
+  @Test
+  fun `Creates multiple out-of-service bed with the correct data`() {
+    `Given an Approved Premises Bed` { firstBed ->
+      `Given an Approved Premises Bed` { secondBed ->
+        val firstReason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+        val secondReason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+
+        val firstFactory = Cas1OutOfServiceBedSeedCsvRowFactory()
+          .withPremisesId(firstBed.room.premises.id)
+          .withBedId(firstBed.id)
+          .withStartDate(LocalDate.of(2024, 7, 1))
+          .withEndDate(LocalDate.of(2024, 7, 3))
+          .withReasonId(firstReason.id)
+          .withReferenceNumber("ABC123")
+          .withNotes("Some notes")
+          .withIsCancelled(false)
+          .withCancellationNotes(null)
+
+        val firstRow = firstFactory.produce()
+
+        val secondRow = firstFactory
+          .withEndDate(LocalDate.of(2024, 7, 4))
+          .withReferenceNumber("XYZ789")
+          .withNotes("Updated notes")
+          .produce()
+
+        val thirdRow = Cas1OutOfServiceBedSeedCsvRowFactory()
+          .withPremisesId(secondBed.room.premises.id)
+          .withBedId(secondBed.id)
+          .withStartDate(LocalDate.of(2024, 8, 15))
+          .withEndDate(LocalDate.of(2024, 8, 18))
+          .withReasonId(secondReason.id)
+          .withReferenceNumber("LMN456")
+          .withNotes("Some other notes")
+          .withIsCancelled(true)
+          .withCancellationNotes("Some cancellation notes")
+          .produce()
+
+        seedWithCsv("multiple-out-of-service-beds") {
+          withRow(firstRow)
+          withRow(secondRow)
+          withRow(thirdRow)
+        }
+
+        val outOfServiceBeds = cas1OutOfServiceBedTestRepository.findAll()
+
+        assertThat(outOfServiceBeds).hasSize(2)
+
+        val firstOutOfServiceBed = outOfServiceBeds.first()
+        assertThat(firstOutOfServiceBed.premises.id).isEqualTo(firstRow.key.premisesId)
+        assertThat(firstOutOfServiceBed.bed.id).isEqualTo(firstRow.key.bedId)
+        assertThat(firstOutOfServiceBed.revisionHistory).hasSize(2)
+        assertThat(firstOutOfServiceBed.startDate).isEqualTo(secondRow.startDate)
+        assertThat(firstOutOfServiceBed.endDate).isEqualTo(secondRow.endDate)
+        assertThat(firstOutOfServiceBed.reason.id).isEqualTo(secondRow.reasonId)
+        assertThat(firstOutOfServiceBed.referenceNumber).isEqualTo(secondRow.referenceNumber)
+        assertThat(firstOutOfServiceBed.notes).isEqualTo(secondRow.notes)
+        assertThat(firstOutOfServiceBed.cancellation).isNull()
+
+        val secondOutOfServiceBed = outOfServiceBeds.last()
+        assertThat(secondOutOfServiceBed.premises.id).isEqualTo(thirdRow.key.premisesId)
+        assertThat(secondOutOfServiceBed.bed.id).isEqualTo(thirdRow.key.bedId)
+        assertThat(secondOutOfServiceBed.revisionHistory).hasSize(1)
+        assertThat(secondOutOfServiceBed.startDate).isEqualTo(thirdRow.startDate)
+        assertThat(secondOutOfServiceBed.endDate).isEqualTo(thirdRow.endDate)
+        assertThat(secondOutOfServiceBed.reason.id).isEqualTo(thirdRow.reasonId)
+        assertThat(secondOutOfServiceBed.referenceNumber).isEqualTo(thirdRow.referenceNumber)
+        assertThat(secondOutOfServiceBed.notes).isEqualTo(thirdRow.notes)
+        assertThat(secondOutOfServiceBed.cancellation).isNotNull
+        assertThat(secondOutOfServiceBed.cancellation!!.notes).isEqualTo(thirdRow.cancellationNotes)
+      }
+    }
+  }
+
+  private fun seedWithCsv(name: String? = null, config: CsvBuilder.() -> Unit) {
+    val fileName = name ?: randomStringMultiCaseWithNumbers(64)
+    generateCsvFile(
+      fileName,
+      csv(config),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesOutOfServiceBeds, fileName)
+  }
+
+  private fun csv(config: CsvBuilder.() -> Unit) = CsvBuilder()
+    .withHeader(
+      "premisesId",
+      "bedId",
+      "startDate",
+      "endDate",
+      "reasonId",
+      "referenceNumber",
+      "notes",
+      "isCancelled",
+      "cancellationNotes",
+    )
+    .newRow()
+    .apply(config)
+    .build()
+
+  private fun CsvBuilder.withRow(row: Cas1OutOfServiceBedSeedCsvRow) = withRow(
+    premisesId = row.key.premisesId,
+    bedId = row.key.bedId,
+    startDate = row.startDate,
+    endDate = row.endDate,
+    reasonId = row.reasonId,
+    referenceNumber = row.referenceNumber,
+    notes = row.notes,
+    isCancelled = row.isCancelled,
+    cancellationNotes = row.cancellationNotes,
+  )
+
+  @Suppress("detekt:LongParameterList")
+  private fun CsvBuilder.withRow(
+    premisesId: UUID? = null,
+    bedId: UUID? = null,
+    startDate: LocalDate? = null,
+    endDate: LocalDate? = null,
+    reasonId: UUID? = null,
+    referenceNumber: String? = null,
+    notes: String? = null,
+    isCancelled: Boolean? = null,
+    cancellationNotes: String? = null,
+  ) = apply {
+    withUnquotedField(premisesId ?: "")
+    withUnquotedField(bedId ?: "")
+    withUnquotedField(startDate ?: "")
+    withUnquotedField(endDate ?: "")
+    withUnquotedField(reasonId ?: "")
+    withUnquotedField(referenceNumber ?: "")
+    withUnquotedField(notes ?: "")
+    withUnquotedField(isCancelled ?: "")
+    withUnquotedField(cancellationNotes ?: "")
+    newRow()
+  }
+}
+
+class Cas1OutOfServiceBedSeedCsvRowFactory : Factory<Cas1OutOfServiceBedSeedCsvRow> {
+  private var premisesId: Yielded<UUID> = { UUID.randomUUID() }
+  private var bedId: Yielded<UUID> = { UUID.randomUUID() }
+  private var startDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var endDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var reasonId: Yielded<UUID> = { UUID.randomUUID() }
+  private var referenceNumber: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
+  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
+  private var isCancelled: Yielded<Boolean> = { false }
+  private var cancellationNotes: Yielded<String?> = { null }
+
+  fun withPremisesId(premisesId: UUID) = apply {
+    this.premisesId = { premisesId }
+  }
+
+  fun withBedId(bedId: UUID) = apply {
+    this.bedId = { bedId }
+  }
+
+  fun withStartDate(startDate: LocalDate) = apply {
+    this.startDate = { startDate }
+  }
+
+  fun withEndDate(endDate: LocalDate) = apply {
+    this.endDate = { endDate }
+  }
+
+  fun withReasonId(reasonId: UUID) = apply {
+    this.reasonId = { reasonId }
+  }
+
+  fun withReferenceNumber(referenceNumber: String?) = apply {
+    this.referenceNumber = { referenceNumber }
+  }
+
+  fun withNotes(notes: String?) = apply {
+    this.notes = { notes }
+  }
+
+  fun withIsCancelled(isCancelled: Boolean) = apply {
+    this.isCancelled = { isCancelled }
+  }
+
+  fun withCancellationNotes(cancellationNotes: String?) = apply {
+    this.cancellationNotes = { cancellationNotes }
+  }
+
+  override fun produce() = Cas1OutOfServiceBedSeedCsvRow(
+    key = Cas1OutOfServiceBedSeedCsvRowKey(
+      premisesId = this.premisesId(),
+      bedId = this.bedId(),
+    ),
+    startDate = this.startDate(),
+    endDate = this.endDate(),
+    reasonId = this.reasonId(),
+    referenceNumber = this.referenceNumber(),
+    notes = this.notes(),
+    isCancelled = this.isCancelled(),
+    cancellationNotes = this.cancellationNotes(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1OutOfServiceBedSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1OutOfServiceBedSeedJobTest.kt
@@ -1,0 +1,479 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.seed.cas1
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedException
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServiceBedSeedCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServiceBedSeedCsvRowKey
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServiceBedSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1OutOfServiceBedSeedJobTest {
+  @Suppress("unused") // Required for @InjectMockKs
+  private val filename = "test"
+
+  @MockK
+  private lateinit var cas1OutOfServiceBedService: Cas1OutOfServiceBedService
+
+  @MockK
+  private lateinit var premisesService: PremisesService
+
+  @InjectMockKs
+  private lateinit var seedJob: Cas1OutOfServiceBedSeedJob
+
+  @Nested
+  inner class DeserializeRow {
+    @Test
+    fun `Deserializes CSV row correctly for an active out-of-service bed`() {
+      val expectedPremisesId = UUID.randomUUID()
+      val expectedBedId = UUID.randomUUID()
+      val expectedReasonId = UUID.randomUUID()
+
+      val inputRow = mapOf(
+        "premisesId" to expectedPremisesId.toString(),
+        "bedId" to expectedBedId.toString(),
+        "startDate" to "2024-01-01",
+        "endDate" to "2024-02-02",
+        "reasonId" to expectedReasonId.toString(),
+        "referenceNumber" to "ABC123",
+        "notes" to "Some notes",
+        "isCancelled" to "false",
+        "cancellationNotes" to "",
+      )
+
+      val actual = seedJob.deserializeRow(inputRow)
+
+      assertThat(actual.key.premisesId).isEqualTo(expectedPremisesId)
+      assertThat(actual.key.bedId).isEqualTo(expectedBedId)
+      assertThat(actual.startDate).isEqualTo(LocalDate.of(2024, 1, 1))
+      assertThat(actual.endDate).isEqualTo(LocalDate.of(2024, 2, 2))
+      assertThat(actual.reasonId).isEqualTo(expectedReasonId)
+      assertThat(actual.referenceNumber).isEqualTo("ABC123")
+      assertThat(actual.notes).isEqualTo("Some notes")
+      assertThat(actual.isCancelled).isFalse
+      assertThat(actual.cancellationNotes).isNull()
+    }
+
+    @Test
+    fun `Deserializes CSV row correctly for a cancelled out-of-service bed`() {
+      val expectedPremisesId = UUID.randomUUID()
+      val expectedBedId = UUID.randomUUID()
+      val expectedReasonId = UUID.randomUUID()
+
+      val inputRow = mapOf(
+        "premisesId" to expectedPremisesId.toString(),
+        "bedId" to expectedBedId.toString(),
+        "startDate" to "2024-01-01",
+        "endDate" to "2024-02-02",
+        "reasonId" to expectedReasonId.toString(),
+        "referenceNumber" to "ABC123",
+        "notes" to "Some notes",
+        "isCancelled" to "true",
+        "cancellationNotes" to "Some cancellation notes",
+      )
+
+      val actual = seedJob.deserializeRow(inputRow)
+
+      assertThat(actual.key.premisesId).isEqualTo(expectedPremisesId)
+      assertThat(actual.key.bedId).isEqualTo(expectedBedId)
+      assertThat(actual.startDate).isEqualTo(LocalDate.of(2024, 1, 1))
+      assertThat(actual.endDate).isEqualTo(LocalDate.of(2024, 2, 2))
+      assertThat(actual.reasonId).isEqualTo(expectedReasonId)
+      assertThat(actual.referenceNumber).isEqualTo("ABC123")
+      assertThat(actual.notes).isEqualTo("Some notes")
+      assertThat(actual.isCancelled).isTrue
+      assertThat(actual.cancellationNotes).isEqualTo("Some cancellation notes")
+    }
+
+    @Test
+    fun `Deserializes CSV row correctly for optional rows`() {
+      val expectedPremisesId = UUID.randomUUID()
+      val expectedBedId = UUID.randomUUID()
+      val expectedReasonId = UUID.randomUUID()
+
+      val inputRow = mapOf(
+        "premisesId" to expectedPremisesId.toString(),
+        "bedId" to expectedBedId.toString(),
+        "startDate" to "2024-01-01",
+        "endDate" to "2024-02-02",
+        "reasonId" to expectedReasonId.toString(),
+        "referenceNumber" to "",
+        "notes" to "",
+        "isCancelled" to "false",
+        "cancellationNotes" to "",
+      )
+
+      val actual = seedJob.deserializeRow(inputRow)
+
+      assertThat(actual.key.premisesId).isEqualTo(expectedPremisesId)
+      assertThat(actual.key.bedId).isEqualTo(expectedBedId)
+      assertThat(actual.startDate).isEqualTo(LocalDate.of(2024, 1, 1))
+      assertThat(actual.endDate).isEqualTo(LocalDate.of(2024, 2, 2))
+      assertThat(actual.reasonId).isEqualTo(expectedReasonId)
+      assertThat(actual.referenceNumber).isNull()
+      assertThat(actual.notes).isNull()
+      assertThat(actual.isCancelled).isFalse
+      assertThat(actual.cancellationNotes).isNull()
+    }
+  }
+
+  @Nested
+  inner class ProcessRow {
+    @Test
+    fun `Throws exception if no Approved Premises with given premises ID exists`() {
+      val row = Cas1OutOfServiceBedSeedCsvRow(
+        key = Cas1OutOfServiceBedSeedCsvRowKey(
+          premisesId = UUID.randomUUID(),
+          bedId = UUID.randomUUID(),
+        ),
+        startDate = LocalDate.parse("2024-01-01"),
+        endDate = LocalDate.parse("2024-02-02"),
+        reasonId = UUID.randomUUID(),
+        referenceNumber = "ABC123",
+        notes = "Some notes",
+        isCancelled = false,
+        cancellationNotes = null,
+      )
+
+      every { premisesService.getPremises(any()) } returns null
+
+      assertThatExceptionOfType(SeedException::class.java)
+        .isThrownBy { seedJob.processRow(row) }
+        .withMessage("No Approved Premises with ID ${row.key.premisesId} exists.")
+
+      verify(exactly = 1) {
+        premisesService.getPremises(row.key.premisesId)
+      }
+
+      confirmVerified()
+    }
+
+    @Test
+    fun `Creates an out-of-service bed for the first row with a given premisesId-bedId pair`() {
+      val row = Cas1OutOfServiceBedSeedCsvRow(
+        key = Cas1OutOfServiceBedSeedCsvRowKey(
+          premisesId = UUID.randomUUID(),
+          bedId = UUID.randomUUID(),
+        ),
+        startDate = LocalDate.parse("2024-01-01"),
+        endDate = LocalDate.parse("2024-02-02"),
+        reasonId = UUID.randomUUID(),
+        referenceNumber = "ABC123",
+        notes = "Some notes",
+        isCancelled = false,
+        cancellationNotes = null,
+      )
+
+      val expectedPremises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      every { premisesService.getPremises(any()) } returns expectedPremises
+
+      every { cas1OutOfServiceBedService.createOutOfServiceBed(any(), any(), any(), any(), any(), any(), any(), any()) } returns
+        ValidatableActionResult.Success(
+          Cas1OutOfServiceBedEntityFactory()
+            .withBed {
+              withRoom {
+                withPremises(expectedPremises)
+              }
+            }
+            .produce(),
+        )
+
+      seedJob.processRow(row)
+
+      verify(exactly = 1) {
+        premisesService.getPremises(row.key.premisesId)
+
+        cas1OutOfServiceBedService.createOutOfServiceBed(
+          expectedPremises,
+          row.startDate,
+          row.endDate,
+          row.reasonId,
+          row.referenceNumber,
+          row.notes,
+          row.key.bedId,
+          createdBy = null,
+        )
+      }
+
+      confirmVerified()
+    }
+
+    @Test
+    fun `Creates a cancelled out-of-service bed for the first row with a given premisesId-bedId pair`() {
+      val row = Cas1OutOfServiceBedSeedCsvRow(
+        key = Cas1OutOfServiceBedSeedCsvRowKey(
+          premisesId = UUID.randomUUID(),
+          bedId = UUID.randomUUID(),
+        ),
+        startDate = LocalDate.parse("2024-01-01"),
+        endDate = LocalDate.parse("2024-02-02"),
+        reasonId = UUID.randomUUID(),
+        referenceNumber = "ABC123",
+        notes = "Some notes",
+        isCancelled = true,
+        cancellationNotes = "Some cancellation notes",
+      )
+
+      val expectedPremises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      every { premisesService.getPremises(any()) } returns expectedPremises
+
+      val expectedOutOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+        .withBed {
+          withRoom {
+            withPremises(expectedPremises)
+          }
+        }
+        .produce()
+
+      every { cas1OutOfServiceBedService.createOutOfServiceBed(any(), any(), any(), any(), any(), any(), any(), any()) } returns
+        ValidatableActionResult.Success(expectedOutOfServiceBed)
+
+      every { cas1OutOfServiceBedService.cancelOutOfServiceBed(any(), any()) } returns
+        ValidatableActionResult.Success(
+          Cas1OutOfServiceBedCancellationEntityFactory()
+            .withOutOfServiceBed(expectedOutOfServiceBed)
+            .produce(),
+        )
+
+      seedJob.processRow(row)
+
+      verify(exactly = 1) {
+        premisesService.getPremises(row.key.premisesId)
+
+        cas1OutOfServiceBedService.createOutOfServiceBed(
+          expectedPremises,
+          row.startDate,
+          row.endDate,
+          row.reasonId,
+          row.referenceNumber,
+          row.notes,
+          row.key.bedId,
+          createdBy = null,
+        )
+
+        cas1OutOfServiceBedService.cancelOutOfServiceBed(
+          any(),
+          row.cancellationNotes,
+        )
+      }
+
+      confirmVerified()
+    }
+
+    @Test
+    fun `Updates an out-of-service bed for the second row with a given premisesId-bedId pair`() {
+      val firstRow = Cas1OutOfServiceBedSeedCsvRow(
+        key = Cas1OutOfServiceBedSeedCsvRowKey(
+          premisesId = UUID.randomUUID(),
+          bedId = UUID.randomUUID(),
+        ),
+        startDate = LocalDate.parse("2024-01-01"),
+        endDate = LocalDate.parse("2024-02-02"),
+        reasonId = UUID.randomUUID(),
+        referenceNumber = "ABC123",
+        notes = "Some notes",
+        isCancelled = false,
+        cancellationNotes = null,
+      )
+
+      val secondRow = Cas1OutOfServiceBedSeedCsvRow(
+        key = firstRow.key,
+        startDate = LocalDate.parse("2024-01-02"),
+        endDate = LocalDate.parse("2024-02-03"),
+        reasonId = UUID.randomUUID(),
+        referenceNumber = "XYZ789",
+        notes = "Some additional notes",
+        isCancelled = false,
+        cancellationNotes = null,
+      )
+
+      val expectedPremises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      every { premisesService.getPremises(any()) } returns expectedPremises
+
+      val expectedOutOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+        .withBed {
+          withRoom {
+            withPremises(expectedPremises)
+          }
+        }
+        .produce()
+
+      every { cas1OutOfServiceBedService.createOutOfServiceBed(any(), any(), any(), any(), any(), any(), any(), any()) } returns
+        ValidatableActionResult.Success(expectedOutOfServiceBed)
+
+      every { cas1OutOfServiceBedService.updateOutOfServiceBed(any(), any(), any(), any(), any(), any(), any()) } returns
+        AuthorisableActionResult.Success(ValidatableActionResult.Success(expectedOutOfServiceBed))
+
+      seedJob.processRow(firstRow)
+
+      verify(exactly = 1) {
+        premisesService.getPremises(firstRow.key.premisesId)
+
+        cas1OutOfServiceBedService.createOutOfServiceBed(
+          expectedPremises,
+          firstRow.startDate,
+          firstRow.endDate,
+          firstRow.reasonId,
+          firstRow.referenceNumber,
+          firstRow.notes,
+          firstRow.key.bedId,
+          createdBy = null,
+        )
+      }
+
+      confirmVerified()
+
+      seedJob.processRow(secondRow)
+
+      verify(exactly = 1) {
+        premisesService.getPremises(secondRow.key.premisesId)
+
+        cas1OutOfServiceBedService.updateOutOfServiceBed(
+          expectedOutOfServiceBed.id,
+          secondRow.startDate,
+          secondRow.endDate,
+          secondRow.reasonId,
+          secondRow.referenceNumber,
+          secondRow.notes,
+          createdBy = null,
+        )
+      }
+
+      confirmVerified()
+    }
+
+    @Test
+    fun `Creates an out-of-service bed for the second row with a different premisesId-bedId pair`() {
+      val firstRow = Cas1OutOfServiceBedSeedCsvRow(
+        key = Cas1OutOfServiceBedSeedCsvRowKey(
+          premisesId = UUID.randomUUID(),
+          bedId = UUID.randomUUID(),
+        ),
+        startDate = LocalDate.parse("2024-01-01"),
+        endDate = LocalDate.parse("2024-02-02"),
+        reasonId = UUID.randomUUID(),
+        referenceNumber = "ABC123",
+        notes = "Some notes",
+        isCancelled = false,
+        cancellationNotes = null,
+      )
+
+      val secondRow = Cas1OutOfServiceBedSeedCsvRow(
+        key = Cas1OutOfServiceBedSeedCsvRowKey(
+          premisesId = UUID.randomUUID(),
+          bedId = UUID.randomUUID(),
+        ),
+        startDate = LocalDate.parse("2024-01-02"),
+        endDate = LocalDate.parse("2024-02-03"),
+        reasonId = UUID.randomUUID(),
+        referenceNumber = "XYZ789",
+        notes = "Some other notes",
+        isCancelled = false,
+        cancellationNotes = null,
+      )
+
+      val firstPremises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val secondPremises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      every { premisesService.getPremises(any()) } returnsMany listOf(firstPremises, secondPremises)
+
+      val firstOutOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+        .withBed {
+          withRoom {
+            withPremises(firstPremises)
+          }
+        }
+        .produce()
+
+      val secondOutOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+        .withBed {
+          withRoom {
+            withPremises(secondPremises)
+          }
+        }
+        .produce()
+
+      every { cas1OutOfServiceBedService.createOutOfServiceBed(any(), any(), any(), any(), any(), any(), any(), any()) } returnsMany
+        listOf(
+          ValidatableActionResult.Success(firstOutOfServiceBed),
+          ValidatableActionResult.Success(secondOutOfServiceBed),
+        )
+
+      every { cas1OutOfServiceBedService.updateOutOfServiceBed(any(), any(), any(), any(), any(), any(), any()) } returnsMany
+        listOf(
+          AuthorisableActionResult.Success(ValidatableActionResult.Success(firstOutOfServiceBed)),
+          AuthorisableActionResult.Success(ValidatableActionResult.Success(secondOutOfServiceBed)),
+        )
+
+      seedJob.processRow(firstRow)
+
+      verify(exactly = 1) {
+        premisesService.getPremises(firstRow.key.premisesId)
+
+        cas1OutOfServiceBedService.createOutOfServiceBed(
+          firstPremises,
+          firstRow.startDate,
+          firstRow.endDate,
+          firstRow.reasonId,
+          firstRow.referenceNumber,
+          firstRow.notes,
+          firstRow.key.bedId,
+          createdBy = null,
+        )
+      }
+
+      confirmVerified()
+
+      seedJob.processRow(secondRow)
+
+      verify(exactly = 1) {
+        premisesService.getPremises(secondRow.key.premisesId)
+
+        cas1OutOfServiceBedService.createOutOfServiceBed(
+          secondPremises,
+          secondRow.startDate,
+          secondRow.endDate,
+          secondRow.reasonId,
+          secondRow.referenceNumber,
+          secondRow.notes,
+          secondRow.key.bedId,
+          createdBy = null,
+        )
+      }
+
+      confirmVerified()
+    }
+  }
+}


### PR DESCRIPTION
> See [APS-924 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-924).

This PR introduces a new type of seed job (`approved_premises_out_of_service_beds`) that can be used with the `script/run_seed_job` shell script and/or internal `POST /seed` API endpoint. This allows for the seeding of CAS1 out-of-service beds in various states.

As seed jobs operate on a per-row basis, an out-of-service bed is identified by the `premisesId`/`bedId` pair, and determines whether to create a new out-of-service bed or update an existing one based on whether it has already encountered that particular pair.

For example, a CSV describing the below table would create two out-of-service bed records, where one has an update to change the end date, reason, and reference number; and the second one has no updates
but has been cancelled:

| premisesId                           | bedId                                | startDate  | endDate    | reasonId | referenceNumber | notes | isCancelled | cancellationNotes |
|--------------------------------------|--------------------------------------|------------|------------|----------|-----------------|-------|-------------|-------------------|
| `6386b222-122b-414c-bee9-3edc8541408a` | `99bf9fe3-a810-4651-ba6e-4ba4cd27cd89` | 2024-01-01 | 2024-02-02 | `1862c...` | ABC123          | Text. | false       |                   |
| `6386b222-122b-414c-bee9-3edc8541408a` | `99bf9fe3-a810-4651-ba6e-4ba4cd27cd89` | 2024-01-01 | 2024-01-02 | `be979...` | XYZ789          | Text. | false       |                   |
| `3605280f-58e9-40eb-a961-b3a43aa78e5e` | `230f3ce0-cfbb-4137-8331-f0a9696c7d9b` | 2024-03-10 | 2024-03-13 | `35566...` | AAA999          | Notes | true        | Logged in error   |