### PR TITLE
[APS-1094] Implement API endpoint for creating a new CAS1 space booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/SpaceBookingController.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.SpaceBookingsCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
+import java.util.UUID
+
+@Service
+class SpaceBookingController(
+  private val userService: UserService,
+  private val offenderService: OffenderService,
+  private val spaceBookingService: Cas1SpaceBookingService,
+  private val spaceBookingTransformer: Cas1SpaceBookingTransformer,
+) : SpaceBookingsCas1Delegate {
+  override fun placementRequestsPlacementRequestIdSpaceBookingsPost(
+    placementRequestId: UUID,
+    body: NewCas1SpaceBooking,
+  ): ResponseEntity<Cas1SpaceBooking> {
+    val user = userService.getUserForRequest()
+
+    val booking = extractEntityFromValidatableActionResult(
+      spaceBookingService.createNewBooking(
+        body.premisesId,
+        placementRequestId,
+        body.arrivalDate,
+        body.departureDate,
+        user,
+      ),
+    )
+
+    val person = offenderService.getPersonInfoResult(
+      booking.placementRequest.application.crn,
+      user.deliusUsername,
+      user.hasQualification(UserQualification.LAO),
+    )
+
+    return ResponseEntity.ok(spaceBookingTransformer.transformJpaToApi(person, booking))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Repository
+interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUID> {
+  fun findByPremisesIdAndPlacementRequestId(premisesId: UUID, placementRequestId: UUID): Cas1SpaceBookingEntity?
+}
+
+@Entity
+@Table(name = "cas1_space_bookings")
+data class Cas1SpaceBookingEntity(
+  @Id
+  val id: UUID,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "premises_id")
+  val premises: ApprovedPremisesEntity,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "placement_request_id")
+  val placementRequest: PlacementRequestEntity,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "created_by_user_id")
+  val createdBy: UserEntity,
+  val createdAt: OffsetDateTime,
+  val arrivalDate: LocalDate,
+  val departureDate: LocalDate,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import kotlinx.datetime.toKotlinDatePeriod
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service
+class Cas1SpaceBookingService(
+  private val premisesService: PremisesService,
+  private val placementRequestService: PlacementRequestService,
+  private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
+  private val cas1SpaceSearchRepository: Cas1SpaceSearchRepository,
+) {
+  fun createNewBooking(
+    premisesId: UUID,
+    placementRequestId: UUID,
+    arrivalDate: LocalDate,
+    departureDate: LocalDate,
+    createdBy: UserEntity,
+  ): ValidatableActionResult<Cas1SpaceBookingEntity> = validated {
+    val premises = premisesService.getPremises(premisesId) as? ApprovedPremisesEntity
+    if (premises == null) {
+      "$.premisesId" hasValidationError "doesNotExist"
+    }
+
+    val placementRequest = placementRequestService.getPlacementRequestOrNull(placementRequestId)
+    if (placementRequest == null) {
+      "$.placementRequestId" hasValidationError "doesNotExist"
+    }
+
+    if (arrivalDate >= departureDate) {
+      "$.departureDate" hasValidationError "shouldBeAfterArrivalDate"
+    }
+
+    if (validationErrors.any()) {
+      return fieldValidationError
+    }
+
+    premises!!
+    placementRequest!!
+
+    when (val existingBooking = cas1SpaceBookingRepository.findByPremisesIdAndPlacementRequestId(premisesId, placementRequestId)) {
+      null -> {}
+      else -> return existingBooking.id hasConflictError "A Space Booking already exists for this premises and placement request"
+    }
+
+    val durationInDays = arrivalDate.until(departureDate).toKotlinDatePeriod().days
+    cas1SpaceSearchRepository.getSpaceAvailabilityForCandidatePremises(listOf(premisesId), arrivalDate, durationInDays)
+
+    val result = cas1SpaceBookingRepository.save(
+      Cas1SpaceBookingEntity(
+        id = UUID.randomUUID(),
+        premises = premises,
+        placementRequest = placementRequest,
+        createdBy = createdBy,
+        createdAt = OffsetDateTime.now(),
+        arrivalDate = arrivalDate,
+        departureDate = departureDate,
+      ),
+    )
+
+    success(result)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingRequirementsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingRequirementsTransformer.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
+
+@Component
+class Cas1SpaceBookingRequirementsTransformer {
+  fun transformJpaToApi(jpa: PlacementRequirementsEntity) = Cas1SpaceBookingRequirements(
+    apType = jpa.apType,
+    gender = jpa.gender,
+    essentialCharacteristics = jpa.essentialCriteria.mapNotNull { it.asCas1SpaceCharacteristic() },
+    desirableCharacteristics = jpa.desirableCriteria.mapNotNull { it.asCas1SpaceCharacteristic() },
+  )
+
+  private fun CharacteristicEntity.asCas1SpaceCharacteristic() = try {
+    Cas1SpaceCharacteristic.valueOf(this.propertyName!!)
+  } catch (_: Exception) {
+    null
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+
+@Component
+class Cas1SpaceBookingTransformer(
+  private val personTransformer: PersonTransformer,
+  private val spaceBookingRequirementsTransformer: Cas1SpaceBookingRequirementsTransformer,
+  private val userTransformer: UserTransformer,
+) {
+  fun transformJpaToApi(person: PersonInfoResult, jpa: Cas1SpaceBookingEntity) = Cas1SpaceBooking(
+    id = jpa.id,
+    person = personTransformer.transformModelToPersonApi(person),
+    requirements = spaceBookingRequirementsTransformer.transformJpaToApi(jpa.placementRequest.placementRequirements),
+    premises = NamedId(
+      id = jpa.premises.id,
+      name = jpa.premises.name,
+    ),
+    apArea = jpa.premises.probationRegion.apArea!!.let {
+      NamedId(
+        id = it.id,
+        name = it.name,
+      )
+    },
+    bookedBy = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),
+    arrivalDate = jpa.arrivalDate,
+    departureDate = jpa.departureDate,
+    createdAt = jpa.createdAt.toInstant(),
+  )
+}

--- a/src/main/resources/db/migration/all/20240731111858__create_cas1_space_booking_table.sql
+++ b/src/main/resources/db/migration/all/20240731111858__create_cas1_space_booking_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE cas1_space_bookings (
+    id UUID NOT NULL,
+    premises_id UUID NOT NULL,
+    placement_request_id UUID NOT NULL,
+    created_by_user_id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    arrival_date DATE NOT NULL,
+    departure_date DATE NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (premises_id) REFERENCES approved_premises(premises_id),
+    FOREIGN KEY (placement_request_id) REFERENCES placement_requests(id),
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id)
+);
+
+CREATE INDEX ON cas1_space_bookings(premises_id, placement_request_id);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -602,10 +602,6 @@ components:
           type: string
           format: uuid
           example: 290fa58c-77b2-47e2-b729-4cd6b2ed1a78
-        placementRequestId:
-          type: string
-          format: uuid
-          example: 6d924fdf-4a79-41b6-a251-89edbf369479
         requirements:
           type: object
           $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
@@ -613,7 +609,6 @@ components:
         - arrivalDate
         - departureDate
         - premisesId
-        - placementRequestId
         - requirements
     Cas1SpaceBookingRequirements:
       type: object

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4975,10 +4975,6 @@ components:
           type: string
           format: uuid
           example: 290fa58c-77b2-47e2-b729-4cd6b2ed1a78
-        placementRequestId:
-          type: string
-          format: uuid
-          example: 6d924fdf-4a79-41b6-a251-89edbf369479
         requirements:
           type: object
           $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
@@ -4986,7 +4982,6 @@ components:
         - arrivalDate
         - departureDate
         - premisesId
-        - placementRequestId
         - requirements
     Cas1SpaceBookingRequirements:
       type: object

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1255,10 +1255,6 @@ components:
           type: string
           format: uuid
           example: 290fa58c-77b2-47e2-b729-4cd6b2ed1a78
-        placementRequestId:
-          type: string
-          format: uuid
-          example: 6d924fdf-4a79-41b6-a251-89edbf369479
         requirements:
           type: object
           $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
@@ -1266,7 +1262,6 @@ components:
         - arrivalDate
         - departureDate
         - premisesId
-        - placementRequestId
         - requirements
     Cas1SpaceBookingRequirements:
       type: object

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1193,10 +1193,6 @@ components:
           type: string
           format: uuid
           example: 290fa58c-77b2-47e2-b729-4cd6b2ed1a78
-        placementRequestId:
-          type: string
-          format: uuid
-          example: 6d924fdf-4a79-41b6-a251-89edbf369479
         requirements:
           type: object
           $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
@@ -1204,7 +1200,6 @@ components:
         - arrivalDate
         - departureDate
         - premisesId
-        - placementRequestId
         - requirements
     Cas1SpaceBookingRequirements:
       type: object

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -693,10 +693,6 @@ components:
           type: string
           format: uuid
           example: 290fa58c-77b2-47e2-b729-4cd6b2ed1a78
-        placementRequestId:
-          type: string
-          format: uuid
-          example: 6d924fdf-4a79-41b6-a251-89edbf369479
         requirements:
           type: object
           $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
@@ -704,7 +700,6 @@ components:
         - arrivalDate
         - departureDate
         - premisesId
-        - placementRequestId
         - requirements
     Cas1SpaceBookingRequirements:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var premises: Yielded<ApprovedPremisesEntity> = { ApprovedPremisesEntityFactory().withDefaults().produce() }
+  private var placementRequest: Yielded<PlacementRequestEntity> = { PlacementRequestEntityFactory().withDefaults().produce() }
+  private var createdBy: Yielded<UserEntity> = { UserEntityFactory().withDefaults().produce() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
+  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var departureDate: Yielded<LocalDate> = { LocalDate.now() }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withPremises(premises: ApprovedPremisesEntity) = apply {
+    this.premises = { premises }
+  }
+
+  fun withPremises(configuration: ApprovedPremisesEntityFactory.() -> Unit) = apply {
+    this.premises = { ApprovedPremisesEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withYieldedPremises(premises: Yielded<ApprovedPremisesEntity>) = apply {
+    this.premises = premises
+  }
+
+  fun withPlacementRequest(placementRequest: PlacementRequestEntity) = apply {
+    this.placementRequest = { placementRequest }
+  }
+
+  fun withPlacementRequest(configuration: PlacementRequestEntityFactory.() -> Unit) = apply {
+    this.placementRequest = { PlacementRequestEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withYieldedPlacementRequest(placementRequest: Yielded<PlacementRequestEntity>) = apply {
+    this.placementRequest = placementRequest
+  }
+
+  fun withCreatedBy(createdBy: UserEntity) = apply {
+    this.createdBy = { createdBy }
+  }
+
+  fun withCreatedBy(configuration: UserEntityFactory.() -> Unit) = apply {
+    this.createdBy = { UserEntityFactory().apply(configuration).produce() }
+  }
+
+  fun withYieldedCreatedBy(createdBy: Yielded<UserEntity>) = apply {
+    this.createdBy = createdBy
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withArrivalDate(arrivalDate: LocalDate) = apply {
+    this.arrivalDate = { arrivalDate }
+  }
+
+  fun withDepartureDate(departureDate: LocalDate) = apply {
+    this.departureDate = { departureDate }
+  }
+
+  override fun produce() = Cas1SpaceBookingEntity(
+    id = this.id(),
+    premises = this.premises(),
+    placementRequest = this.placementRequest(),
+    createdBy = this.createdBy(),
+    createdAt = this.createdAt(),
+    arrivalDate = this.arrivalDate(),
+    departureDate = this.departureDate(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
@@ -56,6 +56,10 @@ class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> 
     this.postcodeDistrict = { postCodeDistrictEntity }
   }
 
+  fun withYieldedPostcodeDistrict(postcodeDistrict: Yielded<PostCodeDistrictEntity>) = apply {
+    this.postcodeDistrict = postcodeDistrict
+  }
+
   fun withEssentialCriteria(essentialCriteria: List<CharacteristicEntity>) = apply {
     this.essentialCriteria = { essentialCriteria }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -1,0 +1,270 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas1SpaceBookingTest : InitialiseDatabasePerClassTestBase() {
+  @Autowired
+  lateinit var transformer: Cas1SpaceBookingTransformer
+
+  @Test
+  fun `Booking a space without JWT returns 401`() {
+    `Given a User` { user, _ ->
+      `Given a Placement Request`(
+        placementRequestAllocatedTo = user,
+        assessmentAllocatedTo = user,
+        createdByUser = user,
+      ) { placementRequest, _ ->
+        webTestClient.post()
+          .uri("/cas1/placement-requests/${placementRequest.id}/space-bookings")
+          .exchange()
+          .expectStatus()
+          .isUnauthorized
+      }
+    }
+  }
+
+  @Test
+  fun `Booking a space for an unknown placement request returns 400 Bad Request`() {
+    `Given a User` { _, jwt ->
+      val premises = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+      }
+
+      val placementRequestId = UUID.randomUUID()
+
+      webTestClient.post()
+        .uri("/cas1/placement-requests/$placementRequestId/space-bookings")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          NewCas1SpaceBooking(
+            arrivalDate = LocalDate.now().plusDays(1),
+            departureDate = LocalDate.now().plusDays(8),
+            premisesId = premises.id,
+            requirements = Cas1SpaceBookingRequirements(
+              apType = ApType.esap,
+              gender = Gender.male,
+              essentialCharacteristics = listOf(),
+              desirableCharacteristics = listOf(),
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("invalid-params[0].propertyName").isEqualTo("$.placementRequestId")
+        .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+    }
+  }
+
+  @Test
+  fun `Booking a space for an unknown premises returns 400 Bad Request`() {
+    `Given a User` { user, jwt ->
+      `Given a Placement Request`(
+        placementRequestAllocatedTo = user,
+        assessmentAllocatedTo = user,
+        createdByUser = user,
+      ) { placementRequest, _ ->
+        webTestClient.post()
+          .uri("/cas1/placement-requests/${placementRequest.id}/space-bookings")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewCas1SpaceBooking(
+              arrivalDate = LocalDate.now().plusDays(1),
+              departureDate = LocalDate.now().plusDays(8),
+              premisesId = UUID.randomUUID(),
+              requirements = Cas1SpaceBookingRequirements(
+                apType = ApType.esap,
+                gender = Gender.male,
+                essentialCharacteristics = listOf(),
+                desirableCharacteristics = listOf(),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBody()
+          .jsonPath("invalid-params[0].propertyName").isEqualTo("$.premisesId")
+          .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+      }
+    }
+  }
+
+  @Test
+  fun `Booking a space where the departure date is before the arrival date returns 400 Bad Request`() {
+    `Given a User` { user, jwt ->
+      `Given a Placement Request`(
+        placementRequestAllocatedTo = user,
+        assessmentAllocatedTo = user,
+        createdByUser = user,
+      ) { placementRequest, _ ->
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist {
+              withYieldedApArea {
+                apAreaEntityFactory.produceAndPersist()
+              }
+            }
+          }
+          withYieldedLocalAuthorityArea {
+            localAuthorityEntityFactory.produceAndPersist()
+          }
+        }
+
+        webTestClient.post()
+          .uri("/cas1/placement-requests/${placementRequest.id}/space-bookings")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewCas1SpaceBooking(
+              arrivalDate = LocalDate.now().plusDays(1),
+              departureDate = LocalDate.now(),
+              premisesId = premises.id,
+              requirements = Cas1SpaceBookingRequirements(
+                apType = ApType.esap,
+                gender = Gender.male,
+                essentialCharacteristics = listOf(),
+                desirableCharacteristics = listOf(),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBody()
+          .jsonPath("invalid-params[0].propertyName").isEqualTo("$.departureDate")
+          .jsonPath("invalid-params[0].errorType").isEqualTo("shouldBeAfterArrivalDate")
+      }
+    }
+  }
+
+  @Test
+  fun `Booking a space returns OK with the correct data`() {
+    `Given a User` { user, jwt ->
+      `Given a Placement Request`(
+        placementRequestAllocatedTo = user,
+        assessmentAllocatedTo = user,
+        createdByUser = user,
+      ) { placementRequest, application ->
+        val essentialCharacteristics = listOf(
+          Cas1SpaceCharacteristic.hasBrailleSignage,
+          Cas1SpaceCharacteristic.hasTactileFlooring,
+        )
+
+        val desirableCharacteristics = listOf(
+          Cas1SpaceCharacteristic.hasEnSuite,
+          Cas1SpaceCharacteristic.hasCallForAssistance,
+          Cas1SpaceCharacteristic.isGroundFloor,
+          Cas1SpaceCharacteristic.isCatered,
+        )
+
+        val essentialCriteria = essentialCharacteristics.map {
+          it.asCharacteristicEntity()
+        }
+
+        val desirableCriteria = desirableCharacteristics.map {
+          it.asCharacteristicEntity()
+        }
+
+        placementRequest.placementRequirements = placementRequirementsFactory.produceAndPersist {
+          withYieldedPostcodeDistrict {
+            postCodeDistrictFactory.produceAndPersist()
+          }
+          withApplication(application as ApprovedPremisesApplicationEntity)
+          withAssessment(placementRequest.assessment)
+          withEssentialCriteria(essentialCriteria)
+          withDesirableCriteria(desirableCriteria)
+        }
+
+        placementRequestRepository.saveAndFlush(placementRequest)
+
+        val premises = approvedPremisesEntityFactory.produceAndPersist {
+          withYieldedProbationRegion {
+            probationRegionEntityFactory.produceAndPersist {
+              withYieldedApArea {
+                apAreaEntityFactory.produceAndPersist()
+              }
+            }
+          }
+          withYieldedLocalAuthorityArea {
+            localAuthorityEntityFactory.produceAndPersist()
+          }
+        }
+
+        val response = webTestClient.post()
+          .uri("/cas1/placement-requests/${placementRequest.id}/space-bookings")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            NewCas1SpaceBooking(
+              arrivalDate = LocalDate.now().plusDays(1),
+              departureDate = LocalDate.now().plusDays(8),
+              premisesId = premises.id,
+              requirements = Cas1SpaceBookingRequirements(
+                apType = placementRequest.placementRequirements.apType,
+                gender = Gender.male,
+                essentialCharacteristics = essentialCharacteristics,
+                desirableCharacteristics = desirableCharacteristics,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .returnResult(Cas1SpaceBooking::class.java)
+
+        val result = response.responseBody.blockFirst()!!
+
+        assertThat(result.person)
+        assertThat(result.requirements.apType).isEqualTo(placementRequest.placementRequirements.apType)
+        assertThat(result.requirements.gender).isEqualTo(placementRequest.placementRequirements.gender)
+        assertThat(result.requirements.essentialCharacteristics).isEqualTo(essentialCharacteristics)
+        assertThat(result.requirements.desirableCharacteristics).isEqualTo(desirableCharacteristics)
+        assertThat(result.premises.id).isEqualTo(premises.id)
+        assertThat(result.premises.name).isEqualTo(premises.name)
+        assertThat(result.apArea.id).isEqualTo(premises.probationRegion.apArea!!.id)
+        assertThat(result.apArea.name).isEqualTo(premises.probationRegion.apArea!!.name)
+        assertThat(result.bookedBy.id).isEqualTo(user.id)
+        assertThat(result.bookedBy.name).isEqualTo(user.name)
+        assertThat(result.bookedBy.deliusUsername).isEqualTo(user.deliusUsername)
+        assertThat(result.arrivalDate).isEqualTo(LocalDate.now().plusDays(1))
+        assertThat(result.departureDate).isEqualTo(LocalDate.now().plusDays(8))
+        assertThat(result.createdAt).satisfies(
+          { it.isAfter(Instant.now().minusSeconds(10)) },
+        )
+      }
+    }
+  }
+
+  private fun Cas1SpaceCharacteristic.asCharacteristicEntity() = characteristicEntityFactory.produceAndPersist {
+    withName(this@asCharacteristicEntity.value)
+    withPropertyName(this@asCharacteristicEntity.value)
+    withServiceScope(ServiceName.approvedPremises.value)
+    withModelScope("*")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -1,0 +1,222 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.SpaceAvailability
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1SpaceBookingServiceTest {
+  @MockK
+  private lateinit var premisesService: PremisesService
+
+  @MockK
+  private lateinit var placementRequestService: PlacementRequestService
+
+  @MockK
+  private lateinit var spaceBookingRepository: Cas1SpaceBookingRepository
+
+  @MockK
+  private lateinit var spaceSearchRepository: Cas1SpaceSearchRepository
+
+  @InjectMockKs
+  private lateinit var service: Cas1SpaceBookingService
+
+  @Nested
+  inner class CreateNewBooking {
+    @Test
+    fun `Returns validation error if no premises with the given ID exists`() {
+      val placementRequest = PlacementRequestEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      every { premisesService.getPremises(any()) } returns null
+      every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
+
+      val result = service.createNewBooking(
+        premisesId = UUID.randomUUID(),
+        placementRequestId = placementRequest.id,
+        arrivalDate = LocalDate.now(),
+        departureDate = LocalDate.now().plusDays(1),
+        createdBy = user,
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      result as ValidatableActionResult.FieldValidationError
+
+      assertThat(result.validationMessages).anySatisfy { key, value ->
+        key == "$.premisesId" && value == "doesNotExist"
+      }
+    }
+
+    @Test
+    fun `Returns validation error if no placement request with the given ID exists`() {
+      val premises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      every { premisesService.getPremises(premises.id) } returns premises
+      every { placementRequestService.getPlacementRequestOrNull(any()) } returns null
+
+      val result = service.createNewBooking(
+        premisesId = premises.id,
+        placementRequestId = UUID.randomUUID(),
+        arrivalDate = LocalDate.now(),
+        departureDate = LocalDate.now().plusDays(1),
+        createdBy = user,
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      result as ValidatableActionResult.FieldValidationError
+
+      assertThat(result.validationMessages).anySatisfy { key, value ->
+        key == "$.placementRequestId" && value == "doesNotExist"
+      }
+    }
+
+    @Test
+    fun `Returns validation error if the departure date is before the arrival date`() {
+      val premises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      every { premisesService.getPremises(premises.id) } returns premises
+      every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
+
+      val result = service.createNewBooking(
+        premisesId = premises.id,
+        placementRequestId = placementRequest.id,
+        arrivalDate = LocalDate.now().plusDays(1),
+        departureDate = LocalDate.now(),
+        createdBy = user,
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      result as ValidatableActionResult.FieldValidationError
+
+      assertThat(result.validationMessages).anySatisfy { key, value ->
+        key == "$.departureDate" && value == "shouldBeAfterArrivalDate"
+      }
+    }
+
+    @Test
+    fun `Returns conflict error if a booking already exists for the same premises and placement request`() {
+      val premises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val existingSpaceBooking = Cas1SpaceBookingEntityFactory()
+        .withPremises(premises)
+        .withPlacementRequest(placementRequest)
+        .produce()
+
+      every { premisesService.getPremises(premises.id) } returns premises
+      every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
+      every { spaceBookingRepository.findByPremisesIdAndPlacementRequestId(premises.id, placementRequest.id) } returns existingSpaceBooking
+
+      val result = service.createNewBooking(
+        premisesId = premises.id,
+        placementRequestId = placementRequest.id,
+        arrivalDate = LocalDate.now(),
+        departureDate = LocalDate.now().plusDays(1),
+        createdBy = user,
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.ConflictError::class.java)
+      result as ValidatableActionResult.ConflictError
+
+      assertThat(result.conflictingEntityId).isEqualTo(existingSpaceBooking.id)
+      assertThat(result.message).contains("A Space Booking already exists")
+    }
+
+    @Test
+    fun `Returns new booking if all data is valid`() {
+      val premises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val placementRequest = PlacementRequestEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val user = UserEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val startDate = LocalDate.now()
+      val durationInDays = 1
+      val departureDate = startDate.plusDays(durationInDays.toLong())
+
+      val spaceAvailability = SpaceAvailability(
+        premisesId = premises.id,
+      )
+
+      every { premisesService.getPremises(premises.id) } returns premises
+      every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
+      every { spaceBookingRepository.findByPremisesIdAndPlacementRequestId(premises.id, placementRequest.id) } returns null
+
+      every {
+        spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(listOf(premises.id), startDate, durationInDays)
+      } returns listOf(spaceAvailability)
+
+      every { spaceBookingRepository.save(any()) } returnsArgument 0
+
+      val result = service.createNewBooking(
+        premisesId = premises.id,
+        placementRequestId = placementRequest.id,
+        arrivalDate = startDate,
+        departureDate = departureDate,
+        createdBy = user,
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
+      result as ValidatableActionResult.Success
+
+      assertThat(result.entity.premises).isEqualTo(premises)
+      assertThat(result.entity.placementRequest).isEqualTo(placementRequest)
+      assertThat(result.entity.arrivalDate).isEqualTo(startDate)
+      assertThat(result.entity.departureDate).isEqualTo(departureDate)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingRequirementsTransformer
+
+@ExtendWith(MockKExtension::class)
+class Cas1SpaceBookingRequirementsTransformerTest {
+  @InjectMockKs
+  private lateinit var transformer: Cas1SpaceBookingRequirementsTransformer
+
+  @Test
+  fun `Placement requirements are transformed correctly`() {
+    val cas1SpaceCharacteristics = Cas1SpaceCharacteristic.entries.map { it.toCharacteristicEntity() }
+
+    val placementRequirements = PlacementRequirementsEntityFactory()
+      .withDefaults()
+      .withEssentialCriteria(cas1SpaceCharacteristics)
+      .withDesirableCriteria(cas1SpaceCharacteristics)
+      .produce()
+
+    val result = transformer.transformJpaToApi(placementRequirements)
+
+    assertThat(result.apType).isEqualTo(placementRequirements.apType)
+    assertThat(result.gender).isEqualTo(placementRequirements.gender)
+    assertThat(result.desirableCharacteristics).isEqualTo(Cas1SpaceCharacteristic.entries)
+    assertThat(result.essentialCharacteristics).isEqualTo(Cas1SpaceCharacteristic.entries)
+  }
+
+  private fun Cas1SpaceCharacteristic.toCharacteristicEntity() = CharacteristicEntityFactory()
+    .withName(this.value)
+    .withPropertyName(this.value)
+    .withServiceScope(ServiceName.approvedPremises.value)
+    .withModelScope("*")
+    .produce()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingRequirementsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asOffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1SpaceBookingTransformerTest {
+  @MockK
+  private lateinit var personTransformer: PersonTransformer
+
+  @MockK
+  private lateinit var requirementsTransformer: Cas1SpaceBookingRequirementsTransformer
+
+  @MockK
+  private lateinit var userTransformer: UserTransformer
+
+  @InjectMockKs
+  private lateinit var transformer: Cas1SpaceBookingTransformer
+
+  @Test
+  fun `Space booking is transformed correctly`() {
+    val personInfo = PersonInfoResult.Success.Full(
+      "SOMECRN",
+      CaseSummaryFactory().produce().asOffenderDetailSummary(),
+      null,
+    )
+
+    val expectedPerson = RestrictedPerson(
+      "SOMECRN",
+      PersonType.restrictedPerson,
+    )
+
+    val spaceBooking = Cas1SpaceBookingEntityFactory()
+      .withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+      .produce()
+
+    val expectedRequirements = Cas1SpaceBookingRequirements(
+      apType = ApType.pipe,
+      gender = Gender.female,
+      essentialCharacteristics = listOf(),
+      desirableCharacteristics = listOf(),
+    )
+
+    val expectedUser = ApprovedPremisesUser(
+      qualifications = listOf(),
+      roles = listOf(),
+      apArea = ApArea(
+        id = UUID.randomUUID(),
+        identifier = "SOMEAPA",
+        name = "Some AP Area",
+      ),
+      service = ServiceName.approvedPremises.value,
+      id = spaceBooking.createdBy.id,
+      name = spaceBooking.createdBy.name,
+      deliusUsername = spaceBooking.createdBy.deliusUsername,
+      region = ProbationRegion(
+        id = UUID.randomUUID(),
+        name = "Some Probation Region",
+      ),
+    )
+
+    every { personTransformer.transformModelToPersonApi(personInfo) } returns expectedPerson
+    every { requirementsTransformer.transformJpaToApi(spaceBooking.placementRequest.placementRequirements) } returns expectedRequirements
+    every { userTransformer.transformJpaToApi(spaceBooking.createdBy, ServiceName.approvedPremises) } returns expectedUser
+
+    val result = transformer.transformJpaToApi(personInfo, spaceBooking)
+
+    assertThat(result.id).isEqualTo(spaceBooking.id)
+    assertThat(result.person).isEqualTo(expectedPerson)
+    assertThat(result.requirements).isEqualTo(expectedRequirements)
+    assertThat(result.premises.id).isEqualTo(spaceBooking.premises.id)
+    assertThat(result.premises.name).isEqualTo(spaceBooking.premises.name)
+    assertThat(result.apArea.id).isEqualTo(spaceBooking.premises.probationRegion.apArea!!.id)
+    assertThat(result.apArea.name).isEqualTo(spaceBooking.premises.probationRegion.apArea!!.name)
+    assertThat(result.bookedBy).isEqualTo(expectedUser)
+    assertThat(result.arrivalDate).isEqualTo(spaceBooking.arrivalDate)
+    assertThat(result.departureDate).isEqualTo(spaceBooking.departureDate)
+    assertThat(result.createdAt).isEqualTo(spaceBooking.createdAt.toInstant())
+  }
+}


### PR DESCRIPTION
> See [APS-1094 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-1094).

This PR implements the `POST /cas1/placement-requests/{placementRequestId}/space-bookings` API endpoint introduced in #2077, which allows a user to create a new booking for a space in an Approved Premises.

A new booking is created by `POST`ing to the endpoint with a request body like:
```jsonc
{ // NewCas1SpaceBooking
  "arrivalDate": "2024-09-01",
  "departureDate": "2024-09-30",
  "premisesId": "00000000-0000-0000-0000-000000000000",
  "placementRequestId": "00000000-0000-0000-0000-000000000000",
  "requirements": { // Cas1SpaceBookingRequirements
    "apType": "pipe",
    "gender": "female",
    "essentialCharacteristics": [
      // Cas1SpaceCharacteristic
      // ...
    ],
    "desirableCharacteristics": [
      // Cas1SpaceCharacteristic
      // ...
    ]
  }
}
```

If the API successfully creates a new booking, it will respond with the new booking, which will look like:
```jsonc
{
  "id": "00000000-0000-0000-0000-000000000000",
  "person": { // Person
    // ...
  },
  "requirements": { // Cas1SpaceBookingRequirements
    "apType": "pipe",
    "gender": "female",
    "essentialCharacteristics": [
      // Cas1SpaceCharacteristic
      // ...
    ],
    "desirableCharacteristics": [
      // Cas1SpaceCharacteristic
      // ...
    ]
  },
  "premises": { // NamedId
    "id": "00000000-0000-0000-0000-000000000000",
    "name": "Some AP"
  },
  "apArea": { // NamedId
    "id": "00000000-0000-0000-0000-000000000000",
    "name": "Some AP Area"
  },
  "bookedBy": { // User
    // ...
  },
  "arrivalDate": "2024-09-01",
  "departureDate": "2024-09-30",
  "createdAt": "2024-08-08T12:34:56.789Z"
}
```

It is worth noting that there is currently some redundancy in what is required in the request body. Ideally the API specification would be updated to account for this but this is yet to be agreed:
- The `placementRequestId` is specified both in the URL as a path parameter and in the request body. The value specified in the request body is currently ignored.
- The `requirements` are already stored within the specified placement request. The booking will be created using those specified in the placement request.

The API validates the information provided in the request body in the following ways:
- The `premisesId` must reference an existing Approved Premises.
- The `placementRequestId` must reference an existing placement request.
- The `arrivalDate` must be before the `departureDate`.

Space availability should be validated in the future, but is not currently implemented - this will be accounted for in a future ticket that will also add availability information to the space search endpoint.