### PR TITLE
improve placement requests crn not found error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -228,7 +228,7 @@ class PlacementRequestsController(
     return placementRequests.mapNotNull {
       val personInfo = offenderService.getInfoForPerson(it.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
-      if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${it.application.crn}")
+      if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${it.application.crn}. Response type is ${personInfo::class}")
 
       placementRequestTransformer.transformJpaToApi(it, personInfo)
     }


### PR DESCRIPTION
An example captured from dev:

```
uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem: Internal Server Error: Unable to get Person Info for CRN: X320742. Response type is class uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult$NotFound
```