### PR TITLE
APS-1151 - Cache Refresh Worker Enhancements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
@@ -9,8 +9,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingReposi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CacheRefreshExclusionsInmateDetailsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
-@SuppressWarnings("LongParameterList")
+@SuppressWarnings("LongParameterList", "MagicNumber")
 class InmateDetailsCacheRefreshWorker(
   private val applicationRepository: ApplicationRepository,
   private val bookingRepository: BookingRepository,
@@ -33,9 +34,16 @@ class InmateDetailsCacheRefreshWorker(
 
     if (loggingEnabled) { log.info("Got $distinctNomsNumbers to refresh for Inmate Details") }
 
+    val started = LocalDateTime.now()
     val refreshStarted = LocalDateTime.now()
+    val candidatesCount = distinctNomsNumbers.size
+    var entryUpdates = 0
+    var entryUpdateFails = 0
 
-    distinctNomsNumbers.shuffled().forEachIndexed { index, nomsNumber ->
+    fun stats() = "Of $candidatesCount candidates we have successfully updated $entryUpdates with $entryUpdateFails update failures. " +
+      "Total time taken ${ChronoUnit.SECONDS.between(started,LocalDateTime.now())} seconds"
+
+    distinctNomsNumbers.shuffled().forEach { nomsNumber ->
       logConspicuously("Current NOMS number: $nomsNumber")
 
       val prematureStopReason = checkShouldStop()
@@ -43,8 +51,8 @@ class InmateDetailsCacheRefreshWorker(
         if (prematureStopReason == PrematureStopReason.LockExpired) {
           val message =
             """Inmate details refresh has stopped prematurely because the lock has expired
-Have processed $index of ${distinctNomsNumbers.size} candidates
-Refresh started at $refreshStarted"""
+Refresh started at $refreshStarted
+${stats()}"""
           logConspicuously(message)
           sentryService.captureErrorMessage(message)
         }
@@ -62,7 +70,7 @@ Refresh started at $refreshStarted"""
           log.info("No upstream call made when refreshing Inmate Details for $nomsNumber, stored result still within soft TTL")
         }
 
-        return@forEachIndexed
+        return@forEach
       }
 
       interruptableSleep(25)
@@ -74,21 +82,24 @@ Refresh started at $refreshStarted"""
       if (prisonsApiResult is ClientResult.Failure.StatusCode) {
         if (!prisonsApiResult.isPreemptivelyCachedResponse) {
           log.error("Unable to refresh Inmate Details for $nomsNumber, response status: ${prisonsApiResult.status}")
+          entryUpdateFails += 1
         }
       }
 
       if (prisonsApiResult is ClientResult.Failure.Other) {
         log.error("Unable to refresh Inmate Details for $nomsNumber: ${prisonsApiResult.exception.message}")
+        entryUpdateFails += 1
       }
 
       if (prisonsApiResult is ClientResult.Success) {
         if (loggingEnabled) {
           log.info("Successfully refreshed Inmate Details for $nomsNumber")
+          entryUpdates += 1
         }
       }
     }
 
-    logConspicuously("Have completed refreshing inmate details cache")
+    logConspicuously("Have completed refreshing inmate details cache. ${stats()}")
 
     interruptableSleep(delayMs)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cache/preemptive/InmateDetailsCacheRefreshWorker.kt
@@ -51,7 +51,7 @@ Refresh started at $refreshStarted"""
         return
       }
 
-      interruptableSleep(50)
+      interruptableSleep(25)
 
       val cacheEntryStatus = prisonsApiClient.getInmateDetailsCacheEntryStatus(nomsNumber)
 
@@ -64,6 +64,8 @@ Refresh started at $refreshStarted"""
 
         return@forEachIndexed
       }
+
+      interruptableSleep(25)
 
       val prisonsApiResult = prisonsApiClient.getInmateDetailsWithCall(nomsNumber)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -187,5 +187,18 @@ class CacheKeySet(
 }
 
 enum class PreemptiveCacheEntryStatus {
-  MISS, REQUIRES_REFRESH, EXISTS
+  /**
+   * No corresponding entry in the cache
+   */
+  MISS,
+
+  /**
+   * An entry exists in the cache, but it needs a refresh
+   */
+  REQUIRES_REFRESH,
+
+  /**
+   * An entry exists in the cache and it doesn't need a refresh
+   */
+  EXISTS,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -28,6 +28,7 @@ class CommunityApiClient(
   private val offenderDetailCacheConfig = WebClientCache.PreemptiveCacheConfig(
     cacheName = "offenderDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),
+    successSoftTtlJitterSeconds = Duration.ofHours(1).toSeconds(),
     failureSoftTtlBackoffSeconds =
     listOf(
       30,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
@@ -18,6 +18,7 @@ class PrisonsApiClient(
   private val inmateDetailsCacheConfig = WebClientCache.PreemptiveCacheConfig(
     cacheName = "inmateDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),
+    successSoftTtlJitterSeconds = Duration.ofHours(1).toSeconds(),
     failureSoftTtlBackoffSeconds = listOf(
       30,
       Duration.ofMinutes(5).toSeconds().toInt(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
@@ -208,8 +208,14 @@ class WebClientCache(
 
   data class PreemptiveCacheConfig(
     val cacheName: String,
+    /**
+     * When the redis entry should be considered for refresh
+     */
     val successSoftTtlSeconds: Int,
     val failureSoftTtlBackoffSeconds: List<Int>,
+    /**
+     * Used to determine the expiry value of the redis record
+     */
     val hardTtlSeconds: Int,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
+import io.netty.util.internal.ThreadLocalRandom
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaZoneId
 import java.time.Instant
@@ -138,3 +139,11 @@ private fun toWeeksString(weeks: Int) = if (weeks != 1) {
 
 fun Instant.toLocalDate(): LocalDate = this.toLocalDateTime().toLocalDate()
 fun Instant.toLocalDateTime(): LocalDateTime = this.atZone(TimeZone.currentSystemDefault().toJavaZoneId()).toLocalDateTime()
+
+fun Instant.minusRandomSeconds(maxOffset: Long): Instant {
+  val randomOffset = ThreadLocalRandom
+    .current()
+    .nextLong(-maxOffset, 0)
+
+  return this.plusSeconds(randomOffset)
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -254,8 +254,8 @@ url-templates:
 preemptive-cache-key-prefix: ""
 preemptive-cache-logging-enabled: false
 preemptive-cache-delay-ms: 10000
-# 10 minutes
-preemptive-cache-lock-duration-ms: 600000
+# 30 minutes
+preemptive-cache-lock-duration-ms: 1800000
 
 arrived-departed-domain-events-disabled: true
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
@@ -271,6 +271,7 @@ class PreemptivelyCachedClient(
   private val cacheConfig = WebClientCache.PreemptiveCacheConfig(
     cacheName = "offenderDetailSummary",
     successSoftTtlSeconds = 5,
+    successSoftTtlJitterSeconds = 2,
     failureSoftTtlBackoffSeconds = listOf(5, 10, 20),
     hardTtlSeconds = 30,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DatesTest.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+class DatesTest {
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DatesTest.kt
@@ -1,4 +1,26 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
 class DatesTest {
+
+  @Nested
+  inner class Instant {
+
+    @SuppressWarnings("UnusedPrivateProperty")
+    @Test
+    fun minusRandomSeconds() {
+      val now = LocalDateTime.of(2020, 1, 1, 12, 30, 0)
+
+      for (i in 1..1000) {
+        val result = now.toInstant(ZoneOffset.UTC).minusRandomSeconds(60 * 30)
+        assertThat(result.toLocalDateTime()).isAfter(LocalDateTime.of(2020, 1, 1, 11, 29, 59))
+        assertThat(result.toLocalDateTime()).isBefore(LocalDateTime.of(2020, 1, 1, 12, 30, 1))
+      }
+    }
+  }
 }


### PR DESCRIPTION
**Increase cache refresh lock to 30 minutes**

This commit decreases the sleep when a cache entry doesn’t need refreshing from 50ms to 25ms. Presumably the sleep was adding to protect overloading prison api, which isn’t required if we don’t refresh a record

The thinking behind setting the lock to 30 minutes:

* After each check we sleep a minimum of 25ms, or 50ms if a call to prison api is made
* There are 29958 cache records in production
* Assuming every entry needs refreshing that is a minimum of 25 minutes, without considering overhead of calling prison api.
* Note that lock timeout is only required to ensure another instance picks up the work if this instance crashes, so it should really be set to a value higher than how long we think it will typically take

**Improve stat logging for inmate cache refresh**

**Introduce jitter when checking cache TTL**

Before this commit all cache entries were considered for reload after 6 hours. If the cache is filled ‘from empty’ by a cache refresh worker this meant we would refresh all entries after 6 hours, leading to spikes of load on the API used to refresh cache entries.

This commit introduces a ‘jitter’ that will be applied whenever checking a cache entries soft TTL. This jitter will be subtracted from the 6 hours, meaning that after 6 hours an entry will _always_ be considered for reload. This will help balance the load and over time as more jitter is applied on each subsequent reload, cache reloading should be distributed across the day.