### PR TITLE
APS-1151 - InmateDetails Cache Refresh Improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
@@ -7,6 +7,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CacheRefreshExclusionsInmateDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
+import java.time.LocalDateTime
 
 @SuppressWarnings("LongParameterList")
 class InmateDetailsCacheRefreshWorker(
@@ -14,6 +16,7 @@ class InmateDetailsCacheRefreshWorker(
   private val bookingRepository: BookingRepository,
   private val cacheRefreshExclusionsInmateDetailsRepository: CacheRefreshExclusionsInmateDetailsRepository,
   private val prisonsApiClient: PrisonsApiClient,
+  private val sentryService: SentryService,
   private val loggingEnabled: Boolean,
   private val delayMs: Long,
   redLock: RedLock,
@@ -30,45 +33,58 @@ class InmateDetailsCacheRefreshWorker(
 
     if (loggingEnabled) { log.info("Got $distinctNomsNumbers to refresh for Inmate Details") }
 
-    distinctNomsNumbers.forEach {
-      logConspicuously("Current NOMS number: $it")
+    val refreshStarted = LocalDateTime.now()
 
-      if (checkShouldStop()) return
+    distinctNomsNumbers.shuffled().forEachIndexed { index, nomsNumber ->
+      logConspicuously("Current NOMS number: $nomsNumber")
+
+      if (checkShouldStop()) {
+        val message = """
+          Inmate details refresh has stopped prematurely.  Is the lock timeout to short? 
+          Have processed $index of ${distinctNomsNumbers.size} candidates
+          Refresh started at $refreshStarted
+          """
+        logConspicuously(message)
+        sentryService.captureErrorMessage(message)
+        return
+      }
 
       interruptableSleep(50)
 
-      val cacheEntryStatus = prisonsApiClient.getInmateDetailsCacheEntryStatus(it)
+      val cacheEntryStatus = prisonsApiClient.getInmateDetailsCacheEntryStatus(nomsNumber)
 
-      logConspicuously("Cache status for $it: $cacheEntryStatus")
+      logConspicuously("Cache status for $nomsNumber: $cacheEntryStatus")
 
       if (cacheEntryStatus == PreemptiveCacheEntryStatus.EXISTS) {
         if (loggingEnabled) {
-          log.info("No upstream call made when refreshing Inmate Details for $it, stored result still within soft TTL")
+          log.info("No upstream call made when refreshing Inmate Details for $nomsNumber, stored result still within soft TTL")
         }
 
-        return@forEach
+        return@forEachIndexed
       }
 
-      val prisonsApiResult = prisonsApiClient.getInmateDetailsWithCall(it)
+      val prisonsApiResult = prisonsApiClient.getInmateDetailsWithCall(nomsNumber)
 
       logConspicuously("Upstream API response: $prisonsApiResult")
 
       if (prisonsApiResult is ClientResult.Failure.StatusCode) {
         if (!prisonsApiResult.isPreemptivelyCachedResponse) {
-          log.error("Unable to refresh Inmate Details for $it, response status: ${prisonsApiResult.status}")
+          log.error("Unable to refresh Inmate Details for $nomsNumber, response status: ${prisonsApiResult.status}")
         }
       }
 
       if (prisonsApiResult is ClientResult.Failure.Other) {
-        log.error("Unable to refresh Inmate Details for $it: ${prisonsApiResult.exception.message}")
+        log.error("Unable to refresh Inmate Details for $nomsNumber: ${prisonsApiResult.exception.message}")
       }
 
       if (prisonsApiResult is ClientResult.Success) {
         if (loggingEnabled) {
-          log.info("Successfully refreshed Inmate Details for $it")
+          log.info("Successfully refreshed Inmate Details for $nomsNumber")
         }
       }
     }
+
+    logConspicuously("Have completed refreshing inmate details cache")
 
     interruptableSleep(delayMs)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/OffenderDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/OffenderDetailsCacheRefreshWorker.kt
@@ -17,13 +17,13 @@ class OffenderDetailsCacheRefreshWorker(
   redLock: RedLock,
   lockDurationMs: Int,
 ) : CacheRefreshWorker(redLock, "offenderDetails", lockDurationMs) {
-  override fun work(checkShouldStop: () -> Boolean) {
+  override fun work(checkShouldStop: () -> PrematureStopReason?) {
     val distinctCrns = (applicationRepository.getDistinctCrns() + bookingRepository.getDistinctCrns()).distinct()
 
     if (loggingEnabled) { log.info("Got $distinctCrns to refresh for Offender Details") }
 
     distinctCrns.forEach {
-      if (checkShouldStop()) return
+      if (checkShouldStop() != null) return
 
       interruptableSleep(50)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/PreemptiveCacheRefresher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/PreemptiveCacheRefresher.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CacheRefreshExclusionsInmateDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 
 @Component
 class PreemptiveCacheRefresher(
@@ -22,6 +23,7 @@ class PreemptiveCacheRefresher(
   private val cacheRefreshExclusionsInmateDetailsRepository: CacheRefreshExclusionsInmateDetailsRepository,
   private val communityApiClient: CommunityApiClient,
   private val prisonsApiClient: PrisonsApiClient,
+  private val sentryService: SentryService,
   @Value("\${preemptive-cache-logging-enabled}") private val loggingEnabled: Boolean,
   @Value("\${preemptive-cache-delay-ms}") private val delayMs: Long,
   @Value("\${preemptive-cache-lock-duration-ms}") private val lockDurationMs: Int,
@@ -55,6 +57,7 @@ class PreemptiveCacheRefresher(
         bookingRepository,
         cacheRefreshExclusionsInmateDetailsRepository,
         prisonsApiClient,
+        sentryService,
         loggingEnabled,
         delayMs,
         redLock,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/InmateDetailsCacheRefreshWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/InmateDetailsCacheRefreshWorkerTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CacheRefreshExclusionsInmateDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 
 class InmateDetailsCacheRefreshWorkerTest {
   private val mockApplicationRepository = mockk<ApplicationRepository>()
@@ -21,12 +22,14 @@ class InmateDetailsCacheRefreshWorkerTest {
   private val mockCacheRefreshExclusionsInmateDetailsRepository = mockk<CacheRefreshExclusionsInmateDetailsRepository>()
   private val mockPrisonsApiClient = mockk<PrisonsApiClient>()
   private val mockRedLock = mockk<RedLock>()
+  private val mockSentryService = mockk<SentryService>()
 
   private val offenderDetailsCacheRefreshWorker = InmateDetailsCacheRefreshWorker(
     mockApplicationRepository,
     mockBookingRepository,
     mockCacheRefreshExclusionsInmateDetailsRepository,
     mockPrisonsApiClient,
+    mockSentryService,
     false,
     0,
     mockRedLock,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/InmateDetailsCacheRefreshWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/InmateDetailsCacheRefreshWorkerTest.kt
@@ -84,7 +84,7 @@ class InmateDetailsCacheRefreshWorkerTest {
       every { mockPrisonsApiClient.getInmateDetailsCacheEntryStatus(it.offenderNo) } returns PreemptiveCacheEntryStatus.EXISTS
     }
 
-    offenderDetailsCacheRefreshWorker.work { false }
+    offenderDetailsCacheRefreshWorker.work { null }
 
     (inmateDetailsNotCached + offenderDetailsCachedButNeedingRefresh).forEach {
       verify(exactly = 1) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/OffenderDetailsCacheRefreshWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/cache/preemptive/OffenderDetailsCacheRefreshWorkerTest.kt
@@ -78,7 +78,7 @@ class OffenderDetailsCacheRefreshWorkerTest {
       every { mockCommunityApiClient.getOffenderDetailsCacheEntryStatus(it.otherIds.crn) } returns PreemptiveCacheEntryStatus.EXISTS
     }
 
-    offenderDetailsCacheRefreshWorker.work { false }
+    offenderDetailsCacheRefreshWorker.work { null }
 
     (offenderDetailsNotCached + offenderDetailsCachedButNeedingRefresh).forEach {
       verify(exactly = 1) {


### PR DESCRIPTION
Analyse of cache misses in production suggests that the refresh worker is stopping prematurely due to redis lock timeouts. This results in an indeterminate number of entries in the cache never being updated by the worker, resulting in user requests being slow as these trigger cache updates instead.

This commit helps address these issues as follows:

1. Adds logging and a sentry alert when the refresh worker ends premature. This includes information to help determine what an optimal lock timeout would be
2. Sorts the noms numbers to refresh randomly to ensure that even if the worker ends prematurely, we’re not just refreshing the same batch of noms numbers (this assumes the SQL query returns them in a consistnet order, that is indeterminate)
3. Adds a log when the inmate cache refresh worker completes to help future investigations