### PR TITLE
APS-1022 - Add CAS1 ‘Gender for AP’ API property

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.GenderForAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationApplication
@@ -74,7 +75,8 @@ class ApplicationsTransformer(
         applicantUserDetails = jpa.applicantUserDetails?.let { cas1ApplicationUserDetailsTransformer.transformJpaToApi(it) },
         caseManagerIsNotApplicant = jpa.caseManagerIsNotApplicant,
         caseManagerUserDetails = jpa.caseManagerUserDetails?.let { cas1ApplicationUserDetailsTransformer.transformJpaToApi(it) },
-        apType = jpa.apType?.asApiType(),
+        apType = jpa.apType.asApiType(),
+        genderForAp = GenderForAp.male,
       )
 
       is DomainTemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1694,6 +1694,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            genderForAp:
+              $ref: '#/components/schemas/GenderForAp'
           required:
             - createdByUserId
             - schemaVersion
@@ -5047,3 +5049,8 @@ components:
         - past
         - current
         - future
+    GenderForAp:
+      type: string
+      enum:
+        - male
+        - female

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6107,6 +6107,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            genderForAp:
+              $ref: '#/components/schemas/GenderForAp'
           required:
             - createdByUserId
             - schemaVersion
@@ -9460,3 +9462,8 @@ components:
         - past
         - current
         - future
+    GenderForAp:
+      type: string
+      enum:
+        - male
+        - female

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2271,6 +2271,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            genderForAp:
+              $ref: '#/components/schemas/GenderForAp'
           required:
             - createdByUserId
             - schemaVersion
@@ -5624,3 +5626,8 @@ components:
         - past
         - current
         - future
+    GenderForAp:
+      type: string
+      enum:
+        - male
+        - female

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2285,6 +2285,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            genderForAp:
+              $ref: '#/components/schemas/GenderForAp'
           required:
             - createdByUserId
             - schemaVersion
@@ -5638,3 +5640,8 @@ components:
         - past
         - current
         - future
+    GenderForAp:
+      type: string
+      enum:
+        - male
+        - female

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1785,6 +1785,8 @@ components:
               type: boolean
             caseManagerUserDetails:
               $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            genderForAp:
+              $ref: '#/components/schemas/GenderForAp'
           required:
             - createdByUserId
             - schemaVersion
@@ -5138,3 +5140,8 @@ components:
         - past
         - current
         - future
+    GenderForAp:
+      type: string
+      enum:
+        - male
+        - female

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.GenderForAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
@@ -144,6 +145,7 @@ class ApplicationsTransformerTest {
     assertThat(result.applicantUserDetails!!.name).isEqualTo("applicant")
     assertThat(result.caseManagerIsNotApplicant).isTrue()
     assertThat(result.caseManagerUserDetails!!.name).isEqualTo("caseManager")
+    assertThat(result.genderForAp).isEqualTo(GenderForAp.male)
   }
 
   @Test


### PR DESCRIPTION
This being added in preparation for supporting Female APs, allowing us to add it in suitable places on the UI.

This is currently hardcoded to ‘Male’ as only applicants for Male APs are supported. As support for female APs is added this will be derived dynamically.