### PR TITLE
Add definitive function to retrieve offender details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -93,6 +93,18 @@ class ApplicationsController(
 
     val applications = applicationService.getAllApplicationsForUsername(user.deliusUsername, serviceName)
 
+      /*
+      This code is inefficient:
+
+      getPersonDetailAndTransformToSummary will retrieve/check user access (via the call to offenderService),
+      but the prior call to getAllApplicationsForUsername has already retrieved this information
+      and filtered out applications that the user cannot access. This leads to duplicate calls being made.
+
+      This check should be moved into getPersonDetailAndTransformToSummary (or a custom version of it to
+      avoid breaking behaviour for other callers), where we filter out any response from
+      offenderService.getInfoForPerson of type PersonInfoResult.Restricted. This will most likely have
+      to be optional as to not 'break' other functions using getPersonDetailAndTransformToSummary
+    */
     return ResponseEntity.ok(getPersonDetailAndTransformToSummary(applications, user))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderDetailsDataSource.kt
@@ -11,6 +11,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerEr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asOffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asUserOffenderAccess
 
+@Deprecated(
+  """
+    This service was introduced as a 'man in the middle' whilst migration from community-api to ap-and-delius-context, 
+    allowing us to switch between the two backends via configuration. That configuration has been removed and it now
+    always uses ap-and-delius-context.
+    
+    This service now introduces unnecessary complexity and it should no longer be used
+    """,
+  ReplaceWith("[OffenderService]"),
+)
 @Component
 class OffenderDetailsDataSource(
   val apDeliusContextApiClient: ApDeliusContextApiClient,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ClientResultFailureArgumentsProvider.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ClientResultFailureArgumentsProvider.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import java.util.stream.Stream
+
+/**
+ * Provides an instance of each subtype of sealed interface ClientResult.Failure
+ */
+class ClientResultFailureArgumentsProvider<T> : ArgumentsProvider {
+  override fun provideArguments(context: ExtensionContext): Stream<Arguments> {
+    return Stream.of(
+      Arguments.of(ClientResult.Failure.CachedValueUnavailable<T>("some-cache-key")),
+      Arguments.of(
+        ClientResult.Failure.StatusCode<T>(
+          HttpMethod.GET,
+          "/",
+          HttpStatus.NOT_FOUND,
+          null,
+          false,
+        ),
+      ),
+      Arguments.of(
+        ClientResult.Failure.Other<T>(
+          HttpMethod.POST,
+          "/",
+          RuntimeException("Some error"),
+        ),
+      ),
+      Arguments.of(
+        ClientResult.Failure.PreemptiveCacheTimeout<T>("some-cache", "some-cache-key", 1000),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
There are several functions in OffenderService that can be used to retrieve offender details whilst also considering Limited Access Restrictions.

All of these functions have at least one of the following issues:

* Makes use of or returns community-api types (deprecated), instead of types provided by ap-and-delius-context
* Retrieves user access information even if the caller indicates that restrictions should be ignored via the ignoreLaoRestrictions boolean arg
* Uses the now deprecated OffenderDetailsDataSource, which adds an additional layer of complexity and obfuscation. This indirection  is no longer required as we’re not switching between community-api and ap-and-delius-context for offender information. This typically also leads to code that maps from the ap-and-delius-context types to community-api types, and then back to the ap-and-delius-context types
* Returns ‘offender not found’ if we get a 404 when calling the bulk offender endpoint. This indicates an API client issue, not that the offender can’t be found and should be treated as an unexpected error

This commit adds a new function OffenderService.getPersonSummaryInfoResults based upon the existing OffenderService.getOffenderSummariesByCrns that does not have any of the aforementioned issues. Furthermore, it introduces a Strategy Pattern to determine how limited access offenders are handled, making the outcome of each strategy clearer, and also provides a way for us to add additional handling strategy in the future to help further optomise code (e.g. filter out offenders for which the user doesn’t have accesss).

This commit deprecates all other methods to bulk retrieve offender information, and documents various performance issues found in the code related to retreiving offenders that would be improved by using this new function.