### PR TITLE
Change to use bulk retrieval of person information when there a group of offenders

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -10,7 +10,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UnknownPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ProbationOffenderSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asOffenderDetailSummary
 
 @Component
 class PersonTransformer {
@@ -89,6 +91,14 @@ class PersonTransformer {
     }
   }
 
+  fun transformPersonSummaryInfoToPersonInfo(personSummaryInfoResult: PersonSummaryInfoResult, inmateStatus: InmateDetail?): PersonInfoResult {
+    return when (personSummaryInfoResult) {
+      is PersonSummaryInfoResult.Success.Full -> PersonInfoResult.Success.Full(personSummaryInfoResult.crn, personSummaryInfoResult.summary.asOffenderDetailSummary(), inmateStatus)
+      is PersonSummaryInfoResult.Success.Restricted -> PersonInfoResult.Success.Restricted(personSummaryInfoResult.crn, personSummaryInfoResult.nomsNumber)
+      is PersonSummaryInfoResult.NotFound -> PersonInfoResult.NotFound(personSummaryInfoResult.crn)
+      is PersonSummaryInfoResult.Unknown -> PersonInfoResult.Unknown(personSummaryInfoResult.crn, personSummaryInfoResult.throwable)
+    }
+  }
   fun transformProbationOffenderToPersonApi(probationOffenderResult: ProbationOffenderSearchResult.Success.Full, nomsNumber: String): FullPerson {
     val probationOffenderDetail = probationOffenderResult.probationOffenderDetail
     val inmateDetail = probationOffenderResult.inmateDetail

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -50,6 +50,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Temporary Accommodation`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addListCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_mockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockOffenderUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
@@ -78,6 +79,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Offender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
@@ -647,6 +649,8 @@ class AssessmentTest : IntegrationTestBase() {
         val (offender4, inmate4) = `Given an Offender`({ withFirstName("Bagatha"); withLastName("") })
         val assessBagatha = createApprovedPremisesAssessmentForStatus(user, offender4, cas1InProgress)
 
+        ApDeliusContext_addListCaseSummaryToBulkResponse(listOf(offender1.asCaseSummary(), offender2.asCaseSummary(), offender3.asCaseSummary(), offender4.asCaseSummary()))
+
         assertAssessmentsReturnedGivenStatus(
           jwt,
           ServiceName.approvedPremises,
@@ -676,6 +680,8 @@ class AssessmentTest : IntegrationTestBase() {
 
         val (offender4, inmate4) = `Given an Offender`({ withCrn("CRN3") })
         val assessCrn3 = createApprovedPremisesAssessmentForStatus(user, offender4, cas1InProgress)
+
+        ApDeliusContext_addListCaseSummaryToBulkResponse(listOf(offender1.asCaseSummary(), offender2.asCaseSummary(), offender3.asCaseSummary(), offender4.asCaseSummary()))
 
         assertAssessmentsReturnedGivenStatus(
           jwt,
@@ -1294,6 +1300,8 @@ class AssessmentTest : IntegrationTestBase() {
             }
           }
 
+          ApDeliusContext_addListCaseSummaryToBulkResponse(offenders.map { (offenderDetails, inmateDetails) -> offenderDetails.asCaseSummary() })
+
           assertResponseForUrl(
             jwt,
             ServiceName.temporaryAccommodation,
@@ -1401,6 +1409,8 @@ class AssessmentTest : IntegrationTestBase() {
             .sortedBy { (it.assessment.application as TemporaryAccommodationApplicationEntity).arrivalDate }
             .map { assessmentSummaryMapper(it.offenderDetails, it.inmateDetails).toSummary(it.assessment) }
 
+          ApDeliusContext_addListCaseSummaryToBulkResponse(offenders.map { (offenderDetails, inmateDetails) -> offenderDetails.asCaseSummary() })
+
           assertResponseForUrl(
             jwt,
             ServiceName.temporaryAccommodation,
@@ -1505,6 +1515,7 @@ class AssessmentTest : IntegrationTestBase() {
           otherAssessment.schemaUpToDate = true
 
           mockOffenderUserAccessCommunityApiCall(user.deliusUsername, otherOffender.first.otherIds.crn, true, true)
+          ApDeliusContext_addListCaseSummaryToBulkResponse(listOf(offender.first.asCaseSummary(), otherOffender.first.asCaseSummary()))
 
           assertResponseForUrl(
             jwt,


### PR DESCRIPTION
This [PR CAS-465](https://dsdmoj.atlassian.net/browse/CAS-465) is to use bulk retrieval of person information when there are a group of offenders that need to retrieve their person information. This will improve the performance of the code and reduce the number of calls to `/probation-cases/summaries` Api end point
- Create a new function `getInfoForPersons` to get a bulk of person information and use it instead of the current `getInfoForPerson` function in case there are a group of offenders. This function will call `getOffenderSummariesByCrns` to unify the point to get offenders information.
- Change the current `getInfoForPerson` to use the new function
- Replace the code when currently call the old function to use the new one when there are a group of offenders that need to retrieve their personal information