### PR TITLE
APS-1152 - Show NotFound/Restricted Offender on CRU Dashboard

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -22,11 +22,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -225,10 +223,8 @@ class PlacementRequestsController(
   }
 
   private fun mapPersonDetailOntoPlacementRequests(placementRequests: List<PlacementRequestEntity>, user: UserEntity): List<PlacementRequest> {
-    return placementRequests.mapNotNull {
+    return placementRequests.map {
       val personInfo = offenderService.getInfoForPerson(it.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
-
-      if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${it.application.crn}. Response type is ${personInfo::class}")
 
       placementRequestTransformer.transformJpaToApi(it, personInfo)
     }


### PR DESCRIPTION
Before this commit we would throw an error if any offenders being retrieved for the CRU Dashboard couldn’t be found, or are restricted.

This led to issues viewing the CRU Dashboard in pre-prod where Delius is not often refreshed, despite us taking regular copies of the CAS database.

This commit changes the CRU Dashboard endpoint to instead return the FullPerson sealed types for NotFound/Restricted, which are handled as expected on the UI (e.g. not clickable links)

Before:

![Screenshot 2024-08-06 at 10 32 45](https://github.com/user-attachments/assets/1369ad47-2f4d-4077-acf2-ba8c3be6515d)

After:

![Screenshot 2024-08-06 at 10 37 57](https://github.com/user-attachments/assets/540f7090-96b2-4f67-81a3-1db9b8c8347b)
