### PR TITLE
CAS-472 move on categories returning inactive ref data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
@@ -10,10 +10,10 @@ import javax.persistence.Table
 
 @Repository
 interface MoveOnCategoryRepository : JpaRepository<MoveOnCategoryEntity, UUID> {
-  @Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.serviceScope = :serviceName OR m.serviceScope = '*'")
+  @Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.serviceScope IN (:serviceName, '*')")
   fun findAllByServiceScope(serviceName: String): List<MoveOnCategoryEntity>
 
-  @Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.serviceScope = :serviceName OR m.serviceScope = '*' AND m.isActive = true")
+  @Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.isActive = true AND m.serviceScope IN (:serviceName, '*')")
   fun findActiveByServiceScope(serviceName: String): List<MoveOnCategoryEntity>
 
   @Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.isActive = true")


### PR DESCRIPTION
PR to fix an issue with the order of precedence in the move on category query, as it was returning categories that had the is_active field set to false. Also improved test coverage in the area, including tests for categories that have a '*' for the service scope.

