### PR TITLE
APS-1073 - Alert on InternalServer & NotImplemented Problems

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnhandledExceptionProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnhandledExceptionProblem.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import org.zalando.problem.AbstractThrowableProblem
+import org.zalando.problem.Exceptional
+import org.zalando.problem.Status
+
+class UnhandledExceptionProblem(detail: String) : AbstractThrowableProblem(null, "Internal Server Error", Status.INTERNAL_SERVER_ERROR, detail) {
+  override fun getCause(): Exceptional? {
+    return null
+  }
+}


### PR DESCRIPTION
Whilst we already alert on unhandled exceptions, we are not alerting when the code explicitly throws an InternalServerErrorProblem or NotImplementedProblem. This commit resolves that.

As part of this change we now throw a new UnhandledExceptionProblem if we can’t handle an exception. This better describes the problem, and avoids the issue of the InternalServerErrorProblem that we used to return being alerted on again by the new code in logInternalServerErrorProblem.