### PR TITLE
APS -1134 - Map CAS1 Booking Cancelled Event json v1 to v2 on-the-fly

### DIFF
--- a/doc/how-to/modifying_domain_event_schemas.md
+++ b/doc/how-to/modifying_domain_event_schemas.md
@@ -1,0 +1,31 @@
+# Modifying Domain Event JSON
+
+## Definition and Usage
+
+Each domain event type has a JSON schema defined in the domain-events-api.yml file. For example, the 'APPROVED_PREMISES_BOOKING_CANCELLED' type has a 'BookingCancelledEnvelope' defined in the domain-events-api.yml file.
+
+When a domain event is generated its JSON is persisted to domain_events.data. This JSON is then used for the following:
+
+1. Consumed by the probation-integration service(s) to retrieve detail about a domain event published to the SQS Queue, via the endpoints defined in domain-events-api.yml
+2. Used by the CAS1 DomainEventDescriber component to produce timeline descriptions for domain events
+
+## Considerings when making changes
+
+If we need to modify a domain event's schema, we need to be mindful that any currently persisted domain event json (i.e. in domain_events.data) will not necessarily conform to this new schema. This may cause issues in the aforementioned use cases because they will deserialize the JSON into a generated Kotlin object built against the latest version of the schema. If the 'legacy' json isn't compatible with this object model, an exception will occur.
+
+For example, if a new mandatory field is added to a domain event's schema, any existing domain event JSON will no longer be readable
+
+Although if will differ on a case-by-case basis, it's only possible to make a change to a domain event schema if existing domain events can be adapted to satisfy the new schema. If they can't, we have to consider adding a new domain event type (e.g. APPROVED_PREMISES_BOOKING_CHANGED_V2). This should be avoided if possible because it will create additional work in both CAS API and receivers of the domain events (probation-integration).
+
+## Making a schema change that is backwards-compatible
+
+Unit and Integration tests will automatically pick up a new schema version defined in DomainEventEntity.kt and test serialization and de-serialization. To enable this when adding a new schema version:
+
+1. Add a new schema version entry to the corresponding DomainEventType (in DomainEventEntity.kt)
+2. Update Cas1DomainEventFactory.kt to ensure that JSON provided for prior schema versions reflect the legacy JSON (see createCas1DomainEventEnvelopeForSchemaVersion for an example of this)
+
+## Managing a change that is not backwards-compatible
+
+In addition to the changes mentioned in the prior section:
+
+1. Update the CAS-specific DomainEventService to adapt domain event json created against the older schema version to the new schema. For an example of this, see Cas1DomainEventMigrationService

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -111,6 +111,8 @@ data class DomainEventEntity(
    *
    * The domain event schema version used for a given domain event record is only required when the
    * initial domain event schema changes in a way that we need to start tracking which schema a domain event uses.
+   *
+   * For information on introducing new schema versions, see the 'modifying_domain_event_schemas.md' file
    */
   val schemaVersion: Int?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -104,7 +104,8 @@ data class DomainEventEntity(
   val metadata: Map<MetaDataName, String?> = emptyMap(),
   /**
    * Use to track the schema version used for the [data] property. The schema version
-   * will be specific to the corresponding [type]
+   * will be specific to the corresponding [type]. This version number relates to
+   * [DomainEventSchemaVersion.versionNo]
    *
    * This will be null for any domain events recorded before this concept was introduced.
    *
@@ -131,7 +132,20 @@ enum class DomainEventCas {
   CAS3,
 }
 
-enum class DomainEventType(val cas: DomainEventCas, val typeName: String, val typeDescription: String, val timelineEventType: TimelineEventType?) {
+data class DomainEventSchemaVersion(val versionNo: Int?, val description: String?)
+
+val DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION = DomainEventSchemaVersion(
+  versionNo = null,
+  description = "The initial version of this domain event",
+)
+
+enum class DomainEventType(
+  val cas: DomainEventCas,
+  val typeName: String,
+  val typeDescription: String,
+  val timelineEventType: TimelineEventType?,
+  val schemaVersions: List<DomainEventSchemaVersion> = listOf(DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION),
+) {
   APPROVED_PREMISES_APPLICATION_SUBMITTED(
     DomainEventCas.CAS1,
     Cas1EventType.applicationSubmitted.value,
@@ -179,6 +193,10 @@ enum class DomainEventType(val cas: DomainEventCas, val typeName: String, val ty
     Cas1EventType.bookingCancelled.value,
     "An Approved Premises Booking has been cancelled",
     TimelineEventType.approvedPremisesBookingCancelled,
+    schemaVersions = listOf(
+      DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
+      DomainEventSchemaVersion(2, "Added mandatory cancelledAtDate and cancellationRecordedAt fields"),
+    ),
   ),
   APPROVED_PREMISES_BOOKING_CHANGED(
     DomainEventCas.CAS1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -125,148 +125,183 @@ enum class MetaDataName {
   CAS1_CANCELLATION_ID,
 }
 
-enum class DomainEventType(val typeName: String, val typeDescription: String, val timelineEventType: TimelineEventType?) {
+enum class DomainEventCas {
+  CAS1,
+  CAS2,
+  CAS3,
+}
+
+enum class DomainEventType(val cas: DomainEventCas, val typeName: String, val typeDescription: String, val timelineEventType: TimelineEventType?) {
   APPROVED_PREMISES_APPLICATION_SUBMITTED(
+    DomainEventCas.CAS1,
     Cas1EventType.applicationSubmitted.value,
     "An application has been submitted for an Approved Premises placement",
     TimelineEventType.approvedPremisesApplicationSubmitted,
   ),
   APPROVED_PREMISES_APPLICATION_ASSESSED(
+    DomainEventCas.CAS1,
     Cas1EventType.applicationAssessed.value,
     "An application has been assessed for an Approved Premises placement",
     TimelineEventType.approvedPremisesApplicationAssessed,
   ),
   APPROVED_PREMISES_BOOKING_MADE(
+    DomainEventCas.CAS1,
     Cas1EventType.bookingMade.value,
     "An Approved Premises booking has been made",
     TimelineEventType.approvedPremisesBookingMade,
   ),
   APPROVED_PREMISES_PERSON_ARRIVED(
+    DomainEventCas.CAS1,
     Cas1EventType.personArrived.value,
     "Someone has arrived at an Approved Premises for their Booking",
     TimelineEventType.approvedPremisesPersonArrived,
   ),
   APPROVED_PREMISES_PERSON_NOT_ARRIVED(
+    DomainEventCas.CAS1,
     Cas1EventType.personNotArrived.value,
     "Someone has failed to arrive at an Approved Premises for their Booking",
     TimelineEventType.approvedPremisesPersonNotArrived,
   ),
   APPROVED_PREMISES_PERSON_DEPARTED(
+    DomainEventCas.CAS1,
     Cas1EventType.personDeparted.value,
     "Someone has left an Approved Premises",
     TimelineEventType.approvedPremisesPersonDeparted,
   ),
   APPROVED_PREMISES_BOOKING_NOT_MADE(
+    DomainEventCas.CAS1,
     Cas1EventType.bookingNotMade.value,
     "It was not possible to create a Booking on this attempt",
     TimelineEventType.approvedPremisesBookingNotMade,
   ),
   APPROVED_PREMISES_BOOKING_CANCELLED(
+    DomainEventCas.CAS1,
     Cas1EventType.bookingCancelled.value,
     "An Approved Premises Booking has been cancelled",
     TimelineEventType.approvedPremisesBookingCancelled,
   ),
   APPROVED_PREMISES_BOOKING_CHANGED(
+    DomainEventCas.CAS1,
     Cas1EventType.bookingChanged.value,
     "An Approved Premises Booking has been changed",
     TimelineEventType.approvedPremisesBookingChanged,
   ),
   APPROVED_PREMISES_APPLICATION_WITHDRAWN(
+    DomainEventCas.CAS1,
     Cas1EventType.applicationWithdrawn.value,
     "An Approved Premises Application has been withdrawn",
     TimelineEventType.approvedPremisesApplicationWithdrawn,
   ),
   APPROVED_PREMISES_ASSESSMENT_APPEALED(
+    DomainEventCas.CAS1,
     Cas1EventType.assessmentAppealed.value,
     "An Approved Premises Assessment has been appealed",
     TimelineEventType.approvedPremisesAssessmentAppealed,
   ),
   APPROVED_PREMISES_ASSESSMENT_ALLOCATED(
+    DomainEventCas.CAS1,
     Cas1EventType.assessmentAllocated.value,
     "An Approved Premises Assessment has been allocated",
     TimelineEventType.approvedPremisesAssessmentAllocated,
   ),
   APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED(
+    DomainEventCas.CAS1,
     Cas1EventType.informationRequestMade.value,
     "An information request has been made for an Approved Premises Assessment",
     TimelineEventType.approvedPremisesInformationRequest,
   ),
   APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN(
+    DomainEventCas.CAS1,
     Cas1EventType.placementApplicationWithdrawn.value,
     "An Approved Premises Request for Placement has been withdrawn",
     TimelineEventType.approvedPremisesPlacementApplicationWithdrawn,
   ),
   APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED(
+    DomainEventCas.CAS1,
     Cas1EventType.placementApplicationAllocated.value,
     "An Approved Premises Request for Placement has been allocated",
     TimelineEventType.approvedPremisesPlacementApplicationAllocated,
   ),
   APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN(
+    DomainEventCas.CAS1,
     Cas1EventType.matchRequestWithdrawn.value,
     "An Approved Premises Match Request has been withdrawn",
     TimelineEventType.approvedPremisesMatchRequestWithdrawn,
   ),
   APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED(
+    DomainEventCas.CAS1,
     Cas1EventType.requestForPlacementCreated.value,
     "An Approved Premises Request for Placement has been created",
     TimelineEventType.approvedPremisesRequestForPlacementCreated,
   ),
   APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED(
+    DomainEventCas.CAS1,
     Cas1EventType.requestForPlacementAssessed.value,
     "An request for placement has been assessed",
     TimelineEventType.approvedPremisesRequestForPlacementAssessed,
   ),
   CAS2_APPLICATION_SUBMITTED(
+    DomainEventCas.CAS2,
     Cas2EventType.applicationSubmitted.value,
     "An application has been submitted for a CAS2 placement",
     null,
   ),
   CAS2_APPLICATION_STATUS_UPDATED(
+    DomainEventCas.CAS2,
     Cas2EventType.applicationStatusUpdated.value,
     "An assessor has updated the status of a CAS2 application",
     null,
   ),
   CAS3_BOOKING_CANCELLED(
+    DomainEventCas.CAS3,
     Cas3EventType.bookingCancelled.value,
     "A booking for a Transitional Accommodation premises has been cancelled",
     null,
   ),
   CAS3_BOOKING_CONFIRMED(
+    DomainEventCas.CAS3,
     Cas3EventType.bookingConfirmed.value,
     "A booking has been confirmed for a Transitional Accommodation premises",
     null,
   ),
   CAS3_BOOKING_PROVISIONALLY_MADE(
+    DomainEventCas.CAS3,
     Cas3EventType.bookingProvisionallyMade.value,
     "A booking has been provisionally made for a Transitional Accommodation premises",
     null,
   ),
   CAS3_PERSON_ARRIVED(
+    DomainEventCas.CAS3,
     Cas3EventType.personArrived.value,
     "Someone has arrived at a Transitional Accommodation premises for their booking",
     null,
   ),
   CAS3_PERSON_ARRIVED_UPDATED(
+    DomainEventCas.CAS3,
     Cas3EventType.personArrivedUpdated.value,
     "Someone has changed arrival date at a Transitional Accommodation premises for their booking",
     null,
   ),
   CAS3_PERSON_DEPARTED(
+    DomainEventCas.CAS3,
     Cas3EventType.personDeparted.value,
     "Someone has left a Transitional Accommodation premises",
     null,
   ),
   CAS3_REFERRAL_SUBMITTED(
+    DomainEventCas.CAS3,
     Cas3EventType.referralSubmitted.value,
     "A referral for Transitional Accommodation has been submitted",
     null,
   ),
   CAS3_PERSON_DEPARTURE_UPDATED(
+    DomainEventCas.CAS3,
     Cas3EventType.personDepartureUpdated.value,
     "Person has updated departure date of Transitional Accommodation premises",
     null,
   ),
   CAS3_BOOKING_CANCELLED_UPDATED(
+    DomainEventCas.CAS3,
     Cas3EventType.bookingCancelledUpdated.value,
     "A cancelled booking for a Transitional Accommodation premises has been updated",
     null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -1,31 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingNotMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.FurtherInformationRequestedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.MatchRequestWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonNotArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PlacementApplicationWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -132,60 +112,8 @@ data class DomainEventEntity(
    * initial domain event schema changes in a way that we need to start tracking which schema a domain event uses.
    */
   val schemaVersion: Int?,
-) {
-  final inline fun <reified T> toDomainEvent(objectMapper: ObjectMapper): DomainEvent<T> {
-    val data = when {
-      T::class == ApplicationSubmittedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == ApplicationAssessedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == BookingMadeEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_BOOKING_MADE ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == PersonArrivedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == PersonNotArrivedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == PersonDepartedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == BookingNotMadeEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == BookingCancelledEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == BookingChangedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == ApplicationWithdrawnEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == AssessmentAppealedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == PlacementApplicationWithdrawnEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == PlacementApplicationAllocatedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == MatchRequestWithdrawnEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == AssessmentAllocatedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == RequestForPlacementCreatedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == RequestForPlacementAssessedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED ->
-        objectMapper.readValue(this.data, T::class.java)
-      T::class == FurtherInformationRequestedEnvelope::class && this.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED ->
-        objectMapper.readValue(this.data, T::class.java)
-      else -> throw RuntimeException("Unsupported DomainEventData type ${T::class.qualifiedName}/${this.type.name}")
-    }
+)
 
-    checkNotNull(this.applicationId) { "application id should not be null" }
-
-    return DomainEvent(
-      id = this.id,
-      applicationId = this.applicationId,
-      crn = this.crn,
-      nomsNumber = this.nomsNumber,
-      occurredAt = this.occurredAt.toInstant(),
-      data = data,
-    )
-  }
-}
 enum class TriggerSourceType { USER, SYSTEM }
 
 enum class MetaDataName {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEve
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReferenceCollection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventMigrationService
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
@@ -48,6 +49,7 @@ class DomainEventService(
   private val userService: UserService,
   @Value("\${domain-events.cas1.emit-enabled}") private val emitDomainEventsEnabled: Boolean,
   private val domainEventUrlConfig: DomainEventUrlConfig,
+  private val cas1DomainEventMigrationService: Cas1DomainEventMigrationService,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -93,7 +95,7 @@ class DomainEventService(
       type == BookingNotMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE ->
         objectMapper.readValue(entity.data, type.java)
       type == BookingCancelledEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED ->
-        objectMapper.readValue(entity.data, type.java)
+        objectMapper.readValue(cas1DomainEventMigrationService.bookingCancelledJson(entity), type.java)
       type == BookingChangedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED ->
         objectMapper.readValue(entity.data, type.java)
       type == ApplicationWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -38,6 +38,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 import javax.transaction.Transactional
+import kotlin.reflect.KClass
 
 @Service
 class DomainEventService(
@@ -50,29 +51,82 @@ class DomainEventService(
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun getApplicationSubmittedDomainEvent(id: UUID) = get<ApplicationSubmittedEnvelope>(id)
-  fun getApplicationAssessedDomainEvent(id: UUID) = get<ApplicationAssessedEnvelope>(id)
-  fun getBookingMadeEvent(id: UUID) = get<BookingMadeEnvelope>(id)
-  fun getPersonArrivedEvent(id: UUID) = get<PersonArrivedEnvelope>(id)
-  fun getPersonNotArrivedEvent(id: UUID) = get<PersonNotArrivedEnvelope>(id)
-  fun getPersonDepartedEvent(id: UUID) = get<PersonDepartedEnvelope>(id)
-  fun getBookingNotMadeEvent(id: UUID) = get<BookingNotMadeEnvelope>(id)
-  fun getBookingCancelledEvent(id: UUID) = get<BookingCancelledEnvelope>(id)
-  fun getBookingChangedEvent(id: UUID) = get<BookingChangedEnvelope>(id)
-  fun getApplicationWithdrawnEvent(id: UUID) = get<ApplicationWithdrawnEnvelope>(id)
-  fun getPlacementApplicationWithdrawnEvent(id: UUID) = get<PlacementApplicationWithdrawnEnvelope>(id)
-  fun getPlacementApplicationAllocatedEvent(id: UUID) = get<PlacementApplicationAllocatedEnvelope>(id)
-  fun getMatchRequestWithdrawnEvent(id: UUID) = get<MatchRequestWithdrawnEnvelope>(id)
-  fun getAssessmentAppealedEvent(id: UUID) = get<AssessmentAppealedEnvelope>(id)
-  fun getAssessmentAllocatedEvent(id: UUID) = get<AssessmentAllocatedEnvelope>(id)
-  fun getRequestForPlacementCreatedEvent(id: UUID) = get<RequestForPlacementCreatedEnvelope>(id)
-  fun getRequestForPlacementAssessedEvent(id: UUID) = get<RequestForPlacementAssessedEnvelope>(id)
-  fun getFurtherInformationRequestMadeEvent(id: UUID) = get<FurtherInformationRequestedEnvelope>(id)
+  fun getApplicationSubmittedDomainEvent(id: UUID) = get(id, ApplicationSubmittedEnvelope::class)
+  fun getApplicationAssessedDomainEvent(id: UUID) = get(id, ApplicationAssessedEnvelope::class)
+  fun getBookingMadeEvent(id: UUID) = get(id, BookingMadeEnvelope::class)
+  fun getPersonArrivedEvent(id: UUID) = get(id, PersonArrivedEnvelope::class)
+  fun getPersonNotArrivedEvent(id: UUID) = get(id, PersonNotArrivedEnvelope::class)
+  fun getPersonDepartedEvent(id: UUID) = get(id, PersonDepartedEnvelope::class)
+  fun getBookingNotMadeEvent(id: UUID) = get(id, BookingNotMadeEnvelope::class)
+  fun getBookingCancelledEvent(id: UUID) = get(id, BookingCancelledEnvelope::class)
+  fun getBookingChangedEvent(id: UUID) = get(id, BookingChangedEnvelope::class)
+  fun getApplicationWithdrawnEvent(id: UUID) = get(id, ApplicationWithdrawnEnvelope::class)
+  fun getPlacementApplicationWithdrawnEvent(id: UUID) = get(id, PlacementApplicationWithdrawnEnvelope::class)
+  fun getPlacementApplicationAllocatedEvent(id: UUID) = get(id, PlacementApplicationAllocatedEnvelope::class)
+  fun getMatchRequestWithdrawnEvent(id: UUID) = get(id, MatchRequestWithdrawnEnvelope::class)
+  fun getAssessmentAppealedEvent(id: UUID) = get(id, AssessmentAppealedEnvelope::class)
+  fun getAssessmentAllocatedEvent(id: UUID) = get(id, AssessmentAllocatedEnvelope::class)
+  fun getRequestForPlacementCreatedEvent(id: UUID) = get(id, RequestForPlacementCreatedEnvelope::class)
+  fun getRequestForPlacementAssessedEvent(id: UUID) = get(id, RequestForPlacementAssessedEnvelope::class)
+  fun getFurtherInformationRequestMadeEvent(id: UUID) = get(id, FurtherInformationRequestedEnvelope::class)
 
-  private inline fun <reified T> get(id: UUID): DomainEvent<T>? {
-    val domainEventEntity = domainEventRepository.findByIdOrNull(id) ?: return null
+  private fun <T : Any> get(id: UUID, type: KClass<T>): DomainEvent<T>? {
+    val entity = domainEventRepository.findByIdOrNull(id) ?: return null
+    return toDomainEvent(entity, type)
+  }
 
-    return domainEventEntity.toDomainEvent(objectMapper)
+  @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
+  fun <T : Any> toDomainEvent(entity: DomainEventEntity, type: KClass<T>): DomainEvent<T> {
+    val data = when {
+      type == ApplicationSubmittedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == ApplicationAssessedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == BookingMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_MADE ->
+        objectMapper.readValue(entity.data, type.java)
+      type == PersonArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == PersonNotArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == PersonDepartedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == BookingNotMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE ->
+        objectMapper.readValue(entity.data, type.java)
+      type == BookingCancelledEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == BookingChangedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == ApplicationWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN ->
+        objectMapper.readValue(entity.data, type.java)
+      type == AssessmentAppealedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == PlacementApplicationWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN ->
+        objectMapper.readValue(entity.data, type.java)
+      type == PlacementApplicationAllocatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == MatchRequestWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN ->
+        objectMapper.readValue(entity.data, type.java)
+      type == AssessmentAllocatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == RequestForPlacementCreatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == RequestForPlacementAssessedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED ->
+        objectMapper.readValue(entity.data, type.java)
+      type == FurtherInformationRequestedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED ->
+        objectMapper.readValue(entity.data, type.java)
+      else -> throw RuntimeException("Unsupported DomainEventData type ${type.qualifiedName}/${entity.type.name}")
+    }
+
+    checkNotNull(entity.applicationId) { "application id should not be null" }
+
+    return DomainEvent(
+      id = entity.id,
+      applicationId = entity.applicationId,
+      crn = entity.crn,
+      nomsNumber = entity.nomsNumber,
+      occurredAt = entity.occurredAt.toInstant(),
+      data = data,
+    )
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -79,47 +79,33 @@ class DomainEventService(
 
   @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
   fun <T : Any> toDomainEvent(entity: DomainEventEntity, type: KClass<T>): DomainEvent<T> {
-    val data = when {
-      type == ApplicationSubmittedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == ApplicationAssessedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == BookingMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_MADE ->
-        objectMapper.readValue(entity.data, type.java)
-      type == PersonArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == PersonNotArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == PersonDepartedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == BookingNotMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE ->
-        objectMapper.readValue(entity.data, type.java)
+    checkNotNull(entity.applicationId) { "application id should not be null" }
+
+    val dataJson = when {
       type == BookingCancelledEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED ->
-        objectMapper.readValue(cas1DomainEventMigrationService.bookingCancelledJson(entity), type.java)
-      type == BookingChangedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == ApplicationWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN ->
-        objectMapper.readValue(entity.data, type.java)
-      type == AssessmentAppealedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == PlacementApplicationWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN ->
-        objectMapper.readValue(entity.data, type.java)
-      type == PlacementApplicationAllocatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == MatchRequestWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN ->
-        objectMapper.readValue(entity.data, type.java)
-      type == AssessmentAllocatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == RequestForPlacementCreatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == RequestForPlacementAssessedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED ->
-        objectMapper.readValue(entity.data, type.java)
-      type == FurtherInformationRequestedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED ->
-        objectMapper.readValue(entity.data, type.java)
+        cas1DomainEventMigrationService.bookingCancelledJson(entity)
+      (type == ApplicationSubmittedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED) ||
+        (type == ApplicationAssessedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED) ||
+        (type == BookingMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_MADE) ||
+        (type == PersonArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED) ||
+        (type == PersonNotArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED) ||
+        (type == PersonDepartedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED) ||
+        (type == BookingNotMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE) ||
+        (type == BookingChangedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED) ||
+        (type == ApplicationWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN) ||
+        (type == AssessmentAppealedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED) ||
+        (type == PlacementApplicationWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN) ||
+        (type == PlacementApplicationAllocatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED) ||
+        (type == MatchRequestWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN) ||
+        (type == AssessmentAllocatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED) ||
+        (type == RequestForPlacementCreatedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED) ||
+        (type == RequestForPlacementAssessedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED) ||
+        (type == FurtherInformationRequestedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED) ->
+        entity.data
       else -> throw RuntimeException("Unsupported DomainEventData type ${type.qualifiedName}/${entity.type.name}")
     }
 
-    checkNotNull(entity.applicationId) { "application id should not be null" }
+    val data = objectMapper.readValue(dataJson, type.java)
 
     return DomainEvent(
       id = entity.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventMigrationService.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
+
+/**
+This is tested by unit tests for [uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService]
+ */
+@Service
+class Cas1DomainEventMigrationService(val objectMapper: ObjectMapper) {
+  fun bookingCancelledJson(entity: DomainEventEntity) =
+    when (entity.schemaVersion) {
+      2 -> entity.data
+      else -> bookingCancelledV1JsonToV2Json(entity)
+    }
+
+  fun bookingCancelledV1JsonToV2Json(domainEventEntity: DomainEventEntity): String {
+    val dataModel: JsonNode = objectMapper.readTree(domainEventEntity.data)
+    val eventDetails = dataModel["eventDetails"] as ObjectNode
+
+    val cancellationRecordedAt = objectMapper.convertValue(domainEventEntity.occurredAt, TextNode::class.java)
+    eventDetails.set<TextNode>("cancellationRecordedAt", cancellationRecordedAt)
+
+    val cancelledAt = objectMapper.convertValue(dataModel["eventDetails"]["cancelledAt"], java.time.Instant::class.java)
+    val cancelledAtDate = objectMapper.convertValue(cancelledAt.toLocalDate(), TextNode::class.java)
+    eventDetails.set<ArrayNode>("cancelledAtDate", cancelledAtDate)
+
+    return objectMapper.writeValueAsString(dataModel)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.jetbrains.kotlinx.dataframe.io.writeExcel
 import org.springframework.stereotype.Service
@@ -24,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Approved
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.LostBedReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.CsvJdbcResultSetConsumer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.ExcelJdbcResultSetConsumer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import java.io.OutputStream
 import java.time.LocalDate
 import java.time.YearMonth
@@ -41,7 +41,7 @@ class Cas1ReportService(
   private val domainEventRepository: DomainEventRepository,
   private val lostBedsRepository: LostBedsRepository,
   private val cas1OutOfServiceBedRepository: Cas1OutOfServiceBedRepository,
-  private val objectMapper: ObjectMapper,
+  private val domainEventService: DomainEventService,
   private val placementApplicationEntityReportRowRepository: PlacementApplicationEntityReportRowRepository,
 ) {
 
@@ -95,7 +95,7 @@ class Cas1ReportService(
 
     val dates = startDate.datesUntil(endDate).toList()
 
-    DailyMetricsReportGenerator(domainEvents, applications, objectMapper)
+    DailyMetricsReportGenerator(domainEvents, applications, domainEventService)
       .createReport(dates, properties)
       .writeExcel(outputStream) {
         WorkbookFactory.create(true)

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1279,8 +1279,10 @@ components:
         - bookingId
         - premises
         - cancelledAt
+        - cancelledAtDate
         - cancelledBy
         - cancellationReason
+        - cancellationRecordedAt
     BookingExtendedEnvelope:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -97,6 +97,10 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     this.metadata = { metadata }
   }
 
+  fun withSchemaVersion(schemaVersion: Int?) = apply {
+    this.schemaVersion = { schemaVersion }
+  }
+
   override fun produce(): DomainEventEntity = DomainEventEntity(
     id = this.id(),
     applicationId = this.applicationId(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingCancelledFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingCancelledFactory.kt
@@ -74,6 +74,10 @@ class BookingCancelledFactory : Factory<BookingCancelled> {
     this.cancellationReason = { cancellationReason }
   }
 
+  fun withCancellationRecordedAt(cancellationRecordedAt: Instant) = apply {
+    this.cancellationRecordedAt = { cancellationRecordedAt }
+  }
+
   override fun produce() = BookingCancelled(
     applicationId = this.applicationId(),
     applicationUrl = this.applicationUrl(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.domainevents.DomainEventSummaryImpl
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createDomainEventOfType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeOfType
 
 class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
@@ -162,9 +162,9 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
         withCreatedBy(userEntity)
       }
 
-      createDomainEventOfType(type, clarificationNote.id)
+      createCas1DomainEventEnvelopeOfType(type, clarificationNote.id)
     } else {
-      createDomainEventOfType(type)
+      createCas1DomainEventEnvelopeOfType(type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.domainevents.DomainEventSummaryImpl
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeOfType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelope
 
 class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
@@ -162,9 +162,9 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
         withCreatedBy(userEntity)
       }
 
-      createCas1DomainEventEnvelopeOfType(type, clarificationNote.id)
+      createCas1DomainEventEnvelope(type, clarificationNote.id)
     } else {
-      createCas1DomainEventEnvelopeOfType(type)
+      createCas1DomainEventEnvelope(type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.domainevents.DomainEventSummaryImpl
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeWithLatestJson
 
 class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
@@ -162,9 +162,9 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
         withCreatedBy(userEntity)
       }
 
-      createCas1DomainEventEnvelope(type, clarificationNote.id)
+      createCas1DomainEventEnvelopeWithLatestJson(type, clarificationNote.id)
     } else {
-      createCas1DomainEventEnvelope(type)
+      createCas1DomainEventEnvelopeWithLatestJson(type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventCas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -71,7 +72,7 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
       withAssessmentSchema(assessmentSchema)
     }
 
-    domainEvents = DomainEventType.entries.filter { it.name.startsWith("APPROVED_PREMISES") }.map {
+    domainEvents = DomainEventType.entries.filter { it.cas == DomainEventCas.CAS1 }.map {
       createDomainEvent(it, otherApplication, otherAssessment, user)
       return@map createDomainEvent(it, application, assessment, user)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.DailyMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.DailyMetricReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService.MonthSpecificReportParams
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
@@ -32,6 +34,9 @@ import java.time.temporal.TemporalAdjusters
 import java.util.UUID
 
 class DailyMetricsReportTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var domainEventService: DomainEventService
 
   @Test
   fun `Get daily metrics report for returns 403 Forbidden if user does not have access`() {
@@ -226,7 +231,7 @@ class DailyMetricsReportTest : IntegrationTestBase() {
         )
       }
 
-      val expectedDataFrame = DailyMetricsReportGenerator(domainEvents, expectedApplications, objectMapper)
+      val expectedDataFrame = DailyMetricsReportGenerator(domainEvents, expectedApplications, domainEventService)
         .createReport(
           datesForMonth,
           MonthSpecificReportParams(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventCas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createDomainEventOfType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeOfType
 import java.util.UUID
 
 class DomainEventTest : InitialiseDatabasePerClassTestBase() {
@@ -59,7 +59,7 @@ class DomainEventTest : InitialiseDatabasePerClassTestBase() {
       roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
-    val envelopedData = createDomainEventOfType(domainEventType)
+    val envelopedData = createCas1DomainEventEnvelopeOfType(domainEventType)
 
     val event = domainEventFactory.produceAndPersist {
       withType(domainEventType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventCas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createDomainEventOfType
 import java.util.UUID
@@ -44,8 +46,13 @@ class DomainEventTest : InitialiseDatabasePerClassTestBase() {
       .isForbidden
   }
 
+  companion object {
+    @JvmStatic
+    fun allCas1DomainEventTypes() = DomainEventType.values().filter { it.cas == DomainEventCas.CAS1 }
+  }
+
   @ParameterizedTest
-  @EnumSource(DomainEventType::class, names = ["APPROVED_PREMISES_.+"], mode = EnumSource.Mode.MATCH_ANY)
+  @MethodSource("allCas1DomainEventTypes")
   fun `Get event returns 200 with correct body`(domainEventType: DomainEventType) {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/config/ClientResultRedisSerializerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/config/ClientResultRedisSerializerTest.kt
@@ -1,16 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.config
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.ClientResultRedisSerializer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 
 class ClientResultRedisSerializerTest {
-  private val objectMapper = jacksonObjectMapper()
+  private val objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper()
   private val clientResponseRedisSerializer = ClientResultRedisSerializer(objectMapper, object : TypeReference<ClientResponseBody>() {})
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
@@ -20,10 +22,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeBookedByFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.StaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.DailyMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService.MonthSpecificReportParams
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
@@ -35,6 +41,15 @@ class DailyMetricsReportGeneratorTest {
     registerModule(JavaTimeModule())
     registerKotlinModule()
   }
+
+  private val domainEventService = DomainEventService(
+    objectMapper,
+    mockk<DomainEventRepository>(),
+    mockk<ConfiguredDomainEventWorker>(),
+    mockk<UserService>(),
+    false,
+    mockk<DomainEventUrlConfig>(),
+  )
 
   private val dates = listOf(
     LocalDate.parse("2023-01-01"),
@@ -139,7 +154,7 @@ class DailyMetricsReportGeneratorTest {
         allBookingMadeEvents,
       ).flatten(),
       applications.flatMap { a -> a.value.flatMap { it.value } },
-      objectMapper,
+      domainEventService,
     )
     val results = generator.createReport(dates, properties)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Approved
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventMigrationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService.MonthSpecificReportParams
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
@@ -42,6 +43,7 @@ class DailyMetricsReportGeneratorTest {
     mockk<UserService>(),
     false,
     mockk<DomainEventUrlConfig>(),
+    mockk<Cas1DomainEventMigrationService>(),
   )
 
   private val dates = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
@@ -1,9 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.generator
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -31,16 +27,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomain
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService.MonthSpecificReportParams
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
 import java.util.UUID
 
 class DailyMetricsReportGeneratorTest {
-  private val objectMapper = ObjectMapper().apply {
-    registerModule(Jdk8Module())
-    registerModule(JavaTimeModule())
-    registerKotlinModule()
-  }
+  private val objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper()
 
   private val domainEventService = DomainEventService(
     objectMapper,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1RedactAssessmentDetailsSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1RedactAssessmentDetailsSeedJobTest.kt
@@ -1,19 +1,19 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.seed.cas1
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 
 class Cas1RedactAssessmentDetailsSeedJobTest {
 
   val service = Cas1RemoveAssessmentDetailsSeedJob(
     fileName = "theFileName",
     assessmentRepository = mockk<AssessmentRepository>(),
-    objectMapper = ObjectMapper(),
+    objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper(),
     applicationService = mockk<ApplicationService>(),
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
@@ -57,6 +57,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Placement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementCreatedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventCas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
@@ -98,6 +99,11 @@ class DomainEventServiceTest {
 
   private val detailUrl = "http://example.com/1234"
 
+  companion object {
+    @JvmStatic
+    fun allCas1DomainEventTypes() = DomainEventType.values().filter { it.cas == DomainEventCas.CAS1 }
+  }
+
   @BeforeEach
   fun setupUserService() {
     every { userService.getUserForRequestOrNull() } returns user
@@ -108,7 +114,7 @@ class DomainEventServiceTest {
   inner class GetDomainEvents {
 
     @ParameterizedTest
-    @EnumSource(DomainEventType::class, names = ["APPROVED_PREMISES_.+"], mode = EnumSource.Mode.MATCH_ANY)
+    @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.DomainEventServiceTest#allCas1DomainEventTypes")
     fun `getDomainEvent returns null when event not found`(domainEventType: DomainEventType) {
       val id = UUID.randomUUID()
       val method = fetchGetterForType(domainEventType)
@@ -119,7 +125,7 @@ class DomainEventServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(DomainEventType::class, names = ["APPROVED_PREMISES_.+"], mode = EnumSource.Mode.MATCH_ANY)
+    @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.DomainEventServiceTest#allCas1DomainEventTypes")
     fun `getDomainEvent returns event`(domainEventType: DomainEventType) {
       val id = UUID.randomUUID()
       val applicationId = UUID.randomUUID()
@@ -138,6 +144,7 @@ class DomainEventServiceTest {
         .withType(domainEventType)
         .withData(objectMapper.writeValueAsString(data))
         .withOccurredAt(occurredAt)
+        .withSchemaVersion(null)
         .produce()
 
       val event = method.invoke(id)
@@ -182,7 +189,7 @@ class DomainEventServiceTest {
   inner class SaveAndEmit {
 
     @ParameterizedTest
-    @EnumSource(DomainEventType::class, names = ["APPROVED_PREMISES_.+"], mode = EnumSource.Mode.MATCH_ANY)
+    @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.DomainEventServiceTest#allCas1DomainEventTypes")
     fun `saveAndEmit persists event and emits event to SNS`(domainEventType: DomainEventType) {
       val id = UUID.randomUUID()
       val applicationId = UUID.randomUUID()
@@ -248,7 +255,7 @@ class DomainEventServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(DomainEventType::class, names = ["APPROVED_PREMISES_.+"], mode = EnumSource.Mode.MATCH_ANY)
+    @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.DomainEventServiceTest#allCas1DomainEventTypes")
     fun `saveAndEmit persists event and does not emit event if emit is false`(domainEventType: DomainEventType) {
       val id = UUID.randomUUID()
       val applicationId = UUID.randomUUID()
@@ -293,7 +300,7 @@ class DomainEventServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(DomainEventType::class, names = ["APPROVED_PREMISES_.+"], mode = EnumSource.Mode.MATCH_ANY)
+    @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.DomainEventServiceTest#allCas1DomainEventTypes")
     fun `saveAndEmit does not emit event to SNS if event fails to persist to database`(domainEventType: DomainEventType) {
       val id = UUID.randomUUID()
       val applicationId = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -67,7 +67,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createDomainEventOfType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeOfType
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -134,7 +134,7 @@ class DomainEventServiceTest {
       val nomsNumber = "theNomsNumber"
 
       val method = fetchGetterForType(domainEventType)
-      val data = createDomainEventOfType(domainEventType)
+      val data = createCas1DomainEventEnvelopeOfType(domainEventType)
 
       every { domainEventRespositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
         .withId(id)
@@ -197,7 +197,7 @@ class DomainEventServiceTest {
       val crn = "CRN"
       val nomsNumber = "theNomsNumber"
       val occurredAt = Instant.now()
-      val data = createDomainEventOfType(domainEventType)
+      val data = createCas1DomainEventEnvelopeOfType(domainEventType)
       val metadata = mapOf(MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER to "value1")
 
       every { domainEventRespositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
@@ -263,7 +263,7 @@ class DomainEventServiceTest {
       val crn = "CRN"
       val nomsNumber = "123"
       val occurredAt = Instant.now()
-      val data = createDomainEventOfType(domainEventType)
+      val data = createCas1DomainEventEnvelopeOfType(domainEventType)
 
       every { domainEventRespositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -308,7 +308,7 @@ class DomainEventServiceTest {
       val crn = "CRN"
       val nomsNumber = "123"
       val occurredAt = Instant.now()
-      val data = createDomainEventOfType(domainEventType)
+      val data = createCas1DomainEventEnvelopeOfType(domainEventType)
 
       every { domainEventRespositoryMock.save(any()) } throws RuntimeException("A database exception")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -1,9 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
@@ -67,6 +63,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeAndJson
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -76,11 +73,7 @@ import java.util.UUID
 class DomainEventServiceTest {
   private val domainEventRespositoryMock = mockk<DomainEventRepository>()
   private val domainEventWorkerMock = mockk<ConfiguredDomainEventWorker>()
-  private val objectMapper = ObjectMapper().apply {
-    registerModule(Jdk8Module())
-    registerModule(JavaTimeModule())
-    registerKotlinModule()
-  }
+  private val objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper()
   private val userService = mockk<UserService>()
   private val user = UserEntityFactory().withDefaultProbationRegion().produce()
   private val mockDomainEventUrlConfig = mockk<DomainEventUrlConfig>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventWorkerTest.kt
@@ -3,10 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 import com.amazonaws.services.sns.model.MessageAttributeValue
 import com.amazonaws.services.sns.model.PublishRequest
 import com.amazonaws.services.sns.model.PublishResult
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
@@ -24,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEve
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AsyncDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SyncDomainEventWorker
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
 import java.time.OffsetDateTime
@@ -32,11 +29,7 @@ import java.util.UUID
 @Suppress("SwallowedException")
 class DomainEventWorkerTest {
   private val hmppsQueueServiceMock = mockk<HmppsQueueService>()
-  private val objectMapper = ObjectMapper().apply {
-    registerModule(Jdk8Module())
-    registerModule(JavaTimeModule())
-    registerKotlinModule()
-  }
+  private val objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper()
   private val hmppsTopicMock = mockk<HmppsTopic>()
 
   private val asyncDomainEventWorker = AsyncDomainEventWorker(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -20,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRep
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import java.util.UUID
 
 class JsonSchemaServiceTest {
@@ -27,7 +27,7 @@ class JsonSchemaServiceTest {
   private val mockApplicationRepository = mockk<ApplicationRepository>()
 
   private val jsonSchemaService = JsonSchemaService(
-    objectMapper = jacksonObjectMapper(),
+    objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper(),
     jsonSchemaRepository = mockJsonSchemaRepository,
     applicationRepository = mockApplicationRepository,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -1,10 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -43,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
@@ -75,11 +71,7 @@ class OffenderServiceTest {
     prisonApiPageSize = 2
   }
 
-  private val objectMapper = ObjectMapper().apply {
-    registerModule(Jdk8Module())
-    registerModule(JavaTimeModule())
-    registerKotlinModule()
-  }
+  private val objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper()
 
   private val offenderService = OffenderService(
     mockCommunityApiClient,
@@ -178,7 +170,7 @@ class OffenderServiceTest {
       HttpMethod.GET,
       "/secure/crn/a-crn/user/distinguished.name/userAccess",
       HttpStatus.FORBIDDEN,
-      jacksonObjectMapper().writeValueAsString(accessBody),
+      ObjectMapperFactory.createRuntimeLikeObjectMapper().writeValueAsString(accessBody),
     )
 
     assertThat(offenderService.getOffenderByCrn("a-crn", "distinguished.name") is AuthorisableActionResult.Unauthorised).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/DomainEventServiceTest.kt
@@ -1,10 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas2
 
 import com.amazonaws.services.sns.model.PublishResult
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -27,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
 import java.time.Instant
@@ -39,11 +36,7 @@ class DomainEventServiceTest {
   private val hmppsQueueServiceMock = mockk<HmppsQueueService>()
   private val mockDomainEventUrlConfig = mockk<DomainEventUrlConfig>()
 
-  private val objectMapper = ObjectMapper().apply {
-    registerModule(Jdk8Module())
-    registerModule(JavaTimeModule())
-    registerKotlinModule()
-  }
+  private val objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper()
 
   private val detailUrl = "http://example.com/123"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/JsonSchemaServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas2
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -13,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import java.util.UUID
 
 class JsonSchemaServiceTest {
@@ -20,7 +20,7 @@ class JsonSchemaServiceTest {
   private val mockApplicationRepository = mockk<Cas2ApplicationRepository>()
 
   private val jsonSchemaService = JsonSchemaService(
-    objectMapper = jacksonObjectMapper(),
+    objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper(),
     jsonSchemaRepository = mockJsonSchemaRepository,
     applicationRepository = mockApplicationRepository,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
@@ -2,10 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas3
 
 import com.amazonaws.services.sns.model.InternalErrorException
 import com.amazonaws.services.sns.model.PublishResult
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -49,6 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
 import java.time.Instant
@@ -62,11 +59,7 @@ class DomainEventServiceTest {
   private val hmppsQueueServiceMock = mockk<HmppsQueueService>()
   private val mockDomainEventUrlConfig = mockk<DomainEventUrlConfig>()
 
-  private val objectMapper = ObjectMapper().apply {
-    registerModule(Jdk8Module())
-    registerModule(JavaTimeModule())
-    registerKotlinModule()
-  }
+  private val objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper()
 
   private val user = UserEntityFactory()
     .withYieldedProbationRegion {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/ObjectMapperFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/ObjectMapperFactory.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+
+object ObjectMapperFactory {
+  fun createRuntimeLikeObjectMapper() = ObjectMapper().apply {
+    disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/ObjectMapperFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/ObjectMapperFactory.kt
@@ -15,5 +15,4 @@ object ObjectMapperFactory {
     registerModule(JavaTimeModule())
     registerKotlinModule()
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
@@ -38,141 +40,172 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Placement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementCreatedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventSchemaVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import java.time.Instant
 import java.util.UUID
 
-fun createCas1DomainEventEnvelopeAndJson(
+fun createCas1DomainEventEnvelopeForSchemaVersion(
   type: DomainEventType,
   objectMapper: ObjectMapper,
+  schemaVersion: DomainEventSchemaVersion,
   requestId: UUID = UUID.randomUUID(),
-): DomainEventJsonAndEnvelope {
-  val expectedEnvelope = createCas1DomainEventEnvelope(type, requestId)
-  return DomainEventJsonAndEnvelope(
-    persistedJson = objectMapper.writeValueAsString(expectedEnvelope),
-    envelope = expectedEnvelope,
+  occurredAt: Instant = Instant.now(),
+): DomainEventEnvelopeAndPersistedJson {
+  val envelope = createCas1DomainEventEnvelopeWithLatestJson(
+    type,
+    requestId,
+    occurredAt = occurredAt,
+  )
+
+  val persistedJson = if (type == DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED && schemaVersion.versionNo == null) {
+    removeEventDetails(
+      objectMapper,
+      objectMapper.writeValueAsString(envelope),
+      listOf("cancelledAtDate", "cancellationRecordedAt"),
+    )
+  } else {
+    objectMapper.writeValueAsString(envelope)
+  }
+
+  return DomainEventEnvelopeAndPersistedJson(
+    envelope = envelope,
+    persistedJson = persistedJson,
   )
 }
 
-data class DomainEventJsonAndEnvelope(
-  val persistedJson: String,
+data class DomainEventEnvelopeAndPersistedJson(
   val envelope: Any,
+  val persistedJson: String,
 )
 
+private fun removeEventDetails(objectMapper: ObjectMapper, json: String, fields: List<String>): String {
+  val dataModel: JsonNode = objectMapper.readTree(json)
+  fields.forEach {
+    (dataModel["eventDetails"] as ObjectNode).remove(it)
+  }
+  return objectMapper.writeValueAsString(dataModel)
+}
+
 @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
-fun createCas1DomainEventEnvelope(type: DomainEventType, requestId: UUID = UUID.randomUUID()): Any {
+fun createCas1DomainEventEnvelopeWithLatestJson(
+  type: DomainEventType,
+  requestId: UUID = UUID.randomUUID(),
+  occurredAt: Instant = Instant.now(),
+): Any {
   val id = UUID.randomUUID()
-  val timestamp = Instant.now()
   val eventType = EventType.entries.find { it.value == type.typeName } ?: throw RuntimeException("Cannot find EventType for $type")
 
   return when (type) {
     DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> ApplicationSubmittedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = ApplicationSubmittedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> ApplicationAssessedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = ApplicationAssessedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> BookingMadeEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = BookingMadeFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> PersonArrivedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = PersonArrivedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> PersonNotArrivedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = PersonNotArrivedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> PersonDepartedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = PersonDepartedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> BookingNotMadeEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = BookingNotMadeFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> {
       return BookingCancelledEnvelope(
         id = id,
-        timestamp = timestamp,
+        timestamp = occurredAt,
         eventType = eventType,
-        eventDetails = BookingCancelledFactory().produce(),
+        eventDetails = BookingCancelledFactory()
+          .withCancellationRecordedAt(occurredAt)
+          .produce(),
       )
     }
     DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> BookingChangedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = BookingChangedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> ApplicationWithdrawnEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = ApplicationWithdrawnFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> AssessmentAppealedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = AssessmentAppealedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> AssessmentAllocatedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = AssessmentAllocatedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> PlacementApplicationWithdrawnEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = PlacementApplicationWithdrawnFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED -> PlacementApplicationAllocatedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = PlacementApplicationAllocatedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN -> MatchRequestWithdrawnEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = MatchRequestWithdrawnFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED -> RequestForPlacementCreatedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = RequestForPlacementCreatedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED -> RequestForPlacementAssessedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = RequestForPlacementAssessedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED -> FurtherInformationRequestedEnvelope(
       id = id,
-      timestamp = timestamp,
+      timestamp = occurredAt,
       eventType = eventType,
       eventDetails = FurtherInformationRequestedFactory()
         .withRequestId(requestId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ApplicationWithdrawnEnvelope
@@ -41,7 +42,25 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventTy
 import java.time.Instant
 import java.util.UUID
 
-fun createCas1DomainEventEnvelopeOfType(type: DomainEventType, requestId: UUID = UUID.randomUUID()): Any {
+fun createCas1DomainEventEnvelopeAndJson(
+  type: DomainEventType,
+  objectMapper: ObjectMapper,
+  requestId: UUID = UUID.randomUUID(),
+): DomainEventJsonAndEnvelope {
+  val expectedEnvelope = createCas1DomainEventEnvelope(type, requestId)
+  return DomainEventJsonAndEnvelope(
+    persistedJson = objectMapper.writeValueAsString(expectedEnvelope),
+    envelope = expectedEnvelope,
+  )
+}
+
+data class DomainEventJsonAndEnvelope(
+  val persistedJson: String,
+  val envelope: Any,
+)
+
+@SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
+fun createCas1DomainEventEnvelope(type: DomainEventType, requestId: UUID = UUID.randomUUID()): Any {
   val id = UUID.randomUUID()
   val timestamp = Instant.now()
   val eventType = EventType.entries.find { it.value == type.typeName } ?: throw RuntimeException("Cannot find EventType for $type")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DomainEventHelpers.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DomainEventHelpers.kt
@@ -41,7 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventTy
 import java.time.Instant
 import java.util.UUID
 
-fun createDomainEventOfType(type: DomainEventType, requestId: UUID = UUID.randomUUID()): Any {
+fun createCas1DomainEventEnvelopeOfType(type: DomainEventType, requestId: UUID = UUID.randomUUID()): Any {
   val id = UUID.randomUUID()
   val timestamp = Instant.now()
   val eventType = EventType.entries.find { it.value == type.typeName } ?: throw RuntimeException("Cannot find EventType for $type")
@@ -89,12 +89,14 @@ fun createDomainEventOfType(type: DomainEventType, requestId: UUID = UUID.random
       eventType = eventType,
       eventDetails = BookingNotMadeFactory().produce(),
     )
-    DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> BookingCancelledEnvelope(
-      id = id,
-      timestamp = timestamp,
-      eventType = eventType,
-      eventDetails = BookingCancelledFactory().produce(),
-    )
+    DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> {
+      return BookingCancelledEnvelope(
+        id = id,
+        timestamp = timestamp,
+        eventType = eventType,
+        eventDetails = BookingCancelledFactory().produce(),
+      )
+    }
     DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> BookingChangedEnvelope(
       id = id,
       timestamp = timestamp,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TimeExtensions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/TimeExtensions.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 import java.sql.Timestamp
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.concurrent.TimeUnit
 
@@ -12,8 +13,13 @@ fun OffsetDateTime.toTimestamp(): Timestamp {
   return Timestamp.from(this.toInstant())
 }
 
-fun OffsetDateTime.roundNanosToMillisToAccountForLossOfPrecisionInPostgres(): OffsetDateTime {
-  val millis = TimeUnit.NANOSECONDS.toMillis(this.nano.toLong())
-  val roundedNanos = TimeUnit.MILLISECONDS.toNanos(millis).toInt()
-  return this.withNano(roundedNanos)
+fun OffsetDateTime.roundNanosToMillisToAccountForLossOfPrecisionInPostgres(): OffsetDateTime =
+  this.withNano(nanosToNearestMilli(this.nano.toLong()))
+
+fun LocalDateTime.roundNanosToMillisToAccountForLossOfPrecisionInPostgres(): LocalDateTime =
+  this.withNano(nanosToNearestMilli(this.nano.toLong()))
+
+private fun nanosToNearestMilli(nanos: Long): Int {
+  val millis = TimeUnit.NANOSECONDS.toMillis(nanos)
+  return TimeUnit.MILLISECONDS.toNanos(millis).toInt()
 }


### PR DESCRIPTION
This PR will adapt the V1 JSON persisted for a APPROVED_PREMISES_BOOKING_CANCELLED domain event to be compatible V2 JSON schema on-the-fly, whenever the domain event JSON is required. This adaption will add the two attributes ‘cancellationRecordedAt’ and ‘cancelledAtDate’

This is required for the following scenarios:

1. When loading domain event details to render on the timeline (in the DomainEventDescriber)
2. When probation-integration retrieves the domain event json via the API

This change allows us to revert the short term fix introduced by https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/ed66ab01ddc5d54705132cb9db43bb28d8befb38, which made the cancellationRecordedAt and cancelledAtDate attributes in the domain event schema optional to allow us to deserialize JSON into Kotlin Objects to render them on the timeline.

DomainEventServiceTest has been updated to leverage the new ‘schemaVersions’ attribute on the DomainEventType enumeration, testing the retrieval of all DomainEventType/SchemaVersion combinations.

This commit also adds a Mark Down file providing guidance on how to do this in the future.