### PR TITLE
Deprecate community api getOffender and cache

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/OffenderDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/OffenderDetailsCacheRefreshWorker.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PreemptiveCacheEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 
+@Deprecated("All usages of this cache are deprecated, therefore the cache should be cleared and then removed")
 class OffenderDetailsCacheRefreshWorker(
   private val applicationRepository: ApplicationRepository,
   private val bookingRepository: BookingRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -38,6 +38,7 @@ class CommunityApiClient(
     hardTtlSeconds = Duration.ofHours(12).toSeconds().toInt(),
   )
 
+  @Deprecated("To get offender details use [OffenderService.getOffenderByCrn] which delegates to ap-delius-context")
   fun getOffenderDetailSummaryWithCall(crn: String) = getRequest<OffenderDetailSummary> {
     path = "/secure/offenders/crn/$crn"
     isPreemptiveCall = true
@@ -45,6 +46,7 @@ class CommunityApiClient(
     preemptiveCacheKey = crn
   }
 
+  @Deprecated("To get offender details use  [OffenderService.getOffenderByCrn] which delegates to ap-delius-context")
   fun getOffenderDetailsCacheEntryStatus(crn: String) = checkPreemptiveCacheStatus(offenderDetailCacheConfig, crn)
 
   @Cacheable(value = ["staffDetailsCache"], unless = IS_NOT_SUCCESSFUL)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -429,7 +429,6 @@ class ApplicationTest : IntegrationTestBase() {
 
         val application = produceAndPersistBasicApplication(crn, userEntity, "TEAM1")
         CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-        loadPreemptiveCacheForOffenderDetails(crn)
 
         CommunityAPI_mockOffenderUserAccessCall(userEntity.deliusUsername, crn, inclusion = false, exclusion = false)
 
@@ -1643,7 +1642,6 @@ class ApplicationTest : IntegrationTestBase() {
         val crn = "X1234"
 
         CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-        loadPreemptiveCacheForOffenderDetails(crn)
 
         approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
           withAddedAt(OffsetDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CaseNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CaseNotesTest.kt
@@ -67,7 +67,6 @@ class CaseNotesTest : IntegrationTestBase() {
               .withStatus(404),
           ),
       )
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/prison-case-notes")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -29,7 +29,6 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -288,9 +287,6 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var redisTemplate: RedisTemplate<String, String>
-
-  @Autowired
-  private lateinit var communityApiClient: CommunityApiClient
 
   @Autowired
   private lateinit var prisonsApiClient: PrisonsApiClient
@@ -960,7 +956,6 @@ abstract class IntegrationTestBase {
     block()
   }
 
-  fun loadPreemptiveCacheForOffenderDetails(crn: String) = communityApiClient.getOffenderDetailSummaryWithCall(crn)
   fun loadPreemptiveCacheForInmateDetails(nomsNumber: String) = prisonsApiClient.getInmateDetailsWithCall(nomsNumber)
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAcctAlertsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAcctAlertsTest.kt
@@ -58,7 +58,6 @@ class PersonAcctAlertsTest : InitialiseDatabasePerClassTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/acct-alerts")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
@@ -60,7 +60,6 @@ class PersonAdjudicationsTest : InitialiseDatabasePerClassTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/adjudications")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRiskToSelfTest.kt
@@ -78,7 +78,6 @@ class PersonOASysRiskToSelfTest : InitialiseDatabasePerClassTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/oasys/risk-to-self")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysRoshTest.kt
@@ -93,7 +93,6 @@ class PersonOASysRoshTest : InitialiseDatabasePerClassTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/oasys/rosh")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
@@ -67,7 +67,6 @@ class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/oasys/sections")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSelectionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSelectionTest.kt
@@ -59,7 +59,6 @@ class PersonOASysSelectionTest : InitialiseDatabasePerClassTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/oasys/selection")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOffencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOffencesTest.kt
@@ -59,7 +59,6 @@ class PersonOffencesTest : InitialiseDatabasePerClassTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/offences")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
@@ -80,7 +80,6 @@ class PersonRisksTest : InitialiseDatabasePerClassTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/people/$crn/risks")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -476,7 +476,6 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
         produceAndPersistBasicApplication(crn, userEntity)
         CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-        loadPreemptiveCacheForOffenderDetails(crn)
 
         webTestClient.get()
           .uri("/cas2/applications")
@@ -1483,7 +1482,6 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           val crn = "X1234"
 
           CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-          loadPreemptiveCacheForOffenderDetails(crn)
 
           cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
             withAddedAt(OffsetDateTime.now())
@@ -1551,7 +1549,6 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           val crn = "X1234"
 
           CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-          loadPreemptiveCacheForOffenderDetails(crn)
 
           cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
             withAddedAt(OffsetDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRiskToSelfTest.kt
@@ -64,7 +64,6 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/cas2/people/$crn/oasys/risk-to-self")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonOASysRoshTest.kt
@@ -63,7 +63,6 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/cas2/people/$crn/oasys/rosh")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2PersonRisksTest.kt
@@ -65,7 +65,6 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
       val crn = "CRN123"
 
       CommunityAPI_mockNotFoundOffenderDetailsCall(crn)
-      loadPreemptiveCacheForOffenderDetails(crn)
 
       webTestClient.get()
         .uri("/cas2/people/$crn/risks")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -57,8 +57,6 @@ fun IntegrationTestBase.`Given an Offender`(
       .produce(),
   )
 
-  loadPreemptiveCacheForOffenderDetails(offenderDetails.otherIds.crn)
-
   when (mockServerErrorForPrisonApi) {
     true -> PrisonAPI_mockServerErrorInmateDetailsCall(inmateDetails.offenderNo)
     false -> PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetails)
@@ -131,8 +129,6 @@ fun IntegrationTestBase.`Given Some Offenders`(
         .withUserRestricted(offenderDetails.currentRestriction)
         .produce(),
     )
-
-    loadPreemptiveCacheForOffenderDetails(offenderDetails.otherIds.crn)
 
     PrisonAPI_mockSuccessfulInmateDetailsCall(inmateDetails)
 


### PR DESCRIPTION
After this commit we are in the position to remove the cache and the corresponding cache worker