### PR TITLE
CAS-445 Get current user details from delius and update

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -109,6 +109,16 @@ class UsersController(
     )
   }
 
+  override fun getCurrentUserDetails(xServiceName: ServiceName): ResponseEntity<User> {
+    if (!userAccessService.userCanViewOwnUserDetails()) {
+      throw ForbiddenProblem()
+    }
+
+    val userFromDelius = userService.getUpdatedCurrentUserDetails(xServiceName)
+    val userTransformed = userTransformer.transformJpaToApi(userFromDelius, xServiceName)
+    return ResponseEntity.ok(userTransformed)
+  }
+
   override fun usersDeliusGet(name: String, xServiceName: ServiceName): ResponseEntity<User> {
     if (!userAccessService.currentUserCanManageUsers(xServiceName)) {
       throw ForbiddenProblem()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -212,6 +212,8 @@ class UserAccessService(
     else -> false
   }
 
+  fun userCanViewOwnUserDetails() = userService.getUserForRequest().hasAnyRole(UserRole.CAS3_REFERRER)
+
   fun currentUserCanManageUsers(xServiceName: ServiceName): Boolean {
     val user = userService.getUserForRequest()
     return (

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3PersonDepartureUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3ReferralSubmittedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
@@ -203,7 +204,7 @@ class DomainEventService(
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
-        service = "CAS3",
+        service = ServiceName.temporaryAccommodation.name,
         triggerSource = null,
         triggeredByUserId = null,
       ),

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3197,7 +3197,7 @@ components:
         propertyName: service
         mapping:
           CAS1: '#/components/schemas/ApprovedPremisesUser'
-          CAS3: '#/components/schemas/TemporaryAccommodationUser'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationUser'
       required:
         - service
         - id

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4238,6 +4238,38 @@ paths:
                 $ref: '_shared.yml#/components/schemas/Problem'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /users/me:
+    get:
+      operationId: getCurrentUserDetails
+      tags:
+        - User
+      summary: Returns the user details from delius for the signed in user
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '_shared.yml#/components/schemas/ServiceName'
+      responses:
+        200:
+          description: successfully retrieved user details
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/User'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: User not found
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /seed:
     post:
       summary: Starts the data seeding process, can only be called from a local connection

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4240,6 +4240,38 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /users/me:
+    get:
+      operationId: getCurrentUserDetails
+      tags:
+        - User
+      summary: Returns the user details from delius for the signed in user
+      parameters:
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+      responses:
+        200:
+          description: successfully retrieved user details
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/User'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: User not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /seed:
     post:
       summary: Starts the data seeding process, can only be called from a local connection
@@ -7610,7 +7642,7 @@ components:
         propertyName: service
         mapping:
           CAS1: '#/components/schemas/ApprovedPremisesUser'
-          CAS3: '#/components/schemas/TemporaryAccommodationUser'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationUser'
       required:
         - service
         - id

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3850,7 +3850,7 @@ components:
         propertyName: service
         mapping:
           CAS1: '#/components/schemas/ApprovedPremisesUser'
-          CAS3: '#/components/schemas/TemporaryAccommodationUser'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationUser'
       required:
         - service
         - id

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3788,7 +3788,7 @@ components:
         propertyName: service
         mapping:
           CAS1: '#/components/schemas/ApprovedPremisesUser'
-          CAS3: '#/components/schemas/TemporaryAccommodationUser'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationUser'
       required:
         - service
         - id

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3288,7 +3288,7 @@ components:
         propertyName: service
         mapping:
           CAS1: '#/components/schemas/ApprovedPremisesUser'
-          CAS3: '#/components/schemas/TemporaryAccommodationUser'
+          temporary-accommodation: '#/components/schemas/TemporaryAccommodationUser'
       required:
         - service
         - id


### PR DESCRIPTION
This commit adds and endpoint to return the current users details as stored in delius, as well as updating the user table so it's up to date. 

It uses the existing community api rather than the integration services, as the code is existing and other things are using the user table, this will require extra caution and testing, so will transition to use the integration service when the rest of the app changes over.