### PR TITLE
CA-365 remove inadvertent use of AWS NotFoundException.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/AssessmentNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/AssessmentNoteService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
 
-import com.amazonaws.services.sns.model.NotFoundException
 import io.sentry.Sentry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -104,12 +103,7 @@ class AssessmentNoteService(
       )
     } else {
       log.error("Email not found for User ${application.createdByUser.id}. Unable to send email for Note ${savedNote.id} on Application ${application.id}")
-      Sentry.captureException(
-        RuntimeException(
-          "Email not found for User ${application.createdByUser.id}. Unable to send email for Note ${savedNote.id} on Application ${application.id}",
-          NotFoundException("Email not found for User ${application.createdByUser.id}"),
-        ),
-      )
+      Sentry.captureMessage("Email not found for User ${application.createdByUser.id}. Unable to send email for Note ${savedNote.id} on Application ${application.id}")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/StatusUpdateService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
 
-import com.amazonaws.services.sns.model.NotFoundException
 import io.sentry.Sentry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -192,12 +191,7 @@ class StatusUpdateService(
       )
     } else {
       log.error("Email not found for User ${application.createdByUser.id}. Unable to send email when updating status of Application ${application.id}")
-      Sentry.captureException(
-        RuntimeException(
-          "Email not found for User ${application.createdByUser.id}. Unable to send email when updating status of Application ${application.id}",
-          NotFoundException("Email not found for User ${application.createdByUser.id}"),
-        ),
-      )
+      Sentry.captureMessage("Email not found for User ${application.createdByUser.id}. Unable to send email when updating status of Application ${application.id}")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/AssessmentNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/AssessmentNoteServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas2
 
-import com.amazonaws.services.sns.model.NotFoundException
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -8,7 +7,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
 import io.sentry.Sentry
-import io.sentry.protocol.SentryId
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -431,23 +429,13 @@ class AssessmentNoteServiceTest {
         every { mockExternalUserService.getUserForRequest() } returns externalUser
         mockkStatic(Sentry::class)
 
-        every {
-          Sentry.captureException(
-            RuntimeException(
-              "Email not found for User ${submittedApplicationWithNoReferrerEmail.createdByUser.id}. " +
-                "Unable to send email for Note ${noteEntity.id} on Application ${submittedApplicationWithNoReferrerEmail.id}",
-              NotFoundException("Email not found for User ${submittedApplicationWithNoReferrerEmail.createdByUser.id}"),
-            ),
-          )
-        } returns SentryId.EMPTY_ID
-
         assessmentNoteService.createAssessmentNote(
           assessmentId = assessment.id,
           NewCas2ApplicationNote(note = "new note"),
         )
 
         verify(exactly = 1) {
-          Sentry.captureException(
+          Sentry.captureMessage(
             any(),
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/StatusUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/StatusUpdateServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas2
 
-import com.amazonaws.services.sns.model.NotFoundException
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -8,7 +7,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
 import io.sentry.Sentry
-import io.sentry.protocol.SentryId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -392,16 +390,6 @@ class StatusUpdateServiceTest {
 
           mockkStatic(Sentry::class)
 
-          every {
-            Sentry.captureException(
-              RuntimeException(
-                "Email not found for User ${submittedApplicationWithNoReferrerEmail.createdByUser.id}. " +
-                  "Unable to send email when updating status of Application ${submittedApplicationWithNoReferrerEmail.id}",
-                NotFoundException("Email not found for User ${submittedApplicationWithNoReferrerEmail.createdByUser.id}"),
-              ),
-            )
-          } returns SentryId.EMPTY_ID
-
           statusUpdateService.createForAssessment(
             assessmentId = assessmentWithNoEmail.id,
             statusUpdate = applicationStatusUpdateWithDetail,
@@ -409,7 +397,7 @@ class StatusUpdateServiceTest {
           )
 
           verify(exactly = 1) {
-            Sentry.captureException(
+            Sentry.captureMessage(
               any(),
             )
           }


### PR DESCRIPTION
Change captureException() to captureMessage() results in NotFoundException no longer needed.  See: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1961#discussion_r1662114917