### PR TITLE
APS-1068: Add Cas1SpaceSearchRequirements API model allow searching for multiple ApTypes and Genders

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -631,6 +631,28 @@ components:
       required:
         - apType
         - gender
+    Cas1SpaceSearchRequirements:
+      type: object
+      properties:
+        apTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApType'
+        needCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
+        riskCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+        genders:
+          type: array
+          items:
+            $ref: '#/components/schemas/Gender'
+      required:
+        - apType
+        - gender
     Cas1SpaceNeedCharacteristic:
       type: string
       enum:
@@ -664,7 +686,7 @@ components:
           description: The 'target' location, in the form of a postcode district
           example: SE5
         requirements:
-          $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
+          $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
       required:
         - startDate
         - durationInDays

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5044,6 +5044,28 @@ components:
       required:
         - apType
         - gender
+    Cas1SpaceSearchRequirements:
+      type: object
+      properties:
+        apTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApType'
+        needCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
+        riskCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+        genders:
+          type: array
+          items:
+            $ref: '#/components/schemas/Gender'
+      required:
+        - apType
+        - gender
     Cas1SpaceNeedCharacteristic:
       type: string
       enum:
@@ -5077,7 +5099,7 @@ components:
           description: The 'target' location, in the form of a postcode district
           example: SE5
         requirements:
-          $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
+          $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
       required:
         - startDate
         - durationInDays

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1284,6 +1284,28 @@ components:
       required:
         - apType
         - gender
+    Cas1SpaceSearchRequirements:
+      type: object
+      properties:
+        apTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApType'
+        needCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
+        riskCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+        genders:
+          type: array
+          items:
+            $ref: '#/components/schemas/Gender'
+      required:
+        - apType
+        - gender
     Cas1SpaceNeedCharacteristic:
       type: string
       enum:
@@ -1317,7 +1339,7 @@ components:
           description: The 'target' location, in the form of a postcode district
           example: SE5
         requirements:
-          $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
+          $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
       required:
         - startDate
         - durationInDays

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1222,6 +1222,28 @@ components:
       required:
         - apType
         - gender
+    Cas1SpaceSearchRequirements:
+      type: object
+      properties:
+        apTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApType'
+        needCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
+        riskCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+        genders:
+          type: array
+          items:
+            $ref: '#/components/schemas/Gender'
+      required:
+        - apType
+        - gender
     Cas1SpaceNeedCharacteristic:
       type: string
       enum:
@@ -1255,7 +1277,7 @@ components:
           description: The 'target' location, in the form of a postcode district
           example: SE5
         requirements:
-          $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
+          $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
       required:
         - startDate
         - durationInDays

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -722,6 +722,28 @@ components:
       required:
         - apType
         - gender
+    Cas1SpaceSearchRequirements:
+      type: object
+      properties:
+        apTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApType'
+        needCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
+        riskCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+        genders:
+          type: array
+          items:
+            $ref: '#/components/schemas/Gender'
+      required:
+        - apType
+        - gender
     Cas1SpaceNeedCharacteristic:
       type: string
       enum:
@@ -755,7 +777,7 @@ components:
           description: The 'target' location, in the form of a postcode district
           example: SE5
         requirements:
-          $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
+          $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
       required:
         - startDate
         - durationInDays


### PR DESCRIPTION
When we book a space in an AP it is for a specific type and particular gender, as per `Cas1SpaceBookingRequirements` -- but when searching for available spaces we allow the matcher to search for availability in multiple types of premises and in premises for both genders.

To do this we introduce a `Cas1SpaceSearchRequirements` API model.