### PR TITLE
[FIX][APS-1065] Ensure out-of-service beds always sort correctly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.findAllByIdOrdered
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import java.time.LocalDate
@@ -280,7 +281,7 @@ class Cas1OutOfServiceBedService(
       getPageableOrAllPages(pageCriteria.withSortBy(sortFieldString), unsafe = true),
     )
 
-    val outOfServiceBeds = outOfServiceBedRepository.findAllById(page.content.map(UUID::fromString))
+    val outOfServiceBeds = outOfServiceBedRepository.findAllByIdOrdered(page.content.map(UUID::fromString))
 
     return Pair(outOfServiceBeds, getMetadata(page, pageCriteria))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RepositoryUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RepositoryUtils.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport
+import org.springframework.stereotype.Component
+import javax.annotation.PostConstruct
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+
+inline fun <reified T, ID> JpaRepository<T, ID>.findAllByIdOrdered(ids: List<ID>): List<T> {
+  return findAllByIdOrdered(ids, T::class.java)
+}
+
+fun <T, ID> JpaRepository<T, ID>.findAllByIdOrdered(ids: List<ID>, cls: Class<T>): List<T> {
+  if (!RepositoryUtilHelper.instanceExists()) {
+    return this.findAllById(ids)
+  }
+
+  val entityInformation = JpaEntityInformationSupport.getEntityInformation(cls, RepositoryUtilHelper.getEntityManager())
+
+  val resultsUnordered = this.findAllById(ids)
+
+  val resultsMap = resultsUnordered.associateBy {
+    @Suppress("UNCHECKED_CAST")
+    entityInformation.getId(it!!)!! as ID
+  }
+
+  return ids.map { resultsMap[it]!! }
+}
+
+@Component
+private class RepositoryUtilHelper(
+  private val entityManagerFactory: EntityManagerFactory,
+) {
+  @PostConstruct
+  @Suppress("UNUSED", "detekt:UnusedPrivateMember")
+  private fun postConstruct() {
+    instance = this
+  }
+
+  companion object {
+    private lateinit var instance: RepositoryUtilHelper
+
+    fun instanceExists(): Boolean {
+      val result = ::instance.isInitialized
+
+      if (!result) {
+        LoggerFactory
+          .getLogger(RepositoryUtilHelper::class.java)
+          .warn("No RepositoryUtilHelper instance has been initialised by the Spring context. Repository utility methods may not work correctly.")
+      }
+
+      return result
+    }
+
+    fun getEntityManager(): EntityManager = instance.entityManagerFactory.createEntityManager()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/util/RepositoryUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/util/RepositoryUtilsTest.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.util
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ApprovedPremisesTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.findAllByIdOrdered
+import java.util.UUID
+
+class RepositoryUtilsTest : IntegrationTestBase() {
+  @Nested
+  inner class FindAllByIdOrdered {
+    @Test
+    fun `Guarantees that results are returned in the same order as the supplied list of IDs`() {
+      val repository = mockk<ApprovedPremisesTestRepository>()
+
+      val id1 = UUID(1L, 1L)
+      val id2 = UUID(2L, 2L)
+      val id3 = UUID(3L, 3L)
+      val id4 = UUID(4L, 4L)
+
+      val expectedIds = listOf(
+        id1,
+        id2,
+        id3,
+        id4,
+      )
+
+      val premises1 = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .withId(id1)
+        .produce()
+
+      val premises2 = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .withId(id2)
+        .produce()
+
+      val premises3 = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .withId(id3)
+        .produce()
+
+      val premises4 = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .withId(id4)
+        .produce()
+
+      every { repository.findAllById(any()) } returns listOf(
+        premises2,
+        premises4,
+        premises3,
+        premises1,
+      )
+
+      val result = repository.findAllByIdOrdered(expectedIds)
+
+      assertThat(result).containsExactly(premises1, premises2, premises3, premises4)
+
+      val reversedResult = repository.findAllByIdOrdered(expectedIds.reversed())
+
+      assertThat(reversedResult).containsExactly(premises4, premises3, premises2, premises1)
+    }
+  }
+}


### PR DESCRIPTION
> See [APS-1065 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-1065).

Currently the `GET /cas1/out-of-service-beds` does not always sort as expected. This issue was not caught by unit or integration testing, which tests all sort fields in both ascending and descending order, and in the tests sorting works correctly.

The underlying issue is that the `findAllById` method provided on the `CrudRepository` interface (and by extension, our JPA repositories) explicitly does not guarantee the order of the returned results. The order is therefore dependent entirely on how the results are returned from the database, which may be non-deterministic.

This PR therefore introduces a new utility method to wrap the `findAllById` method while guaranteeing the order of the returned elements, which solves the issue. To do this, this PR adds the `findAllByIdOrdered` method as an extension to the `JpaRepository` interface, which guarantees that the returned entities will be ordered according to the provided list of
IDs, i.e. that the first entity will have as its ID the first element of the input list, the second entity will have the second element of the input list as its ID, and so on.

This is achieved by constructing a map from the results returned by the original `findAllById` method, using the ID as the key, and then transforming the input list of IDs to the desired entities using the map.

To do this in a generic way requires using reflection. This can be written manually, however it is possible to get the ID using a `JpaEntityInformation` instance. To do this requires an active `EntityManager`, which is difficult to get an instance of outside of a Spring context. Therefore, the `RepositoryUtilHelper` class acts as a bridge to the static context - as a Spring component, the `EntityManagerFactory` is autowired on construction, and the `@PostConstruct` method registers itself to the static `lateinit` instance - allowing it to be accessed by the utility functions.