### PR TITLE
APS-1068: Send essential and desirable characteristics when booking CAS1 space

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -620,14 +620,14 @@ components:
       properties:
         apType:
           $ref: '#/components/schemas/ApType'
-        needCharacteristics:
+        essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
-        riskCharacteristics:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+        desirableCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         gender:
           $ref: '#/components/schemas/Gender'
       required:
@@ -4319,6 +4319,46 @@ components:
         - notMatched
         - unableToMatch
         - matched
+    Cas1SpaceCharacteristic:
+      type: string
+      description: All of the characteristics of both premises and rooms
+      enum:
+        - acceptsChildSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsNonSexualChildOffenders
+        - acceptsSexOffenders
+        - hasArsonInsuranceConditions
+        - hasBrailleSignage
+        - hasCallForAssistance
+        - hasCrib7Bedding
+        - hasEnSuite
+        - hasFixedMobilityAids
+        - hasHearingLoop
+        - hasLift
+        - hasNearbySprinkler
+        - hasSmokeDetector
+        - hasStepFreeAccess
+        - hasStepFreeAccessToCommunalAreas
+        - hasTactileFlooring
+        - hasTurningSpace
+        - hasWheelChairAccessibleBathrooms
+        - hasWideAccessToCommunalAreas
+        - hasWideDoor
+        - hasWideStepFreeAccess
+        - isArsonDesignated
+        - isArsonSuitable
+        - isCatered
+        - isFullyFm
+        - isGroundFloor
+        - isGroundFloorNrOffice
+        - isIAP
+        - isSingle
+        - isStepFreeDesignated
+        - isSuitableForVulnerable
+        - isSuitedForSexOffenders
+        - isTopFloorVulnerable
+        - isWheelchairAccessible
+        - isWheelchairDesignated
     PlacementCriteria:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5033,14 +5033,14 @@ components:
       properties:
         apType:
           $ref: '#/components/schemas/ApType'
-        needCharacteristics:
+        essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
-        riskCharacteristics:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+        desirableCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         gender:
           $ref: '#/components/schemas/Gender'
       required:
@@ -8732,6 +8732,46 @@ components:
         - notMatched
         - unableToMatch
         - matched
+    Cas1SpaceCharacteristic:
+      type: string
+      description: All of the characteristics of both premises and rooms
+      enum:
+        - acceptsChildSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsNonSexualChildOffenders
+        - acceptsSexOffenders
+        - hasArsonInsuranceConditions
+        - hasBrailleSignage
+        - hasCallForAssistance
+        - hasCrib7Bedding
+        - hasEnSuite
+        - hasFixedMobilityAids
+        - hasHearingLoop
+        - hasLift
+        - hasNearbySprinkler
+        - hasSmokeDetector
+        - hasStepFreeAccess
+        - hasStepFreeAccessToCommunalAreas
+        - hasTactileFlooring
+        - hasTurningSpace
+        - hasWheelChairAccessibleBathrooms
+        - hasWideAccessToCommunalAreas
+        - hasWideDoor
+        - hasWideStepFreeAccess
+        - isArsonDesignated
+        - isArsonSuitable
+        - isCatered
+        - isFullyFm
+        - isGroundFloor
+        - isGroundFloorNrOffice
+        - isIAP
+        - isSingle
+        - isStepFreeDesignated
+        - isSuitableForVulnerable
+        - isSuitedForSexOffenders
+        - isTopFloorVulnerable
+        - isWheelchairAccessible
+        - isWheelchairDesignated
     PlacementCriteria:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1273,14 +1273,14 @@ components:
       properties:
         apType:
           $ref: '#/components/schemas/ApType'
-        needCharacteristics:
+        essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
-        riskCharacteristics:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+        desirableCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         gender:
           $ref: '#/components/schemas/Gender'
       required:
@@ -4972,6 +4972,46 @@ components:
         - notMatched
         - unableToMatch
         - matched
+    Cas1SpaceCharacteristic:
+      type: string
+      description: All of the characteristics of both premises and rooms
+      enum:
+        - acceptsChildSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsNonSexualChildOffenders
+        - acceptsSexOffenders
+        - hasArsonInsuranceConditions
+        - hasBrailleSignage
+        - hasCallForAssistance
+        - hasCrib7Bedding
+        - hasEnSuite
+        - hasFixedMobilityAids
+        - hasHearingLoop
+        - hasLift
+        - hasNearbySprinkler
+        - hasSmokeDetector
+        - hasStepFreeAccess
+        - hasStepFreeAccessToCommunalAreas
+        - hasTactileFlooring
+        - hasTurningSpace
+        - hasWheelChairAccessibleBathrooms
+        - hasWideAccessToCommunalAreas
+        - hasWideDoor
+        - hasWideStepFreeAccess
+        - isArsonDesignated
+        - isArsonSuitable
+        - isCatered
+        - isFullyFm
+        - isGroundFloor
+        - isGroundFloorNrOffice
+        - isIAP
+        - isSingle
+        - isStepFreeDesignated
+        - isSuitableForVulnerable
+        - isSuitedForSexOffenders
+        - isTopFloorVulnerable
+        - isWheelchairAccessible
+        - isWheelchairDesignated
     PlacementCriteria:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1211,14 +1211,14 @@ components:
       properties:
         apType:
           $ref: '#/components/schemas/ApType'
-        needCharacteristics:
+        essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
-        riskCharacteristics:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+        desirableCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         gender:
           $ref: '#/components/schemas/Gender'
       required:
@@ -4910,6 +4910,46 @@ components:
         - notMatched
         - unableToMatch
         - matched
+    Cas1SpaceCharacteristic:
+      type: string
+      description: All of the characteristics of both premises and rooms
+      enum:
+        - acceptsChildSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsNonSexualChildOffenders
+        - acceptsSexOffenders
+        - hasArsonInsuranceConditions
+        - hasBrailleSignage
+        - hasCallForAssistance
+        - hasCrib7Bedding
+        - hasEnSuite
+        - hasFixedMobilityAids
+        - hasHearingLoop
+        - hasLift
+        - hasNearbySprinkler
+        - hasSmokeDetector
+        - hasStepFreeAccess
+        - hasStepFreeAccessToCommunalAreas
+        - hasTactileFlooring
+        - hasTurningSpace
+        - hasWheelChairAccessibleBathrooms
+        - hasWideAccessToCommunalAreas
+        - hasWideDoor
+        - hasWideStepFreeAccess
+        - isArsonDesignated
+        - isArsonSuitable
+        - isCatered
+        - isFullyFm
+        - isGroundFloor
+        - isGroundFloorNrOffice
+        - isIAP
+        - isSingle
+        - isStepFreeDesignated
+        - isSuitableForVulnerable
+        - isSuitedForSexOffenders
+        - isTopFloorVulnerable
+        - isWheelchairAccessible
+        - isWheelchairDesignated
     PlacementCriteria:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -711,14 +711,14 @@ components:
       properties:
         apType:
           $ref: '#/components/schemas/ApType'
-        needCharacteristics:
+        essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceNeedCharacteristic'
-        riskCharacteristics:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+        desirableCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceRiskCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         gender:
           $ref: '#/components/schemas/Gender'
       required:
@@ -4410,6 +4410,46 @@ components:
         - notMatched
         - unableToMatch
         - matched
+    Cas1SpaceCharacteristic:
+      type: string
+      description: All of the characteristics of both premises and rooms
+      enum:
+        - acceptsChildSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsNonSexualChildOffenders
+        - acceptsSexOffenders
+        - hasArsonInsuranceConditions
+        - hasBrailleSignage
+        - hasCallForAssistance
+        - hasCrib7Bedding
+        - hasEnSuite
+        - hasFixedMobilityAids
+        - hasHearingLoop
+        - hasLift
+        - hasNearbySprinkler
+        - hasSmokeDetector
+        - hasStepFreeAccess
+        - hasStepFreeAccessToCommunalAreas
+        - hasTactileFlooring
+        - hasTurningSpace
+        - hasWheelChairAccessibleBathrooms
+        - hasWideAccessToCommunalAreas
+        - hasWideDoor
+        - hasWideStepFreeAccess
+        - isArsonDesignated
+        - isArsonSuitable
+        - isCatered
+        - isFullyFm
+        - isGroundFloor
+        - isGroundFloorNrOffice
+        - isIAP
+        - isSingle
+        - isStepFreeDesignated
+        - isSuitableForVulnerable
+        - isSuitedForSexOffenders
+        - isTopFloorVulnerable
+        - isWheelchairAccessible
+        - isWheelchairDesignated
     PlacementCriteria:
       type: string
       enum:


### PR DESCRIPTION
On reflection we've realised that sending:

- need characteristics 
    - `wheelchair` 
    - `enSuite` 
    - `single` 
    - `limitedMobility` 
    - `catered`

- risk characteristics 
    - `arson` 
    - `posesSexualRiskToAdults` 
    - `posesSexualRiskToChildren` 
    - `hateBasedOffences`
    - `atRiskOfExploitation` 
    - `posesNonSexualRiskToChildren`

does not make good sense. This is because:

1. we already have a list of space characteristics (combination of premises and room characteristics) in the form of the placement requirements associated with the placement request.

The list of possible space characteristics is:

- `acceptsChildSexOffenders`
- `acceptsHateCrimeOffenders`
- `acceptsNonSexualChildOffenders`
- `acceptsSexOffenders`
- `hasArsonInsuranceConditions`
- `hasBrailleSignage`
- `hasCallForAssistance`
- `hasCrib7Bedding`
- `hasEnSuite`
- `hasFixedMobilityAids`
- `hasHearingLoop`
- `hasLift`
- `hasNearbySprinkler`
- `hasSmokeDetector`
- `hasStepFreeAccess`
- `hasStepFreeAccessToCommunalAreas`
- `hasTactileFlooring`
- `hasTurningSpace`
- `hasWheelChairAccessibleBathrooms`
- `hasWideAccessToCommunalAreas`
- `hasWideDoor`
- `hasWideStepFreeAccess`
- `isArsonDesignated`
- `isArsonSuitable`
- `isCatered`
- `isFullyFm`
- `isGroundFloor`
- `isGroundFloorNrOffice`
- `isIAP`
- `isSingle
- `isSingle`
- `isStepFreeDesignated`
- `isSuitedForSexOffenders`
- `isTopFloorVulnerable`
- `isWheelchairAccessible`
- `isWheelchairDesignated`

2. recording the characteristics on our space bookings will simplify the process of searching for suitable available spaces:

- "space bookings" have essential characteristics
- "spaces" have characteristics
- "space searches" have essential characteristics (this is to come)