### PR TITLE
APS-1117 : user version

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RequestResponseLoggingFilter.kt
@@ -53,6 +53,7 @@ class RequestResponseLoggingFilter(val sentryService: SentryService) : OncePerRe
     } else {
       log.info("Response Body not logged as content type is $contentType")
     }
+    log.info("Response Headers {}", responseWrapper.headerNames.map { "$it:  ${responseWrapper.getHeaders(it)}" })
 
     if (requestWrapper.isAsyncStarted) {
       requestWrapper.asyncContext.addListener(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/UserVersionFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/UserVersionFilter.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.io.IOException
+import javax.servlet.FilterChain
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class UserVersionFilter(
+  private val userService: UserService,
+  private val requestContextService: RequestContextService,
+) : OncePerRequestFilter() {
+
+  @Throws(ServletException::class, IOException::class)
+  override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
+    when (requestContextService.getServiceForRequest()) {
+      ServiceName.approvedPremises -> {
+        addUserVersionHeader(response)
+      }
+      else -> { }
+    }
+    filterChain.doFilter(request, response)
+  }
+
+  private fun addUserVersionHeader(response: HttpServletResponse) {
+    userService.getUserForRequestVersion()?.let {
+      response.setHeader("X-CAS-User-Version", it.toString())
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -21,6 +21,7 @@ import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.Table
 
+@Suppress("TooManyFunctions")
 @Repository
 interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExecutor<UserEntity> {
   @Query(
@@ -44,6 +45,11 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
 
   @Query("SELECT DISTINCT u FROM UserEntity u join u.qualifications q where q.qualification = :qualification and u.isActive = true")
   fun findActiveUsersWithQualification(qualification: UserQualification): List<UserEntity>
+
+  @Query(
+    "SELECT DISTINCT r.role FROM UserEntity u join u.roles r where u.deliusUsername = :deliusUsername",
+  )
+  fun findRolesByUsername(deliusUsername: String): List<UserRole>
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -288,6 +288,13 @@ data class UserEntity(
   fun hasPermission(permission: UserPermission) = roles.any { it.role.hasPermission(permission) }
 
   override fun toString() = "User $id"
+
+  companion object {
+    fun getVersionHashCode(roles: List<UserRole>) = Objects.hash(
+      roles.map { it.name },
+      roles.map { it.permissions.map { permission -> permission.name } },
+    )
+  }
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -91,6 +91,13 @@ class UserService(
     return userRepository.findByDeliusUsername(username.uppercase())
   }
 
+  fun getUserForRequestVersion(): Int? {
+    return httpAuthService.getDeliusPrincipalOrNull()?.let { deliusPrincipal ->
+      val roles = userRepository.findRolesByUsername(deliusPrincipal.name)
+      return UserEntity.getVersionHashCode(roles)
+    }
+  }
+
   fun getUsersWithQualificationsAndRoles(
     qualifications: List<UserQualification>?,
     roles: List<UserRole>?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -60,6 +60,7 @@ class UserTransformer(
       region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
       service = "CAS1",
       apArea = jpa.apArea?.let { apAreaTransformer.transformJpaToApi(it) } ?: throw InternalServerErrorProblem("CAS1 user ${jpa.id} should have AP Area Set"),
+      version = UserEntity.getVersionHashCode((jpa.roles.map { it.role })),
     )
     ServiceName.temporaryAccommodation -> TemporaryAccommodationUser(
       id = jpa.id,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3244,6 +3244,8 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            version:
+              type: integer
           required:
             - qualifications
             - roles

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7657,6 +7657,8 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            version:
+              type: integer
           required:
             - qualifications
             - roles

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3897,6 +3897,8 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            version:
+              type: integer
           required:
             - qualifications
             - roles

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3835,6 +3835,8 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            version:
+              type: integer
           required:
             - qualifications
             - roles

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3335,6 +3335,8 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            version:
+              type: integer
           required:
             - qualifications
             - roles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
@@ -170,7 +170,7 @@ class PersonalTimelineTest : IntegrationTestBase() {
                         email = userEntity.email,
                         telephoneNumber = userEntity.telephoneNumber,
                         isActive = userEntity.isActive,
-                        version = 30784,
+                        version = 993,
                       ),
                       timelineEvents = listOf(
                         TimelineEvent(
@@ -296,7 +296,7 @@ class PersonalTimelineTest : IntegrationTestBase() {
                         email = userEntity.email,
                         telephoneNumber = userEntity.telephoneNumber,
                         isActive = userEntity.isActive,
-                        version = 30784,
+                        version = 993,
                       ),
                       timelineEvents = listOf(
                         TimelineEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
@@ -170,6 +170,7 @@ class PersonalTimelineTest : IntegrationTestBase() {
                         email = userEntity.email,
                         telephoneNumber = userEntity.telephoneNumber,
                         isActive = userEntity.isActive,
+                        version = 30784,
                       ),
                       timelineEvents = listOf(
                         TimelineEvent(
@@ -295,6 +296,7 @@ class PersonalTimelineTest : IntegrationTestBase() {
                         email = userEntity.email,
                         telephoneNumber = userEntity.telephoneNumber,
                         isActive = userEntity.isActive,
+                        version = 30784,
                       ),
                       timelineEvents = listOf(
                         TimelineEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -80,7 +80,7 @@ class ProfileTest : IntegrationTestBase() {
                   ApprovedPremisesUserPermission.assessPlacementApplication,
                   ApprovedPremisesUserPermission.viewAssignedAssessments,
                 ),
-                version = 2050692243,
+                version = 885605168,
               ),
             ),
           )
@@ -267,7 +267,7 @@ class ProfileTest : IntegrationTestBase() {
                     ApprovedPremisesUserPermission.assessPlacementApplication,
                     ApprovedPremisesUserPermission.viewAssignedAssessments,
                   ),
-                  version = 2050692243,
+                  version = 885605168,
                 ),
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -80,6 +80,7 @@ class ProfileTest : IntegrationTestBase() {
                   ApprovedPremisesUserPermission.assessPlacementApplication,
                   ApprovedPremisesUserPermission.viewAssignedAssessments,
                 ),
+                version = 2050692243,
               ),
             ),
           )
@@ -266,6 +267,7 @@ class ProfileTest : IntegrationTestBase() {
                     ApprovedPremisesUserPermission.assessPlacementApplication,
                     ApprovedPremisesUserPermission.viewAssignedAssessments,
                   ),
+                  version = 2050692243,
                 ),
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRolesAndQu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.KeyValue
@@ -180,32 +181,30 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
 
     mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
 
-    webTestClient.get()
+    val result = webTestClient.get()
       .uri("/users/$id")
       .header("Authorization", "Bearer $jwt")
       .header("X-Service-Name", ServiceName.approvedPremises.value)
       .exchange()
       .expectStatus()
       .isOk
-      .expectBody()
-      .json(
-        objectMapper.writeValueAsString(
-          ApprovedPremisesUser(
-            id = id,
-            region = ProbationRegion(region.id, region.name),
-            deliusUsername = deliusUsername,
-            name = name,
-            email = email,
-            telephoneNumber = telephoneNumber,
-            roles = emptyList(),
-            qualifications = emptyList(),
-            service = "CAS1",
-            isActive = true,
-            apArea = ApArea(apArea.id, apArea.identifier, apArea.name),
-            permissions = emptyList(),
-          ),
-        ),
-      )
+      .returnResult(ApprovedPremisesUser::class.java)
+      .responseBody
+      .blockFirst()
+
+    assertThat(result.id).isEqualTo(id)
+    assertThat(result.region).isEqualTo(ProbationRegion(region.id, region.name))
+    assertThat(result.deliusUsername).isEqualTo(deliusUsername)
+    assertThat(result.name).isEqualTo(name)
+    assertThat(result.email).isEqualTo(email)
+    assertThat(result.telephoneNumber).isEqualTo(telephoneNumber)
+    assertThat(result.roles).isEqualTo(emptyList<ApprovedPremisesUserRole>())
+    assertThat(result.qualifications).isEqualTo(emptyList<UserQualification>())
+    assertThat(result.service).isEqualTo("CAS1")
+    assertThat(result.isActive).isEqualTo(true)
+    assertThat(result.apArea).isEqualTo(ApArea(region.apArea.id, region.apArea.identifier, region.apArea.name))
+    assertThat(result.permissions).isEqualTo(emptyList<UserPermission>())
+    assertThat(result.version).isNotZero()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -477,6 +477,43 @@ class UserServiceTest {
   }
 
   @Nested
+  inner class GetUserForRequestVersion {
+
+    @Test
+    fun `getUserForRequestVersion returns userVersion when user exists`() {
+      val username = "SOMEPERSON"
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+
+      every { mockHttpAuthService.getDeliusPrincipalOrNull() } returns mockPrincipal
+      every { mockPrincipal.name } returns username
+
+      every { mockUserRepository.findRolesByUsername(username) } returns listOf<UserRole>(UserRole.CAS1_USER_MANAGER, UserRole.CAS1_APPEALS_MANAGER)
+
+      assertThat(userService.getUserForRequestVersion()).isEqualTo(1725728026)
+    }
+
+    @Test
+    fun `getUserForRequestOrNull returns null when User has no roles`() {
+      val username = "SOMEPERSON"
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+
+      every { mockHttpAuthService.getDeliusPrincipalOrNull() } returns null
+      every { mockPrincipal.name } returns username
+
+      every { mockUserRepository.findRolesByUsername(username) } returns emptyList<UserRole>()
+
+      assertThat(userService.getUserForRequestVersion()).isNull()
+    }
+
+    @Test
+    fun `getUserForRequestOrNull returns null when no principal is available`() {
+      every { mockHttpAuthService.getDeliusPrincipalOrNull() } returns null
+
+      assertThat(userService.getUserForRequestVersion()).isNull()
+    }
+  }
+
+  @Nested
   inner class UpdateUserPduFromCommunityApiById {
 
     val user = UserEntityFactory().withDefaults().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -46,6 +46,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationReg
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addQualificationForUnitTest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
+import java.time.OffsetDateTime
 import java.util.UUID.randomUUID
 
 class UserTransformerTest {
@@ -196,6 +197,22 @@ class UserTransformerTest {
     }
 
     @Test
+    fun `transformJpaToApi CAS1 should return version`() {
+      val user = buildUserEntity(
+        role = CAS1_JANITOR,
+        apArea = ApAreaEntityFactory().produce(),
+      )
+
+      every { apAreaTransformer.transformJpaToApi(any()) } returns apArea
+
+      val result =
+        userTransformer.transformJpaToApi(user, approvedPremises) as ApprovedPremisesUser
+
+      assertThat(result.version).isNotNull()
+      assertThat(result.version).isEqualTo(-298303991)
+    }
+
+    @Test
     fun `transformJpaToApi CAS3 should return distinct roles for Temporary Accommodation`() {
       val user = buildUserEntity(CAS3_REFERRER)
       user.addRoleForUnitTest(CAS3_REFERRER)
@@ -324,6 +341,7 @@ class UserTransformerTest {
   private fun buildUserEntity(
     role: UserRole,
     apArea: ApAreaEntity? = null,
+    updatedAt: OffsetDateTime? = null,
   ) = UserEntityFactory()
     .withId(randomUUID())
     .withName("username")
@@ -333,6 +351,7 @@ class UserTransformerTest {
     .withIsActive(true)
     .withProbationRegion(buildProbationRegionEntity())
     .withApArea(apArea)
+    .withUpdatedAt(updatedAt)
     .produce()
     .addRoleForUnitTest(role)
     .addQualificationForUnitTest(WOMENS)


### PR DESCRIPTION
Add a 'version' property to the user response which is a hash of a the permission properties on a user's record. 
Add RequestResponseLoggingFilter which adds a header, X-Cas-User-Version, to all CAS 1 Api responses which is a version hash for the user making the request. 

The intention is that the UI recognises the change in the version value of the  logged in user, against the value returned in the API call and looks to fetch the updated user record (with updated permissions)