### PR TITLE
APS-1089 - RemoveRole should remove duplicates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -435,7 +435,7 @@ class UserService(
   }
 
   fun removeRoleFromUser(user: UserEntity, role: UserRole) {
-    user.roles.firstOrNull { it.role == role }?.let { roleAssignment ->
+    user.roles.filter { it.role == role }.forEach { roleAssignment ->
       user.roles.remove(roleAssignment)
       userRoleAssignmentRepository.delete(roleAssignment)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -1200,13 +1200,57 @@ class UserServiceTest {
         .withId(UUID.randomUUID())
         .produce()
 
+      val appealsRoleAssignment = UserRoleAssignmentEntityFactory()
+        .withUser(user)
+        .withRole(UserRole.CAS1_APPEALS_MANAGER)
+        .withId(UUID.randomUUID())
+        .produce()
+
       user.roles.add(managerRoleAssignment)
+      user.roles.add(appealsRoleAssignment)
 
       every { mockUserRoleAssignmentRepository.delete(managerRoleAssignment) } returns Unit
 
       userService.removeRoleFromUser(user, UserRole.CAS1_MANAGER)
 
       verify { mockUserRoleAssignmentRepository.delete(managerRoleAssignment) }
+    }
+
+    @Test
+    fun `remove roles if user has role multiple times`() {
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val managerRoleAssignment = UserRoleAssignmentEntityFactory()
+        .withUser(user)
+        .withRole(UserRole.CAS1_MANAGER)
+        .withId(UUID.randomUUID())
+        .produce()
+
+      val appealsRoleAssignment1 = UserRoleAssignmentEntityFactory()
+        .withUser(user)
+        .withRole(UserRole.CAS1_APPEALS_MANAGER)
+        .withId(UUID.randomUUID())
+        .produce()
+
+      val appealsRoleAssignment2 = UserRoleAssignmentEntityFactory()
+        .withUser(user)
+        .withRole(UserRole.CAS1_APPEALS_MANAGER)
+        .withId(UUID.randomUUID())
+        .produce()
+
+      user.roles.add(managerRoleAssignment)
+      user.roles.add(appealsRoleAssignment1)
+      user.roles.add(appealsRoleAssignment2)
+
+      every { mockUserRoleAssignmentRepository.delete(appealsRoleAssignment1) } returns Unit
+      every { mockUserRoleAssignmentRepository.delete(appealsRoleAssignment2) } returns Unit
+
+      userService.removeRoleFromUser(user, UserRole.CAS1_APPEALS_MANAGER)
+
+      verify { mockUserRoleAssignmentRepository.delete(appealsRoleAssignment1) }
+      verify { mockUserRoleAssignmentRepository.delete(appealsRoleAssignment2) }
     }
   }
 }


### PR DESCRIPTION
We have observed that either due to a bug or a backup/restore issue in pre-prod, users can have the same role assigned multiple times. Whilst this issue is mostly prevelant in pre-prod, there is a single occurance of this in prod too. This can be checked by running

select u.id, u.name, r.role, count(r.role)
from user_role_assignments r
inner join users u on u.id = r.user_id
group by u.id, u.name, r.role
having count(r.role) > 1;

This commit updates the removeRoleFromUser to remove all ocurrances of the roles recorded against a user.