### PR TITLE
CAS-445 update user details from delius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -71,7 +71,7 @@ class UserTransformer(
       roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformTemporaryAccommodationRoleToApi),
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) },
-      service = ServiceName.temporaryAccommodation.value,
+      service = "CAS3",
     )
     ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3972,6 +3972,12 @@ paths:
           description: Filters the user details to those relevant to the specified service.
           schema:
             $ref: '_shared.yml#/components/schemas/ServiceName'
+        - name: fromDelius
+          in: query
+          description: Flag to update the details with the latest stored in delius
+          required: false
+          schema:
+            type: boolean
       responses:
         200:
           description: successfully retrieved information on user

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3974,6 +3974,12 @@ paths:
           description: Filters the user details to those relevant to the specified service.
           schema:
             $ref: '#/components/schemas/ServiceName'
+        - name: fromDelius
+          in: query
+          description: Flag to update the details with the latest stored in delius
+          required: false
+          schema:
+            type: boolean
       responses:
         200:
           description: successfully retrieved information on user

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -279,7 +279,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
             email = email,
             telephoneNumber = telephoneNumber,
             roles = emptyList(),
-            service = ServiceName.temporaryAccommodation.value,
+            service = "CAS3",
             isActive = true,
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -73,7 +73,7 @@ class UserTransformerTest {
       ) as TemporaryAccommodationUser
 
       assertThat(result.roles).contains(reporter)
-      assertThat(result.service).isEqualTo(temporaryAccommodation.value)
+      assertThat(result.service).isEqualTo("CAS3")
       verify(exactly = 1) { probationRegionTransformer.transformJpaToApi(any()) }
     }
 
@@ -85,7 +85,7 @@ class UserTransformerTest {
       ) as TemporaryAccommodationUser
 
       assertThat(result.roles).contains(referrer)
-      assertThat(result.service).isEqualTo(temporaryAccommodation.value)
+      assertThat(result.service).isEqualTo("CAS3")
       verify(exactly = 1) { probationRegionTransformer.transformJpaToApi(any()) }
     }
 


### PR DESCRIPTION
Added an optional parameter to the /profile/v2 endpoint so that user details can be pulled from delius and updated before being returned to the front end.

[https://dsdmoj.atlassian.net/browse/CAS-445](url)