### PR TITLE
APS-1149 - Add retries to API calls

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummaries
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
@@ -15,10 +15,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.User
 
 @Component
 class ApDeliusContextApiClient(
-  @Qualifier("apDeliusContextApiWebClient") webClient: WebClient,
+  @Qualifier("apDeliusContextApiWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
   @Cacheable(value = ["qCodeStaffMembersCache"], unless = IS_NOT_SUCCESSFUL)
   fun getStaffMembers(qCode: String) = getRequest<StaffMembersPage> {
     path = "/approved-premises/$qCode/staff"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApOASysContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApOASysContextApiClient.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.NeedsDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.OffenceDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RiskManagementPlan
@@ -13,10 +13,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RoshS
 
 @Component
 class ApOASysContextApiClient(
-  @Qualifier("apOASysContextApiWebClient") webClient: WebClient,
+  @Qualifier("apOASysContextApiWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
   fun getOffenceDetails(crn: String) = getRequest<OffenceDetails> {
     path = "/offence-details/$crn"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -46,11 +46,11 @@ abstract class BaseHMPPSClient(
 
     val cacheConfig = requestBuilder.preemptiveCacheConfig
 
-    val attempt = AtomicInteger(1)
+    val preemptiveCacheRefreshAttempt = AtomicInteger(1)
 
     try {
       if (cacheConfig != null) {
-        webClientCache.tryGetCachedValue(typeReference, requestBuilder, cacheConfig, attempt)?.let {
+        webClientCache.tryGetCachedValue(typeReference, requestBuilder, cacheConfig, preemptiveCacheRefreshAttempt)?.let {
           return it
         }
       }
@@ -76,7 +76,7 @@ abstract class BaseHMPPSClient(
       return ClientResult.Success(result.statusCode, deserialized, false)
     } catch (exception: WebClientResponseException) {
       if (cacheConfig != null && requestBuilder.isPreemptiveCall) {
-        webClientCache.cacheFailedWebClientResponse(requestBuilder, cacheConfig, exception, attempt.get(), method)
+        webClientCache.cacheFailedWebClientResponse(requestBuilder, cacheConfig, exception, preemptiveCacheRefreshAttempt.get(), method)
       }
 
       if (!exception.statusCode.is2xxSuccessful) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -80,7 +80,13 @@ abstract class BaseHMPPSClient(
       }
 
       if (!exception.statusCode.is2xxSuccessful) {
-        return ClientResult.Failure.StatusCode(method, requestBuilder.path ?: "", exception.statusCode, exception.responseBodyAsString, false)
+        return ClientResult.Failure.StatusCode(
+          method,
+          requestBuilder.path ?: "",
+          exception.statusCode,
+          exception.responseBodyAsString,
+          false,
+        )
       } else {
         throw exception
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -7,12 +7,12 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
-import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import java.util.concurrent.atomic.AtomicInteger
 
 abstract class BaseHMPPSClient(
-  private val webClient: WebClient,
+  private val webClientConfig: WebClientConfig,
   private val objectMapper: ObjectMapper,
   private val webClientCache: WebClientCache,
 ) {
@@ -54,6 +54,8 @@ abstract class BaseHMPPSClient(
           return it
         }
       }
+
+      val webClient = webClientConfig.webClient
 
       val request = webClient.method(method)
         .uri(requestBuilder.path ?: "")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CaseNotesClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CaseNotesClient.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.CaseNotesPage
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -11,10 +11,10 @@ import java.time.LocalTime
 
 @Component
 class CaseNotesClient(
-  @Qualifier("caseNotesWebClient") webClient: WebClient,
+  @Qualifier("caseNotesWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
   fun getCaseNotesPage(nomsNumber: String, from: LocalDate, page: Int, pageSize: Int) = getRequest<CaseNotesPage> {
     val fromLocalDateTime = LocalDateTime.of(from, LocalTime.MIN)
     path = "/case-notes/$nomsNumber?startDate=$fromLocalDateTime&page=$page&size=$pageSize"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -8,9 +8,9 @@ import org.springframework.core.io.buffer.DataBufferUtils
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Conviction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedDocuments
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
@@ -19,10 +19,10 @@ import java.io.OutputStream
 
 @Component
 class CommunityApiClient(
-  @Qualifier("communityApiWebClient") private val webClient: WebClient,
+  @Qualifier("communityApiWebClient") private val webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
 
   @Cacheable(value = ["staffDetailsCache"], unless = IS_NOT_SUCCESSFUL)
   fun getStaffUserDetails(deliusUsername: String) = getRequest<StaffUserDetails> {
@@ -45,7 +45,7 @@ class CommunityApiClient(
     val path = "/secure/offenders/crn/$crn/documents/$documentId"
 
     return try {
-      val bodyDataBuffer = webClient.get().uri(path)
+      val bodyDataBuffer = webClientConfig.webClient.get().uri(path)
         .retrieve()
         .bodyToFlux(DataBuffer::class.java)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/GovUKBankHolidaysApiClient.kt
@@ -4,16 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UKBankHolidays
 
 @Component
 class GovUKBankHolidaysApiClient(
-  @Qualifier("govUKBankHolidaysApiWebClient") webClient: WebClient,
+  @Qualifier("govUKBankHolidaysApiWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
   @Cacheable(value = ["ukBankHolidaysCache"], unless = IS_NOT_SUCCESSFUL)
   fun getUKBankHolidays() = getRequest<UKBankHolidays> {
     path = "/bank-holidays.json"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/HMPPSTierApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/HMPPSTierApiClient.kt
@@ -3,15 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
 
 @Component
 class HMPPSTierApiClient(
-  @Qualifier("hmppsTierApiWebClient") webClient: WebClient,
+  @Qualifier("hmppsTierApiWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
   fun getTier(crn: String) = getRequest<Tier> {
     path = "/crn/$crn/tier"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ManageUsersApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ManageUsersApiClient.kt
@@ -3,15 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.manageusers.ExternalUserDetails
 
 @Component
 class ManageUsersApiClient(
-  @Qualifier("manageUsersApiWebClient") webClient: WebClient,
+  @Qualifier("manageUsersApiWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
 
   fun getExternalUserDetails(username: String, jwt: String) = getRequest<ExternalUserDetails> {
     withHeader("Authorization", "Bearer $jwt")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/NomisUserRolesApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/NomisUserRolesApiClient.kt
@@ -3,15 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.nomisuserroles.NomisUserDetail
 
 @Component
 class NomisUserRolesApiClient(
-  @Qualifier("nomisUserRolesApiWebClient") webClient: WebClient,
+  @Qualifier("nomisUserRolesApiWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
 
   fun getUserDetails(jwt: String) = getRequest<NomisUserDetail> {
     withHeader("Authorization", "Bearer $jwt")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/PrisonsApiClient.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.AdjudicationsPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.Alert
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
@@ -11,10 +11,10 @@ import java.time.Duration
 
 @Component
 class PrisonsApiClient(
-  @Qualifier("prisonsApiWebClient") webClient: WebClient,
+  @Qualifier("prisonsApiWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
   private val inmateDetailsCacheConfig = WebClientCache.PreemptiveCacheConfig(
     cacheName = "inmateDetails",
     successSoftTtlSeconds = Duration.ofHours(6).toSeconds().toInt(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ProbationOffenderSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ProbationOffenderSearchApiClient.kt
@@ -3,16 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.ProbationOffenderDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.probationoffendersearchapi.ProbationOffenderSearchNomsRequest
 
 @Component
 class ProbationOffenderSearchApiClient(
-  @Qualifier("probationOffenderSearchApiWebClient") webClient: WebClient,
+  @Qualifier("probationOffenderSearchApiWebClient") webClientConfig: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
-) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {
+) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
 
   fun searchOffenderByNomsNumber(nomsNumber: String) = postRequest<List<ProbationOffenderDetail>> {
     path = "/search"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -19,6 +19,10 @@ import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 import java.time.Duration
 
+data class WebClientConfig(
+  val webClient: WebClient,
+)
+
 @Configuration
 class WebClientConfiguration(
   @Value("\${upstream-timeout-ms}") private val upstreamTimeoutMs: Long,
@@ -47,28 +51,30 @@ class WebClientConfiguration(
     authorizedClients: OAuth2AuthorizedClientRepository,
     authorizedClientManager: OAuth2AuthorizedClientManager,
     @Value("\${services.community-api.base-url}") communityApiBaseUrl: String,
-  ): WebClient {
+  ): WebClientConfig {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
     oauth2Client.setDefaultClientRegistrationId("delius-backed-apis")
 
-    return WebClient.builder()
-      .baseUrl(communityApiBaseUrl)
-      .filter(oauth2Client)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .exchangeStrategies(
-        ExchangeStrategies.builder().codecs {
-          it.defaultCodecs().maxInMemorySize(defaultMaxResponseInMemorySizeBytes)
-        }.build(),
-      )
-      .build()
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(communityApiBaseUrl)
+        .filter(oauth2Client)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .exchangeStrategies(
+          ExchangeStrategies.builder().codecs {
+            it.defaultCodecs().maxInMemorySize(defaultMaxResponseInMemorySizeBytes)
+          }.build(),
+        )
+        .build(),
+    )
   }
 
   @Bean(name = ["apDeliusContextApiWebClient"])
@@ -77,28 +83,30 @@ class WebClientConfiguration(
     authorizedClients: OAuth2AuthorizedClientRepository,
     authorizedClientManager: OAuth2AuthorizedClientManager,
     @Value("\${services.ap-delius-context-api.base-url}") communityApiBaseUrl: String,
-  ): WebClient {
+  ): WebClientConfig {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
     oauth2Client.setDefaultClientRegistrationId("delius-backed-apis")
 
-    return WebClient.builder()
-      .baseUrl(communityApiBaseUrl)
-      .filter(oauth2Client)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .exchangeStrategies(
-        ExchangeStrategies.builder().codecs {
-          it.defaultCodecs().maxInMemorySize(defaultMaxResponseInMemorySizeBytes)
-        }.build(),
-      )
-      .build()
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(communityApiBaseUrl)
+        .filter(oauth2Client)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .exchangeStrategies(
+          ExchangeStrategies.builder().codecs {
+            it.defaultCodecs().maxInMemorySize(defaultMaxResponseInMemorySizeBytes)
+          }.build(),
+        )
+        .build(),
+    )
   }
 
   @Bean(name = ["hmppsTierApiWebClient"])
@@ -106,23 +114,25 @@ class WebClientConfiguration(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClientManager: OAuth2AuthorizedClientManager,
     @Value("\${services.hmpps-tier.base-url}") hmppsTierApiBaseUrl: String,
-  ): WebClient {
+  ): WebClientConfig {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
     oauth2Client.setDefaultClientRegistrationId("hmpps-tier")
 
-    return WebClient.builder()
-      .baseUrl(hmppsTierApiBaseUrl)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .filter(oauth2Client)
-      .build()
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(hmppsTierApiBaseUrl)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .filter(oauth2Client)
+        .build(),
+    )
   }
 
   @Bean(name = ["prisonsApiWebClient"])
@@ -131,30 +141,32 @@ class WebClientConfiguration(
     authorizedClients: OAuth2AuthorizedClientRepository,
     authorizedClientManager: OAuth2AuthorizedClientManager,
     @Value("\${services.prisons-api.base-url}") prisonsApiBaseUrl: String,
-  ): WebClient {
+  ): WebClientConfig {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
     oauth2Client.setDefaultClientRegistrationId("prisons-api")
 
     log.info("Using maxInMemorySize of $prisonApiMaxResponseInMemorySizeBytes bytes for Prison API Web Client")
 
-    return WebClient.builder()
-      .baseUrl(prisonsApiBaseUrl)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .exchangeStrategies(
-        ExchangeStrategies.builder().codecs {
-          it.defaultCodecs().maxInMemorySize(prisonApiMaxResponseInMemorySizeBytes)
-        }.build(),
-      )
-      .filter(oauth2Client)
-      .build()
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(prisonsApiBaseUrl)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .exchangeStrategies(
+          ExchangeStrategies.builder().codecs {
+            it.defaultCodecs().maxInMemorySize(prisonApiMaxResponseInMemorySizeBytes)
+          }.build(),
+        )
+        .filter(oauth2Client)
+        .build(),
+    )
   }
 
   @Bean(name = ["caseNotesWebClient"])
@@ -162,23 +174,25 @@ class WebClientConfiguration(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
     @Value("\${services.case-notes.base-url}") caseNotesBaseUrl: String,
-  ): WebClient {
+  ): WebClientConfig {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
 
     oauth2Client.setDefaultClientRegistrationId("case-notes")
 
-    return WebClient.builder()
-      .baseUrl(caseNotesBaseUrl)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(caseNotesServiceUpstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(caseNotesServiceUpstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .filter(oauth2Client)
-      .build()
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(caseNotesBaseUrl)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(caseNotesServiceUpstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(caseNotesServiceUpstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .filter(oauth2Client)
+        .build(),
+    )
   }
 
   @Bean(name = ["apOASysContextApiWebClient"])
@@ -187,74 +201,82 @@ class WebClientConfiguration(
     authorizedClients: OAuth2AuthorizedClientRepository,
     authorizedClientManager: OAuth2AuthorizedClientManager,
     @Value("\${services.ap-oasys-context-api.base-url}") apOASysContextApiBaseUrl: String,
-  ): WebClient {
+  ): WebClientConfig {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
 
     oauth2Client.setDefaultClientRegistrationId("ap-oasys-context")
 
-    return WebClient.builder()
-      .baseUrl(apOASysContextApiBaseUrl)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .filter(oauth2Client)
-      .build()
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(apOASysContextApiBaseUrl)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .filter(oauth2Client)
+        .build(),
+    )
   }
 
   @Bean(name = ["govUKBankHolidaysApiWebClient"])
   fun govUKBankHolidaysApiClient(
     @Value("\${services.gov-uk-bank-holidays-api.base-url}") govUKBankHolidaysApiBaseUrl: String,
-  ): WebClient {
-    return WebClient.builder()
-      .baseUrl(govUKBankHolidaysApiBaseUrl)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .build()
+  ): WebClientConfig {
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(govUKBankHolidaysApiBaseUrl)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .build(),
+    )
   }
 
   @Bean(name = ["nomisUserRolesApiWebClient"])
   fun nomisUserRolesApiClient(
     @Value("\${services.nomis-user-roles-api.base-url}") nomisUserRolesBaseUrl: String,
-  ): WebClient {
-    return WebClient.builder()
-      .baseUrl(nomisUserRolesBaseUrl)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .build()
+  ): WebClientConfig {
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(nomisUserRolesBaseUrl)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .build(),
+    )
   }
 
   @Bean(name = ["manageUsersApiWebClient"])
   fun manageUsersApiClient(
     @Value("\${services.manage-users-api.base-url}") manageUsersBaseUrl: String,
-  ): WebClient {
-    return WebClient.builder()
-      .baseUrl(manageUsersBaseUrl)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .build()
+  ): WebClientConfig {
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(manageUsersBaseUrl)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .build(),
+    )
   }
 
   @Bean(name = ["probationOffenderSearchApiWebClient"])
@@ -262,27 +284,29 @@ class WebClientConfiguration(
     clientRegistrations: ClientRegistrationRepository,
     authorizedClients: OAuth2AuthorizedClientRepository,
     @Value("\${services.probation-offender-search-api.base-url}") probationOffenderSearchBaseUrl: String,
-  ): WebClient {
+  ): WebClientConfig {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
 
     oauth2Client.setDefaultClientRegistrationId("delius-backed-apis")
 
-    return WebClient.builder()
-      .baseUrl(probationOffenderSearchBaseUrl)
-      .clientConnector(
-        ReactorClientHttpConnector(
-          HttpClient
-            .create()
-            .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
-        ),
-      )
-      .filter(oauth2Client)
-      .exchangeStrategies(
-        ExchangeStrategies.builder().codecs {
-          it.defaultCodecs().maxInMemorySize(probationOffenderSearchApiMaxResponseInMemorySizeBytes)
-        }.build(),
-      )
-      .build()
+    return WebClientConfig(
+      webClient = WebClient.builder()
+        .baseUrl(probationOffenderSearchBaseUrl)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .filter(oauth2Client)
+        .exchangeStrategies(
+          ExchangeStrategies.builder().codecs {
+            it.defaultCodecs().maxInMemorySize(probationOffenderSearchApiMaxResponseInMemorySizeBytes)
+          }.build(),
+        )
+        .build(),
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -21,6 +21,7 @@ import java.time.Duration
 
 data class WebClientConfig(
   val webClient: WebClient,
+  val maxRetryAttempts: Long = 1,
 )
 
 @Configuration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -27,6 +27,7 @@ import org.zalando.problem.spring.web.advice.ProblemHandling
 import org.zalando.problem.spring.web.advice.io.MessageNotReadableAdviceTrait
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeserializationValidationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isTypeInThrowableChain
 
 @ControllerAdvice
 class ExceptionHandling(
@@ -81,19 +82,6 @@ class ExceptionHandling(
     return UnhandledExceptionProblem(
       detail = "There was an unexpected problem",
     )
-  }
-
-  private fun <T> isTypeInThrowableChain(throwable: Throwable, causeType: Class<T>): Boolean {
-    if (throwable.javaClass == causeType) {
-      return true
-    }
-
-    val cause = throwable.cause
-    if (cause != null) {
-      return isTypeInThrowableChain(cause, causeType)
-    } else {
-      return false
-    }
   }
 
   override fun handleMessageNotReadableException(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ThrowableUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ThrowableUtils.kt
@@ -6,3 +6,16 @@ fun findRootCause(throwable: Throwable, topMost: Boolean = true): Throwable? {
 
   return findRootCause(throwable.cause!!, false)
 }
+
+fun <T> isTypeInThrowableChain(throwable: Throwable, causeType: Class<T>): Boolean {
+  if (throwable.javaClass == causeType) {
+    return true
+  }
+
+  val cause = throwable.cause
+  if (cause != null) {
+    return isTypeInThrowableChain(cause, causeType)
+  } else {
+    return false
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ThrowableUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/ThrowableUtils.kt
@@ -13,9 +13,9 @@ fun <T> isTypeInThrowableChain(throwable: Throwable, causeType: Class<T>): Boole
   }
 
   val cause = throwable.cause
-  if (cause != null) {
-    return isTypeInThrowableChain(cause, causeType)
+  return if (cause != null) {
+    isTypeInThrowableChain(cause, causeType)
   } else {
-    return false
+    false
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -620,7 +620,7 @@ abstract class IntegrationTestBase {
       .responseTimeout(Duration.ofMinutes(20))
       .build()
 
-    wiremockManager.setupTests()
+    wiremockManager.beforeTest()
 
     cacheManager.cacheNames.forEach {
       cacheManager.getCache(it)!!.clear()
@@ -631,7 +631,7 @@ abstract class IntegrationTestBase {
   }
 
   fun teardownTests() {
-    wiremockManager.teardownTests()
+    wiremockManager.afterTest()
   }
 
   fun setupFactories() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PreemptiveCacheTest.kt
@@ -16,12 +16,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.BaseHMPPSClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CacheKeySet
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.MarshallableHttpMethod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.WebClientCache
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import java.time.Duration
@@ -264,7 +264,7 @@ class PreemptiveCacheTest : IntegrationTestBase() {
 
 @Component
 class PreemptivelyCachedClient(
-  @Qualifier("communityApiWebClient") private val webClient: WebClient,
+  @Qualifier("communityApiWebClient") private val webClient: WebClientConfig,
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
 ) : BaseHMPPSClient(webClient, objectMapper, webClientCache) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WiremockManager.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WiremockManager.kt
@@ -75,4 +75,8 @@ class WiremockManager {
   fun afterTest() {
     wiremockServer.resetAll()
   }
+
+  fun resetRequestJournal() {
+    wiremockServer.resetRequests()
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WiremockManager.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WiremockManager.kt
@@ -64,7 +64,7 @@ class WiremockManager {
   @Value("\${wiremock.port}")
   lateinit var wiremockPort: Number
 
-  fun setupTests() {
+  fun beforeTest() {
     if (!this::wiremockServer.isInitialized || !wiremockServer.isRunning) {
       log.info("Starting wiremock on port $wiremockPort")
       wiremockServer = WireMockServer(wiremockPort.toInt())
@@ -72,7 +72,7 @@ class WiremockManager {
     }
   }
 
-  fun teardownTests() {
+  fun afterTest() {
     wiremockServer.resetAll()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/BaseHMPPSClientPreemptiveCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/BaseHMPPSClientPreemptiveCacheTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.MarshallableHttpM
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.WebClientCache
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import java.time.Duration
 import java.time.Instant

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/BaseHMPPSClientRetryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/BaseHMPPSClientRetryTest.kt
@@ -1,0 +1,195 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.client
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.http.Fault
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.env.Environment
+import org.springframework.core.env.get
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.WebClientCache
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockUnsuccesfullCaseDetailCall
+
+class BaseHMPPSClientRetryTest : InitialiseDatabasePerClassTestBase() {
+
+  companion object {
+    const val CRN = "ABC123"
+
+    @JvmStatic
+    fun successHttpStatusCode() =
+      HttpStatus.entries.filter { it.is2xxSuccessful }.filter { it.value() != 204 }.map { it.value() }
+
+    @JvmStatic
+    fun errorHttpStatusCodesForRetries(): List<Int> {
+      return listOf(500, 501, 502, 503)
+    }
+
+    @JvmStatic
+    fun errorHttpStatusCodeThatDontRetry(): List<Int> {
+      return HttpStatus.entries
+        .filter { it.is4xxClientError || it.is5xxServerError }
+        .filter { errorHttpStatusCodesForRetries().contains(it.value()) }
+        .map { it.value() }
+    }
+  }
+
+  @AfterEach
+  fun resetRequestJournal() {
+    wiremockManager.resetRequestJournal()
+  }
+
+  @Autowired
+  lateinit var webClientCache: WebClientCache
+
+  @Autowired
+  @Qualifier("apDeliusContextApiWebClient")
+  lateinit var apDeliusContextApiWebClientConfig: WebClientConfig
+
+  @Autowired
+  lateinit var environment: Environment
+
+  fun setupTestClient(maxRetries: Long) =
+    ApDeliusContextApiClient(
+      WebClientConfig(
+        apDeliusContextApiWebClientConfig.webClient,
+        maxRetries,
+      ),
+      objectMapper,
+      webClientCache,
+    )
+
+  @ParameterizedTest
+  @MethodSource("successHttpStatusCode")
+  fun `Don't retry for success outcomes`(httpStatusCode: Int) {
+    APDeliusContext_mockSuccessfulCaseDetailCall(
+      crn = CRN,
+      response = CaseDetailFactory().produce(),
+      responseStatus = httpStatusCode,
+    )
+
+    val client = setupTestClient(maxRetries = 2)
+
+    val result = client.getCaseDetail(CRN)
+
+    assertThat(result).isInstanceOf(ClientResult.Success::class.java)
+
+    wiremockManager.wiremockServer.verify(1, getRequestedFor(urlEqualTo("/probation-cases/$CRN/details")))
+  }
+
+  @Test
+  fun `Dont retry if maxRetries is 0`() {
+    APDeliusContext_mockUnsuccesfullCaseDetailCall(
+      crn = CRN,
+      responseStatus = 500,
+    )
+
+    val client = setupTestClient(maxRetries = 0)
+
+    val result = client.getCaseDetail(CRN)
+
+    assertThat(result).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
+
+    wiremockManager.wiremockServer.verify(1, getRequestedFor(urlEqualTo("/probation-cases/$CRN/details")))
+  }
+
+  @ParameterizedTest
+  @MethodSource("errorHttpStatusCodesForRetries")
+  fun `Retry for all applicable error status codes`(httpStatusCode: Int) {
+    APDeliusContext_mockUnsuccesfullCaseDetailCall(
+      crn = CRN,
+      responseStatus = httpStatusCode,
+    )
+
+    val client = setupTestClient(maxRetries = 2)
+
+    val result = client.getCaseDetail(CRN)
+
+    assertThat(result).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
+    result as ClientResult.Failure.StatusCode
+    assertThat(result.status.value()).isEqualTo(httpStatusCode)
+
+    wiremockManager.wiremockServer.verify(3, getRequestedFor(urlEqualTo("/probation-cases/$CRN/details")))
+  }
+
+  @ParameterizedTest
+  @MethodSource("errorHttpStatusCodeThatDontRetry")
+  fun `Don't retry for all applicable error status codes`(httpStatusCode: Int) {
+    APDeliusContext_mockUnsuccesfullCaseDetailCall(
+      crn = CRN,
+      responseStatus = httpStatusCode,
+    )
+
+    val client = setupTestClient(maxRetries = 2)
+
+    val result = client.getCaseDetail(CRN)
+
+    assertThat(result).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
+    result as ClientResult.Failure.StatusCode
+    assertThat(result.status.value()).isEqualTo(httpStatusCode)
+
+    wiremockManager.wiremockServer.verify(3, getRequestedFor(urlEqualTo("/probation-cases/$CRN/details")))
+  }
+
+  @Test
+  fun `Retry connection prematurely closed errors`() {
+    mockOAuth2ClientCredentialsCallIfRequired {
+      wiremockServer.stubFor(
+        WireMock.get(urlEqualTo("/probation-cases/$CRN/details"))
+          .willReturn(
+            aResponse()
+              .withFault(Fault.RANDOM_DATA_THEN_CLOSE),
+          ),
+      )
+    }
+
+    val client = setupTestClient(maxRetries = 2)
+
+    val result = client.getCaseDetail(CRN)
+
+    assertThat(result).isInstanceOf(ClientResult.Failure.Other::class.java)
+    result as ClientResult.Failure.Other
+    assertThat(result.exception.cause!!.message).startsWith("Connection prematurely closed BEFORE response")
+
+    wiremockManager.wiremockServer.verify(3, getRequestedFor(urlEqualTo("/probation-cases/$CRN/details")))
+  }
+
+  @Test
+  fun `Don't retry timeouts`() {
+    val clientTimeout = environment["upstream-timeout-ms"]!!.toInt()
+
+    mockOAuth2ClientCredentialsCallIfRequired {
+      wiremockServer.stubFor(
+        WireMock.get(urlEqualTo("/probation-cases/$CRN/details"))
+          .willReturn(
+            aResponse()
+              .withFixedDelay(clientTimeout + 500)
+              .withFault(Fault.RANDOM_DATA_THEN_CLOSE),
+          ),
+      )
+    }
+
+    val client = setupTestClient(maxRetries = 2)
+
+    val result = client.getCaseDetail(CRN)
+
+    assertThat(result).isInstanceOf(ClientResult.Failure.Other::class.java)
+    result as ClientResult.Failure.Other
+    assertThat(result.exception.cause).isInstanceOf(io.netty.handler.timeout.ReadTimeoutException::class.java)
+
+    wiremockManager.wiremockServer.verify(1, getRequestedFor(urlEqualTo("/probation-cases/$CRN/details")))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -30,10 +30,17 @@ fun IntegrationTestBase.APDeliusContext_mockSuccessfulStaffMembersCall(staffMemb
     ),
   )
 
-fun IntegrationTestBase.APDeliusContext_mockSuccessfulCaseDetailCall(crn: String, response: CaseDetail) =
+fun IntegrationTestBase.APDeliusContext_mockSuccessfulCaseDetailCall(crn: String, response: CaseDetail, responseStatus: Int = 200) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/probation-cases/$crn/details",
     responseBody = response,
+    responseStatus = responseStatus,
+  )
+
+fun IntegrationTestBase.APDeliusContext_mockUnsuccesfullCaseDetailCall(crn: String, responseStatus: Int) =
+  mockUnsuccessfulGetCall(
+    url = "/probation-cases/$crn/details",
+    responseStatus = responseStatus,
   )
 
 fun IntegrationTestBase.APDeliusContext_mockSuccessfulTeamsManagingCaseCall(crn: String, response: ManagingTeamsResponse) =

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -174,7 +174,7 @@ preemptive-cache-lock-duration-ms: 10000
 arrived-departed-domain-events-disabled: false
 manual-bookings-domain-events-disabled: false
 
-upstream-timeout-ms: 2000
+upstream-timeout-ms: 500
 
 migration-job:
   throttle-enabled: false


### PR DESCRIPTION
If API requests fail with a connection error (other than timeout) or with 500, 501, 502 or 503, the API client will now retry the request 1 additional time.

This helps work around stale connection errors we’ve observed in production where an idle connection in the netty connection pool has (presumably) been timed out by the target server. Given how intermittent this issue is in production,  a retry should, with luck, provide us with a working connection.

The error we’ve been seeing is “Connection prematurely closed BEFORE response; nested exception is reactor.netty.http.client.PrematureCloseException: Connection prematurely closed BEFORE response”. A specific integration test has been added for this scenario.