### PR TITLE
Deprecate unpopulated ap-delius-context field

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
@@ -47,6 +47,7 @@ data class Ldu(
 data class Profile(
   val ethnicity: String?,
   val genderIdentity: String?,
+  @Deprecated("This is not currently populated by ap-delius-context")
   val selfDescribedGender: String?,
   val nationality: String?,
   val religion: String?,


### PR DESCRIPTION
After reviewing the ap-and-delius-context open api spec i’ve found a field that we include in our response model that isn’t provided by the API. This commit deprecates that field to make it clear in the code that it isn’t currently populate whilst we determine what to do about this fields usage