### PR TITLE
APS-1129 - Add connection pool leak detection

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
     hikari:
       maximum-pool-size: 20
       connection-timeout: 15000
+      leakDetectionThreshold: 20000
 
   flyway:
     repeatable-sql-migration-prefix: "R"


### PR DESCRIPTION
We have observed under load that we’re running out of connections. Enabling leak detection will help us close in on threads that are retaining the connection for an unexpected amount of time.

We’re currently setting this quite high (20 seconds), over time we can reduce this

Example log output. We can use the thread id to find more information in app insights:

```
2024-08-02 14:35:09.455  WARN 7610 --- [l-1 housekeeper] com.zaxxer.hikari.pool.ProxyLeakTask     : Connection leak detection triggered for org.postgresql.jdbc.PgConnection@488279d3 on thread http-nio-8080-exec-2, stack trace follows |  

java.lang.Exception: Apparent connection leak detected
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:128)
	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:122)
	at org.hibernate.internal.NonContextualJdbcConnectionAccess.obtainConnection(NonContextualJdbcConnectionAccess.java:38)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:108)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getPhysicalConnection(LogicalConnectionManagedImpl.java:138)
```