### PR TITLE
APS-1134 Fix timeline bug for legacy cas1 booking cancelled events

### DIFF
--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1279,10 +1279,8 @@ components:
         - bookingId
         - premises
         - cancelledAt
-        - cancelledAtDate
         - cancelledBy
         - cancellationReason
-        - cancellationRecordedAt
     BookingExtendedEnvelope:
       type: object
       properties:


### PR DESCRIPTION
In commit e80e1e3 we introduced some additional mandatory fields to the CAS1 booking cancelled event.

This leads to an error when rendering an application timeline that includes ‘legacy’ CAS1 booking cancelled events. In this case we see an error beacuse the new mandatory fields are not in the legacy event JSON.

This commit provides a short term fix for the issue by making the new CAS1 event fields optional so we can still unmarshall legacy event JSON for the timeline.

Note that these _are_ mandatory on the receiver and will always be populated by the API so once we have a proper fix in place to deal with legacy domain event schemas on the timeline we should revert this change.