### PR TITLE
Deprecate OffenderDetailSummary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
@@ -2,6 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community
 
 import java.time.LocalDate
 
+@Deprecated(
+  """This is the community api model. Instead we should be using [CaseSummary] which is the model provided by 
+    ap-and-delius, which has been tailored for CAS usage. See APS-1085 for some notes on how to replace usage of this 
+    class in some circumstances. Note that OffenderDetailsUtils provides functions to convert between these two types"""
+)
 data class OffenderDetailSummary(
   val offenderId: Long?,
   val title: String?,


### PR DESCRIPTION
OffenderDetailSummary is from the community api model. Instead we should be using [CaseSummary] which is the model provided by ap-and-delius, which has been tailored for CAS usage. Currently we use both which is confusing and duplication of effort.

See APS-1085 for some notes on how to replace usage of this class in some circumstances. Note that OffenderDetailsUtils provides functions to convert between these two types