### PR TITLE
Rename getInfoForPerson to getPersonInfoResult

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -185,7 +185,7 @@ class ApplicationsController(
     val user = userService.getUserForRequest()
 
     val personInfo =
-      when (val personInfoResult = offenderService.getInfoForPerson(body.crn, user.deliusUsername, false)) {
+      when (val personInfoResult = offenderService.getPersonInfoResult(body.crn, user.deliusUsername, false)) {
         is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> throw NotFoundProblem(
           personInfoResult.crn,
           "Offender",
@@ -534,7 +534,7 @@ class ApplicationsController(
       is AuthorisableActionResult.Success -> applicationResult.entity
     }
 
-    val personInfo = offenderService.getInfoForPerson(assessment.application.crn, user.deliusUsername, false)
+    val personInfo = offenderService.getPersonInfoResult(assessment.application.crn, user.deliusUsername, false)
 
     return ResponseEntity.ok(assessmentTransformer.transformJpaToApi(assessment, personInfo))
   }
@@ -615,7 +615,7 @@ class ApplicationsController(
     user: UserEntity,
     ignoreLaoRestrictions: Boolean = false,
   ): Application {
-    val personInfo = offenderService.getInfoForPerson(application.crn, user.deliusUsername, ignoreLaoRestrictions)
+    val personInfo = offenderService.getPersonInfoResult(application.crn, user.deliusUsername, ignoreLaoRestrictions)
 
     return applicationsTransformer.transformJpaToApi(application, personInfo)
   }
@@ -626,7 +626,7 @@ class ApplicationsController(
     ignoreLaoRestrictions: Boolean = false,
   ): List<ApplicationSummary> {
     val crns = applications.map { it.getCrn() }
-    val personInfoResults = offenderService.getInfoForPersons(crns.toSet(), user.deliusUsername, ignoreLaoRestrictions)
+    val personInfoResults = offenderService.getPersonInfoResults(crns.toSet(), user.deliusUsername, ignoreLaoRestrictions)
 
     return applications.map {
       val crn = it.getCrn()
@@ -642,7 +642,7 @@ class ApplicationsController(
     user: UserEntity,
     ignoreLaoRestrictions: Boolean = false,
   ): Application {
-    val personInfo = offenderService.getInfoForPerson(offlineApplication.crn, user.deliusUsername, ignoreLaoRestrictions)
+    val personInfo = offenderService.getPersonInfoResult(offlineApplication.crn, user.deliusUsername, ignoreLaoRestrictions)
 
     return applicationsTransformer.transformJpaToApi(offlineApplication, personInfo)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -99,7 +99,7 @@ class AssessmentController(
 
   private fun transformDomainToApi(user: UserEntity, summaries: List<DomainAssessmentSummary>, ignoreLaoRestrictions: Boolean = false): List<AssessmentSummary> {
     val crns = summaries.map { it.crn }
-    val personInfoResults = offenderService.getInfoForPersons(crns.toSet(), user.deliusUsername, ignoreLaoRestrictions)
+    val personInfoResults = offenderService.getPersonInfoResults(crns.toSet(), user.deliusUsername, ignoreLaoRestrictions)
 
     return summaries.map {
       val crn = it.crn
@@ -122,7 +122,7 @@ class AssessmentController(
 
     val ignoreLaoRestrictions = (assessment.application is ApprovedPremisesApplicationEntity) && user.hasQualification(UserQualification.LAO)
 
-    val personInfo = offenderService.getInfoForPerson(assessment.application.crn, user.deliusUsername, ignoreLaoRestrictions)
+    val personInfo = offenderService.getPersonInfoResult(assessment.application.crn, user.deliusUsername, ignoreLaoRestrictions)
 
     return ResponseEntity.ok(
       assessmentTransformer.transformJpaToApi(assessment, personInfo),
@@ -165,7 +165,7 @@ class AssessmentController(
     val ignoreLao =
       (assessment.application is ApprovedPremisesApplicationEntity) && user.hasQualification(UserQualification.LAO)
 
-    val personInfo = offenderService.getInfoForPerson(assessment.application.crn, user.deliusUsername, ignoreLao)
+    val personInfo = offenderService.getPersonInfoResult(assessment.application.crn, user.deliusUsername, ignoreLao)
 
     return ResponseEntity.ok(
       assessmentTransformer.transformJpaToApi(assessment, personInfo),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PeopleController.kt
@@ -62,7 +62,7 @@ class PeopleController(
   override fun peopleSearchGet(crn: String): ResponseEntity<Person> {
     val user = userService.getUserForRequest()
 
-    val personInfo = offenderService.getInfoForPerson(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+    val personInfo = offenderService.getPersonInfoResult(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
     when (personInfo) {
       is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")
@@ -249,7 +249,7 @@ class PeopleController(
   override fun peopleCrnTimelineGet(crn: String): ResponseEntity<PersonalTimeline> {
     val user = userService.getUserForRequest()
 
-    val personInfo = offenderService.getInfoForPerson(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+    val personInfo = offenderService.getPersonInfoResult(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
     val personalTimeline = when (personInfo) {
       is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -64,7 +64,7 @@ class PlacementRequestsController(
 
     return ResponseEntity.ok(
       requests.first.map {
-        val personInfo = offenderService.getInfoForPerson(it.application.crn, user.deliusUsername, false)
+        val personInfo = offenderService.getPersonInfoResult(it.application.crn, user.deliusUsername, false)
 
         placementRequestTransformer.transformJpaToApi(it, personInfo)
       },
@@ -209,7 +209,7 @@ class PlacementRequestsController(
     forUser: UserEntity,
     placementRequestAndCancellations: PlacementRequestAndCancellations,
   ): PlacementRequestDetail {
-    val personInfo = offenderService.getInfoForPerson(
+    val personInfo = offenderService.getPersonInfoResult(
       placementRequestAndCancellations.placementRequest.application.crn,
       forUser.deliusUsername,
       ignoreLaoRestrictions = false,
@@ -224,7 +224,7 @@ class PlacementRequestsController(
 
   private fun mapPersonDetailOntoPlacementRequests(placementRequests: List<PlacementRequestEntity>, user: UserEntity): List<PlacementRequest> {
     return placementRequests.map {
-      val personInfo = offenderService.getInfoForPerson(it.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+      val personInfo = offenderService.getPersonInfoResult(it.application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
       placementRequestTransformer.transformJpaToApi(it, personInfo)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -318,7 +318,7 @@ class PremisesController(
 
     val crns = premises.bookings.map { it.crn }
     val personInfoResults = async {
-      offenderService.getInfoForPersons(
+      offenderService.getPersonInfoResults(
         crns.toSet(),
         user.deliusUsername,
         user.hasQualification(UserQualification.LAO),
@@ -380,7 +380,7 @@ class PremisesController(
     }
 
     val personInfo =
-      offenderService.getInfoForPerson(body.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+      offenderService.getPersonInfoResult(body.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
     if (personInfo !is PersonInfoResult.Success) throw InternalServerErrorProblem("Unable to get Person Info for CRN: ${body.crn}")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -139,7 +139,7 @@ class Cas1AutoScript(
 
     val personInfo =
       when (
-        val personInfoResult = offenderService.getInfoForPerson(
+        val personInfoResult = offenderService.getPersonInfoResult(
           crn = crn,
           deliusUsername = null,
           ignoreLaoRestrictions = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
@@ -60,7 +60,7 @@ class Cas1DuplicateApplicationSeedJob(
 
     val personInfo =
       when (
-        val personInfoResult = offenderService.getInfoForPerson(
+        val personInfoResult = offenderService.getPersonInfoResult(
           crn = sourceApplication.crn,
           deliusUsername = null,
           ignoreLaoRestrictions = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -160,7 +160,7 @@ class BookingService(
       return AuthorisableActionResult.Unauthorised()
     }
 
-    val personInfo = offenderService.getInfoForPerson(booking.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+    val personInfo = offenderService.getPersonInfoResult(booking.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
 
     val staffMember = booking.keyWorkerStaffCode?.let { keyWorkerStaffCode ->
       val premises = booking.premises

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -499,16 +499,16 @@ class OffenderService(
   ) = communityApiClient.getDocument(crn, documentId, outputStream)
 
   @SuppressWarnings("CyclomaticComplexMethod", "NestedBlockDepth", "ReturnCount")
-  fun getInfoForPerson(
+  fun getPersonInfoResult(
     crn: String,
     deliusUsername: String?,
     ignoreLaoRestrictions: Boolean,
   ): PersonInfoResult {
     check(ignoreLaoRestrictions || deliusUsername != null) { "If ignoreLao is false, delius username must be provided " }
-    return getInfoForPersons(setOf(crn), deliusUsername, ignoreLaoRestrictions).first()
+    return getPersonInfoResults(setOf(crn), deliusUsername, ignoreLaoRestrictions).first()
   }
 
-  fun getInfoForPersons(
+  fun getPersonInfoResults(
     crns: Set<String>,
     deliusUsername: String?,
     ignoreLaoRestrictions: Boolean,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -381,7 +381,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
   }
 
   private fun getOffenderDetailForApplication(application: ApplicationEntity, deliusUsername: String): OffenderDetailSummary {
-    return when (val personInfo = realOffenderService.getInfoForPerson(application.crn, deliusUsername, true)) {
+    return when (val personInfo = realOffenderService.getPersonInfoResult(application.crn, deliusUsername, true)) {
       is PersonInfoResult.Success.Full -> personInfo.offenderDetailSummary
       else -> throw Exception("No offender found for CRN ${application.crn}")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -467,7 +467,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
     application: ApplicationEntity,
     deliusUsername: String,
   ): OffenderDetailSummary {
-    return when (val personInfo = realOffenderService.getInfoForPerson(application.crn, deliusUsername, true)) {
+    return when (val personInfo = realOffenderService.getPersonInfoResult(application.crn, deliusUsername, true)) {
       is PersonInfoResult.Success.Full -> personInfo.offenderDetailSummary
       else -> error("No offender found for CRN ${application.crn}")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -354,7 +354,7 @@ class BookingServiceTest {
       every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
-      every { mockOffenderService.getInfoForPerson(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
+      every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
       every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.Success(keyWorker)
 
       val result = bookingService.getBooking(bookingEntity.id)
@@ -394,7 +394,7 @@ class BookingServiceTest {
       every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
-      every { mockOffenderService.getInfoForPerson(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
+      every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
       every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.NotFound("Staff Code", keyWorker.code)
       mockkStatic(Sentry::class)
       every { Sentry.captureException(any()) } returns SentryId.EMPTY_ID
@@ -414,7 +414,7 @@ class BookingServiceTest {
       every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
-      every { mockOffenderService.getInfoForPerson(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
+      every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
       every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.NotFound("QCode", premises.qCode)
 
       assertThatExceptionOfType(InternalServerErrorProblem::class.java)
@@ -427,7 +427,7 @@ class BookingServiceTest {
       every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
-      every { mockOffenderService.getInfoForPerson(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
+      every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
       every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.Unauthorised()
 
       assertThatExceptionOfType(ForbiddenProblem::class.java)
@@ -454,7 +454,7 @@ class BookingServiceTest {
       every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns otherBooking
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, otherBooking) } returns true
-      every { mockOffenderService.getInfoForPerson(otherBooking.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
+      every { mockOffenderService.getPersonInfoResult(otherBooking.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
 
       assertThatExceptionOfType(IllegalStateException::class.java)
         .isThrownBy { bookingService.getBooking(bookingEntity.id) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -658,7 +658,7 @@ class OffenderServiceTest {
 
       every { mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(PersonSummaryInfoResult.NotFound(crn), null) } returns PersonInfoResult.NotFound(crn)
 
-      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+      val result = offenderService.getPersonInfoResult(crn, deliusUsername, false)
       assertThat(result is PersonInfoResult.NotFound).isTrue
     }
 
@@ -693,7 +693,7 @@ class OffenderServiceTest {
           ),
       )
 
-      val exception = assertThrows<RuntimeException> { offenderService.getInfoForPerson(crn, deliusUsername, false) }
+      val exception = assertThrows<RuntimeException> { offenderService.getPersonInfoResult(crn, deliusUsername, false) }
       assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/ABC123: 500 INTERNAL_SERVER_ERROR")
     }
 
@@ -725,7 +725,7 @@ class OffenderServiceTest {
           ),
       )
 
-      val exception = assertThrows<RuntimeException> { offenderService.getInfoForPerson(crn, deliusUsername, false) }
+      val exception = assertThrows<RuntimeException> { offenderService.getPersonInfoResult(crn, deliusUsername, false) }
       assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/ABC123/user/USER/userAccess: 403 FORBIDDEN")
     }
 
@@ -752,7 +752,7 @@ class OffenderServiceTest {
         null,
       )
 
-      assertThrows<RuntimeException> { offenderService.getInfoForPerson(crn, deliusUsername, false) }
+      assertThrows<RuntimeException> { offenderService.getPersonInfoResult(crn, deliusUsername, false) }
     }
 
     @Test
@@ -797,7 +797,7 @@ class OffenderServiceTest {
         )
       } returns PersonInfoResult.Success.Restricted(crn, nomsNumber)
 
-      val result = offenderService.getInfoForPerson(crn, deliusUsername, ignoreLaoRestrictions = false)
+      val result = offenderService.getPersonInfoResult(crn, deliusUsername, ignoreLaoRestrictions = false)
 
       assertThat(result is PersonInfoResult.Success.Restricted).isTrue
       result as PersonInfoResult.Success.Restricted
@@ -838,7 +838,7 @@ class OffenderServiceTest {
         )
       } returns PersonInfoResult.Success.Full(crn, offenderDetails, null)
 
-      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+      val result = offenderService.getPersonInfoResult(crn, deliusUsername, false)
 
       assertThat(result is PersonInfoResult.Success.Full).isTrue
       result as PersonInfoResult.Success.Full
@@ -894,7 +894,7 @@ class OffenderServiceTest {
         )
       } returns PersonInfoResult.Success.Full(crn, offenderDetails, null)
 
-      val result = offenderService.getInfoForPerson(crn, deliusUsername, ignoreLaoRestrictions = true)
+      val result = offenderService.getPersonInfoResult(crn, deliusUsername, ignoreLaoRestrictions = true)
 
       assertThat(result is PersonInfoResult.Success.Full).isTrue
       result as PersonInfoResult.Success.Full
@@ -944,7 +944,7 @@ class OffenderServiceTest {
         )
       } returns PersonInfoResult.Success.Full(crn, offenderDetails, inmateDetail)
 
-      val result = offenderService.getInfoForPerson(crn, deliusUsername, false)
+      val result = offenderService.getPersonInfoResult(crn, deliusUsername, false)
 
       assertThat(result is PersonInfoResult.Success.Full).isTrue
       result as PersonInfoResult.Success.Full


### PR DESCRIPTION
This commit renames two functions on OffenderService:

* getInfoForPerson -> getPersonInfoResult
* getInfoForPersons -> getPersonInfoResults

This seems trivial, but these functions now reflect the name of the class they return which are already confusing enough in their genericness! It helps disambiguate from functions that return PersonInfoSummaryResults (Which will be better named in a subsequent commit)