### PR TITLE
APS-1149 Only retry specific status codes

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/BaseHMPPSClientRetryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/BaseHMPPSClientRetryTest.kt
@@ -42,7 +42,7 @@ class BaseHMPPSClientRetryTest : InitialiseDatabasePerClassTestBase() {
     fun errorHttpStatusCodeThatDontRetry(): List<Int> {
       return HttpStatus.entries
         .filter { it.is4xxClientError || it.is5xxServerError }
-        .filter { errorHttpStatusCodesForRetries().contains(it.value()) }
+        .filter { !errorHttpStatusCodesForRetries().contains(it.value()) }
         .map { it.value() }
     }
   }
@@ -141,7 +141,7 @@ class BaseHMPPSClientRetryTest : InitialiseDatabasePerClassTestBase() {
     result as ClientResult.Failure.StatusCode
     assertThat(result.status.value()).isEqualTo(httpStatusCode)
 
-    wiremockManager.wiremockServer.verify(3, getRequestedFor(urlEqualTo("/probation-cases/$CRN/details")))
+    wiremockManager.wiremockServer.verify(1, getRequestedFor(urlEqualTo("/probation-cases/$CRN/details")))
   }
 
   @Test


### PR DESCRIPTION
ba71b6e990f51a60434c193fee1fb34ed2ff912f introduces retrying calls to API calls.

The intention was to only retry on specific status codes, but due to a combination of bad retry logic and a bad test, the code was retrying for all status codes. This commit fixes that.