### PR TITLE
Cas 438 persist pdu id to applications table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -25,6 +25,7 @@ import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.Inheritance
 import javax.persistence.InheritanceType
@@ -510,6 +511,9 @@ class TemporaryAccommodationApplicationEntity(
   var pdu: String?,
   var name: String?,
   var prisonReleaseTypes: String?,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "probation_delivery_unit_id")
+  var probationDeliveryUnit: ProbationDeliveryUnitEntity?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -100,6 +101,7 @@ class ApplicationService(
   private val applicationListener: ApplicationListener,
   private val clock: Clock,
   private val lockableApplicationRepository: LockableApplicationRepository,
+  private val probationDeliveryUnitRepository: ProbationDeliveryUnitRepository,
 ) {
   fun getApplication(applicationId: UUID) = applicationRepository.findByIdOrNull(applicationId)
 
@@ -487,6 +489,7 @@ class ApplicationService(
       isConcerningSexualBehaviour = null,
       isConcerningArsonBehaviour = null,
       prisonReleaseTypes = null,
+      probationDeliveryUnit = null,
     )
   }
 
@@ -914,6 +917,9 @@ class ApplicationService(
       personReleaseDate = submitApplication.personReleaseDate
       pdu = submitApplication.pdu
       prisonReleaseTypes = submitApplication.prisonReleaseTypes?.joinToString(",")
+      probationDeliveryUnit = submitApplication.probationDeliveryUnitId?.let {
+        probationDeliveryUnitRepository.findByIdOrNull(it)
+      }
     }
 
     assessmentService.createTemporaryAccommodationAssessment(application, submitApplication.summaryData!!)

--- a/src/main/resources/db/migration/all/20240808140000__add_pdu_id_column.sql
+++ b/src/main/resources/db/migration/all/20240808140000__add_pdu_id_column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE temporary_accommodation_applications
+    ADD COLUMN probation_delivery_unit_id UUID;
+
+ALTER TABLE temporary_accommodation_applications
+    ADD FOREIGN KEY (probation_delivery_unit_id) REFERENCES probation_delivery_units(id);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2578,6 +2578,9 @@ components:
               example: '2024-02-21'
             pdu:
               type: string
+            probationDeliveryUnitId:
+              type: string
+              format: uuid
             isHistoryOfSexualOffence:
               type: boolean
             isConcerningSexualBehaviour:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6951,6 +6951,9 @@ components:
               example: '2024-02-21'
             pdu:
               type: string
+            probationDeliveryUnitId:
+              type: string
+              format: uuid
             isHistoryOfSexualOffence:
               type: boolean
             isConcerningSexualBehaviour:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3231,6 +3231,9 @@ components:
               example: '2024-02-21'
             pdu:
               type: string
+            probationDeliveryUnitId:
+              type: string
+              format: uuid
             isHistoryOfSexualOffence:
               type: boolean
             isConcerningSexualBehaviour:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3169,6 +3169,9 @@ components:
               example: '2024-02-21'
             pdu:
               type: string
+            probationDeliveryUnitId:
+              type: string
+              format: uuid
             isHistoryOfSexualOffence:
               type: boolean
             isConcerningSexualBehaviour:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2669,6 +2669,9 @@ components:
               example: '2024-02-21'
             pdu:
               type: string
+            probationDeliveryUnitId:
+              type: string
+              format: uuid
             isHistoryOfSexualOffence:
               type: boolean
             isConcerningSexualBehaviour:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -54,6 +55,7 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var isConcerningArsonBehaviour: Yielded<Boolean?> = { null }
   private var dutyToReferOutcome: Yielded<String?> = { null }
   private var prisonReleaseTypes: Yielded<String?> = { null }
+  private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity?> = { null }
   fun withId(id: UUID) = apply {
     this.id = { id }
   }
@@ -233,5 +235,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     pdu = this.pdu(),
     name = this.name(),
     prisonReleaseTypes = this.prisonReleaseTypes(),
+    probationDeliveryUnit = this.probationDeliveryUnit(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2409,7 +2409,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Submit Temporary Accommodation application returns 200 with optionl elements in the request`() {
+    fun `Submit Temporary Accommodation application returns 200 with optional elements in the request`() {
       `Given a User`(
         staffUserDetailsConfigBlock = {
           withTeams(
@@ -2446,6 +2446,14 @@ class ApplicationTest : IntegrationTestBase() {
               )
             }
 
+            val pdu = probationDeliveryUnitFactory.produceAndPersist {
+              withProbationRegion(
+                probationRegionEntityFactory.produceAndPersist {
+                  withId(submittingUser.probationRegion.id)
+                },
+              )
+            }
+
             webTestClient.post()
               .uri("/applications/$applicationId/submission")
               .header("Authorization", "Bearer $jwt")
@@ -2469,6 +2477,7 @@ class ApplicationTest : IntegrationTestBase() {
                     "Parole",
                     "CRD licence",
                   ),
+                  probationDeliveryUnitId = pdu.id,
                 ),
               )
               .exchange()
@@ -2483,6 +2492,8 @@ class ApplicationTest : IntegrationTestBase() {
             assertThat(persistedApplication.personReleaseDate).isEqualTo(LocalDate.now())
             assertThat(persistedApplication.dutyToReferOutcome).isEqualTo("Accepted – Prevention/ Relief Duty")
             assertThat(persistedApplication.prisonReleaseTypes).isEqualTo("Parole,CRD licence")
+            assertThat(persistedApplication.probationDeliveryUnit!!.id).isEqualTo(pdu.id)
+            assertThat(persistedApplication.probationDeliveryUnit!!.name).isEqualTo(pdu.name)
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -60,6 +60,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
@@ -128,6 +129,7 @@ class ApplicationServiceTest {
   private val mockPlacementApplicationAutomaticRepository = mockk<PlacementApplicationAutomaticRepository>()
   private val mockApplicationListener = mockk<ApplicationListener>()
   private val mockLockableApplicationRepository = mockk<LockableApplicationRepository>()
+  private val mockProbationDeliveryUnitRepository = mockk<ProbationDeliveryUnitRepository>()
 
   private val applicationService = ApplicationService(
     mockUserRepository,
@@ -154,6 +156,7 @@ class ApplicationServiceTest {
     mockApplicationListener,
     Clock.systemDefaultZone(),
     mockLockableApplicationRepository,
+    mockProbationDeliveryUnitRepository,
   )
 
   @Test
@@ -2326,6 +2329,7 @@ class ApplicationServiceTest {
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
       every { mockJsonSchemaService.validate(newestSchema, application.data!!) } returns true
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+      every { mockProbationDeliveryUnitRepository.findByIdOrNull(any()) } returns null
       every {
         mockAssessmentService.createTemporaryAccommodationAssessment(
           application,
@@ -2392,6 +2396,7 @@ class ApplicationServiceTest {
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
       every { mockJsonSchemaService.validate(newestSchema, application.data!!) } returns true
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
+      every { mockProbationDeliveryUnitRepository.findByIdOrNull(any()) } returns null
       every {
         mockAssessmentService.createTemporaryAccommodationAssessment(
           application,


### PR DESCRIPTION
Ref: CAS-438, https://dsdmoj.atlassian.net/browse/CAS-438

As a part of the CAS-307: Capture PP's PDU and other core information in referral from Delius work, we are now planning to record and save the ID of the probation delivery unit (PDU).

In ticket CAS-366: FE: Implement new user journey in FE with pre-populated nDelius data the form will now return the PDU id as first class field called probationDeliveryUnitId. This needs to be saved into the db alongside the name of the PDU (determinable via the existing probation_delivery_units table).

Create a new probation_delivery_unit_id field and save the value returned from the UI probationDeliveryUnitId in it.