### PR TITLE
APS-969 - Allow ASSESSORs to assess placement_applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateUsersPduFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/Cas3UpdateUsersPduFromCommunityApiJob.kt
@@ -14,7 +14,7 @@ class Cas3UpdateUsersPduFromCommunityApiJob(
   @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught")
   override fun process() {
     val cas3Roles = listOf(UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER, UserRole.CAS3_REPORTER)
-    userRepository.findActiveUsersWithRoles(cas3Roles).forEach {
+    userRepository.findActiveUsersWithAtLeastOneRole(cas3Roles).forEach {
       migrationLogger.info("Updating user PDU. User id ${it.id}")
       try {
         userService.updateUserPduFromCommunityApiById(it.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
@@ -142,7 +142,7 @@ class PlacementApplicationService(
       )
     }
 
-    if (!assigneeUser.hasRole(UserRole.CAS1_MATCHER)) {
+    if (!assigneeUser.hasPermission(UserPermission.CAS1_ASSESS_PLACEMENT_APPLICATION)) {
       return AuthorisableActionResult.Success(
         ValidatableActionResult.FieldValidationError(
           ValidationErrors().apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -154,7 +154,7 @@ class UserService(
       requiredRole = requiredRole.filter { it != UserRole.CAS1_APPEALS_MANAGER }
     }
 
-    var users = userRepository.findActiveUsersWithRoles(requiredRole)
+    var users = userRepository.findActiveUsersWithAtLeastOneRole(requiredRole)
 
     userQualifications.forEach { qualification ->
       users = users.filter { it.hasQualification(qualification) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -73,6 +73,7 @@ class ProfileTest : IntegrationTestBase() {
                 permissions = listOf(
                   ApprovedPremisesUserPermission.assessApplication,
                   ApprovedPremisesUserPermission.assessAppealedApplication,
+                  ApprovedPremisesUserPermission.assessPlacementApplication,
                   ApprovedPremisesUserPermission.viewAssignedAssessments,
                 ),
               ),
@@ -258,6 +259,7 @@ class ProfileTest : IntegrationTestBase() {
                   permissions = listOf(
                     ApprovedPremisesUserPermission.assessApplication,
                     ApprovedPremisesUserPermission.assessAppealedApplication,
+                    ApprovedPremisesUserPermission.assessPlacementApplication,
                     ApprovedPremisesUserPermission.viewAssignedAssessments,
                   ),
                 ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -2189,7 +2189,7 @@ class TasksTest {
     }
 
     @Test
-    fun `Get a Placement Application Task for an application returns users with MATCHER roles`() {
+    fun `Get a Placement Application Task for an application returns users with MATCHER or ASSESSOR roles`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
 
         val (matcherUser1, _) = `Given a User`(
@@ -2239,6 +2239,10 @@ class TasksTest {
                       ),
                       userTransformer.transformJpaToAPIUserWithWorkload(
                         matcherUser2,
+                        UserWorkload(0, 0, 0),
+                      ),
+                      userTransformer.transformJpaToAPIUserWithWorkload(
+                        assessorUser,
                         UserWorkload(0, 0, 0),
                       ),
                       userTransformer.transformJpaToAPIUserWithWorkload(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -464,12 +464,13 @@ class PlacementApplicationServiceTest {
       ),
     )
 
-    @Test
-    fun `Reallocating an allocated application returns successfully`() {
+    @CsvSource("CAS1_MATCHER,CAS1_ASSESSOR")
+    @ParameterizedTest
+    fun `Reallocating an allocated application returns successfully`(role: UserRole) {
       assigneeUser.apply {
         roles += UserRoleAssignmentEntityFactory()
           .withUser(this)
-          .withRole(UserRole.CAS1_MATCHER)
+          .withRole(role)
           .produce()
       }
 
@@ -658,7 +659,7 @@ class PlacementApplicationServiceTest {
     }
 
     @Test
-    fun `Reallocating a placement application when user to assign to is not a MATCHER returns a field validation error`() {
+    fun `Reallocating a placement application when user to assign to is not a MATCHER or ASSESSOR returns a field validation error`() {
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
       val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -899,7 +899,7 @@ class UserServiceTest {
         .withDefaultProbationRegion()
         .produce()
 
-      every { mockUserRepository.findActiveUsersWithRoles(any()) } returns listOf(userWithLao, userWithoutLao)
+      every { mockUserRepository.findActiveUsersWithAtLeastOneRole(any()) } returns listOf(userWithLao, userWithoutLao)
       every { mockFeatureFlagService.getBooleanFlag(any()) } returns true
 
       val allocatableUser = userService.getAllocatableUsersForAllocationType(
@@ -919,7 +919,7 @@ class UserServiceTest {
         .withDefaultProbationRegion()
         .produce()
 
-      every { mockUserRepository.findActiveUsersWithRoles(any()) } returns listOf(user)
+      every { mockUserRepository.findActiveUsersWithAtLeastOneRole(any()) } returns listOf(user)
       every { mockFeatureFlagService.getBooleanFlag(any()) } returns true
 
       val allocatableUser = userService.getAllocatableUsersForAllocationType(
@@ -928,7 +928,7 @@ class UserServiceTest {
         UserPermission.CAS1_ASSESS_APPEALED_APPLICATION,
       )
 
-      verify(exactly = 1) { mockUserRepository.findActiveUsersWithRoles(listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS1_APPEALS_MANAGER)) }
+      verify(exactly = 1) { mockUserRepository.findActiveUsersWithAtLeastOneRole(listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS1_APPEALS_MANAGER)) }
     }
   }
 }


### PR DESCRIPTION
This commit allows users with the role ASSESSOR to be considered when allocating/reallocating assessments of placement applications by including them in the task’s users list.

This commit also changes permissions on various endpoints required to complete the assessment of a placement application, ensuring users with the ASSESSOR role can access them.