### PR TITLE
Upper case CRN when call Approved-premises-and-delius endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
@@ -26,17 +26,17 @@ class ApDeliusContextApiClient(
 
   @Cacheable(value = ["teamsManagingCaseCache"], unless = IS_NOT_SUCCESSFUL)
   fun getTeamsManagingCase(crn: String) = getRequest<ManagingTeamsResponse> {
-    path = "/teams/managingCase/$crn"
+    path = "/teams/managingCase/${crn.uppercase()}"
   }
 
   @Cacheable(value = ["crnGetCaseDetailCache"], unless = IS_NOT_SUCCESSFUL)
   fun getCaseDetail(crn: String) = getRequest<CaseDetail> {
-    path = "/probation-cases/$crn/details"
+    path = "/probation-cases/${crn.uppercase()}/details"
   }
 
   fun getSummariesForCrns(crns: List<String>) = getRequest<CaseSummaries> {
     path = "/probation-cases/summaries"
-    body = crns
+    body = crns.map { it.uppercase() }
   }
 
   fun getUserAccessForCrns(deliusUsername: String, crns: List<String>) = getRequest<UserAccess> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -414,7 +414,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
   private fun createAndSubmitApplication(apType: ApType, crn: String, withArrivalDate: Boolean = true, shortNotice: Boolean = false): ApprovedPremisesApplicationEntity {
     val (referrer, jwt) = referrerDetails
     val (offenderDetails, _) = `Given an Offender`(
-      offenderDetailsConfigBlock = { withCrn(crn) },
+      offenderDetailsConfigBlock = { withCrn(crn.uppercase()) },
     )
 
     CommunityAPI_mockSuccessfulRegistrationsCall(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Name
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
 
@@ -613,7 +613,7 @@ class BookingSearchTest : IntegrationTestBase() {
         SortOrder.descending -> "descending"
       }
       val crns = mutableListOf<String>()
-      repeat(15) { crns += randomStringMultiCaseWithNumbers(8) }
+      repeat(15) { crns += randomStringUpperCase(8) }
 
       val applicationSchema = temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
         withPermissiveSchema()
@@ -630,7 +630,7 @@ class BookingSearchTest : IntegrationTestBase() {
         val offenderName = "${offendersCrnAndName[it]?.forename} ${offendersCrnAndName[it]?.surname}"
         val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
           withName(offenderName)
-          withCrn(it)
+          withCrn(it.uppercase())
           withProbationRegion(userEntity.probationRegion)
           withCreatedByUser(userEntity)
           withApplicationSchema(applicationSchema)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateApplicationOffenderNameJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas3UpdateApplicationOffenderNameJobTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addListCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 
 class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
 
@@ -39,6 +40,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
         temporaryAccommodationApplicationEntityFactory.produceAndPersist {
           withApplicationSchema(applicationSchema)
           withProbationRegion(probationRegion)
+          withCrn(randomStringUpperCase(8))
           withCreatedByUser(user)
         }
       }.take(10).toList()
@@ -91,6 +93,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
         temporaryAccommodationApplicationEntityFactory.produceAndPersist {
           withApplicationSchema(applicationSchema)
           withProbationRegion(probationRegion)
+          withCrn(randomStringUpperCase(8))
           withCreatedByUser(user)
         }
       }.take(10).toList()
@@ -144,6 +147,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
       val temporaryAccommodationApplication = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
         withApplicationSchema(applicationSchema)
         withProbationRegion(probationRegion)
+        withCrn(randomStringUpperCase(8))
         withCreatedByUser(user)
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -494,7 +494,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
 
   private fun createAndSubmitApplication(crn: String): ApprovedPremisesApplicationEntity {
     val (referrer, jwt) = referrerDetails
-    val (offenderDetails, _) = `Given an Offender`({ withCrn(crn) })
+    val (offenderDetails, _) = `Given an Offender`({ withCrn(crn.uppercase()) })
 
     CommunityAPI_mockSuccessfulRegistrationsCall(
       offenderDetails.otherIds.crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationReportTest.kt
@@ -312,7 +312,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
 
     fun assertRow(row: ApplicationReportRow, shouldIncludePii: Boolean = true) {
       assertThat(row.application_id).isEqualTo(application.id.toString())
-      assertThat(row.crn).isEqualTo("AppSubmittedWithSuccessfulAppealsClarificationsAndWithdrawn")
+      assertThat(row.crn).isEqualTo("APPSUBMITTEDWITHSUCCESSFULAPPEALSCLARIFICATIONSANDWITHDRAWN")
       assertThat(row.noms).isEqualTo("noms1")
       assertThat(row.age_in_years).isEqualTo("25")
       assertThat(row.gender).isEqualTo("Male")
@@ -469,7 +469,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
 
     fun assertRow(row: ApplicationReportRow) {
       assertThat(row.application_id).isEqualTo(application.id.toString())
-      assertThat(row.crn).isEqualTo("AppSubmittedWithAcceptedAssessment")
+      assertThat(row.crn).isEqualTo("APPSUBMITTEDWITHACCEPTEDASSESSMENT")
       assertThat(row.noms).isEqualTo("noms3")
       assertThat(row.age_in_years).isEqualTo("50")
       assertThat(row.gender).isEqualTo("Female")
@@ -574,7 +574,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
 
     fun assertRow(row: ApplicationReportRow) {
       assertThat(row.application_id).isEqualTo(application.id.toString())
-      assertThat(row.crn).isEqualTo("AppSubmittedNoAssessment")
+      assertThat(row.crn).isEqualTo("APPSUBMITTEDNOASSESSMENT")
       assertThat(row.noms).isEqualTo("noms2")
       assertThat(row.age_in_years).isEqualTo("20")
       assertThat(row.gender).isEqualTo("Female")
@@ -663,7 +663,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
 
     fun assertRow(row: ApplicationReportRow) {
       assertThat(row.application_id).isEqualTo(application.id.toString())
-      assertThat(row.crn).isEqualTo("appWithdrawnDuringReportingPeriod")
+      assertThat(row.crn).isEqualTo("APPWITHDRAWNDURINGREPORTINGPERIOD")
 
       assertThat(row.application_withdrawal_date).isEqualTo("2020-02-12T11:25:00Z")
       assertThat(row.application_withdrawal_reason).isEqualTo("death")
@@ -810,7 +810,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
     val (applicant, jwt) = applicantDetails
     val (offenderDetails, _) = `Given an Offender`(
       offenderDetailsConfigBlock = {
-        withCrn(crn)
+        withCrn(crn.uppercase())
         withDateOfBirth(dateOfBirth)
         withGender(gender)
         withNomsNumber(nomsNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -222,7 +222,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       assertThat(row.request_for_placement_id).matches("placement_request:[a-f0-9-]+")
       assertThat(row.request_for_placement_type).isEqualTo("STANDARD")
-      assertThat(row.crn).matches("StandardRFPNotAllocated")
+      assertThat(row.crn).matches("STANDARDRFPNOTALLOCATED")
     }
   }
 
@@ -278,7 +278,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.request_for_placement_id).matches("placement_request:[a-f0-9-]+")
       assertThat(row.request_for_placement_type).isEqualTo("STANDARD")
       assertThat(row.requested_arrival_date).isEqualTo("2020-02-02")
-      assertThat(row.crn).matches("StandardRFPMatched")
+      assertThat(row.crn).matches("STANDARDRFPMATCHED")
     }
   }
 
@@ -306,7 +306,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.request_for_placement_id).matches("placement_request:[a-f0-9-]+")
       assertThat(row.request_for_placement_type).isEqualTo("STANDARD")
       assertThat(row.requested_arrival_date).isEqualTo("2020-02-03")
-      assertThat(row.crn).matches("StandardRFPNotMatched")
+      assertThat(row.crn).matches("STANDARDRFPNOTMATCHED")
     }
   }
 
@@ -339,7 +339,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.request_for_placement_id).matches("placement_request:[a-f0-9-]+")
       assertThat(row.request_for_placement_type).isEqualTo("STANDARD")
       assertThat(row.requested_arrival_date).isEqualTo("2020-02-04")
-      assertThat(row.crn).matches("StandardRFPMNotMatchedAndThenMatched")
+      assertThat(row.crn).matches("STANDARDRFPMNOTMATCHEDANDTHENMATCHED")
     }
   }
 
@@ -379,7 +379,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.request_for_placement_id).matches("placement_application:[a-f0-9-]+")
       assertThat(row.request_for_placement_type).isEqualTo("ROTL")
       assertThat(row.requested_arrival_date).isEqualTo("2020-02-05")
-      assertThat(row.crn).matches("ROTLRFPMultiDates")
+      assertThat(row.crn).matches("ROTLRFPMULTIDATES")
     }
   }
 
@@ -500,12 +500,12 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
     val (applicant, jwt) = `Given a User`()
     val (offenderDetails, _) = `Given an Offender`(
       offenderDetailsConfigBlock = {
-        withCrn(crn)
+        withCrn(crn.uppercase())
       },
     )
 
     APDeliusContext_mockSuccessfulCaseDetailCall(
-      crn,
+      crn.uppercase(),
       CaseDetailFactory().from(offenderDetails.asCaseDetail()).produce(),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RequestForPlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RequestForPlacementReportTest.kt
@@ -272,7 +272,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_decision_made_date).isEqualTo("2020-12-01T09:15:45Z")
       assertThat(row.request_for_placement_withdrawal_date).isEqualTo("2021-03-15T00:10:00Z")
       assertThat(row.request_for_placement_withdrawal_reason).isEqualTo("DUPLICATE_PLACEMENT_REQUEST")
-      assertThat(row.crn).isEqualTo("StandardRFPAcceptedAndWithdrawnManager")
+      assertThat(row.crn).isEqualTo("STANDARDRFPACCEPTEDANDWITHDRAWNMANAGER")
     }
   }
 
@@ -308,7 +308,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_decision_made_date).isEqualTo("2020-04-01T09:15:45Z")
       assertThat(row.request_for_placement_withdrawal_date).isNull()
       assertThat(row.request_for_placement_withdrawal_reason).isNull()
-      assertThat(row.crn).isEqualTo("StandardRFPRejectedManager")
+      assertThat(row.crn).isEqualTo("STANDARDRFPREJECTEDMANAGER")
     }
   }
 
@@ -334,7 +334,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_decision_made_date).isNull()
       assertThat(row.request_for_placement_withdrawal_date).isNull()
       assertThat(row.request_for_placement_withdrawal_reason).isNull()
-      assertThat(row.crn).isEqualTo("StandardRFPNotAssessed")
+      assertThat(row.crn).isEqualTo("STANDARDRFPNOTASSESSED")
     }
   }
 
@@ -417,7 +417,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_decision_made_date).isEqualTo("2021-03-24T15:20:00Z")
       assertThat(row.request_for_placement_withdrawal_date).isNull()
       assertThat(row.request_for_placement_withdrawal_reason).isNull()
-      assertThat(row.crn).isEqualTo("${type}PlacementAppAssessed")
+      assertThat(row.crn).isEqualTo("${type}PlacementAppAssessed".uppercase())
     }
   }
 
@@ -471,7 +471,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_decision_made_date).isEqualTo("2025-12-01T15:20:00Z")
       assertThat(row.request_for_placement_withdrawal_date).isNull()
       assertThat(row.request_for_placement_withdrawal_reason).isNull()
-      assertThat(row.crn).isEqualTo("PlacementAppRejected")
+      assertThat(row.crn).isEqualTo("PLACEMENTAPPREJECTED")
     }
   }
 
@@ -564,12 +564,12 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
     val (applicant, jwt) = `Given a User`()
     val (offenderDetails, _) = `Given an Offender`(
       offenderDetailsConfigBlock = {
-        withCrn(crn)
+        withCrn(crn.uppercase())
       },
     )
 
     APDeliusContext_mockSuccessfulCaseDetailCall(
-      crn,
+      crn.uppercase(),
       CaseDetailFactory().from(offenderDetails.asCaseDetail()).produce(),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -82,11 +82,12 @@ fun IntegrationTestBase.`Given a Placement Application`(
   }
 }
 
+@SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.`Given a Placement Application`(
   assessmentDecision: AssessmentDecision = AssessmentDecision.ACCEPTED,
   createdByUser: UserEntity,
   schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity,
-  crn: String = randomStringMultiCaseWithNumbers(8),
+  crn: String = randomStringMultiCaseWithNumbers(8).uppercase(),
   allocatedToUser: UserEntity? = null,
   submittedAt: OffsetDateTime? = null,
   decision: PlacementApplicationDecision? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -77,7 +77,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   }
 
   val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
-    crn?.let { withCrn(it) }
+    crn?.let { withCrn(it.uppercase()) }
     name?.let { withName(it) }
     withCreatedByUser(createdByUser)
     withApplicationSchema(applicationSchema)


### PR DESCRIPTION
This PR is to make sure that when a call is made to Approved premises and delius endpoints the CRN is provided in uppercase as these endpoints are case sensitive