### PR TITLE
APS-1085 Improve PersonTransformer readability

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
@@ -13,81 +14,102 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateS
 
 @Component
 class PersonTransformer {
-  fun transformModelToPersonApi(personInfoResult: PersonInfoResult) = when (personInfoResult) {
-    is PersonInfoResult.Success.Full -> FullPerson(
-      type = PersonType.fullPerson,
-      crn = personInfoResult.offenderDetailSummary.otherIds.crn,
-      pncNumber = personInfoResult.offenderDetailSummary.otherIds.pncNumber,
-      name = "${personInfoResult.offenderDetailSummary.firstName} ${personInfoResult.offenderDetailSummary.surname}",
-      dateOfBirth = personInfoResult.offenderDetailSummary.dateOfBirth,
-      sex = personInfoResult.offenderDetailSummary.gender,
-      status = inmateStatusToPersonInfoApiStatus(personInfoResult.inmateDetail?.custodyStatus),
-      nomsNumber = personInfoResult.inmateDetail?.offenderNo,
-      ethnicity = personInfoResult.offenderDetailSummary.offenderProfile.ethnicity,
-      nationality = personInfoResult.offenderDetailSummary.offenderProfile.nationality,
-      religionOrBelief = personInfoResult.offenderDetailSummary.offenderProfile.religion,
-      genderIdentity = when (personInfoResult.offenderDetailSummary.offenderProfile.genderIdentity) {
-        "Prefer to self-describe" -> personInfoResult.offenderDetailSummary.offenderProfile.selfDescribedGender
-        else -> personInfoResult.offenderDetailSummary.offenderProfile.genderIdentity
-      },
-      prisonName = inmateStatusToPersonInfoApiStatus(personInfoResult.inmateDetail?.custodyStatus).takeIf { it == PersonStatus.inCustody }?.let {
-        personInfoResult.inmateDetail?.assignedLivingUnit?.agencyName ?: personInfoResult.inmateDetail?.assignedLivingUnit?.agencyId
-      },
-      isRestricted = (personInfoResult.offenderDetailSummary.currentExclusion || personInfoResult.offenderDetailSummary.currentRestriction),
-    )
-    is PersonInfoResult.Success.Restricted -> RestrictedPerson(
-      type = PersonType.restrictedPerson,
-      crn = personInfoResult.crn,
-    )
-    is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> UnknownPerson(
-      type = PersonType.unknownPerson,
-      crn = personInfoResult.crn,
-    )
+  fun transformModelToPersonApi(personInfoResult: PersonInfoResult): Person {
+    return when (personInfoResult) {
+      is PersonInfoResult.Success.Full -> {
+        val offenderDetailSummary = personInfoResult.offenderDetailSummary
+        val inmateDetail = personInfoResult.inmateDetail
+        FullPerson(
+          type = PersonType.fullPerson,
+          crn = offenderDetailSummary.otherIds.crn,
+          pncNumber = offenderDetailSummary.otherIds.pncNumber,
+          name = "${offenderDetailSummary.firstName} ${offenderDetailSummary.surname}",
+          dateOfBirth = offenderDetailSummary.dateOfBirth,
+          sex = offenderDetailSummary.gender,
+          status = inmateStatusToPersonInfoApiStatus(inmateDetail?.custodyStatus),
+          nomsNumber = inmateDetail?.offenderNo,
+          ethnicity = offenderDetailSummary.offenderProfile.ethnicity,
+          nationality = offenderDetailSummary.offenderProfile.nationality,
+          religionOrBelief = offenderDetailSummary.offenderProfile.religion,
+          genderIdentity = when (offenderDetailSummary.offenderProfile.genderIdentity) {
+            "Prefer to self-describe" -> offenderDetailSummary.offenderProfile.selfDescribedGender
+            else -> offenderDetailSummary.offenderProfile.genderIdentity
+          },
+          prisonName = inmateStatusToPersonInfoApiStatus(inmateDetail?.custodyStatus).takeIf { it == PersonStatus.inCustody }
+            ?.let {
+              inmateDetail?.assignedLivingUnit?.agencyName
+                ?: inmateDetail?.assignedLivingUnit?.agencyId
+            },
+          isRestricted = (offenderDetailSummary.currentExclusion || offenderDetailSummary.currentRestriction),
+        )
+      }
+
+      is PersonInfoResult.Success.Restricted -> RestrictedPerson(
+        type = PersonType.restrictedPerson,
+        crn = personInfoResult.crn,
+      )
+
+      is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> UnknownPerson(
+        type = PersonType.unknownPerson,
+        crn = personInfoResult.crn,
+      )
+    }
   }
 
-  fun transformSummaryToPersonApi(personInfoResult: PersonSummaryInfoResult) = when (personInfoResult) {
-    is PersonSummaryInfoResult.Success.Full -> FullPerson(
-      type = PersonType.fullPerson,
-      crn = personInfoResult.crn,
-      name = "${personInfoResult.summary.name.forename} ${personInfoResult.summary.name.surname}",
-      dateOfBirth = personInfoResult.summary.dateOfBirth,
-      sex = personInfoResult.summary.gender ?: "Not Found",
-      status = PersonStatus.unknown,
-      nomsNumber = personInfoResult.summary.nomsId,
-      ethnicity = personInfoResult.summary.profile?.ethnicity,
-      nationality = personInfoResult.summary.profile?.nationality,
-      religionOrBelief = personInfoResult.summary.profile?.religion,
-      genderIdentity = personInfoResult.summary.profile?.genderIdentity,
-      prisonName = null,
-      isRestricted = (personInfoResult.summary.currentRestriction == true || personInfoResult.summary.currentExclusion == true),
-    )
-    is PersonSummaryInfoResult.Success.Restricted -> RestrictedPerson(
-      type = PersonType.restrictedPerson,
-      crn = personInfoResult.crn,
-    )
-    is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> UnknownPerson(
-      type = PersonType.unknownPerson,
-      crn = personInfoResult.crn,
-    )
+  fun transformSummaryToPersonApi(personInfoResult: PersonSummaryInfoResult): Person {
+    return when (personInfoResult) {
+      is PersonSummaryInfoResult.Success.Full -> {
+        val caseSummary = personInfoResult.summary
+        FullPerson(
+          type = PersonType.fullPerson,
+          crn = personInfoResult.crn,
+          name = "${caseSummary.name.forename} ${caseSummary.name.surname}",
+          dateOfBirth = caseSummary.dateOfBirth,
+          sex = caseSummary.gender ?: "Not Found",
+          status = PersonStatus.unknown,
+          nomsNumber = caseSummary.nomsId,
+          ethnicity = caseSummary.profile?.ethnicity,
+          nationality = caseSummary.profile?.nationality,
+          religionOrBelief = caseSummary.profile?.religion,
+          genderIdentity = caseSummary.profile?.genderIdentity,
+          prisonName = null,
+          isRestricted = (caseSummary.currentRestriction == true || caseSummary.currentExclusion == true),
+        )
+      }
+
+      is PersonSummaryInfoResult.Success.Restricted -> RestrictedPerson(
+        type = PersonType.restrictedPerson,
+        crn = personInfoResult.crn,
+      )
+
+      is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> UnknownPerson(
+        type = PersonType.unknownPerson,
+        crn = personInfoResult.crn,
+      )
+    }
   }
 
-  fun transformProbationOffenderToPersonApi(probationOffenderResult: ProbationOffenderSearchResult.Success.Full, nomsNumber: String) =
-    FullPerson(
+  fun transformProbationOffenderToPersonApi(probationOffenderResult: ProbationOffenderSearchResult.Success.Full, nomsNumber: String): FullPerson {
+    val probationOffenderDetail = probationOffenderResult.probationOffenderDetail
+    val inmateDetail = probationOffenderResult.inmateDetail
+    return FullPerson(
       type = PersonType.fullPerson,
-      crn = probationOffenderResult.probationOffenderDetail.otherIds.crn,
-      name = "${probationOffenderResult.probationOffenderDetail.firstName} ${probationOffenderResult.probationOffenderDetail.surname}",
-      dateOfBirth = probationOffenderResult.probationOffenderDetail.dateOfBirth!!,
-      sex = probationOffenderResult.probationOffenderDetail.gender ?: "Not found",
-      status = inmateStatusToPersonInfoApiStatus(probationOffenderResult.inmateDetail?.custodyStatus),
-      nomsNumber = probationOffenderResult.probationOffenderDetail.otherIds.nomsNumber,
-      pncNumber = probationOffenderResult.probationOffenderDetail.otherIds.pncNumber ?: "Not found",
-      nationality = probationOffenderResult.probationOffenderDetail.offenderProfile?.nationality ?: "Not found",
-      prisonName = inmateStatusToPersonInfoApiStatus(probationOffenderResult.inmateDetail?.custodyStatus).takeIf { it == PersonStatus.inCustody }?.let {
-        probationOffenderResult.inmateDetail?.assignedLivingUnit?.agencyName
-          ?: probationOffenderResult.inmateDetail?.assignedLivingUnit?.agencyId
-      },
-      isRestricted = (probationOffenderResult.probationOffenderDetail.currentExclusion ?: false || probationOffenderResult.probationOffenderDetail.currentRestriction ?: false),
+      crn = probationOffenderDetail.otherIds.crn,
+      name = "${probationOffenderDetail.firstName} ${probationOffenderDetail.surname}",
+      dateOfBirth = probationOffenderDetail.dateOfBirth!!,
+      sex = probationOffenderDetail.gender ?: "Not found",
+      status = inmateStatusToPersonInfoApiStatus(inmateDetail?.custodyStatus),
+      nomsNumber = probationOffenderDetail.otherIds.nomsNumber,
+      pncNumber = probationOffenderDetail.otherIds.pncNumber ?: "Not found",
+      nationality = probationOffenderDetail.offenderProfile?.nationality ?: "Not found",
+      prisonName = inmateStatusToPersonInfoApiStatus(inmateDetail?.custodyStatus).takeIf { it == PersonStatus.inCustody }
+        ?.let {
+          inmateDetail?.assignedLivingUnit?.agencyName
+            ?: inmateDetail?.assignedLivingUnit?.agencyId
+        },
+      isRestricted = (probationOffenderDetail.currentExclusion ?: false || probationOffenderDetail.currentRestriction ?: false),
     )
+  }
 
   fun inmateStatusToPersonInfoApiStatus(status: InmateStatus?) = when (status) {
     InmateStatus.IN -> PersonStatus.inCustody


### PR DESCRIPTION
This commit removes repeated use of the same property traversal in PersonTransformer. This helps clarifies the key entities in various result data classes, in preparation for some rationalisation and simplification work, with the ultimate aim of removing data classes bound to the community API