### PR TITLE
CAS-365 - Remove CAS3 Booking Report implicit JPA Timestamp to Date conversion

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BookingsReportGenerator.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Bookings
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toYesNo
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -21,7 +22,7 @@ class BookingsReportGenerator : ReportGenerator<BookingsReportDataAndPersonInfo,
       BookingsReportRow(
         bookingId = booking.bookingId,
         referralId = booking.referralId,
-        referralDate = booking.referralDate,
+        referralDate = booking.referralDate?.toLocalDate(),
         personName = personInfo.tryGetDetails {
           val nameParts = listOf(it.name.forename) + it.name.middleNames + it.name.surname
           nameParts.joinToString(" ")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingsReportRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import java.sql.Timestamp
+import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -87,7 +88,7 @@ interface BookingsReportRepository : JpaRepository<BookingEntity, UUID> {
 interface BookingsReportData {
   val bookingId: String
   val referralId: String?
-  val referralDate: LocalDate?
+  val referralDate: Instant?
   val riskOfSeriousHarm: String?
   val registeredSexOffender: Boolean?
   val historyOfSexualOffence: Boolean?

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -2079,7 +2079,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
     @Test
     fun `Get bookings report returns OK with correct body and correct duty to refer local authority area name`() {
       `Given a User`(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->
-        `Given an Offender` { offenderDetails, inmateDetails ->
+        `Given an Offender` { offenderDetails, _ ->
           val startDate = LocalDate.of(2023, 4, 1)
           val endDate = LocalDate.of(2023, 4, 30)
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
@@ -3601,6 +3601,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
       withProbationRegion(userEntity.probationRegion)
       withApplicationSchema(applicationSchema)
       withDutyToReferLocalAuthorityAreaName("London")
+      withSubmittedAt(OffsetDateTime.now())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
@@ -398,7 +398,7 @@ class Cas3ReportServiceTest {
   class TestBookingsReportData(
     override val bookingId: String,
     override val referralId: String?,
-    override val referralDate: LocalDate?,
+    override val referralDate: Instant?,
     override val riskOfSeriousHarm: String?,
     override val registeredSexOffender: Boolean?,
     override val historyOfSexualOffence: Boolean?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ReportsTestHelper.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BookingsReportDataAndPersonInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportData
 import java.sql.Timestamp
+import java.time.Instant
 import java.time.LocalDate
 
 fun List<BookingEntity>.toBookingsReportData(): List<BookingsReportData> = this
@@ -18,8 +19,8 @@ fun List<BookingEntity>.toBookingsReportData(): List<BookingsReportData> = this
         get() = it.id.toString()
       override val referralId: String?
         get() = application?.id?.toString()
-      override val referralDate: LocalDate?
-        get() = application?.submittedAt?.toLocalDate()
+      override val referralDate: Instant?
+        get() = application?.submittedAt?.toInstant()
       override val riskOfSeriousHarm: String?
         get() = application?.riskRatings?.roshRisks?.value?.overallRisk
       override val registeredSexOffender: Boolean?


### PR DESCRIPTION
BookingsReportData.referralDate previous required an implicit converstion from a timestamptz field in the database to a LocalDate value in the Kotlin Model. This relies on JPA/Hibernate to determine how to convert between these two types (and understand in what timezone this should be applied). As of Hibernate 6 this conversion is no longer supported.

This commit removes this implicit conversion and instead manages the conversion ‘in code’ using the JDK timezone (which is Europe/London on deployment). Regardless of HIbernate compatibility, this results in code that better identifies the type of the database column we are using to provide this data.

I've also updated the integration test to set an application submission date as this would have caused the test to fail on the spring boot 3 branch