### PR TITLE
APS-117: Normalise user roles list before calculating user version

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -299,10 +299,13 @@ data class UserEntity(
   override fun toString() = "User $id"
 
   companion object {
-    fun getVersionHashCode(roles: List<UserRole>) = Objects.hash(
-      roles.map { it.name },
-      roles.map { it.permissions.map { permission -> permission.name } },
-    )
+    fun getVersionHashCode(roles: List<UserRole>): Int? {
+      val normalisedRoles = roles.toSet().sortedBy { it.name }
+      return Objects.hash(
+        normalisedRoles.map { it.name },
+        normalisedRoles.map { it.permissions.map { permission -> permission.name } },
+      )
+    }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -98,7 +98,7 @@ class UserService(
 
   fun getUserForRequestVersion(): Int? {
     return httpAuthService.getDeliusPrincipalOrNull()?.let { deliusPrincipal ->
-      val roles = userRepository.findRolesByUsername(deliusPrincipal.name)
+      val roles = userRepository.findRolesByUsername(deliusPrincipal.name.uppercase())
       return UserEntity.getVersionHashCode(roles)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -488,6 +488,36 @@ class UserServiceTest {
   inner class GetUserForRequestVersion {
 
     @Test
+    fun `getUserForRequestVersion returns same value for version when roles are duplicated`() {
+      val username = "SOMEPERSON"
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+
+      every { mockHttpAuthService.getDeliusPrincipalOrNull() } returns mockPrincipal
+      every { mockPrincipal.name } returns username
+
+      every { mockUserRepository.findRolesByUsername(username) } returns listOf<UserRole>(UserRole.CAS1_USER_MANAGER, UserRole.CAS1_APPEALS_MANAGER)
+      val nonDuplicatRoleValue = userService.getUserForRequestVersion()
+      every { mockUserRepository.findRolesByUsername(username) } returns listOf<UserRole>(UserRole.CAS1_USER_MANAGER, UserRole.CAS1_USER_MANAGER, UserRole.CAS1_APPEALS_MANAGER)
+      val duplicateRoleValue = userService.getUserForRequestVersion()
+      assertThat(nonDuplicatRoleValue).isEqualTo(duplicateRoleValue)
+    }
+
+    @Test
+    fun `getUserForRequestVersion returns same value for version when roles are in different order`() {
+      val username = "SOMEPERSON"
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+
+      every { mockHttpAuthService.getDeliusPrincipalOrNull() } returns mockPrincipal
+      every { mockPrincipal.name } returns username
+
+      every { mockUserRepository.findRolesByUsername(username) } returns listOf<UserRole>(UserRole.CAS1_USER_MANAGER, UserRole.CAS1_APPEALS_MANAGER, UserRole.CAS1_ASSESSOR)
+      val unorderedRoleValue = userService.getUserForRequestVersion()
+      every { mockUserRepository.findRolesByUsername(username) } returns listOf<UserRole>(UserRole.CAS1_APPEALS_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS1_USER_MANAGER)
+      val orderedRoleValue = userService.getUserForRequestVersion()
+      assertThat(unorderedRoleValue).isEqualTo(orderedRoleValue)
+    }
+
+    @Test
     fun `getUserForRequestVersion returns userVersion when user exists`() {
       val username = "SOMEPERSON"
       val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
@@ -497,7 +527,7 @@ class UserServiceTest {
 
       every { mockUserRepository.findRolesByUsername(username) } returns listOf<UserRole>(UserRole.CAS1_USER_MANAGER, UserRole.CAS1_APPEALS_MANAGER)
 
-      assertThat(userService.getUserForRequestVersion()).isEqualTo(1725728026)
+      assertThat(userService.getUserForRequestVersion()).isEqualTo(1496059656)
     }
 
     @Test


### PR DESCRIPTION
Ensure that duplicates are removed from the user's role list and the list is sorted before calculating user version to ensure consistent responses. 
Uppercase Delius username when executing query to retrieve roles by username.