### PR TITLE
/profile/v2 return LoadError if user update attempted and staff record not found

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -27,7 +27,7 @@ class ProfileController(
     val username = userService.getDeliusUserNameForRequest()
     var getUserResponse = userService.getUserForProfile(username)
     if (getUserResponse.user != null && !getUserResponse.createdOnGet) {
-      val updateResponse = userService.updateUserFromCommunityApiById(getUserResponse.user!!.id, xServiceName)
+      val updateResponse = userService.updateUserFromCommunityApi(getUserResponse.user!!, xServiceName)
       getUserResponse = (updateResponse as AuthorisableActionResult.Success<GetUserResponse>).entity
     }
     return ResponseEntity(userTransformer.transformProfileResponseToApi(username, getUserResponse, xServiceName), HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -15,6 +16,8 @@ class ProfileController(
   private val userService: UserService,
   private val userTransformer: UserTransformer,
 ) : ProfileApiDelegate {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
   override fun profileGet(xServiceName: ServiceName): ResponseEntity<User> {
     val userEntity = userService.getUserForRequest()
 
@@ -25,7 +28,10 @@ class ProfileController(
     val username = userService.getDeliusUserNameForRequest()
     var getUserResponse = userService.getUserForProfile(username)
     if (getUserResponse is UserService.GetUserResponse.Success && !getUserResponse.createdOnGet) {
+      log.info("On call to /profile/v2 user record for $username already exists, so will update")
       getUserResponse = userService.updateUserFromCommunityApi(getUserResponse.user, xServiceName)
+    } else {
+      log.info("On call to /profile/v2 user record for $username was created")
     }
     return ResponseEntity(userTransformer.transformProfileResponseToApi(username, getUserResponse, xServiceName), HttpStatus.OK)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -7,8 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ProfileApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProfileResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.GetUserResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 
@@ -26,9 +24,8 @@ class ProfileController(
   override fun profileV2Get(xServiceName: ServiceName): ResponseEntity<ProfileResponse> {
     val username = userService.getDeliusUserNameForRequest()
     var getUserResponse = userService.getUserForProfile(username)
-    if (getUserResponse.user != null && !getUserResponse.createdOnGet) {
-      val updateResponse = userService.updateUserFromCommunityApi(getUserResponse.user!!, xServiceName)
-      getUserResponse = (updateResponse as AuthorisableActionResult.Success<GetUserResponse>).entity
+    if (getUserResponse is UserService.GetUserResponse.Success && !getUserResponse.createdOnGet) {
+      getUserResponse = userService.updateUserFromCommunityApi(getUserResponse.user, xServiceName)
     }
     return ResponseEntity(userTransformer.transformProfileResponseToApi(username, getUserResponse, xServiceName), HttpStatus.OK)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -26,13 +26,16 @@ class ProfileController(
 
   override fun profileV2Get(xServiceName: ServiceName): ResponseEntity<ProfileResponse> {
     val username = userService.getDeliusUserNameForRequest()
-    var getUserResponse = userService.getUserForProfile(username)
-    if (getUserResponse is UserService.GetUserResponse.Success && !getUserResponse.createdOnGet) {
+    val getUserResponse = userService.getUserForProfile(username)
+
+    val responseToReturn = if (getUserResponse is UserService.GetUserResponse.Success && !getUserResponse.createdOnGet) {
       log.info("On call to /profile/v2 user record for $username already exists, so will update")
-      getUserResponse = userService.updateUserFromCommunityApi(getUserResponse.user, xServiceName)
+      userService.updateUserFromCommunityApi(getUserResponse.user, xServiceName)
     } else {
       log.info("On call to /profile/v2 user record for $username was created")
+      getUserResponse
     }
-    return ResponseEntity(userTransformer.transformProfileResponseToApi(username, getUserResponse, xServiceName), HttpStatus.OK)
+
+    return ResponseEntity(userTransformer.transformProfileResponseToApi(username, responseToReturn, xServiceName), HttpStatus.OK)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -117,7 +117,7 @@ class UsersController(
       throw ForbiddenProblem()
     }
 
-    val getUserResponse = userService.getExistingUserOrCreate(name, throwExceptionOnStaffRecordNotFound = false)
+    val getUserResponse = userService.getExistingUserOrCreate(name)
     return when (getUserResponse) {
       UserService.GetUserResponse.StaffRecordNotFound -> throw NotFoundProblem(name, "user", "username")
       is UserService.GetUserResponse.Success -> ResponseEntity.ok(userTransformer.transformJpaToApi(getUserResponse.user, xServiceName))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/UpdateAllUsersFromCommunityApiJob.kt
@@ -16,7 +16,10 @@ class UpdateAllUsersFromCommunityApiJob(
     userRepository.findAll().forEach {
       log.info("Updating user ${it.id}")
       try {
-        userService.updateUserFromCommunityApiById(it.id, ServiceName.approvedPremises)
+        when (userService.updateUserFromCommunityApi(it, ServiceName.approvedPremises)) {
+          UserService.GetUserResponse.StaffRecordNotFound -> log.error("Unable to update ${it.id}, no staff record")
+          is UserService.GetUserResponse.Success -> {}
+        }
       } catch (exception: Exception) {
         log.error("Unable to update user ${it.id}", exception)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/GetUserResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/GetUserResponse.kt
@@ -1,9 +1,0 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
-
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-
-data class GetUserResponse(
-  val user: UserEntity?,
-  var staffRecordFound: Boolean,
-  var createdOnGet: Boolean = false,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateUsersFromApiSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateUsersFromApiSeedJob.kt
@@ -28,8 +28,11 @@ class UpdateUsersFromApiSeedJob(
     val service = row.serviceName
 
     log.info("Updating user with username $username for service $service")
-    val user = userService.getExistingUserOrCreate(username)
-    userService.updateUserFromCommunityApi(user, service)
+    val user = userService.getExistingUserOrCreateDeprecated(username)
+    when (userService.updateUserFromCommunityApi(user, service)) {
+      UserService.GetUserResponse.StaffRecordNotFound -> error("Could not find staff record for user $username")
+      is UserService.GetUserResponse.Success -> { }
+    }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateUsersFromApiSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UpdateUsersFromApiSeedJob.kt
@@ -29,7 +29,7 @@ class UpdateUsersFromApiSeedJob(
 
     log.info("Updating user with username $username for service $service")
     val user = userService.getExistingUserOrCreate(username)
-    userService.updateUserFromCommunityApiById(user.id, service)
+    userService.updateUserFromCommunityApi(user, service)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
@@ -78,7 +78,7 @@ class UsersSeedJob(
     log.info("Setting roles for ${row.deliusUsername} to exactly ${row.roles.joinToString(",")}, qualifications to exactly: ${row.qualifications.joinToString(",")}")
 
     val user = try {
-      userService.getExistingUserOrCreate(row.deliusUsername)
+      userService.getExistingUserOrCreateDeprecated(row.deliusUsername)
     } catch (exception: Exception) {
       throw RuntimeException("Could not get user ${row.deliusUsername}", exception)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/ApStaffUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/ApStaffUsersSeedJob.kt
@@ -34,7 +34,7 @@ class ApStaffUsersSeedJob(
     seedLogger.info("Processing AP Staff seeding for ${row.deliusUsername}")
 
     val user = try {
-      userService.getExistingUserOrCreate(row.deliusUsername)
+      userService.getExistingUserOrCreateDeprecated(row.deliusUsername)
     } catch (exception: Exception) {
       throw RuntimeException("Could not get user ${row.deliusUsername}", exception)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -57,7 +57,7 @@ class Cas1AutoScript(
   private fun seedUser(seedUser: SeedUser) {
     try {
       val getUserResponse = userService
-        .getExistingUserOrCreate(username = seedUser.username, throwExceptionOnStaffRecordNotFound = false)
+        .getExistingUserOrCreate(username = seedUser.username)
 
       when (getUserResponse) {
         UserService.GetUserResponse.StaffRecordNotFound -> seedLogger.error("Seeding user with ${seedUser.username} failed as staff record not found")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -56,16 +56,19 @@ class Cas1AutoScript(
   @SuppressWarnings("TooGenericExceptionCaught")
   private fun seedUser(seedUser: SeedUser) {
     try {
-      val user = userService
+      val getUserResponse = userService
         .getExistingUserOrCreate(username = seedUser.username, throwExceptionOnStaffRecordNotFound = true)
-        .user
 
-      user?.let {
-        seedUser.roles.forEach { role ->
-          userService.addRoleToUser(user = user, role = role)
+      when (getUserResponse) {
+        UserService.GetUserResponse.StaffRecordNotFound -> seedLogger.error("Seeding user with ${seedUser.username} failed as staff record not found")
+        is UserService.GetUserResponse.Success -> {
+          val user = getUserResponse.user
+          seedUser.roles.forEach { role ->
+            userService.addRoleToUser(user = user, role = role)
+          }
+          val roles = user.roles.map { it.role }.joinToString(", ")
+          seedLogger.info("  -> User '${user.name}' (${user.deliusUsername}) seeded with roles $roles")
         }
-        val roles = user.roles.map { it.role }.joinToString(", ")
-        seedLogger.info("  -> User '${user.name}' (${user.deliusUsername}) seeded with roles $roles")
       }
     } catch (e: Exception) {
       seedLogger.error("Seeding user with ${seedUser.username} failed", e)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -57,7 +57,7 @@ class Cas1AutoScript(
   private fun seedUser(seedUser: SeedUser) {
     try {
       val getUserResponse = userService
-        .getExistingUserOrCreate(username = seedUser.username, throwExceptionOnStaffRecordNotFound = true)
+        .getExistingUserOrCreate(username = seedUser.username, throwExceptionOnStaffRecordNotFound = false)
 
       when (getUserResponse) {
         UserService.GetUserResponse.StaffRecordNotFound -> seedLogger.error("Seeding user with ${seedUser.username} failed as staff record not found")
@@ -154,7 +154,7 @@ class Cas1AutoScript(
         is PersonInfoResult.Success.Full -> personInfoResult
       }
 
-    val createdByUser = userService.getExistingUserOrCreate(deliusUserName)
+    val createdByUser = userService.getExistingUserOrCreateDeprecated(deliusUserName)
 
     val newApplicationEntity = extractEntityFromValidatableActionResult(
       applicationService.createApprovedPremisesApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -158,8 +158,10 @@ class TaskService(
     val assigneeUserResult = userService.updateUserFromCommunityApiById(userToAllocateToId, ServiceName.approvedPremises)
 
     val assigneeUser =
-      if (assigneeUserResult is AuthorisableActionResult.Success && assigneeUserResult.entity.staffRecordFound) {
-        assigneeUserResult.entity.user!!
+      if (assigneeUserResult is AuthorisableActionResult.Success &&
+        assigneeUserResult.entity is UserService.GetUserResponse.Success
+      ) {
+        assigneeUserResult.entity.user
       } else {
         return AuthorisableActionResult.NotFound()
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -366,7 +366,8 @@ class UserService(
         updatedAt = null,
       ),
     )
-    return GetUserResponse(savedUser, true)
+
+    return GetUserResponse(savedUser, staffRecordFound = true, createdOnGet = true)
   }
 
   private fun findProbationRegionFromArea(probationArea: StaffProbationArea): ProbationRegionEntity? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -70,7 +70,7 @@ class UserService(
 
   fun getUserForRequest(): UserEntity {
     val username = getDeliusUserNameForRequest()
-    val user = getExistingUserOrCreate(username)
+    val user = getExistingUserOrCreateDeprecated(username)
     ensureCas3UserHasCas3ReferrerRole(user)
 
     return user
@@ -304,7 +304,8 @@ class UserService(
     }
   }
 
-  fun getExistingUserOrCreate(username: String) = when (val result = getExistingUserOrCreate(username, throwExceptionOnStaffRecordNotFound = false)) {
+  @Deprecated("Callers should handle GetUserResponse directly", ReplaceWith("getExistingUserOrCreate(username)"))
+  fun getExistingUserOrCreateDeprecated(username: String) = when (val result = getExistingUserOrCreate(username, throwExceptionOnStaffRecordNotFound = false)) {
     GetUserResponse.StaffRecordNotFound -> throw InternalServerErrorProblem("Could not find staff record for user $username")
     is GetUserResponse.Success -> result.user
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -208,10 +208,10 @@ class UserService(
     force: Boolean = false,
   ): AuthorisableActionResult<GetUserResponse> {
     val user = userRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()
-    return updateUserFromCommunityApiById(user, forService, force)
+    return updateUserFromCommunityApi(user, forService, force)
   }
 
-  fun updateUserFromCommunityApiById(
+  fun updateUserFromCommunityApi(
     user: UserEntity,
     forService: ServiceName,
     force: Boolean = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -14,9 +14,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.GetUserResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.UserWorkload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission as ApiUserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as ApiUserQualification
 
@@ -76,11 +76,11 @@ class UserTransformer(
     ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
   }
 
-  fun transformProfileResponseToApi(userName: String, userResponse: GetUserResponse, xServiceName: ServiceName): ProfileResponse {
-    if (!userResponse.staffRecordFound) {
-      return ProfileResponse(userName, ProfileResponse.LoadError.staffRecordNotFound, user = null)
+  fun transformProfileResponseToApi(userName: String, userResponse: UserService.GetUserResponse, xServiceName: ServiceName): ProfileResponse {
+    return when (userResponse) {
+      UserService.GetUserResponse.StaffRecordNotFound -> ProfileResponse(userName, ProfileResponse.LoadError.staffRecordNotFound)
+      is UserService.GetUserResponse.Success -> ProfileResponse(userName, user = transformJpaToApi(userResponse.user, xServiceName))
     }
-    return ProfileResponse(userName, loadError = null, transformJpaToApi(userResponse.user!!, xServiceName))
   }
 
   private fun transformApprovedPremisesRoleToApi(userRole: UserRoleAssignmentEntity): ApprovedPremisesUserRole? =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission
@@ -16,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.util.UUID
@@ -210,7 +212,7 @@ class ProfileTest : IntegrationTestBase() {
     val profileV2Endpoint = "/profile/v2"
 
     @Test
-    fun `Getting own Approved Premises profile returns OK with correct body`() {
+    fun `Getting existing CAS1 profile returns OK with correct body`() {
       val id = UUID.randomUUID()
       val deliusUsername = "JIMJIMMERSON"
       val email = "foo@bar.com"
@@ -272,7 +274,7 @@ class ProfileTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Getting own Temporary Accommodation profile returns OK with correct body`() {
+    fun `Getting existing CAS3 profile returns OK with correct body`() {
       val id = UUID.randomUUID()
       val deliusUsername = "JIMJIMMERSON"
       val email = "foo@bar.com"
@@ -351,7 +353,7 @@ class ProfileTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `user details are updated when staff has been updated in delius`() {
+    fun `User details are updated when staff has been updated in delius`() {
       val id = UUID.randomUUID()
       val deliusUsername = "JIMJIMMERSON"
       val email = "foo@bar.com"
@@ -413,7 +415,7 @@ class ProfileTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Getting own Temporary Accommodation profile returns OK for CAS3_REPORTER with correct body`() {
+    fun `Getting existing CAS3 profile returns OK for CAS3_REPORTER with correct body`() {
       val id = UUID.randomUUID()
       val deliusUsername = "JIMJIMMERSON"
       val email = "foo@bar.com"
@@ -492,7 +494,51 @@ class ProfileTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Getting profile with no Delius staff record returns correct response`() {
+    fun `Getting new profile persists new user`() {
+      val deliusUsername = "JIMJIMMERSON"
+      val email = "foo@bar.com"
+      val telephoneNumber = "123445677"
+
+      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+        subject = deliusUsername,
+        authSource = "delius",
+        roles = listOf("ROLE_PROBATION"),
+      )
+
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+      }
+
+      probationAreaProbationRegionMappingFactory.produceAndPersist {
+        withProbationRegion(region)
+        withProbationAreaDeliusCode(region.deliusCode)
+      }
+
+      CommunityAPI_mockSuccessfulStaffUserDetailsCall(
+        StaffUserDetailsFactory()
+          .withUsername(deliusUsername)
+          .withEmail(email)
+          .withTelephoneNumber(telephoneNumber)
+          .withProbationAreaCode(region.deliusCode)
+          .produce(),
+      )
+
+      val response = webTestClient.get()
+        .uri(profileV2Endpoint)
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult<ProfileResponse>()
+        .responseBody
+        .blockFirst()
+
+      assertThat(response!!.user!!.deliusUsername).isEqualTo(deliusUsername)
+    }
+
+    @Test
+    fun `Getting new profile with no Delius staff record returns correct response`() {
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt("nonStaffUser")
       mockOAuth2ClientCredentialsCallIfRequired()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserCaseSensitivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserCaseSensitivityTest.kt
@@ -13,7 +13,7 @@ class UserCaseSensitivityTest : IntegrationTestBase() {
   @Test
   fun `Fetching a user with lowercase username returns the user with normalised uppercase username`() {
     `Given a User` { userEntity, _ ->
-      val returnedUser = userService.getExistingUserOrCreate(userEntity.deliusUsername.lowercase())
+      val returnedUser = userService.getExistingUserOrCreateDeprecated(userEntity.deliusUsername.lowercase())
 
       assertThat(returnedUser.id).isEqualTo(userEntity.id)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
@@ -42,7 +42,7 @@ class SeedUsersTest : SeedTestBase() {
         it.throwable != null &&
         it.throwable.cause != null &&
         it.throwable.message!!.contains("Could not get user INVALID-USER") &&
-        it.throwable.cause!!.message!!.contains("Unable to complete GET request to /secure/staff/username/INVALID-USER")
+        it.throwable.cause!!.message!!.contains("Could not find staff record for user INVALID-USER")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -38,7 +38,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskEntityTyp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.GetUserResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.TypedTask
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -422,7 +421,7 @@ class TaskServiceTest {
       )
     } returns
       AuthorisableActionResult.Success(
-        GetUserResponse(user, true),
+        UserService.GetUserResponse.Success(user),
       )
 
     return user

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -100,7 +100,7 @@ class UserServiceTest {
 
       every { mockUserRepository.findByDeliusUsername(username) } returns user
 
-      assertThat(userService.getExistingUserOrCreate(username)).isEqualTo(user)
+      assertThat(userService.getExistingUserOrCreateDeprecated(username)).isEqualTo(user)
       verify(exactly = 1) { userService.getExistingUserOrCreate(username, false) }
     }
 
@@ -156,7 +156,7 @@ class UserServiceTest {
 
       every { mockUserRepository.findByDeliusUsername(username) } returns user
 
-      assertThat(userService.getExistingUserOrCreate(username)).isEqualTo(user)
+      assertThat(userService.getExistingUserOrCreateDeprecated(username)).isEqualTo(user)
 
       verify(exactly = 0) { mockUserRepository.save(any()) }
     }
@@ -260,7 +260,7 @@ class UserServiceTest {
       every { mockProbationAreaProbationRegionMappingRepository.findByProbationAreaDeliusCode("AREACODE") } returns null
 
       assertThatThrownBy {
-        userService.getExistingUserOrCreate(username)
+        userService.getExistingUserOrCreateDeprecated(username)
       }
         .hasMessage("Unknown probation region code 'AREACODE' for user 'SOMEPERSON'")
         .isInstanceOf(RuntimeException::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -209,13 +209,15 @@ class UserServiceTest {
         .withDeliusCode(pduDeliusCode)
         .produce()
 
-      val result = userService.getExistingUserOrCreate(username)
+      val result = userService.getExistingUserOrCreate(username, throwExceptionOnStaffRecordNotFound = false)
 
-      assertThat(result.name).isEqualTo("Jim Jimmerson")
-      assertThat(result.teamCodes).isEqualTo(listOf("TC1", "TC2"))
-      assertThat(result.apArea).isEqualTo(apArea)
-      assertThat(result.probationDeliveryUnit?.deliusCode).isEqualTo(pduDeliusCode)
-      assertThat(result.createdAt).isWithinTheLastMinute()
+      assertThat(result.createdOnGet).isEqualTo(true)
+
+      assertThat(result.user!!.name).isEqualTo("Jim Jimmerson")
+      assertThat(result.user!!.teamCodes).isEqualTo(listOf("TC1", "TC2"))
+      assertThat(result.user!!.apArea).isEqualTo(apArea)
+      assertThat(result.user!!.probationDeliveryUnit?.deliusCode).isEqualTo(pduDeliusCode)
+      assertThat(result.user!!.createdAt).isWithinTheLastMinute()
 
       verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }
       verify(exactly = 1) { mockUserRepository.save(any()) }
@@ -223,7 +225,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getExistingUserOrCreate throws intenal server error problem if can't resolve region`() {
+    fun `getExistingUserOrCreate throws internal server error problem if can't resolve region`() {
       val username = "SOMEPERSON"
       val pduDeliusCode = randomStringMultiCaseWithNumbers(7)
       val brought = KeyValue(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -91,7 +91,7 @@ class UserServiceTest {
   inner class GetExistingUserOrCreate {
 
     @Test
-    fun `getExistingUserOrCreate calls overloaded function with throwExceptionOnStaffRecordNotFound parameter set false`() {
+    fun `getExistingUserOrCreateDeprecated calls overloaded function with throwExceptionOnStaffRecordNotFound parameter set false`() {
       val username = "SOMEPERSON"
 
       val user = UserEntityFactory()
@@ -101,11 +101,11 @@ class UserServiceTest {
       every { mockUserRepository.findByDeliusUsername(username) } returns user
 
       assertThat(userService.getExistingUserOrCreateDeprecated(username)).isEqualTo(user)
-      verify(exactly = 1) { userService.getExistingUserOrCreate(username, false) }
+      verify(exactly = 1) { userService.getExistingUserOrCreate(username) }
     }
 
     @Test
-    fun `getExistingUserOrCreate when user has no delius staff record and throwExceptionOnStaffRecordNotFound is false does not throw error`() {
+    fun `getExistingUserOrCreate when user has no delius staff record`() {
       val username = "SOMEPERSON"
 
       every { mockUserRepository.findByDeliusUsername(username) } returns null
@@ -116,34 +116,19 @@ class UserServiceTest {
         body = null,
       )
 
-      val result = userService.getExistingUserOrCreate(username, throwExceptionOnStaffRecordNotFound = false)
+      val result = userService.getExistingUserOrCreate(username)
 
       assertThat(result).isInstanceOf(GetUserResponse.StaffRecordNotFound::class.java)
     }
 
     @Test
-    fun `getExistingUserOrCreate when user has no delius staff record and throwExceptionOnStaffRecordNotFound is true throws error`() {
-      val username = "SOMEPERSON"
-
-      every { mockUserRepository.findByDeliusUsername(username) } returns null
-      every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Failure.StatusCode(
-        HttpMethod.GET,
-        "/secure/staff/username",
-        HttpStatus.NOT_FOUND,
-        body = null,
-      )
-
-      assertThrows<RuntimeException> { userService.getExistingUserOrCreate(username, true) }
-    }
-
-    @Test
-    fun `getExistingUserOrCreate when user has no delius staff record and throwExceptionOnStaffRecordNotFound is true and clientResult is failure throws error`() {
+    fun `getExistingUserOrCreate when clientResult is failure throws error`() {
       val username = "SOMEPERSON"
 
       every { mockUserRepository.findByDeliusUsername(username) } returns null
       every { mockCommunityApiClient.getStaffUserDetails(username) } returns ClientResult.Failure.PreemptiveCacheTimeout("", "", 0)
 
-      assertThrows<RuntimeException> { userService.getExistingUserOrCreate(username, true) }
+      assertThrows<RuntimeException> { userService.getExistingUserOrCreate(username) }
     }
 
     @Test
@@ -209,7 +194,7 @@ class UserServiceTest {
         .withDeliusCode(pduDeliusCode)
         .produce()
 
-      val result = userService.getExistingUserOrCreate(username, throwExceptionOnStaffRecordNotFound = false)
+      val result = userService.getExistingUserOrCreate(username)
 
       assertThat(result).isInstanceOf(GetUserResponse.Success::class.java)
       result as GetUserResponse.Success

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -936,6 +936,30 @@ class UserServiceTest {
 
       assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
     }
+
+    @Test
+    fun `it returns StaffRecordNotFound if staff record not found`() {
+      val user = userFactory
+        .withDefaults()
+        .withDeliusUsername("theUsername")
+        .produce()
+
+      every { mockUserRepository.findByIdOrNull(id) } returns user
+
+      every { mockCommunityApiClient.getStaffUserDetails("theUsername") } returns ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/secure/staff/username",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+
+      val result = userService.updateUserFromCommunityApiById(id, ServiceName.approvedPremises)
+
+      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
+      val getUserResponse = (result as AuthorisableActionResult.Success).entity
+
+      assertThat(getUserResponse).isEqualTo(GetUserResponse.StaffRecordNotFound)
+    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -38,8 +38,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_WORKFLOW_MANAGER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REFERRER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.GetUserResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.UserWorkload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
@@ -289,7 +289,7 @@ class UserTransformerTest {
     fun `transformProfileResponseToApi Should successfully transfer user response when staff record not found`() {
       val result = userTransformer.transformProfileResponseToApi(
         "userName",
-        GetUserResponse(null, false),
+        UserService.GetUserResponse.StaffRecordNotFound,
         approvedPremises,
       )
 
@@ -311,7 +311,7 @@ class UserTransformerTest {
 
       val result = userTransformer.transformProfileResponseToApi(
         "userName",
-        GetUserResponse(user, true),
+        UserService.GetUserResponse.Success(user),
         approvedPremises,
       )
 


### PR DESCRIPTION
This PR fixes some edge cases with how /profile/v2 behaves:

* If a call to /profile/v2 leads to an existing user being updated and the Delius staff record doesn't exist, a loadError will be returned instead of a 500 status code
* If a call to /profile/v2 leads to a user record being created, an update was immediately attempted as UserService was not setting createdOnGet to true on the GetUserResponse response. This PR corrects that behaviour

This PR also replaces the GetUserResponse data class with a sealed hierarchy, forcing callers to deal with the StaffRecordNotFound outcome, and deprecates various functionality to try and reduce complexity in UserService