### PR TITLE
CAS-445 update user details from profile

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -31,7 +31,7 @@ class UsersController(
     val userEntity = when (val result = userService.updateUserFromCommunityApiById(id, xServiceName)) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, "User")
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
-      is AuthorisableActionResult.Success -> result.entity
+      is AuthorisableActionResult.Success -> result.entity.user!!
     }
 
     return ResponseEntity(userTransformer.transformJpaToApi(userEntity, xServiceName), HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/GetUserResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/GetUserResponse.kt
@@ -5,4 +5,5 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 data class GetUserResponse(
   val user: UserEntity?,
   var staffRecordFound: Boolean,
+  var createdOnGet: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -155,10 +155,14 @@ class TaskService(
       return AuthorisableActionResult.Unauthorised()
     }
 
-    val assigneeUser = when (val assigneeUserResult = userService.updateUserFromCommunityApiById(userToAllocateToId, ServiceName.approvedPremises)) {
-      is AuthorisableActionResult.Success -> assigneeUserResult.entity
-      else -> return AuthorisableActionResult.NotFound()
-    }
+    val assigneeUserResult = userService.updateUserFromCommunityApiById(userToAllocateToId, ServiceName.approvedPremises)
+
+    val assigneeUser =
+      if (assigneeUserResult is AuthorisableActionResult.Success && assigneeUserResult.entity.staffRecordFound) {
+        assigneeUserResult.entity.user!!
+      } else {
+        return AuthorisableActionResult.NotFound()
+      }
 
     val result = when (taskType) {
       TaskType.assessment -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -71,7 +71,7 @@ class UserTransformer(
       roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformTemporaryAccommodationRoleToApi),
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) },
-      service = ServiceName.temporaryAccommodation.value,
+      service = "CAS3",
     )
     ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -281,7 +281,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
             email = email,
             telephoneNumber = telephoneNumber,
             roles = emptyList(),
-            service = ServiceName.temporaryAccommodation.value,
+            service = "CAS3",
             isActive = true,
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskEntityTyp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.GetUserResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.TypedTask
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -414,7 +415,15 @@ class TaskServiceTest {
       }
       .produce()
 
-    every { userServiceMock.updateUserFromCommunityApiById(user.id, ServiceName.approvedPremises) } returns AuthorisableActionResult.Success(user)
+    every {
+      userServiceMock.updateUserFromCommunityApiById(
+        user.id,
+        ServiceName.approvedPremises,
+      )
+    } returns
+      AuthorisableActionResult.Success(
+        GetUserResponse(user, true),
+      )
 
     return user
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -714,7 +714,7 @@ class UserServiceTest {
       val result = userService.updateUserFromCommunityApiById(id, ServiceName.approvedPremises)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      val entity = (result as AuthorisableActionResult.Success).entity
+      val entity = (result as AuthorisableActionResult.Success).entity.user!!
 
       assertThat(entity.id).isEqualTo(user.id)
 
@@ -874,7 +874,7 @@ class UserServiceTest {
       val result = userService.updateUserFromCommunityApiById(id, forService, force)
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      val entity = (result as AuthorisableActionResult.Success).entity
+      val entity = (result as AuthorisableActionResult.Success).entity.user!!
 
       assertThat(entity.id).isEqualTo(user.id)
       assertThat(entity.name).isEqualTo(deliusUser.staff.fullName)
@@ -923,7 +923,7 @@ class UserServiceTest {
       assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
       result as AuthorisableActionResult.Success
 
-      var entity = result.entity
+      var entity = result.entity.user!!
 
       assertThat(entity.email).isEqualTo("null")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -73,7 +73,7 @@ class UserTransformerTest {
       ) as TemporaryAccommodationUser
 
       assertThat(result.roles).contains(reporter)
-      assertThat(result.service).isEqualTo(temporaryAccommodation.value)
+      assertThat(result.service).isEqualTo("CAS3")
       verify(exactly = 1) { probationRegionTransformer.transformJpaToApi(any()) }
     }
 
@@ -85,7 +85,7 @@ class UserTransformerTest {
       ) as TemporaryAccommodationUser
 
       assertThat(result.roles).contains(referrer)
-      assertThat(result.service).isEqualTo(temporaryAccommodation.value)
+      assertThat(result.service).isEqualTo("CAS3")
       verify(exactly = 1) { probationRegionTransformer.transformJpaToApi(any()) }
     }
 


### PR DESCRIPTION
PR to update the user details from delius when calling the /v2 profile endpoint. The call to delius is skipped if the user is created as part of the get request.