### PR TITLE
APS-1134 - Add fields to CAS1 booking cancelled domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -122,6 +122,16 @@ data class DomainEventEntity(
   @Column(name = "value")
   @CollectionTable(name = "domain_events_metadata", joinColumns = [ JoinColumn(name = "domain_event_id") ])
   val metadata: Map<MetaDataName, String?> = emptyMap(),
+  /**
+   * Use to track the schema version used for the [data] property. The schema version
+   * will be specific to the corresponding [type]
+   *
+   * This will be null for any domain events recorded before this concept was introduced.
+   *
+   * The domain event schema version used for a given domain event record is only required when the
+   * initial domain event schema changes in a way that we need to start tracking which schema a domain event uses.
+   */
+  val schemaVersion: Int?,
 ) {
   final inline fun <reified T> toDomainEvent(objectMapper: ObjectMapper): DomainEvent<T> {
     val data = when {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -14,4 +14,5 @@ data class DomainEvent<T> (
   val occurredAt: Instant,
   val data: T,
   val metadata: Map<MetaDataName, String?> = emptyMap(),
+  val schemaVersion: Int? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1196,7 +1196,7 @@ class BookingService(
     cancellation: CancellationEntity,
     reason: CancellationReasonEntity,
   ) {
-    val dateTime = OffsetDateTime.now()
+    val now = OffsetDateTime.now()
 
     val domainEventId = UUID.randomUUID()
 
@@ -1228,11 +1228,12 @@ class BookingService(
         applicationId = applicationId,
         crn = booking.crn,
         nomsNumber = offenderDetails.otherIds.nomsNumber,
-        occurredAt = dateTime.toInstant(),
+        occurredAt = now.toInstant(),
         bookingId = booking.id,
+        schemaVersion = 2,
         data = BookingCancelledEnvelope(
           id = domainEventId,
-          timestamp = dateTime.toInstant(),
+          timestamp = now.toInstant(),
           eventType = EventType.bookingCancelled,
           eventDetails = BookingCancelled(
             applicationId = applicationId,
@@ -1252,7 +1253,9 @@ class BookingService(
             ),
             cancelledBy = staffDetails.toStaffMember(),
             cancelledAt = cancellation.date.atTime(0, 0).toInstant(ZoneOffset.UTC),
+            cancelledAtDate = cancellation.date,
             cancellationReason = reason.name,
+            cancellationRecordedAt = now.toInstant(),
           ),
         ),
         metadata = mapOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -234,6 +234,7 @@ class DomainEventService(
         triggeredByUserId = userService.getUserForRequestOrNull()?.id,
         nomsNumber = domainEvent.nomsNumber,
         metadata = domainEvent.metadata,
+        schemaVersion = domainEvent.schemaVersion,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DomainEventService.kt
@@ -106,6 +106,7 @@ class DomainEventService(
         service = "CAS2",
         triggerSource = null,
         triggeredByUserId = null,
+        schemaVersion = domainEvent.schemaVersion,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventService.kt
@@ -206,6 +206,7 @@ class DomainEventService(
         service = "CAS3",
         triggerSource = null,
         triggeredByUserId = null,
+        schemaVersion = domainEvent.schemaVersion,
       ),
     )
 

--- a/src/main/resources/db/migration/all/20240807112608__add_domain_event_schema_version_column.sql
+++ b/src/main/resources/db/migration/all/20240807112608__add_domain_event_schema_version_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domain_events ADD COLUMN schema_version int NULL;

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1255,13 +1255,22 @@ components:
         premises:
           $ref: '#/components/schemas/Premises'
         cancelledAt:
+          deprecated: true
+          description: cancelledAtDate should be used instead
           type: string
           example: '2022-11-30T14:51:30'
           format: date-time
+        cancelledAtDate:
+          type: string
+          format: date
         cancelledBy:
           $ref: '#/components/schemas/StaffMember'
         cancellationReason:
           type: string
+        cancellationRecordedAt:
+          type: string
+          example: '2022-11-30T14:51:30'
+          format: date-time
       required:
         - personReference
         - deliusEventNumber
@@ -1270,8 +1279,10 @@ components:
         - bookingId
         - premises
         - cancelledAt
+        - cancelledAtDate
         - cancelledBy
         - cancellationReason
+        - cancellationRecordedAt
     BookingExtendedEnvelope:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -29,6 +29,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var triggeredByUserId: Yielded<UUID?> = { null }
   private var nomsNumber: Yielded<String?> = { randomStringMultiCaseWithNumbers(8) }
   private var metadata: Yielded<Map<MetaDataName, String?>> = { emptyMap() }
+  private var schemaVersion: Yielded<Int?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -111,5 +112,6 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     triggeredByUserId = this.triggeredByUserId(),
     nomsNumber = this.nomsNumber(),
     metadata = this.metadata(),
+    schemaVersion = this.schemaVersion(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingCancelledFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingCancelledFactory.kt
@@ -18,11 +18,13 @@ class BookingCancelledFactory : Factory<BookingCancelled> {
   private var deliusEventNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var bookingId: Yielded<UUID> = { UUID.randomUUID() }
   private var cancelledAt: Yielded<Instant> = { Instant.now() }
+  private var cancelledAtDate: Yielded<LocalDate> = { LocalDate.now() }
   private var cancelledBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
   private var premises: Yielded<Premises> = { EventPremisesFactory().produce() }
   private var arrivalOn: Yielded<LocalDate> = { LocalDate.now() }
   private var departureOn: Yielded<LocalDate> = { LocalDate.now() }
   private var cancellationReason: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var cancellationRecordedAt: Yielded<Instant> = { Instant.now() }
 
   fun withApplicationId(applicationId: UUID) = apply {
     this.applicationId = { applicationId }
@@ -46,6 +48,10 @@ class BookingCancelledFactory : Factory<BookingCancelled> {
 
   fun withCancelledAt(cancelledAt: Instant) = apply {
     this.cancelledAt = { cancelledAt }
+  }
+
+  fun withCancelledAtDate(cancelledAtDate: LocalDate) = apply {
+    this.cancelledAtDate = { cancelledAtDate }
   }
 
   fun withCancelledBy(cancelledBy: StaffMember) = apply {
@@ -75,8 +81,10 @@ class BookingCancelledFactory : Factory<BookingCancelled> {
     deliusEventNumber = this.deliusEventNumber(),
     bookingId = this.bookingId(),
     cancelledAt = this.cancelledAt(),
+    cancelledAtDate = this.cancelledAtDate(),
     cancelledBy = this.cancelledBy(),
     premises = this.premises(),
     cancellationReason = this.cancellationReason(),
+    cancellationRecordedAt = this.cancellationRecordedAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -140,6 +140,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Withdrawabl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -2555,7 +2556,7 @@ class BookingServiceTest {
       assertThat(domainEvent.applicationId).isEqualTo(application.id)
       assertThat(domainEvent.crn).isEqualTo(application.crn)
       assertThat(domainEvent.nomsNumber).isEqualTo(offenderDetails.otherIds.nomsNumber)
-      assertThat(domainEvent.nomsNumber).isEqualTo(offenderDetails.otherIds.nomsNumber)
+      assertThat(domainEvent.schemaVersion).isEqualTo(2)
 
       val data = domainEvent.data.eventDetails
       assertThat(data.applicationId).isEqualTo(application.id)
@@ -2571,7 +2572,9 @@ class BookingServiceTest {
       assertThat(data.premises.localAuthorityAreaName).isEqualTo(premises.localAuthorityArea!!.name)
 
       assertThat(data.cancelledAt).isEqualTo(Instant.parse("2022-08-25T00:00:00.00Z"))
+      assertThat(data.cancelledAtDate).isEqualTo(LocalDate.parse("2022-08-25"))
       assertThat(data.cancellationReason).isEqualTo(reason.name)
+      assertThat(data.cancellationRecordedAt).isWithinTheLastMinute()
       assertThat(data.bookingId).isEqualTo(bookingEntity.id)
 
       verify(exactly = 1) {


### PR DESCRIPTION
Before this commit, the CAS1 booking cancelled domain event details did not provide:

1. The date (and only the date) of when the cancellation occurred
2. The datetime of when the cancellation was recorded

The domain event did provide a datetime for when the cancellation occurred, but the time was always set to midnight UTC. This is currently being used by probation-integration services to set the time the contact occurred. This has resulted in two issues:

1. The cancellation appears to happen at either midnight or 1am, depending on the current daylight savings
2. If multiple cancellations happen for the same CRN in the same day, due to limitations in contact recorded only one contact is seen (despite referrals being correctly deleted in Delius).

This commit introduces the values mentoned at the top of this description. These fields can then be used by probation-integration to resolve the aforementioned issues.

This change is not backwards compatible, because once probation-integration have changed their code to expect these new fields, we can no longer replay existing booking cancelled domain events in their current state. To support these scenarios (if they occur), we are setting domain_events.schema_version to ‘2’ for any new booking cancelled domain event. If replay of a ‘legacy’ domain event is required, the replay logic will need to be updated to detect usage of the legacy detail schema (i.e. where domain_events.schema_version is null), and the json will need updating in the database to add these two additional fields.