### PR TITLE
Remove comparison checks from update user.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -19,6 +19,7 @@ interface ProbationRegionRepository : JpaRepository<ProbationRegionEntity, UUID>
 data class ProbationRegionEntity(
   @Id
   val id: UUID,
+  @Deprecated(message = "There can be multiple codes to a region, so use probation_area_probation_region_mappings to get the correct code")
   val name: String,
   /**
    * If the AP Area for a user is required, instead use [UserEntity.apArea]


### PR DESCRIPTION
update to always save the user details that are returned from delius. Hibernate won't perform the update if the values are not changed.