### PR TITLE
APS-1068: add missing risk characteristic (CAS1 spaces)

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -644,6 +644,7 @@ components:
       enum:
         - atRiskOfExploitation
         - arson
+        - hateBasedOffences
         - posesSexualRiskToAdults
         - posesSexualRiskToChildren
         - posesNonSexualRiskToChildren

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5057,6 +5057,7 @@ components:
       enum:
         - atRiskOfExploitation
         - arson
+        - hateBasedOffences
         - posesSexualRiskToAdults
         - posesSexualRiskToChildren
         - posesNonSexualRiskToChildren

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1297,6 +1297,7 @@ components:
       enum:
         - atRiskOfExploitation
         - arson
+        - hateBasedOffences
         - posesSexualRiskToAdults
         - posesSexualRiskToChildren
         - posesNonSexualRiskToChildren

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1235,6 +1235,7 @@ components:
       enum:
         - atRiskOfExploitation
         - arson
+        - hateBasedOffences
         - posesSexualRiskToAdults
         - posesSexualRiskToChildren
         - posesNonSexualRiskToChildren

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -735,6 +735,7 @@ components:
       enum:
         - atRiskOfExploitation
         - arson
+        - hateBasedOffences
         - posesSexualRiskToAdults
         - posesSexualRiskToChildren
         - posesNonSexualRiskToChildren


### PR DESCRIPTION
We missed the `hateBasedOffences` risk characteristic which we'll use when finding and booking CAS1 spaces