### PR TITLE
Increase probation offender search api client

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -25,6 +25,7 @@ class WebClientConfiguration(
   @Value("\${case-notes-service-upstream-timeout-ms}") private val caseNotesServiceUpstreamTimeoutMs: Long,
   @Value("\${web-clients.max-response-in-memory-size-bytes}") private val defaultMaxResponseInMemorySizeBytes: Int,
   @Value("\${web-clients.prison-api-max-response-in-memory-size-bytes}") private val prisonApiMaxResponseInMemorySizeBytes: Int,
+  @Value("\${web-clients.probation-offender-search-api-max-response-in-memory-size-bytes}") private val probationOffenderSearchApiMaxResponseInMemorySizeBytes: Int,
 ) {
 
   private val log = LoggerFactory.getLogger(this::class.java)
@@ -279,7 +280,7 @@ class WebClientConfiguration(
       .filter(oauth2Client)
       .exchangeStrategies(
         ExchangeStrategies.builder().codecs {
-          it.defaultCodecs().maxInMemorySize(defaultMaxResponseInMemorySizeBytes)
+          it.defaultCodecs().maxInMemorySize(probationOffenderSearchApiMaxResponseInMemorySizeBytes)
         }.build(),
       )
       .build()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/community/OffenderDetailSummary.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 @Deprecated(
   """This is the community api model. Instead we should be using [CaseSummary] which is the model provided by 
     ap-and-delius, which has been tailored for CAS usage. See APS-1085 for some notes on how to replace usage of this 
-    class in some circumstances. Note that OffenderDetailsUtils provides functions to convert between these two types"""
+    class in some circumstances. Note that OffenderDetailsUtils provides functions to convert between these two types""",
 )
 data class OffenderDetailSummary(
   val offenderId: Long?,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -262,6 +262,8 @@ case-notes-service-upstream-timeout-ms: 30000
 web-clients:
   # 0.7MB
   max-response-in-memory-size-bytes: 750000
+  # 1.5MB
+  probation-offender-search-api-max-response-in-memory-size-bytes: 1572864
   # 2.5 MB
   prison-api-max-response-in-memory-size-bytes: 2621440
 


### PR DESCRIPTION
Testing in dev has identified that the default buffer size is insufficient when calling the probation offender search api. This commit increases the size of that buffer.