### PR TITLE
[APS-1093] Implement `POST /cas1/spaces/search` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/SpaceSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/SpaceSearchController.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.SpaceSearchesCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
+
+@Service
+class SpaceSearchController(
+  private val spaceSearchService: Cas1SpaceSearchService,
+  private val spaceSearchResultTransformer: Cas1SpaceSearchResultsTransformer,
+) : SpaceSearchesCas1Delegate {
+  override fun spacesSearchPost(cas1SpaceSearchParameters: Cas1SpaceSearchParameters): ResponseEntity<Cas1SpaceSearchResults> {
+    val results = spaceSearchService.findSpaces(cas1SpaceSearchParameters)
+
+    return ResponseEntity.ok(spaceSearchResultTransformer.transformDomainToApi(cas1SpaceSearchParameters, results))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1SpaceSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1SpaceSearchRepository.kt
@@ -1,0 +1,276 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1
+
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
+import java.sql.ResultSet
+import java.time.LocalDate
+import java.util.UUID
+
+private const val AP_TYPE_FILTER = """
+  AND result.ap_type IN (:apTypes)
+"""
+
+private const val GENDER_FILTER = """
+  AND EXISTS (
+    SELECT 1
+    FROM premises_characteristics pc
+    WHERE
+      pc.premises_id = result.premises_id
+      AND pc.characteristic_id IN (:genderCharacteristics)
+  )
+"""
+
+private const val PREMISES_CHARACTERISTICS_FILTER = """
+  AND EXISTS (
+    SELECT 1
+    FROM premises_characteristics pc
+    WHERE
+      pc.premises_id = result.premises_id
+      AND pc.characteristic_id IN (:premisesCharacteristics)
+  )
+"""
+
+private const val ROOM_CHARACTERISTICS_FILTER = """
+  AND EXISTS (
+    SELECT 1
+    FROM room_characteristics rc
+    JOIN rooms r
+    ON rc.room_id = r.id
+    WHERE
+      r.premises_id = result.premises_id
+      AND rc.characteristic_id IN (:roomCharacteristics)
+  )
+"""
+
+private const val CANDIDATE_PREMISES_QUERY_TEMPLATE = """
+SELECT
+  result.*
+FROM
+(
+  SELECT
+    p.id AS premises_id,
+    ST_Distance(
+      (SELECT point FROM postcode_districts pd WHERE pd.outcode = :outcode)::geography,
+      ap.point::geography
+    ) * 0.000621371 AS distance_in_miles,
+    ap.ap_code AS ap_code,
+    ap.q_code AS delius_q_code,
+    CASE
+      WHEN EXISTS (
+        SELECT 1
+        FROM premises_characteristics pc
+        JOIN characteristics c
+        ON pc.characteristic_id = c.id
+        WHERE
+          c.property_name = 'isPIPE'
+          AND pc.premises_id = p.id
+      ) THEN 'PIPE'
+      WHEN EXISTS (
+        SELECT 1
+        FROM premises_characteristics pc
+        JOIN characteristics c
+        ON pc.characteristic_id = c.id
+        WHERE
+          c.property_name = 'isESAP'
+          AND pc.premises_id = p.id
+      ) THEN 'ESAP'
+      WHEN EXISTS (
+        SELECT 1
+        FROM premises_characteristics pc
+        JOIN characteristics c
+        ON pc.characteristic_id = c.id
+        WHERE
+          c.property_name = 'isRecoveryFocussed'
+          AND pc.premises_id = p.id
+      ) THEN 'RFAP'
+      WHEN EXISTS (
+        SELECT 1
+        FROM premises_characteristics pc
+        JOIN characteristics c
+        ON pc.characteristic_id = c.id
+        WHERE
+          c.property_name = 'isSemiSpecialistMentalHealth'
+          AND pc.premises_id = p.id
+      ) THEN 'MHAP'
+      ELSE 'NORMAL'
+    END AS ap_type,
+    p.name AS name,
+    p.address_line1 AS address_line1,
+    p.address_line2 AS address_line2,
+    p.town AS town,
+    p.postcode AS postcode,
+    aa.id AS ap_area_id,
+    aa.name AS ap_area_name,
+    (
+      SELECT COUNT(*)
+      FROM beds b
+      JOIN rooms r
+      ON b.room_id = r.id
+      WHERE r.premises_id = p.id
+    ) AS total_spaces_count
+  FROM approved_premises ap
+  JOIN premises p
+  ON ap.premises_id = p.id
+  JOIN probation_regions pr
+  ON p.probation_region_id = pr.id
+  JOIN ap_areas aa
+  ON pr.ap_area_id = aa.id
+) AS result
+WHERE
+  1 = 1
+#GENDER_FILTER#
+#AP_TYPE_FILTER#
+#PREMISES_CHARACTERISTICS_FILTER#
+#ROOM_CHARACTERISTICS_FILTER#
+ORDER BY result.distance_in_miles
+"""
+
+private const val SPACE_AVAILABILITY_QUERY = """
+SELECT
+  p.id AS premises_id
+FROM premises p
+WHERE id IN (:premisesIds)
+"""
+
+@Repository
+class Cas1SpaceSearchRepository(
+  private val jdbcTemplate: NamedParameterJdbcTemplate,
+) {
+  fun findAllPremisesWithCharacteristicsByDistance(
+    targetPostcodeDistrict: String,
+    apTypes: List<ApprovedPremisesType>,
+    genderCharacteristics: List<UUID>,
+    premisesCharacteristics: List<UUID>,
+    roomCharacteristics: List<UUID>,
+  ): List<CandidatePremises> {
+    val (query, parameters) = resolveCandidatePremisesQueryTemplate(
+      targetPostcodeDistrict,
+      apTypes,
+      genderCharacteristics,
+      premisesCharacteristics,
+      roomCharacteristics,
+    )
+
+    return jdbcTemplate.query(query, parameters) { rs, _ ->
+      CandidatePremises(
+        rs.getUUID("premises_id"),
+        rs.getFloat("distance_in_miles"),
+        rs.getString("ap_code"),
+        rs.getString("delius_q_code"),
+        ApprovedPremisesType.valueOf(rs.getString("ap_type")),
+        rs.getString("name"),
+        rs.getString("address_line1"),
+        rs.getString("address_line2"),
+        rs.getString("town"),
+        rs.getString("postcode"),
+        rs.getUUID("ap_area_id"),
+        rs.getString("ap_area_name"),
+        rs.getInt("total_spaces_count"),
+      )
+    }
+  }
+
+  private fun resolveCandidatePremisesQueryTemplate(
+    targetPostcodeDistrict: String,
+    apTypes: List<ApprovedPremisesType>,
+    genderCharacteristics: List<UUID>,
+    premisesCharacteristics: List<UUID>,
+    roomCharacteristics: List<UUID>,
+  ): Pair<String, Map<String, Any>> {
+    var query = CANDIDATE_PREMISES_QUERY_TEMPLATE
+    val params = mutableMapOf<String, Any>(
+      "outcode" to targetPostcodeDistrict,
+    )
+
+    val transformedApTypes = apTypes.transformForQuery()
+
+    when {
+      transformedApTypes.isEmpty() -> {
+        query = query.replace("#AP_TYPE_FILTER#", "")
+      }
+      else -> {
+        query = query.replace("#AP_TYPE_FILTER#", AP_TYPE_FILTER)
+        params["apTypes"] = transformedApTypes
+      }
+    }
+
+    when {
+      genderCharacteristics.isEmpty() -> {
+        query = query.replace("#GENDER_FILTER#", "")
+      }
+      else -> {
+        query = query.replace("#GENDER_FILTER#", GENDER_FILTER)
+        params["genderCharacteristics"] = genderCharacteristics
+      }
+    }
+
+    when {
+      premisesCharacteristics.isEmpty() -> {
+        query = query.replace("#PREMISES_CHARACTERISTICS_FILTER#", "")
+      }
+      else -> {
+        query = query.replace("#PREMISES_CHARACTERISTICS_FILTER#", PREMISES_CHARACTERISTICS_FILTER)
+        params["premisesCharacteristics"] = premisesCharacteristics
+      }
+    }
+
+    when {
+      roomCharacteristics.isEmpty() -> {
+        query = query.replace("#ROOM_CHARACTERISTICS_FILTER#", "")
+      }
+      else -> {
+        query = query.replace("#ROOM_CHARACTERISTICS_FILTER#", ROOM_CHARACTERISTICS_FILTER)
+        params["roomCharacteristics"] = roomCharacteristics
+      }
+    }
+
+    return query to params
+  }
+
+  fun getSpaceAvailabilityForCandidatePremises(
+    premisesIds: List<UUID>,
+    startDate: LocalDate,
+    durationInDays: Int,
+  ): List<SpaceAvailability> = jdbcTemplate.query(
+    SPACE_AVAILABILITY_QUERY,
+    mapOf<String, Any>(
+      "premisesIds" to premisesIds,
+      "startDate" to startDate,
+      "duration" to durationInDays,
+    ),
+  ) { rs, _ ->
+    SpaceAvailability(
+      rs.getUUID("premises_id"),
+    )
+  }
+
+  private fun ResultSet.getUUID(columnLabel: String) = UUID.fromString(this.getString(columnLabel))
+
+  private fun List<ApprovedPremisesType>.transformForQuery() = this.map {
+    when (it) {
+      ApprovedPremisesType.MHAP_ST_JOSEPHS, ApprovedPremisesType.MHAP_ELLIOTT_HOUSE -> "MHAP"
+      else -> it.name
+    }
+  }
+}
+
+data class CandidatePremises(
+  val premisesId: UUID,
+  val distanceInMiles: Float,
+  val apCode: String,
+  val deliusQCode: String,
+  val apType: ApprovedPremisesType,
+  val name: String,
+  val addressLine1: String,
+  val addressLine2: String?,
+  val town: String?,
+  val postcode: String,
+  val apAreaId: UUID,
+  val apAreaName: String,
+  val totalSpaceCount: Int,
+)
+
+data class SpaceAvailability(
+  val premisesId: UUID,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
@@ -1,0 +1,130 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.SpaceAvailability
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApprovedPremisesType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.zipBy
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class Cas1SpaceSearchService(
+  private val characteristicService: CharacteristicService,
+  private val spaceSearchRepository: Cas1SpaceSearchRepository,
+) {
+  fun findSpaces(searchParameters: Cas1SpaceSearchParameters): List<Cas1SpaceSearchResult> {
+    val requiredCharacteristics = getRequiredCharacteristics(searchParameters)
+
+    val candidatePremises = getCandidatePremises(searchParameters.targetPostcodeDistrict, requiredCharacteristics)
+
+    if (candidatePremises.isEmpty()) {
+      return emptyList()
+    }
+
+    val availability = getAvailabilityForCandidatePremises(
+      candidatePremises,
+      searchParameters.startDate,
+      searchParameters.durationInDays,
+    )
+
+    return candidatePremises
+      .zipBy(availability, CandidatePremises::premisesId, SpaceAvailability::premisesId)
+      .map(Cas1SpaceSearchResult::fromPair)
+  }
+
+  private fun getRequiredCharacteristics(searchParameters: Cas1SpaceSearchParameters) = RequiredCharacteristics(
+    searchParameters.requirements.apTypes?.map { it.asApprovedPremisesType() } ?: listOf(),
+    getGenderCharacteristics(searchParameters),
+    getSpaceCharacteristics(searchParameters),
+  )
+
+  private fun getGenderCharacteristics(searchParameters: Cas1SpaceSearchParameters): List<UUID> {
+    val characteristicNames = mutableListOf<String?>()
+
+    searchParameters.requirements.genders?.forEach {
+      characteristicNames += when (it) {
+        Gender.male -> null
+        Gender.female -> null
+      }
+    }
+
+    return getCharacteristicGroup(characteristicNames).premisesCharacteristics
+  }
+
+  private fun getSpaceCharacteristics(searchParameters: Cas1SpaceSearchParameters): CharacteristicGroup {
+    val characteristicNames = searchParameters.requirements.spaceCharacteristics?.map { it.value } ?: listOf()
+
+    return getCharacteristicGroup(characteristicNames)
+  }
+
+  private fun getCharacteristicGroup(characteristicNames: List<String?>): CharacteristicGroup {
+    val characteristics = characteristicService.getCharacteristicsByPropertyNames(characteristicNames.filterNotNull())
+
+    return CharacteristicGroup(
+      characteristics.filter { it.isPremisesCharacteristic() }.map { it.id },
+      characteristics.filter { it.isRoomCharacteristic() }.map { it.id },
+    )
+  }
+
+  private fun getCandidatePremises(
+    targetPostcodeDistrict: String,
+    requiredCharacteristics: RequiredCharacteristics,
+  ): List<CandidatePremises> {
+    return spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+      targetPostcodeDistrict,
+      requiredCharacteristics.apTypes,
+      requiredCharacteristics.genders,
+      requiredCharacteristics.space.premisesCharacteristics,
+      requiredCharacteristics.space.roomCharacteristics,
+    )
+  }
+
+  private fun getAvailabilityForCandidatePremises(
+    candidatePremises: List<CandidatePremises>,
+    startDate: LocalDate,
+    durationInDays: Int,
+  ): List<SpaceAvailability> {
+    return spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+      candidatePremises.map { it.premisesId },
+      startDate,
+      durationInDays,
+    )
+  }
+
+  private fun CharacteristicEntity.isPremisesCharacteristic(): Boolean =
+    this.serviceMatches(ServiceName.approvedPremises.value) && this.modelMatches("premises")
+
+  private fun CharacteristicEntity.isRoomCharacteristic(): Boolean =
+    this.serviceMatches(ServiceName.approvedPremises.value) && this.modelMatches("room")
+}
+
+data class RequiredCharacteristics(
+  val apTypes: List<ApprovedPremisesType>,
+  val genders: List<UUID>,
+  val space: CharacteristicGroup,
+)
+
+data class CharacteristicGroup(
+  val premisesCharacteristics: List<UUID>,
+  val roomCharacteristics: List<UUID>,
+)
+
+data class Cas1SpaceSearchResult(
+  val candidatePremises: CandidatePremises,
+  val spaceAvailability: SpaceAvailability,
+) {
+  companion object {
+    fun fromPair(pair: Pair<CandidatePremises, SpaceAvailability>) = Cas1SpaceSearchResult(
+      pair.first,
+      pair.second,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceSearchResultsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceSearchResultsTransformer.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchResultSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult as ApiSpaceSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchResult as DomainSpaceSearchResult
+
+@Component
+class Cas1SpaceSearchResultsTransformer {
+  fun transformDomainToApi(searchParameters: Cas1SpaceSearchParameters, results: List<DomainSpaceSearchResult>) =
+    Cas1SpaceSearchResults(
+      resultsCount = results.size,
+      searchCriteria = searchParameters,
+      results = results.map {
+        ApiSpaceSearchResult(
+          premises = Cas1PremisesSearchResultSummary(
+            id = it.candidatePremises.premisesId,
+            apCode = it.candidatePremises.apCode,
+            deliusQCode = it.candidatePremises.deliusQCode,
+            apType = it.candidatePremises.apType.asApiType(),
+            name = it.candidatePremises.name,
+            addressLine1 = it.candidatePremises.addressLine1,
+            addressLine2 = it.candidatePremises.addressLine2,
+            town = it.candidatePremises.town,
+            postcode = it.candidatePremises.postcode,
+            apArea = NamedId(
+              id = it.candidatePremises.apAreaId,
+              name = it.candidatePremises.apAreaName,
+            ),
+            totalSpaceCount = it.candidatePremises.totalSpaceCount,
+            premisesCharacteristics = listOf(),
+          ),
+          distanceInMiles = it.candidatePremises.distanceInMiles.toBigDecimal(),
+          spacesAvailable = listOf(),
+        )
+      },
+    )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/CollectionUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/CollectionUtils.kt
@@ -1,3 +1,17 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 fun<T> Collection<T>.containsAny(vararg values: T): Boolean = values.toSet().intersect(this.toSet()).isNotEmpty()
+
+fun<T, U, ID> Iterable<T>.zipBy(
+  other: Iterable<U>,
+  keySelector1: T.() -> ID,
+  keySelector2: U.() -> ID,
+): Iterable<Pair<T, U>> {
+  val otherMap = other.associateBy(keySelector2)
+
+  return this.map {
+    val key = it.keySelector1()
+
+    Pair(it, otherMap[key]!!)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -1,0 +1,106 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
+import java.time.LocalDate
+
+class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
+  @Autowired
+  lateinit var transformer: Cas1SpaceSearchResultsTransformer
+
+  @Test
+  fun `Search for Spaces without JWT returns 401`() {
+    webTestClient.post()
+      .uri("/cas1/spaces/search")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Search for Spaces returns OK with correct body`() {
+    postCodeDistrictFactory.produceAndPersist {
+      withOutcode("SE1")
+      withLatitude(-0.07)
+      withLongitude(51.48)
+    }
+
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+      }
+
+      val searchParameters = Cas1SpaceSearchParameters(
+        startDate = LocalDate.now(),
+        durationInDays = 14,
+        targetPostcodeDistrict = "SE1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = null,
+          spaceCharacteristics = null,
+          genders = null,
+        ),
+      )
+
+      val response = webTestClient.post()
+        .uri("/cas1/spaces/search")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(searchParameters)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1SpaceSearchResults::class.java)
+
+      val results = response.responseBody.blockFirst()!!
+
+      assertThat(results.resultsCount).isEqualTo(5)
+      assertThat(results.searchCriteria).isEqualTo(searchParameters)
+
+      assertThatResultMatches(results.results[0], premises[0])
+      assertThatResultMatches(results.results[1], premises[1])
+      assertThatResultMatches(results.results[2], premises[2])
+      assertThatResultMatches(results.results[3], premises[3])
+      assertThatResultMatches(results.results[4], premises[4])
+    }
+  }
+
+  private fun assertThatResultMatches(actual: Cas1SpaceSearchResult, expected: ApprovedPremisesEntity) {
+    assertThat(actual.spacesAvailable).isEmpty()
+    assertThat(actual.distanceInMiles).isGreaterThan(0f.toBigDecimal())
+    assertThat(actual.premises).isNotNull
+    assertThat(actual.premises!!.id).isEqualTo(expected.id)
+    assertThat(actual.premises!!.apCode).isEqualTo(expected.apCode)
+    assertThat(actual.premises!!.deliusQCode).isEqualTo(expected.qCode)
+    assertThat(actual.premises!!.apType).isEqualTo(ApType.normal)
+    assertThat(actual.premises!!.name).isEqualTo(expected.name)
+    assertThat(actual.premises!!.addressLine1).isEqualTo(expected.addressLine1)
+    assertThat(actual.premises!!.addressLine2).isEqualTo(expected.addressLine2)
+    assertThat(actual.premises!!.town).isEqualTo(expected.town)
+    assertThat(actual.premises!!.postcode).isEqualTo(expected.postcode)
+    assertThat(actual.premises!!.apArea).isNotNull
+    assertThat(actual.premises!!.apArea!!.id).isEqualTo(expected.probationRegion.apArea!!.id)
+    assertThat(actual.premises!!.apArea!!.name).isEqualTo(expected.probationRegion.apArea!!.name)
+    assertThat(actual.premises!!.totalSpaceCount).isEqualTo(expected.rooms.flatMap { it.beds }.count())
+    assertThat(actual.premises!!.premisesCharacteristics).isEmpty()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
@@ -1,0 +1,581 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.SpaceAvailability
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApprovedPremisesType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchService
+import java.time.LocalDate
+import java.util.UUID
+import java.util.stream.Stream
+import kotlin.enums.enumEntries
+
+@ExtendWith(MockKExtension::class)
+class Cas1SpaceSearchServiceTest {
+  @MockK
+  private lateinit var characteristicService: CharacteristicService
+
+  @MockK
+  private lateinit var spaceSearchRepository: Cas1SpaceSearchRepository
+
+  @InjectMockKs
+  private lateinit var service: Cas1SpaceSearchService
+
+  @Test
+  fun `findSpaces returns premises ordered by distance with the correct space availability`() {
+    val candidatePremises1 = CandidatePremises(
+      UUID.randomUUID(),
+      1.0f,
+      "AP1234",
+      "QCODE1",
+      ApprovedPremisesType.NORMAL,
+      "Some AP",
+      "1 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      3,
+    )
+
+    val candidatePremises2 = CandidatePremises(
+      UUID.randomUUID(),
+      2.0f,
+      "AP2345",
+      "QCODE2",
+      ApprovedPremisesType.ESAP,
+      "Some Other AP",
+      "2 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      6,
+    )
+
+    val candidatePremises3 = CandidatePremises(
+      UUID.randomUUID(),
+      3.0f,
+      "AP3456",
+      "QCODE3",
+      ApprovedPremisesType.PIPE,
+      "Some AP",
+      "3 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      9,
+    )
+
+    val genderCharacteristics = Gender.entries.map { characteristicCalled(it.value) }
+    val spaceCharacteristics = Cas1SpaceCharacteristic.entries.map { characteristicWithRandomModelScopeCalled(it.value) }
+
+    every {
+      characteristicService.getCharacteristicsByPropertyNames(any())
+    } returnsMany listOf(
+      genderCharacteristics,
+      spaceCharacteristics,
+    )
+
+    every {
+      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
+
+    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
+    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
+    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
+
+    every {
+      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(spaceAvailability3, spaceAvailability1, spaceAvailability2)
+
+    val result = service.findSpaces(
+      Cas1SpaceSearchParameters(
+        startDate = LocalDate.parse("2024-08-01"),
+        durationInDays = 14,
+        targetPostcodeDistrict = "TB1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = ApType.entries,
+          genders = Gender.entries,
+          spaceCharacteristics = Cas1SpaceCharacteristic.entries,
+        ),
+      ),
+    )
+
+    assertThat(result).hasSize(3)
+    assertThat(result).containsExactly(
+      Cas1SpaceSearchResult(candidatePremises1, spaceAvailability1),
+      Cas1SpaceSearchResult(candidatePremises2, spaceAvailability2),
+      Cas1SpaceSearchResult(candidatePremises3, spaceAvailability3),
+    )
+
+    verify(exactly = 1) {
+      characteristicService.getCharacteristicsByPropertyNames(
+        listOf(
+          // TBD: gender characteristics
+        ),
+      )
+
+      characteristicService.getCharacteristicsByPropertyNames(
+        Cas1SpaceCharacteristic.entries.map { it.value },
+      )
+
+      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+        "TB1",
+        ApType.entries.map { it.asApprovedPremisesType() },
+        genderCharacteristics.map { it.id },
+        spaceCharacteristics.filter { it.modelMatches("premises") }.map { it.id },
+        spaceCharacteristics.filter { it.modelMatches("room") }.map { it.id },
+      )
+
+      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+        listOf(candidatePremises1.premisesId, candidatePremises2.premisesId, candidatePremises3.premisesId),
+        LocalDate.parse("2024-08-01"),
+        14,
+      )
+    }
+
+    confirmVerified()
+  }
+
+  @ParameterizedTest
+  @MethodSource("apTypeArgs")
+  fun `findSpaces uses the correct list of AP types`(apTypes: List<ApType>) {
+    val candidatePremises1 = CandidatePremises(
+      UUID.randomUUID(),
+      1.0f,
+      "AP1234",
+      "QCODE1",
+      ApprovedPremisesType.NORMAL,
+      "Some AP",
+      "1 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      3,
+    )
+
+    val candidatePremises2 = CandidatePremises(
+      UUID.randomUUID(),
+      2.0f,
+      "AP2345",
+      "QCODE2",
+      ApprovedPremisesType.ESAP,
+      "Some Other AP",
+      "2 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      6,
+    )
+
+    val candidatePremises3 = CandidatePremises(
+      UUID.randomUUID(),
+      3.0f,
+      "AP3456",
+      "QCODE3",
+      ApprovedPremisesType.PIPE,
+      "Some AP",
+      "3 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      9,
+    )
+
+    val genderCharacteristics = Gender.entries.map { characteristicCalled(it.value) }
+    val spaceCharacteristics = Cas1SpaceCharacteristic.entries.map { characteristicWithRandomModelScopeCalled(it.value) }
+
+    every {
+      characteristicService.getCharacteristicsByPropertyNames(any())
+    } returnsMany listOf(
+      genderCharacteristics,
+      spaceCharacteristics,
+    )
+
+    every {
+      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
+
+    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
+    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
+    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
+
+    every {
+      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(spaceAvailability3, spaceAvailability1, spaceAvailability2)
+
+    service.findSpaces(
+      Cas1SpaceSearchParameters(
+        startDate = LocalDate.parse("2024-08-01"),
+        durationInDays = 14,
+        targetPostcodeDistrict = "TB1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = apTypes,
+          genders = Gender.entries,
+          spaceCharacteristics = Cas1SpaceCharacteristic.entries,
+        ),
+      ),
+    )
+
+    verify(exactly = 1) {
+      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+        "TB1",
+        apTypes.map { it.asApprovedPremisesType() },
+        any(),
+        any(),
+        any(),
+      )
+    }
+
+    verify {
+      characteristicService.getCharacteristicsByPropertyNames(any())
+
+      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+        any(),
+        any(),
+        any(),
+      )
+    }
+
+    confirmVerified()
+  }
+
+  @ParameterizedTest
+  @MethodSource("genderArgs")
+  fun `findSpaces uses the correct gender characteristics`(genders: List<Gender>) {
+    val candidatePremises1 = CandidatePremises(
+      UUID.randomUUID(),
+      1.0f,
+      "AP1234",
+      "QCODE1",
+      ApprovedPremisesType.NORMAL,
+      "Some AP",
+      "1 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      3,
+    )
+
+    val candidatePremises2 = CandidatePremises(
+      UUID.randomUUID(),
+      2.0f,
+      "AP2345",
+      "QCODE2",
+      ApprovedPremisesType.ESAP,
+      "Some Other AP",
+      "2 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      6,
+    )
+
+    val candidatePremises3 = CandidatePremises(
+      UUID.randomUUID(),
+      3.0f,
+      "AP3456",
+      "QCODE3",
+      ApprovedPremisesType.PIPE,
+      "Some AP",
+      "3 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      9,
+    )
+
+    val genderCharacteristics = genders.map { characteristicCalled(it.value) }
+    val spaceCharacteristics = Cas1SpaceCharacteristic.entries.map { characteristicWithRandomModelScopeCalled(it.value) }
+
+    every {
+      characteristicService.getCharacteristicsByPropertyNames(any())
+    } returnsMany listOf(
+      genderCharacteristics,
+      spaceCharacteristics,
+    )
+
+    every {
+      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
+
+    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
+    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
+    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
+
+    every {
+      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(spaceAvailability3, spaceAvailability1, spaceAvailability2)
+
+    service.findSpaces(
+      Cas1SpaceSearchParameters(
+        startDate = LocalDate.parse("2024-08-01"),
+        durationInDays = 14,
+        targetPostcodeDistrict = "TB1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = ApType.entries,
+          genders = genders,
+          spaceCharacteristics = Cas1SpaceCharacteristic.entries,
+        ),
+      ),
+    )
+
+    verify(exactly = 1) {
+      characteristicService.getCharacteristicsByPropertyNames(
+        listOf(
+          // TBD: gender characteristics
+        ),
+      )
+
+      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+        any(),
+        any(),
+        genderCharacteristics.map { it.id },
+        any(),
+        any(),
+      )
+    }
+
+    verify {
+      characteristicService.getCharacteristicsByPropertyNames(any())
+
+      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+        any(),
+        any(),
+        any(),
+      )
+    }
+
+    confirmVerified()
+  }
+
+  @ParameterizedTest
+  @MethodSource("spaceCharacteristicArgs")
+  fun `findSpaces uses the correct space characteristics`(spaceCharacteristics: List<Cas1SpaceCharacteristic>) {
+    val candidatePremises1 = CandidatePremises(
+      UUID.randomUUID(),
+      1.0f,
+      "AP1234",
+      "QCODE1",
+      ApprovedPremisesType.NORMAL,
+      "Some AP",
+      "1 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      3,
+    )
+
+    val candidatePremises2 = CandidatePremises(
+      UUID.randomUUID(),
+      2.0f,
+      "AP2345",
+      "QCODE2",
+      ApprovedPremisesType.ESAP,
+      "Some Other AP",
+      "2 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      6,
+    )
+
+    val candidatePremises3 = CandidatePremises(
+      UUID.randomUUID(),
+      3.0f,
+      "AP3456",
+      "QCODE3",
+      ApprovedPremisesType.PIPE,
+      "Some AP",
+      "3 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      9,
+    )
+
+    val genderCharacteristics = Gender.entries.map { characteristicCalled(it.value) }
+    val spaceCharacteristicEntities = spaceCharacteristics.map { characteristicWithRandomModelScopeCalled(it.value) }
+
+    every {
+      characteristicService.getCharacteristicsByPropertyNames(any())
+    } returnsMany listOf(
+      genderCharacteristics,
+      spaceCharacteristicEntities,
+    )
+
+    every {
+      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
+
+    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
+    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
+    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
+
+    every {
+      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(spaceAvailability3, spaceAvailability1, spaceAvailability2)
+
+    service.findSpaces(
+      Cas1SpaceSearchParameters(
+        startDate = LocalDate.parse("2024-08-01"),
+        durationInDays = 14,
+        targetPostcodeDistrict = "TB1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = ApType.entries,
+          genders = Gender.entries,
+          spaceCharacteristics = spaceCharacteristics,
+        ),
+      ),
+    )
+
+    verify(exactly = 1) {
+      characteristicService.getCharacteristicsByPropertyNames(
+        spaceCharacteristics.map { it.value },
+      )
+
+      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
+        any(),
+        any(),
+        any(),
+        spaceCharacteristicEntities.filter { it.modelMatches("premises") }.map { it.id },
+        spaceCharacteristicEntities.filter { it.modelMatches("room") }.map { it.id },
+      )
+    }
+
+    verify {
+      characteristicService.getCharacteristicsByPropertyNames(any())
+
+      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
+        any(),
+        any(),
+        any(),
+      )
+    }
+
+    confirmVerified()
+  }
+
+  private fun characteristicCalled(name: String) = CharacteristicEntityFactory()
+    .withName(name)
+    .withPropertyName(name)
+    .withServiceScope(ServiceName.approvedPremises.value)
+    .withModelScope("*")
+    .produce()
+
+  private fun characteristicWithRandomModelScopeCalled(name: String) = CharacteristicEntityFactory()
+    .withName(name)
+    .withPropertyName(name)
+    .withServiceScope(ServiceName.approvedPremises.value)
+    .produce()
+
+  companion object {
+    @JvmStatic
+    @BeforeAll
+    fun setup() {
+      clearAllMocks()
+    }
+
+    @JvmStatic
+    fun apTypeArgs(): Stream<Arguments> = generateListEnumArgs<ApType>()
+
+    @JvmStatic
+    fun genderArgs(): Stream<Arguments> = generateListEnumArgs<Gender>()
+
+    @JvmStatic
+    fun spaceCharacteristicArgs(): Stream<Arguments> = generateListEnumArgs<Cas1SpaceCharacteristic>()
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private inline fun <reified T : Enum<T>> generateListEnumArgs(): Stream<Arguments> = Stream.concat(
+      enumEntries<T>().map { Arguments.of(listOf(it)) }.stream(),
+      Stream.of(Arguments.of(enumEntries<T>())),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceSearchResultsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceSearchResultsTransformerTest.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.SpaceAvailability
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
+import java.time.LocalDate
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult as ApiSpaceSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchResult as DomainSpaceSearchResult
+
+class Cas1SpaceSearchResultsTransformerTest {
+  private val transformer = Cas1SpaceSearchResultsTransformer()
+
+  @Test
+  fun `transformDomainToApi transforms correctly`() {
+    val searchParameters = Cas1SpaceSearchParameters(
+      startDate = LocalDate.now(),
+      durationInDays = 14,
+      targetPostcodeDistrict = "AB1",
+      requirements = Cas1SpaceSearchRequirements(
+        apTypes = ApType.entries,
+        spaceCharacteristics = Cas1SpaceCharacteristic.entries,
+        genders = Gender.entries,
+      ),
+    )
+
+    val candidatePremises1 = CandidatePremises(
+      UUID.randomUUID(),
+      1.0f,
+      "AP1234",
+      "QCODE1",
+      ApprovedPremisesType.NORMAL,
+      "Some AP",
+      "1 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      3,
+    )
+
+    val candidatePremises2 = CandidatePremises(
+      UUID.randomUUID(),
+      2.0f,
+      "AP2345",
+      "QCODE2",
+      ApprovedPremisesType.NORMAL,
+      "Some Other AP",
+      "2 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      6,
+    )
+
+    val candidatePremises3 = CandidatePremises(
+      UUID.randomUUID(),
+      3.0f,
+      "AP3456",
+      "QCODE3",
+      ApprovedPremisesType.NORMAL,
+      "Some AP",
+      "3 The Street",
+      null,
+      "Townsbury",
+      "TB1 2AB",
+      UUID.randomUUID(),
+      "Some AP Area",
+      9,
+    )
+
+    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
+    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
+    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
+
+    val searchResults = listOf(
+      DomainSpaceSearchResult(
+        candidatePremises = candidatePremises1,
+        spaceAvailability = spaceAvailability1,
+      ),
+      DomainSpaceSearchResult(
+        candidatePremises = candidatePremises2,
+        spaceAvailability = spaceAvailability2,
+      ),
+      DomainSpaceSearchResult(
+        candidatePremises = candidatePremises3,
+        spaceAvailability = spaceAvailability3,
+      ),
+    )
+
+    val actual = transformer.transformDomainToApi(searchParameters, searchResults)
+    assertThat(actual.searchCriteria).isNotNull
+    assertThat(actual.searchCriteria).isEqualTo(searchParameters)
+    assertThat(actual.resultsCount).isEqualTo(3)
+    assertThatTransformedResultMatches(actual.results[0], candidatePremises1)
+    assertThatTransformedResultMatches(actual.results[1], candidatePremises2)
+    assertThatTransformedResultMatches(actual.results[2], candidatePremises3)
+  }
+
+  private fun assertThatTransformedResultMatches(actual: ApiSpaceSearchResult, expected: CandidatePremises) {
+    assertThat(actual.premises).isNotNull
+    assertThat(actual.premises!!.id).isEqualTo(expected.premisesId)
+    assertThat(actual.premises!!.apCode).isEqualTo(expected.apCode)
+    assertThat(actual.premises!!.deliusQCode).isEqualTo(expected.deliusQCode)
+    assertThat(actual.premises!!.apType).isEqualTo(expected.apType.asApiType())
+    assertThat(actual.premises!!.name).isEqualTo(expected.name)
+    assertThat(actual.premises!!.addressLine1).isEqualTo(expected.addressLine1)
+    assertThat(actual.premises!!.addressLine2).isEqualTo(expected.addressLine2)
+    assertThat(actual.premises!!.town).isEqualTo(expected.town)
+    assertThat(actual.premises!!.postcode).isEqualTo(expected.postcode)
+    assertThat(actual.premises!!.apArea).isNotNull
+    assertThat(actual.premises!!.apArea!!.id).isEqualTo(expected.apAreaId)
+    assertThat(actual.premises!!.apArea!!.name).isEqualTo(expected.apAreaName)
+    assertThat(actual.premises!!.totalSpaceCount).isEqualTo(expected.totalSpaceCount)
+    assertThat(actual.premises!!.premisesCharacteristics).isEmpty()
+    assertThat(actual.distanceInMiles).isEqualTo(expected.distanceInMiles.toBigDecimal())
+    assertThat(actual.spacesAvailable).isEmpty()
+  }
+}


### PR DESCRIPTION
> See [APS-1093 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-1093).

This PR introduces the ability for users to be able to search for available spaces in Approved Premises. A search is performed by `POST`ing to the `/cas1/spaces/search` endpoint with a request body like:
```json
{
  "startDate": "2024-07-22",
  "durationInDays": 84,
  "targetPostcodeDistrict": "SE5",
  "requirements": {
    "apTypes": [
      "normal",
    ],
    "spaceCharacteristics": [
      "single"
    ],
    "genders": [
      "male"
    ]
  }
}
```

To which the API will respond with a list of candidate premises matching the search criteria and their availability, which looks like:
```json
{
  "searchCriteria": {
    "startDate": "2024-07-22",
    "durationInDays": 84,
    "targetPostcodeDistrict": "SE5",
    "requirements": {
      "apTypes": [
        "normal",
      ],
      "spaceCharacteristics": [
        "single"
      ],
      "genders": [
        "male"
      ]
    }
  },
  "resultsCount": 4,
  "results": [
    {
      "premises": {
        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
        "apCode": "NEHOPE1",
        "deliusQCode": "Q005",
        "apType": "normal",
        "name": "Hope House",
        "addressLine1": "1 The Street",
        "addressLine2": "Blackmore End",
        "town": "Braintree",
        "postcode": "LS1 3AD",
        "apArea": {
          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
          "name": "string"
        },
        "totalSpaceCount": 22,
        "premisesCharacteristics": [
          {
            "propertyName": "string",
            "name": "string"
          }
        ]
      },
      "distanceInMiles": 2.1,
      "spacesAvailable": []
    }
  ]
}
```

Currently, no availability information is possible, as the requisite booking entities have not been implemented yet. This functionality has been stubbed out in a way that should be straightforward to implement when appropriate.

Additionally, filtering by gender has no effect, as currently only male APs are supported in the service. This has also been stubbed out in a way that should be straightforward to introduce.