### PR TITLE
Drop implicit ‘.csv’ for seed job execution

### DIFF
--- a/doc/how-to/run_seed_job_remotely.md
+++ b/doc/how-to/run_seed_job_remotely.md
@@ -27,7 +27,7 @@ To process a seed CSV against a non-local environment:
 - Run the helper script from within the container to trigger the seed job:
 
   ```shell
-  /app/run_seed_job {seed type} {file name without path or extension}
+  /app/run_seed_job {seed type} {file name}
   ```
 
 - `seed type` is a value from the [`SeedFileType`](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/d8dc87aefa0294289a7bcb08048fbd8679b9954c/src/main/resources/static/_shared.yml#L3240) enum in the OpenAPI spec.  e.g.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
@@ -8,7 +8,7 @@ abstract class SeedJob<RowType> (
   val requiredHeaders: Set<String>? = null,
 ) {
   init {
-    if (fileName.contains("/") || fileName.contains("\\") || fileName.contains(".")) {
+    if (fileName.contains("/") || fileName.contains("\\")) {
       throw RuntimeException("Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -145,7 +145,7 @@ class SeedService(
   @Async
   fun seedDataAsync(seedFileType: SeedFileType, filename: String) = seedData(seedFileType, filename)
 
-  fun seedData(seedFileType: SeedFileType, filename: String) = seedData(seedFileType, filename) { "${seedConfig.filePrefix}/${this.fileName}.csv" }
+  fun seedData(seedFileType: SeedFileType, filename: String) = seedData(seedFileType, filename) { "${seedConfig.filePrefix}/${this.fileName}" }
 
   private fun seedData(seedFileType: SeedFileType, filename: String, resolveCsvPath: SeedJob<*>.() -> String) {
     seedLogger.info("Starting seed request: $seedFileType - $filename")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCharacteristicsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCharacteristicsTest.kt
@@ -24,7 +24,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
         "hasWideDoor,,temporary-accommodation,room\n",
     )
 
-    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-missing-name")
+    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-missing-name.csv")
 
     assertThat(characteristicRepository.count()).isEqualTo(0)
 
@@ -45,7 +45,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
         "hasWideDoor,Is the entrance wide?,temporary-accommodation,bar\n",
     )
 
-    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-unknown-scope")
+    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-unknown-scope.csv")
 
     assertThat(characteristicRepository.count()).isEqualTo(0)
 
@@ -66,7 +66,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
         "hasWideDoor,Is the entrance wide?,temporary-accommodation,\n",
     )
 
-    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-missing-scope")
+    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-missing-scope.csv")
 
     assertThat(characteristicRepository.count()).isEqualTo(0)
 
@@ -88,8 +88,8 @@ class SeedCharacteristicsTest : SeedTestBase() {
         "isIap,Is this an IAP?,approved-premises,premises\n",
     )
 
-    seedService.seedData(SeedFileType.characteristics, "valid-characteristics")
-    seedService.seedData(SeedFileType.characteristics, "valid-characteristics")
+    seedService.seedData(SeedFileType.characteristics, "valid-characteristics.csv")
+    seedService.seedData(SeedFileType.characteristics, "valid-characteristics.csv")
 
     val apWideDoorRoom = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "hasWideDoor",
@@ -138,7 +138,7 @@ class SeedCharacteristicsTest : SeedTestBase() {
         "hasWideDoor,Is the DOOR wide?,approved-premises,room\n",
     )
 
-    seedService.seedData(SeedFileType.characteristics, "valid-characteristics-update")
+    seedService.seedData(SeedFileType.characteristics, "valid-characteristics-update.csv")
 
     val updatedCharacteristic = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "hasWideDoor",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
@@ -41,7 +41,7 @@ class Cas1RedactAssessmentDetailsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRedactAssessmentDetails, "valid-csv")
+    seedService.seedData(SeedFileType.approvedPremisesRedactAssessmentDetails, "valid-csv.csv")
 
     val expectedJson = """{"sufficient-information":{"sufficient-information":{"sufficientInformation":"yes","query":""}}}"""
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/ApStaffUsersSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/ApStaffUsersSeedJobTest.kt
@@ -36,7 +36,7 @@ class APStaffUsersSeedJobTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesApStaffUsers, "invalid-user")
+    seedService.seedData(SeedFileType.approvedPremisesApStaffUsers, "invalid-user.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -77,7 +77,7 @@ class APStaffUsersSeedJobTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesApStaffUsers, "unknown-user")
+    seedService.seedData(SeedFileType.approvedPremisesApStaffUsers, "unknown-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("UNKNOWN-USER")
 
@@ -128,7 +128,7 @@ class APStaffUsersSeedJobTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesApStaffUsers, "pre-existing-user")
+    seedService.seedData(SeedFileType.approvedPremisesApStaffUsers, "pre-existing-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("PRE-EXISTING-USER")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesBookingCancellationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesBookingCancellationTest.kt
@@ -25,7 +25,7 @@ class SeedApprovedPremisesBookingCancellationTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesCancelBookings, "booking-does-not-exist")
+    seedService.seedData(SeedFileType.approvedPremisesCancelBookings, "booking-does-not-exist.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -78,7 +78,7 @@ class SeedApprovedPremisesBookingCancellationTest : SeedTestBase() {
         ),
       )
 
-      seedService.seedData(SeedFileType.approvedPremisesCancelBookings, "booking-not-for-ap")
+      seedService.seedData(SeedFileType.approvedPremisesCancelBookings, "booking-not-for-ap.csv")
 
       assertThat(logEntries)
         .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -132,7 +132,7 @@ class SeedApprovedPremisesBookingCancellationTest : SeedTestBase() {
         ),
       )
 
-      seedService.seedData(SeedFileType.approvedPremisesCancelBookings, "booking-for-ap")
+      seedService.seedData(SeedFileType.approvedPremisesCancelBookings, "booking-for-ap.csv")
 
       val savedBooking = bookingRepository.findByIdOrNull(booking.id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesOfflineApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesOfflineApplicationsTest.kt
@@ -22,7 +22,7 @@ class SeedApprovedPremisesOfflineApplicationsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesOfflineApplications, "offline-applications")
+    seedService.seedData(SeedFileType.approvedPremisesOfflineApplications, "offline-applications.csv")
 
     assertThat(offlineApplicationRepository.findAll()).anyMatch {
       it.crn == "NEWCRN"
@@ -45,7 +45,7 @@ class SeedApprovedPremisesOfflineApplicationsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesOfflineApplications, "offline-applications")
+    seedService.seedData(SeedFileType.approvedPremisesOfflineApplications, "offline-applications.csv")
 
     val matchingOfflineApplications = offlineApplicationRepository.findAll().filter {
       it.crn == "EXISTINGCRN"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesRoomsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesRoomsTest.kt
@@ -53,7 +53,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-service-scope")
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-service-scope.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -96,7 +96,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-model-scope")
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-model-scope.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -121,7 +121,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-missing-premises")
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-missing-premises.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -151,7 +151,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-room-invalid-boolean")
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-room-invalid-boolean.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -171,7 +171,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
         "HOPE,NESPU01,1,1,yes,yes,no,no",
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-room-missing-headers")
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-room-missing-headers.csv")
 
     val expectedErrorMessage = "The headers provided: " +
       "[apCode, bedCode, roomNumber, bedCount, isSingle, isGroundFloor, isFullyFm, hasCrib7Bedding] " +
@@ -241,7 +241,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-rooms")
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-rooms.csv")
 
     val persistedRoom5 = roomRepository.findByCode("NEABC-5")
     val persistedRoom4 = roomRepository.findByCode("NEABC-4")
@@ -337,7 +337,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "updated-ap-rooms")
+    seedService.seedData(SeedFileType.approvedPremisesRooms, "updated-ap-rooms.csv")
 
     val updatedRoom = roomRepository.findByCode("NEABC-4")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesTest.kt
@@ -39,7 +39,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-probation")
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-probation.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -69,7 +69,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-local-authority")
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-local-authority.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -109,7 +109,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-service-scope")
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-service-scope.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -149,7 +149,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-model-scope")
+    seedService.seedData(SeedFileType.approvedPremises, "invalid-model-scope.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -176,7 +176,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "new-ap-invalid-boolean")
+    seedService.seedData(SeedFileType.approvedPremises, "new-ap-invalid-boolean.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -196,7 +196,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
         "HOPE,Q00,North East,Leeds,Yorkshire & The Humber,Leeds,Leeds,1 The Street, Leeds",
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "new-ap-missing-headers")
+    seedService.seedData(SeedFileType.approvedPremises, "new-ap-missing-headers.csv")
 
     val expectedErrorMessage = "The headers provided: " +
       "[name, apCode, qCode, apArea, pdu, probationRegion, localAuthorityArea, town, addressLine1] " +
@@ -257,7 +257,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "new-ap")
+    seedService.seedData(SeedFileType.approvedPremises, "new-ap.csv")
 
     val persistedApprovedPremises = approvedPremisesRepository.findByApCode(csvRow.apCode)
     assertThat(persistedApprovedPremises).isNotNull
@@ -315,7 +315,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremises, "update-ap")
+    seedService.seedData(SeedFileType.approvedPremises, "update-ap.csv")
 
     val persistedApprovedPremises = approvedPremisesRepository.findByApCode(csvRow.apCode)
     assertThat(persistedApprovedPremises).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedAssessmentMoreInfoBugFixTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedAssessmentMoreInfoBugFixTest.kt
@@ -44,7 +44,7 @@ class SeedAssessmentMoreInfoBugFixTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesAssessmentMoreInfoBugFix, "valid-csv")
+    seedService.seedData(SeedFileType.approvedPremisesAssessmentMoreInfoBugFix, "valid-csv.csv")
 
     val expectedJson = """{
       "sufficient-information-confirm":{"confirm":"yes"},

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ApAreaEmailAddressTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ApAreaEmailAddressTest.kt
@@ -23,7 +23,7 @@ class SeedCas1ApAreaEmailAddressTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "invalid-ap-area-id")
+    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "invalid-ap-area-id.csv")
 
     Assertions.assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -46,9 +46,9 @@ class SeedCas1ApAreaEmailAddressTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "invalid-ap-area-id")
+    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "invalid-ap-area-id.csv")
 
-    Assertions.assertThat(logEntries)
+    assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
       .anyMatch {
         it.level == "error" &&
@@ -66,7 +66,7 @@ class SeedCas1ApAreaEmailAddressTest : SeedTestBase() {
         "SWSC,me@here.com",
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "missing-headers")
+    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "missing-headers.csv")
 
     val expectedErrorMessage = "The headers provided: " +
       "[totally, wrong_headers] " +
@@ -95,7 +95,7 @@ class SeedCas1ApAreaEmailAddressTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "valid-csv")
+    seedService.seedData(SeedFileType.approvedPremisesApAreaEmailAddresses, "valid-csv.csv")
 
     assertThat(apAreaRepository.findByIdentifier("SWSC")!!.emailAddress).isEqualTo("swsc@test.com")
     assertThat(apAreaRepository.findByIdentifier("Mids")!!.emailAddress).isEqualTo("mids@midlands.com")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingAdhocPropertyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingAdhocPropertyTest.kt
@@ -21,7 +21,7 @@ class SeedCas1BookingAdhocPropertyTest : SeedTestBase() {
       bookingIdListToCsvRows(listOf(invalidId to false)),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesBookingAdhocProperty, "invalid-booking-id")
+    seedService.seedData(SeedFileType.approvedPremisesBookingAdhocProperty, "invalid-booking-id.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -67,7 +67,7 @@ class SeedCas1BookingAdhocPropertyTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesBookingAdhocProperty, "valid-booking-ids")
+    seedService.seedData(SeedFileType.approvedPremisesBookingAdhocProperty, "valid-booking-ids.csv")
 
     assertThat(bookingRepository.findByIdOrNull(booking1.id)!!.adhoc).isTrue()
     assertThat(bookingRepository.findByIdOrNull(booking2.id)!!.adhoc).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DomainEventReplayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DomainEventReplayTest.kt
@@ -38,7 +38,7 @@ class SeedCas1DomainEventReplayTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesReplayDomainEvents, "valid-csv")
+    seedService.seedData(SeedFileType.approvedPremisesReplayDomainEvents, "valid-csv.csv")
 
     val message = snsDomainEventListener.blockForMessage(DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
@@ -70,7 +70,7 @@ class SeedCas1DuplicateApplicationTest : SeedTestBase() {
           ),
         )
 
-        seedService.seedData(SeedFileType.approvedPremisesDuplicateApplication, "valid-csv")
+        seedService.seedData(SeedFileType.approvedPremisesDuplicateApplication, "valid-csv.csv")
 
         val newApplication = approvedPremisesApplicationRepository.findAll()
           .filter { it.crn == sourceApplication.crn }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
@@ -51,7 +51,7 @@ class SeedCas1LinkBookingToPlacementRequestTest : SeedTestBase() {
         .build(),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesLinkBookingToPlacementRequest, "valid-csv")
+    seedService.seedData(SeedFileType.approvedPremisesLinkBookingToPlacementRequest, "valid-csv.csv")
 
     val updatedPlacementRequest = placementRequestRepository.findByIdOrNull(placementRequest.id)!!
     assertThat(updatedPlacementRequest.booking!!.id).isEqualTo(booking.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
@@ -391,13 +391,13 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
   }
 
   private fun seedWithCsv(name: String? = null, config: CsvBuilder.() -> Unit) {
-    val fileName = name ?: randomStringMultiCaseWithNumbers(64)
+    val fileName = (name ?: randomStringMultiCaseWithNumbers(64))
     generateCsvFile(
       fileName,
       csv(config),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesOutOfServiceBeds, fileName)
+    seedService.seedData(SeedFileType.approvedPremisesOutOfServiceBeds, fileName + ".csv")
   }
 
   private fun csv(config: CsvBuilder.() -> Unit) = CsvBuilder()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -48,7 +48,7 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
           ),
         )
 
-        seedService.seedData(SeedFileType.approvedPremisesWithdrawPlacementRequest, "valid-csv")
+        seedService.seedData(SeedFileType.approvedPremisesWithdrawPlacementRequest, "valid-csv.csv")
 
         assertThat(logEntries).anyMatch {
           it.level == "error" &&
@@ -96,7 +96,7 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
           ),
         )
 
-        seedService.seedData(SeedFileType.approvedPremisesWithdrawPlacementRequest, "valid-csv")
+        seedService.seedData(SeedFileType.approvedPremisesWithdrawPlacementRequest, "valid-csv.csv")
 
         assertPlacementApplicationNotWithdrawn(placementApplication)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
@@ -273,7 +273,7 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesUpdateEventNumber, "valid-csv")
+    seedService.seedData(SeedFileType.approvedPremisesUpdateEventNumber, "valid-csv.csv")
   }
 
   private fun createApplication(): Pair<ApprovedPremisesApplicationEntity, OffenderDetailSummary> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
@@ -49,7 +49,7 @@ class SeedCas2ApplicationTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.cas2Applications, "unknown-cas2-application")
+    seedService.seedData(SeedFileType.cas2Applications, "unknown-cas2-application.csv")
 
     val persistedApplication = cas2ApplicationRepository.getReferenceById(UUID.fromString(applicationId))
 
@@ -91,7 +91,7 @@ class SeedCas2ApplicationTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.cas2Applications, "in-progress-cas2-application")
+    seedService.seedData(SeedFileType.cas2Applications, "in-progress-cas2-application.csv")
 
     val persistedApplication = cas2ApplicationRepository.getReferenceById(UUID.fromString(applicationId))
 
@@ -141,7 +141,7 @@ class SeedCas2ApplicationTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.cas2Applications, "submitted-cas2-application")
+    seedService.seedData(SeedFileType.cas2Applications, "submitted-cas2-application.csv")
 
     val persistedApplication = cas2ApplicationRepository.getReferenceById(UUID.fromString(applicationId))
 
@@ -192,7 +192,7 @@ class SeedCas2ApplicationTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.cas2Applications, "in-review-cas2-application")
+    seedService.seedData(SeedFileType.cas2Applications, "in-review-cas2-application.csv")
 
     val persistedApplication = cas2ApplicationRepository.getReferenceById(UUID.fromString(applicationId))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedExternalUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedExternalUsersTest.kt
@@ -28,7 +28,7 @@ class SeedExternalUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.externalUsers, "unknown-external-user")
+    seedService.seedData(SeedFileType.externalUsers, "unknown-external-user.csv")
 
     val persistedUser = externalUserRepository.findByUsername("CAS2_ASSESSOR_FAKE")
 
@@ -60,7 +60,7 @@ class SeedExternalUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.externalUsers, "existing-external-user")
+    seedService.seedData(SeedFileType.externalUsers, "existing-external-user.csv")
 
     val persistedUser = externalUserRepository.findByUsername("CAS2_ASSESSOR_FAKE")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedNomisUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedNomisUsersTest.kt
@@ -28,7 +28,7 @@ class SeedNomisUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.nomisUsers, "unknown-nomis-user")
+    seedService.seedData(SeedFileType.nomisUsers, "unknown-nomis-user.csv")
 
     val persistedUser = nomisUserRepository.findByNomisUsername("ROGER_SMITH_FAKE")
 
@@ -60,7 +60,7 @@ class SeedNomisUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.nomisUsers, "existing-nomis-user")
+    seedService.seedData(SeedFileType.nomisUsers, "existing-nomis-user.csv")
 
     val persistedUser = nomisUserRepository.findByNomisUsername("ROGER_SMITH_FAKE")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedScaffoldingTest.kt
@@ -24,20 +24,6 @@ class SeedScaffoldingTest : SeedTestBase() {
   }
 
   @Test
-  fun `Attempting to process a file containing dots logs an error`() {
-    seedService.seedData(SeedFileType.approvedPremises, "afile.csv")
-
-    assertThat(logEntries).anyMatch {
-      it.level == "error" &&
-        it.message == "Unable to complete Seed Job" &&
-        it.throwable != null &&
-        it.throwable.message!!.contains(
-          "Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied",
-        )
-    }
-  }
-
-  @Test
   fun `Attempting to process a file containing forward slashes logs an error`() {
     seedService.seedData(SeedFileType.approvedPremises, "/afile")
 
@@ -90,7 +76,7 @@ RogerSmith,CAS1_MANAGER,
       """.trimIndent(),
     )
 
-    seedService.seedData(SeedFileType.user, "malformed")
+    seedService.seedData(SeedFileType.user, "malformed.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationBedspaceTest.kt
@@ -25,7 +25,7 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "invalid-ta-bedspace-premises-name")
+    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "invalid-ta-bedspace-premises-name.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -62,7 +62,7 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "new-ta-bedspace")
+    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "new-ta-bedspace.csv")
 
     val persistedPremises = temporaryAccommodationPremisesRepository.findByName(premises.name)
     assertThat(persistedPremises).isNotNull
@@ -112,7 +112,7 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "update-ta-bedspace")
+    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "update-ta-bedspace.csv")
 
     val persistedPremises = temporaryAccommodationPremisesRepository.findByName(premises.name)
     assertThat(persistedPremises).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationPremisesTest.kt
@@ -25,7 +25,7 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "invalid-probation-ta")
+    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "invalid-probation-ta.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -53,7 +53,7 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "invalid-local-authority-ta")
+    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "invalid-local-authority-ta.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -91,7 +91,7 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "new-ta-premises")
+    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "new-ta-premises.csv")
 
     val persistedPremises = temporaryAccommodationPremisesRepository.findByName(csvRow.name)
     assertThat(persistedPremises).isNotNull
@@ -152,7 +152,7 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "update-ta-premises")
+    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "update-ta-premises.csv")
 
     val persistedPremises = temporaryAccommodationPremisesRepository.findByName(csvRow.name)
     assertThat(persistedPremises).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationSmokeTest.kt
@@ -33,8 +33,8 @@ class SeedTemporaryAccommodationSmokeTest : SeedTestBase() {
         "APP,APP-2,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,app@email.com",
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "ta-smoketest-premises")
-    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "ta-smoketest-bedspace")
+    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "ta-smoketest-premises.csv")
+    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "ta-smoketest-bedspace.csv")
 
     assertThat(logEntries).noneMatch {
       it.level == "error"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
@@ -108,7 +108,7 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.updateNomsNumber, "valid-csv")
+    seedService.seedData(SeedFileType.updateNomsNumber, "valid-csv.csv")
 
     val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(application.id)
     assertThat(updatedApplication!!.nomsNumber).isEqualTo(NEW_NOMS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateUsersFromApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateUsersFromApiTest.kt
@@ -48,7 +48,7 @@ class SeedUpdateUsersFromApiTest : SeedTestBase() {
 
     withCsv("known-user-csv", csv)
 
-    seedService.seedData(SeedFileType.updateUsersFromApi, "known-user-csv")
+    seedService.seedData(SeedFileType.updateUsersFromApi, "known-user-csv.csv")
 
     val persistedUser = userRepository.findByDeliusUsername(USERNAME)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
@@ -34,7 +34,7 @@ class SeedUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.user, "invalid-user")
+    seedService.seedData(SeedFileType.user, "invalid-user.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -77,7 +77,7 @@ class SeedUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.user, "unknown-user")
+    seedService.seedData(SeedFileType.user, "unknown-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("UNKNOWN-USER")
 
@@ -116,7 +116,7 @@ class SeedUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.user, "known-user")
+    seedService.seedData(SeedFileType.user, "known-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("KNOWN-USER")
 
@@ -154,7 +154,7 @@ class SeedUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.user, "unknown-role")
+    seedService.seedData(SeedFileType.user, "unknown-role.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -188,7 +188,7 @@ class SeedUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.user, "unknown-qualification")
+    seedService.seedData(SeedFileType.user, "unknown-qualification.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -223,7 +223,7 @@ class SeedUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.user, "known-user")
+    seedService.seedData(SeedFileType.user, "known-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("KNOWN-USER")
 
@@ -273,7 +273,7 @@ class SeedUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.temporaryAccommodationUsers, "multi-service-user")
+    seedService.seedData(SeedFileType.temporaryAccommodationUsers, "multi-service-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("MULTI-SERVICE-USER")
 
@@ -340,7 +340,7 @@ class SeedUsersTest : SeedTestBase() {
 
     var iteration = 1
     repeat(20) {
-      seedService.seedData(SeedFileType.user, "users-many-times-base-job")
+      seedService.seedData(SeedFileType.user, "users-many-times-base-job.csv")
 
       seedInfos.forEach {
         val persistedUser = userRepository.findByDeliusUsername(it.staffUserDetails.username.uppercase())!!
@@ -421,7 +421,7 @@ class SeedUsersTest : SeedTestBase() {
 
     var iteration = 1
     repeat(20) {
-      seedService.seedData(SeedFileType.approvedPremisesUsers, "users-many-times-ap-job")
+      seedService.seedData(SeedFileType.approvedPremisesUsers, "users-many-times-ap-job.csv")
 
       seedInfos.forEach {
         val persistedUser = userRepository.findByDeliusUsername(it.staffUserDetails.username.uppercase())!!
@@ -471,7 +471,7 @@ class SeedUsersTest : SeedTestBase() {
       ),
     )
 
-    seedService.seedData(SeedFileType.user, "known-user")
+    seedService.seedData(SeedFileType.user, "known-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("KNOWN-USER")
 


### PR DESCRIPTION
Before this commit when running a seed job the API required that the ‘.csv’ extension was not included when specifying the filename. This has proven to be counter-intuative and leads to user error.