### PR TITLE
APS-1155 Remove offenderDetails Cache

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CacheService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CacheService.kt
@@ -17,7 +17,6 @@ class CacheService(
 
   fun clearCache(cacheName: CacheType) {
     when (cacheName) {
-      CacheType.offenderDetails -> clearPreemptiveCache("offenderDetails")
       CacheType.inmateDetails -> clearPreemptiveCache("inmateDetails")
       CacheType.qCodeStaffMembers -> clearRegularCache("qCodeStaffMembersCache")
       CacheType.userAccess -> clearRegularCache("userAccessCache")

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4798,7 +4798,6 @@ components:
         - staffDetails
         - teamsManagingCase
         - ukBankHolidays
-        - offenderDetails
         - inmateDetails
     BedOccupancyRange:
       type: object

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2065,52 +2065,6 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
-  /applications/{applicationId}/placement-applications:
-    get:
-      tags:
-        - Application data timeline
-      summary: Returns domain event summary
-      parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: includeInitialRequestForPlacement
-          in: query
-          description: If true, will return a PlacementApplication of type 'Initial' representing the placement requests as part of the original application submission (i.e. when arrival date is known).
-          required: false
-          schema:
-            type: boolean
-        - name: X-Service-Name
-          in: header
-          required: true
-          description: If given, only users for this service will be returned
-          schema:
-            $ref: '#/components/schemas/ServiceName'
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PlacementApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        404:
-          description: invalid CRN
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /applications/{applicationId}/documents:
     get:
       tags:
@@ -9217,7 +9171,6 @@ components:
         - staffDetails
         - teamsManagingCase
         - ukBankHolidays
-        - offenderDetails
         - inmateDetails
     BedOccupancyRange:
       type: object

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5451,7 +5451,6 @@ components:
         - staffDetails
         - teamsManagingCase
         - ukBankHolidays
-        - offenderDetails
         - inmateDetails
     BedOccupancyRange:
       type: object

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5389,7 +5389,6 @@ components:
         - staffDetails
         - teamsManagingCase
         - ukBankHolidays
-        - offenderDetails
         - inmateDetails
     BedOccupancyRange:
       type: object

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4889,7 +4889,6 @@ components:
         - staffDetails
         - teamsManagingCase
         - ukBankHolidays
-        - offenderDetails
         - inmateDetails
     BedOccupancyRange:
       type: object


### PR DESCRIPTION
This commit completes the removal of the offender details cache now that is has been cleared in production.

As part of this work I had to update the PreemptiveCacheTest to use the prisonsApiWebClient and the communityApiWebClient no longer has a pre-emptive cache configured