### PR TITLE
Reduce connection pool timeout

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
   datasource:
     hikari:
       maximum-pool-size: 20
+      connection-timeout: 15000
 
   flyway:
     repeatable-sql-migration-prefix: "R"


### PR DESCRIPTION
When we have experienced extreme load issues, we’ve found that the default connection pool timeout of 30s is exacerbating the issue as by the time the connection becomes available we’ve had a client timeout/give up, so the request is no longer required.

This commit reduces that timeout to 15 seconds to try to allow clients to fail fast in these circumstances