### PR TITLE
APS-1106 - Provide more info when a PDU can't be found for a user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/CasSimpleResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/CasSimpleResult.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.results
+
+sealed interface CasSimpleResult<SuccessType> {
+  data class Success<SuccessType>(val value: SuccessType) : CasSimpleResult<SuccessType>
+  data class Failure<SuccessType>(val message: String) : CasSimpleResult<SuccessType>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.UserWorkload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffProbationArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasSimpleResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1UserMappingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
@@ -225,15 +226,15 @@ class UserService(
       is ClientResult.Failure -> staffUserDetailsResponse.throwException()
     }
 
-    when (val probationDeliveryUnit = findDeliusUserLastPdu(deliusUser)) {
-      null -> {
+    when (val pduResult = findDeliusUserLastPdu(deliusUser)) {
+      is CasSimpleResult.Failure -> {
         val userLastBoroughCode = deliusUser.teams?.filter { it.endDate == null }?.maxByOrNull { it.startDate }?.borough?.code
         throw Exception("Unable to find community API borough code $userLastBoroughCode in CAS")
       }
 
-      else -> {
-        if (user.probationDeliveryUnit?.id != probationDeliveryUnit.id) {
-          user.probationDeliveryUnit = probationDeliveryUnit
+      is CasSimpleResult.Success -> {
+        if (user.probationDeliveryUnit?.id != pduResult.value.id) {
+          user.probationDeliveryUnit = pduResult.value
           userRepository.save(user)
         }
       }
@@ -259,8 +260,9 @@ class UserService(
       }
     }
 
-    findDeliusUserLastPdu(deliusUser)?.let { probationDeliveryUnit ->
-      user.probationDeliveryUnit = probationDeliveryUnit
+    val pduResult = findDeliusUserLastPdu(deliusUser)
+    if (pduResult is CasSimpleResult.Success) {
+      user.probationDeliveryUnit = pduResult.value
     }
 
     if (forService == ServiceName.approvedPremises) {
@@ -327,7 +329,7 @@ class UserService(
       }
     }
 
-    val staffProbationDeliveryUnit = findDeliusUserLastPdu(staffUserDetails)
+    val pduResult = findDeliusUserLastPdu(staffUserDetails)
 
     val apArea = cas1UserMappingService.determineApArea(staffProbationRegion, staffUserDetails)
 
@@ -344,7 +346,10 @@ class UserService(
         roles = mutableListOf(),
         qualifications = mutableListOf(),
         probationRegion = staffProbationRegion,
-        probationDeliveryUnit = staffProbationDeliveryUnit,
+        probationDeliveryUnit = when (pduResult) {
+          is CasSimpleResult.Failure -> null
+          is CasSimpleResult.Success -> pduResult.value
+        },
         isActive = true,
         apArea = apArea,
         teamCodes = staffUserDetails.getTeamCodes(),
@@ -360,15 +365,15 @@ class UserService(
       .findByProbationAreaDeliusCode(probationArea.code)?.probationRegion
   }
 
-  private fun findDeliusUserLastPdu(deliusUser: StaffUserDetails): ProbationDeliveryUnitEntity? {
+  private fun findDeliusUserLastPdu(deliusUser: StaffUserDetails): CasSimpleResult<ProbationDeliveryUnitEntity> {
     deliusUser.teams?.filter { t -> t.endDate == null }?.sortedByDescending { t -> t.startDate }?.forEach {
       val probationDeliveryUnit = probationDeliveryUnitRepository.findByDeliusCode(it.borough.code)
       if (probationDeliveryUnit != null) {
-        return probationDeliveryUnit
+        return CasSimpleResult.Success(probationDeliveryUnit)
       }
     }
 
-    return null
+    return CasSimpleResult.Failure("PDU Could not be loaded")
   }
 
   fun addRoleToUser(user: UserEntity, role: UserRole) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationDeliveryUnitEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationDeliveryUnitEntityFactory.kt
@@ -13,6 +13,10 @@ class ProbationDeliveryUnitEntityFactory : Factory<ProbationDeliveryUnitEntity> 
   private var deliusCode: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var probationRegion: Yielded<ProbationRegionEntity>? = null
 
+  fun withDefaults() = apply {
+    this.probationRegion = { ProbationRegionEntityFactory().withDefaults().produce() }
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateUsersPduFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateUsersPduFromCommunityApiMigrationTest.kt
@@ -340,12 +340,15 @@ class UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
         .withUsername(userTwo.deliusUsername)
         .withTeams(
           listOf(
-            StaffUserTeamMembershipFactory().withBorough(
-              KeyValue(
-                code = "PDUCODE5",
-                description = "PDUDESCRIPTION5",
-              ),
-            )
+            StaffUserTeamMembershipFactory()
+              .withCode("TEAM1")
+              .withDescription("TEAM 1")
+              .withBorough(
+                KeyValue(
+                  code = "PDUCODE5",
+                  description = "PDUDESCRIPTION5",
+                ),
+              )
               .produce(),
           ),
         )
@@ -366,7 +369,7 @@ class UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
         it.level == "error" &&
           it.message == "Unable to update user PDU. User id ${userTwo.id}" &&
           it.throwable != null &&
-          it.throwable.message == "Unable to find community API borough code PDUCODE5 in CAS"
+          it.throwable.message == "PDU could not be determined for user USER2. Considered 1 teams TEAM 1 (TEAM1) with borough PDUDESCRIPTION5 (PDUCODE5)"
       }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -499,6 +499,7 @@ class UserServiceTest {
     @Test
     fun `Throw exception if can't determine PDU, no teams`() {
       val deliusUser = StaffUserDetailsFactory()
+        .withUsername("theusername")
         .withTeams(emptyList())
         .produce()
 
@@ -509,12 +510,13 @@ class UserServiceTest {
 
       assertThatThrownBy {
         userService.updateUserPduFromCommunityApiById(user.id)
-      }.hasMessage("Unable to find community API borough code null in CAS")
+      }.hasMessage("PDU could not be determined for user theusername. Considered 0 teams")
     }
 
     @Test
     fun `Throw exception if can't determine PDU, no teams without end date`() {
       val deliusUser = StaffUserDetailsFactory()
+        .withUsername("theusername")
         .withTeams(
           listOf(
             StaffUserTeamMembershipFactory()
@@ -531,15 +533,18 @@ class UserServiceTest {
 
       assertThatThrownBy {
         userService.updateUserPduFromCommunityApiById(user.id)
-      }.hasMessage("Unable to find community API borough code null in CAS")
+      }.hasMessage("PDU could not be determined for user theusername. Considered 0 teams")
     }
 
     @Test
     fun `Throw exception if no mapping for only team's borough`() {
       val deliusUser = StaffUserDetailsFactory()
+        .withUsername("theusername")
         .withTeams(
           listOf(
             StaffUserTeamMembershipFactory()
+              .withCode("team1")
+              .withDescription("team 1")
               .withBorough(KeyValue("boroughcode1", "borough1"))
               .withStartDate(LocalDate.of(2024, 1, 1))
               .withEndDate(null)
@@ -557,26 +562,32 @@ class UserServiceTest {
 
       assertThatThrownBy {
         userService.updateUserPduFromCommunityApiById(user.id)
-      }.hasMessage("Unable to find community API borough code boroughcode1 in CAS")
+      }.hasMessage("PDU could not be determined for user theusername. Considered 1 teams team 1 (team1) with borough borough1 (boroughcode1)")
     }
 
     @Test
     fun `Throw exception if no mapping for any active team's borough`() {
       val deliusUser = StaffUserDetailsFactory()
+        .withUsername("theusername")
         .withTeams(
           listOf(
             StaffUserTeamMembershipFactory()
-              .withBorough(KeyValue("boroughcode2", "borough2"))
-              .withStartDate(LocalDate.of(2024, 1, 2))
+              .withCode("team3")
+              .withDescription("team 3")
+              .withBorough(KeyValue("boroughcode3", "borough3"))
               .withStartDate(LocalDate.of(2024, 1, 3))
               .withEndDate(LocalDate.of(2024, 1, 4))
               .produce(),
             StaffUserTeamMembershipFactory()
+              .withCode("team2")
+              .withDescription("team 2")
               .withBorough(KeyValue("boroughcode2", "borough2"))
               .withStartDate(LocalDate.of(2024, 1, 2))
               .withEndDate(null)
               .produce(),
             StaffUserTeamMembershipFactory()
+              .withCode("team1")
+              .withDescription("team 1")
               .withBorough(KeyValue("boroughcode1", "borough1"))
               .withStartDate(LocalDate.of(2024, 1, 1))
               .withEndDate(null)
@@ -595,7 +606,7 @@ class UserServiceTest {
 
       assertThatThrownBy {
         userService.updateUserPduFromCommunityApiById(user.id)
-      }.hasMessage("Unable to find community API borough code boroughcode2 in CAS")
+      }.hasMessage("PDU could not be determined for user theusername. Considered 2 teams team 2 (team2) with borough borough2 (boroughcode2), team 1 (team1) with borough borough1 (boroughcode1)")
     }
 
     @Test


### PR DESCRIPTION
This PR adds some regression tests for updating pdu logic, refactors the code to remove duplication and then captures more information when a PDU can't be found to help determine why mapping failed for a given user.