### PR TITLE
APS-1151 - Increase pre-emptive cache lock duration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/PreemptiveCacheRefresher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/PreemptiveCacheRefresher.kt
@@ -114,7 +114,7 @@ abstract class CacheRefreshWorker(
       try {
         lock = redLock.lock(cacheName, lockDurationMs) ?: continue
 
-        log.info("Got cache refresh lock for $cacheName")
+        log.info("Got cache refresh lock for $cacheName for $lockDurationMs ms")
         val lockExpiresAt = System.currentTimeMillis() + lock.validity
 
         try {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -254,7 +254,8 @@ url-templates:
 preemptive-cache-key-prefix: ""
 preemptive-cache-logging-enabled: false
 preemptive-cache-delay-ms: 10000
-preemptive-cache-lock-duration-ms: 120000
+# 10 minutes
+preemptive-cache-lock-duration-ms: 600000
 
 arrived-departed-domain-events-disabled: true
 


### PR DESCRIPTION
We’re observing that the cache lock duration is currently insufficient to refresh the entire cache.

This commit increases it from 2 minutes to 10 minutes to help us determine how long will be required once the cache state has normalised (i.e. fully refreshed).

The downside of a longer lock is that no other instance will be able to pick up the cache refresh work if the worker unexpectedly dies. Given that the cache being 100% up to date is not mission critical, a maximum delay of 10 minutes before the refresh worker starts again should not be an issue.