### PR TITLE
Add Seed Job to Force Updating User from Community API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateUsersFromApiSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateUsersFromApiSeedJob.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.util.UUID
+
+class UpdateUsersFromApiSeedJob(
+  fileName: String,
+  val userService: UserService,
+) : SeedJob<UpdateUserFromApiCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "delius_username",
+    "service_name",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = UpdateUserFromApiCsvRow(
+    deliusUsername = columns["delius_username"]!!.trim(),
+    serviceName = ServiceName.valueOf(columns["service_name"]!!.trim()),
+  )
+
+  override fun processRow(row: UpdateUserFromApiCsvRow) {
+    val username = row.deliusUsername
+    val service = row.serviceName
+
+    log.info("Updating user with username $username for service $service")
+    val user = userService.getExistingUserOrCreate(username)
+    userService.updateUserFromCommunityApiById(user.id, service)
+  }
+}
+
+data class UpdateUserFromApiCsvRow(
+  val deliusUsername: String,
+  val serviceName: ServiceName,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationBedspaceSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationPremisesSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UpdateUsersFromApiSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApStaffUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesBookingCancelSeedJob
@@ -317,6 +318,11 @@ class SeedService(
           filename,
           getBean(Cas1OutOfServiceBedService::class),
           getBean(PremisesService::class),
+        )
+
+        SeedFileType.updateUsersFromApi -> UpdateUsersFromApiSeedJob(
+          filename,
+          getBean(UserService::class),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -74,6 +74,7 @@ import java.io.IOException
 import java.nio.file.Path
 import javax.annotation.PostConstruct
 import kotlin.io.path.absolutePathString
+import kotlin.reflect.KClass
 
 @Service
 class SeedService(
@@ -159,163 +160,163 @@ class SeedService(
       val job: SeedJob<*> = when (seedFileType) {
         SeedFileType.approvedPremises -> ApprovedPremisesSeedJob(
           filename,
-          applicationContext.getBean(PremisesRepository::class.java),
-          applicationContext.getBean(ProbationRegionRepository::class.java),
-          applicationContext.getBean(LocalAuthorityAreaRepository::class.java),
-          applicationContext.getBean(CharacteristicRepository::class.java),
+          getBean(PremisesRepository::class),
+          getBean(ProbationRegionRepository::class),
+          getBean(LocalAuthorityAreaRepository::class),
+          getBean(CharacteristicRepository::class),
         )
         SeedFileType.approvedPremisesRooms -> ApprovedPremisesRoomsSeedJob(
           filename,
-          applicationContext.getBean(PremisesRepository::class.java),
-          applicationContext.getBean(RoomRepository::class.java),
-          applicationContext.getBean(BedRepository::class.java),
-          applicationContext.getBean(CharacteristicRepository::class.java),
+          getBean(PremisesRepository::class),
+          getBean(RoomRepository::class),
+          getBean(BedRepository::class),
+          getBean(CharacteristicRepository::class),
         )
         SeedFileType.user -> UsersSeedJob(
           filename,
           ServiceName.values().toList(),
-          applicationContext.getBean(UserService::class.java),
+          getBean(UserService::class),
         )
         SeedFileType.approvedPremisesApStaffUsers -> ApStaffUsersSeedJob(
           filename,
-          applicationContext.getBean(UserService::class.java),
+          getBean(UserService::class),
           seedLogger,
         )
         SeedFileType.nomisUsers -> NomisUsersSeedJob(
           filename,
-          applicationContext.getBean(NomisUserRepository::class.java),
+          getBean(NomisUserRepository::class),
         )
         SeedFileType.externalUsers -> ExternalUsersSeedJob(
           filename,
-          applicationContext.getBean(ExternalUserRepository::class.java),
+          getBean(ExternalUserRepository::class),
         )
         SeedFileType.cas2Applications -> Cas2ApplicationsSeedJob(
           filename,
-          applicationContext.getBean(Cas2ApplicationRepository::class.java),
-          applicationContext.getBean(NomisUserRepository::class.java),
-          applicationContext.getBean(ExternalUserRepository::class.java),
-          applicationContext.getBean(Cas2StatusUpdateRepository::class.java),
-          applicationContext.getBean(Cas2AssessmentRepository::class.java),
-          applicationContext.getBean(JsonSchemaService::class.java),
-          applicationContext.getBean(Cas2PersistedApplicationStatusFinder::class.java),
+          getBean(Cas2ApplicationRepository::class),
+          getBean(NomisUserRepository::class),
+          getBean(ExternalUserRepository::class),
+          getBean(Cas2StatusUpdateRepository::class),
+          getBean(Cas2AssessmentRepository::class),
+          getBean(JsonSchemaService::class),
+          getBean(Cas2PersistedApplicationStatusFinder::class),
         )
         SeedFileType.approvedPremisesUsers -> UsersSeedJob(
           filename,
           listOf(ServiceName.approvedPremises),
-          applicationContext.getBean(UserService::class.java),
+          getBean(UserService::class),
         )
         SeedFileType.temporaryAccommodationUsers -> UsersSeedJob(
           filename,
           listOf(ServiceName.temporaryAccommodation),
-          applicationContext.getBean(UserService::class.java),
+          getBean(UserService::class),
         )
         SeedFileType.characteristics -> CharacteristicsSeedJob(
           filename,
-          applicationContext.getBean(CharacteristicRepository::class.java),
+          getBean(CharacteristicRepository::class),
         )
         SeedFileType.updateNomsNumber -> Cas1UpdateNomsNumberSeedJob(
           filename,
-          applicationContext.getBean(ApplicationRepository::class.java),
-          applicationContext.getBean(ApplicationTimelineNoteService::class.java),
-          applicationContext.getBean(BookingRepository::class.java),
+          getBean(ApplicationRepository::class),
+          getBean(ApplicationTimelineNoteService::class),
+          getBean(BookingRepository::class),
         )
         SeedFileType.temporaryAccommodationPremises -> TemporaryAccommodationPremisesSeedJob(
           filename,
-          applicationContext.getBean(PremisesRepository::class.java),
-          applicationContext.getBean(ProbationRegionRepository::class.java),
-          applicationContext.getBean(LocalAuthorityAreaRepository::class.java),
-          applicationContext.getBean(ProbationDeliveryUnitRepository::class.java),
-          applicationContext.getBean(CharacteristicService::class.java),
+          getBean(PremisesRepository::class),
+          getBean(ProbationRegionRepository::class),
+          getBean(LocalAuthorityAreaRepository::class),
+          getBean(ProbationDeliveryUnitRepository::class),
+          getBean(CharacteristicService::class),
         )
         SeedFileType.temporaryAccommodationBedspace -> TemporaryAccommodationBedspaceSeedJob(
           filename,
-          applicationContext.getBean(PremisesRepository::class.java),
-          applicationContext.getBean(CharacteristicService::class.java),
-          applicationContext.getBean(RoomService::class.java),
+          getBean(PremisesRepository::class),
+          getBean(CharacteristicService::class),
+          getBean(RoomService::class),
         )
 
         SeedFileType.approvedPremisesOfflineApplications -> ApprovedPremisesOfflineApplicationsSeedJob(
           filename,
-          applicationContext.getBean(OfflineApplicationRepository::class.java),
+          getBean(OfflineApplicationRepository::class),
         )
 
         SeedFileType.approvedPremisesBookings -> ApprovedPremisesBookingSeedJob(
           filename,
-          applicationContext.getBean(BookingRepository::class.java),
-          applicationContext.getBean(BookingService::class.java),
-          applicationContext.getBean(CommunityApiClient::class.java),
-          applicationContext.getBean(BedRepository::class.java),
-          applicationContext.getBean(DepartureReasonRepository::class.java),
-          applicationContext.getBean(MoveOnCategoryRepository::class.java),
-          applicationContext.getBean(DestinationProviderRepository::class.java),
-          applicationContext.getBean(NonArrivalReasonRepository::class.java),
-          applicationContext.getBean(CancellationReasonRepository::class.java),
+          getBean(BookingRepository::class),
+          getBean(BookingService::class),
+          getBean(CommunityApiClient::class),
+          getBean(BedRepository::class),
+          getBean(DepartureReasonRepository::class),
+          getBean(MoveOnCategoryRepository::class),
+          getBean(DestinationProviderRepository::class),
+          getBean(NonArrivalReasonRepository::class),
+          getBean(CancellationReasonRepository::class),
         )
 
         SeedFileType.approvedPremisesCancelBookings -> ApprovedPremisesBookingCancelSeedJob(
           filename,
-          applicationContext.getBean(BookingService::class.java),
-          applicationContext.getBean(BookingRepository::class.java),
+          getBean(BookingService::class),
+          getBean(BookingRepository::class),
         )
 
         SeedFileType.approvedPremisesApAreaEmailAddresses -> Cas1ApAreaEmailAddressSeedJob(
           filename,
-          applicationContext.getBean(ApAreaRepository::class.java),
+          getBean(ApAreaRepository::class),
         )
 
         SeedFileType.approvedPremisesBookingAdhocProperty -> Cas1BookingAdhocPropertySeedJob(
           filename,
-          applicationContext.getBean(BookingRepository::class.java),
+          getBean(BookingRepository::class),
         )
 
         SeedFileType.approvedPremisesAssessmentMoreInfoBugFix -> Cas1FurtherInfoBugFixSeedJob(
           filename,
-          applicationContext.getBean(AssessmentRepository::class.java),
+          getBean(AssessmentRepository::class),
         )
 
         SeedFileType.approvedPremisesRedactAssessmentDetails -> Cas1RemoveAssessmentDetailsSeedJob(
           filename,
-          applicationContext.getBean(AssessmentRepository::class.java),
-          applicationContext.getBean(ObjectMapper::class.java),
-          applicationContext.getBean(ApplicationService::class.java),
+          getBean(AssessmentRepository::class),
+          getBean(ObjectMapper::class),
+          getBean(ApplicationService::class),
         )
 
         SeedFileType.approvedPremisesWithdrawPlacementRequest -> Cas1WithdrawPlacementRequestSeedJob(
           filename,
-          applicationContext.getBean(PlacementRequestService::class.java),
-          applicationContext.getBean(ApplicationService::class.java),
+          getBean(PlacementRequestService::class),
+          getBean(ApplicationService::class),
         )
 
         SeedFileType.approvedPremisesReplayDomainEvents -> Cas1DomainEventReplaySeedJob(
           filename,
-          applicationContext.getBean(DomainEventService::class.java),
+          getBean(DomainEventService::class),
         )
 
         SeedFileType.approvedPremisesDuplicateApplication -> Cas1DuplicateApplicationSeedJob(
           filename,
-          applicationContext.getBean(ApplicationService::class.java),
-          applicationContext.getBean(OffenderService::class.java),
+          getBean(ApplicationService::class),
+          getBean(OffenderService::class),
         )
 
         SeedFileType.approvedPremisesUpdateEventNumber -> Cas1UpdateEventNumberSeedJob(
           filename,
-          applicationContext.getBean(ApplicationService::class.java),
-          applicationContext.getBean(ApplicationRepository::class.java),
-          applicationContext.getBean(DomainEventRepository::class.java),
-          applicationContext.getBean(ObjectMapper::class.java),
+          getBean(ApplicationService::class),
+          getBean(ApplicationRepository::class),
+          getBean(DomainEventRepository::class),
+          getBean(ObjectMapper::class),
         )
 
         SeedFileType.approvedPremisesLinkBookingToPlacementRequest -> Cas1LinkedBookingToPlacementRequestSeedJob(
           filename,
-          applicationContext.getBean(PlacementRequestRepository::class.java),
-          applicationContext.getBean(BookingRepository::class.java),
-          applicationContext.getBean(ApplicationTimelineNoteService::class.java),
+          getBean(PlacementRequestRepository::class),
+          getBean(BookingRepository::class),
+          getBean(ApplicationTimelineNoteService::class),
         )
 
         SeedFileType.approvedPremisesOutOfServiceBeds -> Cas1OutOfServiceBedSeedJob(
           filename,
-          applicationContext.getBean(Cas1OutOfServiceBedService::class.java),
-          applicationContext.getBean(PremisesService::class.java),
+          getBean(Cas1OutOfServiceBedService::class),
+          getBean(PremisesService::class),
         )
       }
 
@@ -326,6 +327,8 @@ class SeedService(
       seedLogger.error("Unable to complete Seed Job", exception)
     }
   }
+
+  private fun <T : Any> getBean(clazz: KClass<T>) = applicationContext.getBean(clazz.java)
 
   private fun <T> processJob(job: SeedJob<T>, resolveCsvPath: SeedJob<T>.() -> String) {
     // During processing, the CSV file is processed one row at a time to avoid OOM issues.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -201,7 +201,7 @@ class UserService(
     return AuthorisableActionResult.Success(user)
   }
 
-  fun updateUserFromCommunityApiById(id: UUID, forService: ServiceName): AuthorisableActionResult<UserEntity> {
+  fun updateUserFromCommunityApiById(id: UUID, forService: ServiceName, force: Boolean = false): AuthorisableActionResult<UserEntity> {
     var user = userRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()
 
     val deliusUser = when (val staffUserDetailsResponse = communityApiClient.getStaffUserDetails(user.deliusUsername)) {
@@ -209,7 +209,7 @@ class UserService(
       is ClientResult.Failure -> staffUserDetailsResponse.throwException()
     }
 
-    if (userHasChanged(user, deliusUser)) {
+    if (userHasChanged(user, deliusUser) || force) {
       user = updateUser(user, deliusUser, forService)
     }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3921,6 +3921,7 @@ components:
         - approved_premises_users
         - characteristics
         - update_noms_number
+        - update_users_from_api
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8334,6 +8334,7 @@ components:
         - approved_premises_users
         - characteristics
         - update_noms_number
+        - update_users_from_api
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4574,6 +4574,7 @@ components:
         - approved_premises_users
         - characteristics
         - update_noms_number
+        - update_users_from_api
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4512,6 +4512,7 @@ components:
         - approved_premises_users
         - characteristics
         - update_noms_number
+        - update_users_from_api
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4012,6 +4012,7 @@ components:
         - approved_premises_users
         - characteristics
         - update_noms_number
+        - update_users_from_api
         - approved_premises_ap_staff_users
         - approved_premises_offline_applications
         - approved_premises_bookings

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MigrationJobScaffoldingTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class MigrationJobScaffoldingTest : SeedTestBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCharacteristicsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCharacteristicsTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class SeedCharacteristicsTest : SeedTestBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedCsvRow

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/ApStaffUsersSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/ApStaffUsersSeedJobTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesBookingCancellationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesBookingCancellationTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.CancelBookingSeedCsvRow
 import java.util.UUID

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesOfflineApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesOfflineApplicationsTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.OfflineApplicationsSeedCsvRow
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesRoomsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesRoomsTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesRoomsSeedCsvRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesTest.kt
@@ -11,7 +11,7 @@ import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.PrecisionModel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesSeedCsvRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDouble

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedAssessmentMoreInfoBugFixTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedAssessmentMoreInfoBugFixTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedCsvRow

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedBookingsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedBookingsTest.kt
@@ -11,12 +11,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Approved Premises Bed`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesBookingSeedCsvRow

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ApAreaEmailAddressTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ApAreaEmailAddressTest.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedCsvRow
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingAdhocPropertyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingAdhocPropertyTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import java.util.UUID
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DomainEventReplayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DomainEventReplayTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DomainEventReplaySeedCsvRow

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
@@ -7,11 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulNeedsDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
@@ -5,8 +5,8 @@ import io.github.bluegroundltd.kfactory.Yielded
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Approved Premises Bed`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -8,9 +8,9 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Region
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Team
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed.SeedCasUpdateEventNumberTest.CONSTANTS.NEW_CONVICTION_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed.SeedCasUpdateEventNumberTest.CONSTANTS.NEW_EVENT_NUMBER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed.SeedCasUpdateEventNumberTest.CONSTANTS.NEW_OFFENCE_ID
@@ -32,6 +31,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed.Se
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed.SeedCasUpdateEventNumberTest.CONSTANTS.OLD_OFFENCE_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
@@ -8,7 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedExternalUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedExternalUsersTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedNomisUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedNomisUsersTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedScaffoldingTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationBedspaceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationPremisesTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationSmokeTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.TestInstance
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.LogEntry

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateUsersFromApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateUsersFromApiTest.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedUpdateUsersFromApiTest : SeedTestBase() {
+
+  companion object {
+    const val USERNAME: String = "KNOWN-USERNAME"
+  }
+
+  @Test
+  fun `Update existing user`() {
+    userEntityFactory.produceAndPersist {
+      withDeliusUsername(USERNAME)
+      withEmail("oldemail@localhost")
+      withYieldedProbationRegion {
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        }
+      }
+    }
+
+    CommunityAPI_mockSuccessfulStaffUserDetailsCall(
+      StaffUserDetailsFactory()
+        .withUsername(USERNAME)
+        .withEmail("updatedemail@localhost")
+        .produce(),
+    )
+
+    val csv = CsvBuilder()
+      .withUnquotedFields(
+        "delius_username",
+        "service_name",
+      )
+      .newRow()
+      .withQuotedField(USERNAME)
+      .withQuotedField(ServiceName.approvedPremises)
+      .newRow()
+      .build()
+
+    withCsv("known-user-csv", csv)
+
+    seedService.seedData(SeedFileType.updateUsersFromApi, "known-user-csv")
+
+    val persistedUser = userRepository.findByDeliusUsername(USERNAME)
+
+    assertThat(persistedUser).isNotNull
+    assertThat(persistedUser!!.email).isEqualTo("updatedemail@localhost")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded


### PR DESCRIPTION
There is a requirement to be able to re-evaluate some user’s AP Areas in production as they are currently associated with the deprecated ‘National’ AP Area.

This commit adds a seed job to force an update of users from the community API to satisfy that requirement.