### PR TITLE
APS-1067 - Allow  assessor users to list assigned tasks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -79,7 +79,7 @@ class TasksController(
   ): ResponseEntity<List<Task>> {
     val user = userService.getUserForRequest()
 
-    if (!user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_MATCHER)) {
+    if (!user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_ASSESSOR)) {
       throw ForbiddenProblem()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -90,7 +90,7 @@ class TasksTest {
       }
 
       @Test
-      fun `Get all tasks without workflow manager or matcher permissions returns 403`() {
+      fun `Get all tasks without workflow manager, matcher or assessor permissions returns 403`() {
         `Given a User` { _, jwt ->
           webTestClient.get()
             .uri("/tasks")
@@ -102,8 +102,8 @@ class TasksTest {
       }
 
       @ParameterizedTest
-      @EnumSource(value = UserRole::class, names = ["CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
-      fun `Get all tasks returns 200 when have CAS1_WORKFLOW_MANAGER OR CAS1_MATCHER roles`(role: UserRole) {
+      @EnumSource(value = UserRole::class, names = ["CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR"])
+      fun `Get all tasks returns 200 when have CAS1_WORKFLOW_MANAGER, CAS1_MATCHER or CAS1_ASSESSOR roles`(role: UserRole) {
         `Given a User`(roles = listOf(role)) { _, jwt ->
           `Given a User` { otherUser, _ ->
             `Given an Offender` { offenderDetails, _ ->


### PR DESCRIPTION
As a pre-requisite to allowing assesors to be assigned tasks, we need to ensure they can view any assigned tasks on the UI without a permissions error ocurring. This commit enables that functionality.