### PR TITLE
Fix an issue in CAS3 Booking report to calculate Actual Nights Stayed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
@@ -62,7 +62,7 @@ class BookingsReportGenerator : ReportGenerator<BookingsReportDataAndPersonInfo,
         actualNightsStayed = if (booking.startDate == null) {
           null
         } else {
-          booking.actualEndDate?.let { ChronoUnit.DAYS.between(LocalDateTime.of(booking.startDate, LocalTime.MAX), it.toLocalDateTime()).toInt() }
+          booking.actualEndDate?.let { ChronoUnit.DAYS.between(LocalDateTime.of(booking.startDate, LocalTime.MAX), it.toLocalDateTime()).toInt() + 1 }
         },
         accommodationOutcome = booking.accommodationOutcome,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -499,7 +499,7 @@ class BookingsReportGeneratorTest {
       BookingsReportProperties(ServiceName.approvedPremises, null, startDate, endDate),
     )
     assertThat(actual.count()).isEqualTo(1)
-    assertThat(actual[0][BookingsReportRow::actualNightsStayed]).isEqualTo(86L)
+    assertThat(actual[0][BookingsReportRow::actualNightsStayed]).isEqualTo(87L)
   }
 
   @Test


### PR DESCRIPTION
This [PR CAS-483](https://dsdmoj.atlassian.net/browse/CAS-483) is to fix in issue in calculate the Actual Nights Stayed to include start date in CAS3 booking report