### PR TITLE
CAS-390 added search by name functionality for assessments.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -61,6 +61,7 @@ class AssessmentController(
     sortBy: AssessmentSortField?,
     statuses: List<AssessmentStatus>?,
     crn: String?,
+    crnOrName: String?,
     page: Int?,
     perPage: Int?,
   ): ResponseEntity<List<AssessmentSummary>> {
@@ -74,7 +75,7 @@ class AssessmentController(
       ServiceName.temporaryAccommodation -> {
         val (summaries, metadata) = assessmentService.getAssessmentSummariesForUserCAS3(
           user,
-          crn,
+          crn ?: crnOrName,
           xServiceName,
           domainSummaryStatuses,
           PageCriteria(resolvedSortBy, resolvedSortDirection, page, perPage),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -128,7 +128,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
              join applications ap on a.application_id = ap.id
              left outer join temporary_accommodation_applications taa on ap.id = taa.id
        where taa.probation_region_id = ?1
-             and (?2 is null OR ap.crn = ?2)
+             and (?2 is null OR ap.crn = ?2 OR lower(taa.name) LIKE CONCAT('%', lower(?2),'%'))
              and a.reallocated_at is null
              and ((?3) is null OR
                                 (
@@ -167,7 +167,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
   )
   fun findTemporaryAccommodationAssessmentSummariesForRegionAndCrnAndStatus(
     probationRegionId: UUID,
-    crn: String?,
+    crnOrName: String?,
     statuses: List<String> = emptyList(),
     page: Pageable? = null,
   ): Page<DomainAssessmentSummary>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -121,7 +121,7 @@ class AssessmentService(
 
   fun getAssessmentSummariesForUserCAS3(
     user: UserEntity,
-    crn: String?,
+    crnOrName: String?,
     serviceName: ServiceName,
     statuses: List<DomainAssessmentSummaryStatus>,
     pageCriteria: PageCriteria<AssessmentSortField>,
@@ -137,7 +137,7 @@ class AssessmentService(
         }
         val response = assessmentRepository.findTemporaryAccommodationAssessmentSummariesForRegionAndCrnAndStatus(
           user.probationRegion.id,
-          crn,
+          crnOrName,
           statuses.map { it.name },
           getPageableOrAllPages(pageCriteria.withSortBy(sortFieldString)),
         )

--- a/src/main/resources/db/migration/all/20240808102000__add_indexes_assessment_search.sql
+++ b/src/main/resources/db/migration/all/20240808102000__add_indexes_assessment_search.sql
@@ -1,0 +1,2 @@
+CREATE EXTENSION IF NOT EXISTS  pg_trgm;
+CREATE INDEX temporary_accommodation_applications_lower_name_trgm_idx ON temporary_accommodation_applications USING gin (lower(name) gin_trgm_ops);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3643,6 +3643,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: crnOrName
+          in: query
+          description: Filters results using an exact match or CRN, or partial match on name
+          required: false
+          schema:
+            type: string
         - name: page
           in: query
           description: Page number of results to return. If blank, returns all results

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3645,6 +3645,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: crnOrName
+          in: query
+          description: Filters results using an exact match or CRN, or partial match on name
+          required: false
+          schema:
+            type: string
         - name: page
           in: query
           description: Page number of results to return. If blank, returns all results

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentEmailServiceTest.kt
@@ -195,7 +195,7 @@ class Cas1AssessmentEmailServiceTest {
 
     @Test
     fun `assessmentAllocated sends an email to a user if they have an email address and an emergency assessment with a deadline of today`() {
-      val deadline = OffsetDateTime.now().minusHours(2)
+      val deadline = OffsetDateTime.now()
       service.assessmentAllocated(applicant, assessmentID, application, deadline, true)
 
       mockEmailNotificationService.assertEmailRequestCount(1)


### PR DESCRIPTION
PR to add search by name feature for filtering assessments. Extended the existing CAS3 query to include the name. 

-  Depending on query time we may want to add an index on the TAA.name column as lower case. 
-  the crn parameter will be removed from the controller in a following PR, once the UI has removed it's usage
-  fixed an unrelated cas1 test that failed if ran between midnight and 01:59.

[https://dsdmoj.atlassian.net/browse/CAS-390](url)