### PR TITLE
CAS-365: Update SQL to use ApprovedPremisesEntity and apCode.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -126,8 +126,8 @@ interface PremisesRepository : JpaRepository<PremisesEntity, UUID> {
   @Query("SELECT p FROM PremisesEntity p WHERE name = :name AND TYPE(p) = :type")
   fun <T : PremisesEntity> findByName(name: String, type: Class<T>): PremisesEntity?
 
-  @Query("SELECT p FROM PremisesEntity p WHERE ap_code = :apCode AND TYPE(p) = :type")
-  fun <T : PremisesEntity> findByApCode(apCode: String, type: Class<T>): PremisesEntity?
+  @Query("SELECT p FROM ApprovedPremisesEntity p WHERE apCode = :apCode")
+  fun findByApCode(apCode: String): ApprovedPremisesEntity?
 
   @Query("SELECT CAST(COUNT(b) as int) FROM PremisesEntity p JOIN p.rooms r JOIN r.beds b on (b.endDate IS NULL OR b.endDate >= CURRENT_DATE) WHERE r.premises = :premises")
   fun getBedCount(premises: PremisesEntity): Int

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/ApprovedPremisesRoomsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/ApprovedPremisesRoomsSeedJob.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
 
 import org.slf4j.LoggerFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
@@ -165,7 +164,7 @@ class ApprovedPremisesRoomsSeedJob(
   }
 
   private fun findExistingPremisesOrThrow(row: ApprovedPremisesRoomsSeedCsvRow): PremisesEntity {
-    return premisesRepository.findByApCode(row.apCode, ApprovedPremisesEntity::class.java)
+    return premisesRepository.findByApCode(row.apCode)
       ?: throw RuntimeException(
         "Error: no premises with apCode '${row.apCode}' found. " +
           "Please seed premises before rooms/beds.",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/ApprovedPremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/ApprovedPremisesSeedJob.kt
@@ -102,11 +102,7 @@ class ApprovedPremisesSeedJob(
   )
 
   override fun processRow(row: ApprovedPremisesSeedCsvRow) {
-    val existingPremises = premisesRepository.findByApCode(row.apCode, ApprovedPremisesEntity::class.java)
-
-    if (existingPremises != null && existingPremises !is ApprovedPremisesEntity) {
-      throw RuntimeException("Premises ${row.apCode} is of type ${existingPremises::class.qualifiedName}, cannot be updated with Approved Premises Seed Job")
-    }
+    val existingPremises = premisesRepository.findByApCode(row.apCode)
 
     val probationRegion = probationRegionRepository.findByName(row.probationRegion)
       ?: throw RuntimeException("Probation Region ${row.probationRegion} does not exist")


### PR DESCRIPTION
Existing SQL causes an error when upgrading Spring boot:
`SELECT p FROM PremisesEntity p WHERE ap_code = :apCode AND TYPE(p) = :type
`
Changing to this which resolves the problem:
`SELECT p FROM ApprovedPremisesEntity p WHERE apCode = :apCode`
