### PR TITLE
APS-1079 - Add indexes to optimise task workload query

### DIFF
--- a/src/main/resources/db/migration/all/20240716164234__add-indexes-to-optimise-task-workload-query.sql
+++ b/src/main/resources/db/migration/all/20240716164234__add-indexes-to-optimise-task-workload-query.sql
@@ -1,0 +1,3 @@
+CREATE INDEX assessments_allocation_idx ON assessments (allocated_to_user_id,reallocated_at);
+CREATE INDEX placement_requests_allocation_idx ON placement_requests (allocated_to_user_id,reallocated_at);
+CREATE INDEX placement_applications_allocation_idx ON placement_applications (allocated_to_user_id,reallocated_at);


### PR DESCRIPTION
This commits adds indexes to ‘task’ types in database to optimise any query that determines which tasks are allocated to a given user. We include ‘reallocated_at’ in this index because this is always checked alongside the allocated_to_user_id (because if reallocated, these tasks are effectively inactive and should be ignored)