### PR TITLE
CAS2-505 Change soft delete period from 14 to 32 days.

### DIFF
--- a/src/main/resources/db/migration/all/20240812103000__create_cas_2_summary_views_make_32_days.sql
+++ b/src/main/resources/db/migration/all/20240812103000__create_cas_2_summary_views_make_32_days.sql
@@ -1,0 +1,25 @@
+-- change INTERVAL to 32 days
+DROP VIEW IF EXISTS cas_2_application_live_summary CASCADE;
+CREATE OR REPLACE VIEW cas_2_application_live_summary AS SELECT
+    a.id,
+    a.crn,
+    a.noms_number,
+    a.created_by_user_id,
+    a.name,
+    a.created_at,
+    a.submitted_at,
+    a.hdc_eligibility_date,
+    a.label,
+    a.status_id,
+    a.referring_prison_code,
+    a.abandoned_at
+FROM cas_2_application_summary a
+WHERE (a.conditional_release_date IS NULL OR a.conditional_release_date >= current_date)
+AND a.abandoned_at IS NULL
+AND a.status_id IS NULL
+   OR (a.status_id = '004e2419-9614-4c1e-a207-a8418009f23d' AND a.status_created_at > (current_date - INTERVAL '32 DAY')) -- Referral withdrawn
+   OR (a.status_id = 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9' AND a.status_created_at > (current_date - INTERVAL '32 DAY')) -- Referral cancelled
+   OR (a.status_id = '89458555-3219-44a2-9584-c4f715d6b565' AND a.status_created_at > (current_date - INTERVAL '32 DAY')) -- Awaiting arrival
+   OR (a.status_id NOT IN ('004e2419-9614-4c1e-a207-a8418009f23d',
+                           'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9',
+                           '89458555-3219-44a2-9584-c4f715d6b565'));

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AppealEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AppealEntityFactory.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 
 class AppealEntityFactory : Factory<AppealEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var appealDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var appealDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
   private var appealDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var decision: Yielded<String> = { randomOf(AppealDecision.entries).value }
   private var decisionDetail: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
@@ -17,7 +17,7 @@ class ArrivalEntityFactory : Factory<ArrivalEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
   private var arrivalDateTime: Yielded<Instant> = { Instant.now().randomDateTimeBefore(14) }
-  private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
+  private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(14) }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 class ArrivalEntityFactory : Factory<ArrivalEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
   private var arrivalDateTime: Yielded<Instant> = { Instant.now().randomDateTimeBefore(14) }
   private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
@@ -20,7 +20,7 @@ class ArrivalEntityFactory : Factory<ArrivalEntity> {
   private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ArrivalEntityFactory.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 class ArrivalEntityFactory : Factory<ArrivalEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
-  private var arrivalDateTime: Yielded<Instant> = { Instant.now().randomDateTimeBefore() }
+  private var arrivalDateTime: Yielded<Instant> = { Instant.now().randomDateTimeBefore(14) }
   private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -45,7 +45,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var premises: Yielded<PremisesEntity>? = null
   private var serviceName: Yielded<ServiceName> = { randomOf(listOf(ServiceName.approvedPremises, ServiceName.temporaryAccommodation)) }
   private var bed: Yielded<BedEntity?> = { null }
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
   private var application: Yielded<ApplicationEntity?> = { null }
   private var offlineApplication: Yielded<OfflineApplicationEntity?> = { null }
   private var turnarounds: Yielded<MutableList<TurnaroundEntity>>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -31,7 +31,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var crn: Yielded<String> = { randomStringUpperCase(6) }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
-  private var departureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
+  private var departureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(14) }
   private var originalArrivalDate: Yielded<LocalDate>? = null
   private var originalDepartureDate: Yielded<LocalDate>? = null
   private var keyWorkerStaffCode: Yielded<String?> = { null }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 class BookingEntityFactory : Factory<BookingEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var crn: Yielded<String> = { randomStringUpperCase(6) }
-  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
   private var departureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
   private var originalArrivalDate: Yielded<LocalDate>? = null
   private var originalDepartureDate: Yielded<LocalDate>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
@@ -18,7 +18,7 @@ class CancellationEntityFactory : Factory<CancellationEntity> {
   private var reason: Yielded<CancellationReasonEntity>? = null
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
   private var otherReason: Yielded<String?> = { null }
 
   fun withDefaults() = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CancellationEntityFactory.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 
 class CancellationEntityFactory : Factory<CancellationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
   private var reason: Yielded<CancellationReasonEntity>? = null
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConfirmationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ConfirmationEntityFactory.kt
@@ -11,10 +11,10 @@ import java.util.UUID
 
 class ConfirmationEntityFactory : Factory<ConfirmationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore() }
+  private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(14) }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 class DepartureEntityFactory : Factory<DepartureEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeAfter() }
+  private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeAfter(14) }
   private var reason: Yielded<DepartureReasonEntity>? = null
   private var moveOnCategory: Yielded<MoveOnCategoryEntity>? = null
   private var destinationProvider: Yielded<DestinationProviderEntity>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
@@ -21,7 +21,7 @@ class DepartureEntityFactory : Factory<DepartureEntity> {
   private var destinationProvider: Yielded<DestinationProviderEntity>? = null
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExtensionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExtensionEntityFactory.kt
@@ -17,7 +17,7 @@ class ExtensionEntityFactory : Factory<ExtensionEntity> {
   private var newDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExtensionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ExtensionEntityFactory.kt
@@ -13,8 +13,8 @@ import java.util.UUID
 
 class ExtensionEntityFactory : Factory<ExtensionEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var previousDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
-  private var newDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var previousDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
+  private var newDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedCancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LostBedCancellationEntityFactory.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 
 class LostBedCancellationEntityFactory : Factory<LostBedCancellationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(14) }
   private var notes: Yielded<String>? = null
   private var lostBed: Yielded<LostBedsEntity>? = null
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 
 class NonArrivalEntityFactory : Factory<NonArrivalEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore() }
+  private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
   private var reason: Yielded<NonArrivalReasonEntity>? = null
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NonArrivalEntityFactory.kt
@@ -18,7 +18,7 @@ class NonArrivalEntityFactory : Factory<NonArrivalEntity> {
   private var reason: Yielded<NonArrivalReasonEntity>? = null
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenderDetailsSummaryFactory.kt
@@ -21,7 +21,7 @@ class OffenderDetailsSummaryFactory : Factory<OffenderDetailSummary> {
   private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var pncNumber: Yielded<String?> = { null }
   private var gender: Yielded<String> = { randomOf(listOf("Male", "Female", "Other")) }
-  private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(20).randomDateBefore() }
+  private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(20).randomDateBefore(14) }
   private var currentRestriction: Yielded<Boolean> = { false }
   private var currentExclusion: Yielded<Boolean> = { false }
   private var ethnicity: Yielded<String> = { randomStringUpperCase(6) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationOffenderDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationOffenderDetailFactory.kt
@@ -15,7 +15,7 @@ class ProbationOffenderDetailFactory : Factory<ProbationOffenderDetail> {
   private var offenderId: Yielded<Long> = { randomInt(100000, 900000).toLong() }
   private var firstName: Yielded<String> = { randomStringUpperCase(8) }
   private var surname: Yielded<String> = { randomStringUpperCase(8) }
-  private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(20).randomDateBefore() }
+  private var dateOfBirth: Yielded<LocalDate> = { LocalDate.now().minusYears(20).randomDateBefore(14) }
   private var gender: Yielded<String?> = { randomOf(listOf("Male", "Female", "Other")) }
   private var otherIds: Yielded<IDs> = { IDs(crn = "CRN") }
   private var offenderProfile: Yielded<OffenderProfile> = { OffenderProfile() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TurnaroundEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TurnaroundEntityFactory.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 public class TurnaroundEntityFactory : Factory<TurnaroundEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var workingDayCount: Yielded<Int> = { randomInt(0, 14) }
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore() }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
   private var booking: Yielded<BookingEntity>? = null
 
   fun withId(id: UUID) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3BookingCancelledEventDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3BookingCancelledEventDetailsFactory.kt
@@ -18,7 +18,7 @@ class CAS3BookingCancelledEventDetailsFactory : Factory<CAS3BookingCancelledEven
   private var cancellationReason: Yielded<String> = { randomStringMultiCaseWithNumbers(12) }
   private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(12) }
   private var applicationId: Yielded<UUID?> = { null }
-  private var cancelledAt: Yielded<LocalDate?> = { LocalDate.now().randomDateBefore() }
+  private var cancelledAt: Yielded<LocalDate?> = { LocalDate.now().randomDateBefore(14) }
   private var cancelledBy: Yielded<StaffMember?> = { StaffMemberFactory().produce() }
 
   fun withPersonReference(configuration: PersonReferenceFactory.() -> Unit) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3PersonArrivedEventDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/cas3/CAS3PersonArrivedEventDetailsFactory.kt
@@ -21,7 +21,7 @@ class CAS3PersonArrivedEventDetailsFactory : Factory<CAS3PersonArrivedEventDetai
   private var premisesId: Yielded<UUID> = { UUID.randomUUID() }
   private var premises: Yielded<Premises> = { PremisesFactory().produce() }
   private var arrivedAt: Yielded<Instant> = { Instant.now() }
-  private var expectedDepartureOn: Yielded<LocalDate> = { LocalDate.now().randomDateAfter() }
+  private var expectedDepartureOn: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(14) }
   private var notes: Yielded<String> = { randomStringLowerCase(20) }
   private var applicationId: Yielded<UUID?> = { null }
   private var recordedBy: Yielded<StaffMember?> = { StaffMemberFactory().produce() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -224,7 +224,7 @@ class ReportsTest : IntegrationTestBase() {
             it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
 
             val firstDepartureUpdate = departureEntityFactory.produceAndPersist {
-              withDateTime(OffsetDateTime.now().randomDateTimeBefore())
+              withDateTime(OffsetDateTime.now().randomDateTimeBefore(14))
               withBooking(it)
               withYieldedDestinationProvider { destinationProviderEntityFactory.produceAndPersist() }
               withYieldedReason { departureReasonEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -213,7 +213,7 @@ class ReportsTest : IntegrationTestBase() {
           bookings[2].let {
             val firstArrivalUpdate = arrivalEntityFactory.produceAndPersist {
               withBooking(it)
-              withArrivalDate(LocalDate.now().randomDateBefore())
+              withArrivalDate(LocalDate.now().randomDateBefore(14))
             }
             val secondArrivalUpdate = arrivalEntityFactory.produceAndPersist {
               withBooking(it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -419,7 +419,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 withCreatedByUser(userEntity)
                 withCrn(offenderDetails.otherIds.crn)
                 withData("{}")
-                withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
+                withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(14))
               }
             }
 
@@ -535,7 +535,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                     withCreatedByUser(userAPrisonA)
                     withCrn(offenderDetails.otherIds.crn)
                     withData("{}")
-                    withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
+                    withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                     withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
                   }.id,
                 )
@@ -602,7 +602,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 withCreatedByUser(userCPrisonB)
                 withCrn(offenderDetails.otherIds.crn)
                 withData("{}")
-                withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
+                withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                 withReferringPrisonCode(userCPrisonB.activeCaseloadId!!)
               }
 
@@ -682,7 +682,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                     withCrn(offenderDetails.otherIds.crn)
                     withData("{}")
                     withCreatedAt(OffsetDateTime.now().minusDays(it.toLong()))
-                    withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore())
+                    withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                     withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
                     withConditionalReleaseDate(LocalDate.now().randomDateAfter())
                   }.id,
@@ -767,7 +767,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                   withCreatedByUser(userAPrisonA)
                   withCrn(offenderDetails.otherIds.crn)
                   withData("{}")
-                  withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
+                  withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                   withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
                 }.id,
               )
@@ -786,8 +786,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                   withCreatedByUser(userBPrisonA)
                   withCrn(offenderDetails.otherIds.crn)
                   withData("{}")
-                  withCreatedAt(OffsetDateTime.now().randomDateTimeBefore())
-                  withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore())
+                  withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(14))
+                  withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                   withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
                 }.id,
               )
@@ -857,7 +857,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                     withCrn(offenderDetails.otherIds.crn)
                     withData("{}")
                     withCreatedAt(OffsetDateTime.now().minusDays(it.toLong()))
-                    withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore())
+                    withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                     withReferringPrisonCode(caseAdminPrisonA.activeCaseloadId!!)
                     withConditionalReleaseDate(LocalDate.now().randomDateAfter())
                   }.id,
@@ -873,7 +873,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                     withCrn(offenderDetails.otherIds.crn)
                     withData("{}")
                     withCreatedAt(OffsetDateTime.now().minusDays(it.toLong() + 6))
-                    withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore())
+                    withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                     withReferringPrisonCode(caseAdminPrisonA.activeCaseloadId!!)
                     withConditionalReleaseDate(LocalDate.now())
                   }.id,
@@ -887,7 +887,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 withCrn(offenderDetails.otherIds.crn)
                 withData("{}")
                 withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(14))
-                withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore())
+                withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                 withReferringPrisonCode(caseAdminPrisonA.activeCaseloadId!!)
                 withConditionalReleaseDate(LocalDate.now().randomDateBefore())
               }.id
@@ -902,7 +902,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 withCrn(offenderDetails.otherIds.crn)
                 withData("{}")
                 withCreatedAt(OffsetDateTime.now())
-                withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore())
+                withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                 withReferringPrisonCode("other_prison")
               }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -224,8 +224,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
         }
       }
 
-      fun unexpiredDateTime() = OffsetDateTime.now().randomDateTimeBefore()
-      fun expiredDateTime() = unexpiredDateTime().minusDays(15)
+      fun unexpiredDateTime() = OffsetDateTime.now().randomDateTimeBefore(32)
+      fun expiredDateTime() = unexpiredDateTime().minusDays(33)
 
       val unexpiredApplicationIds = mutableSetOf<UUID>()
       val expiredApplicationIds = mutableSetOf<UUID>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -558,7 +558,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                     withCreatedAt(OffsetDateTime.now().minusDays(it.toLong()))
                     withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
                     withSubmittedAt(OffsetDateTime.now().minusDays(it.toLong()))
-                    withConditionalReleaseDate(LocalDate.now().randomDateAfter())
+                    withConditionalReleaseDate(LocalDate.now().randomDateAfter(14))
                   }.id,
                 )
               }
@@ -684,7 +684,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                     withCreatedAt(OffsetDateTime.now().minusDays(it.toLong()))
                     withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                     withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
-                    withConditionalReleaseDate(LocalDate.now().randomDateAfter())
+                    withConditionalReleaseDate(LocalDate.now().randomDateAfter(14))
                   }.id,
                 )
               }
@@ -859,7 +859,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                     withCreatedAt(OffsetDateTime.now().minusDays(it.toLong()))
                     withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                     withReferringPrisonCode(caseAdminPrisonA.activeCaseloadId!!)
-                    withConditionalReleaseDate(LocalDate.now().randomDateAfter())
+                    withConditionalReleaseDate(LocalDate.now().randomDateAfter(14))
                   }.id,
                 )
               }
@@ -983,7 +983,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                     withCrn(offenderDetails.otherIds.crn)
                     withData("{}")
                     withSubmittedAt(OffsetDateTime.now().minusDays(it.toLong()))
-                    withConditionalReleaseDate(LocalDate.now().randomDateAfter())
+                    withConditionalReleaseDate(LocalDate.now().randomDateAfter(14))
                   }.id,
                 )
               }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -588,7 +588,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 withCreatedAt(OffsetDateTime.now().minusDays(14))
                 withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
                 withSubmittedAt(OffsetDateTime.now())
-                withConditionalReleaseDate(LocalDate.now().randomDateBefore())
+                withConditionalReleaseDate(LocalDate.now().randomDateBefore(14))
               }.id
 
               addStatusUpdates(userBPrisonAApplicationIds.first(), assessor)
@@ -714,7 +714,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 withCreatedAt(OffsetDateTime.now().minusDays(14))
                 withReferringPrisonCode(userAPrisonA.activeCaseloadId!!)
                 withSubmittedAt(OffsetDateTime.now())
-                withConditionalReleaseDate(LocalDate.now().randomDateBefore())
+                withConditionalReleaseDate(LocalDate.now().randomDateBefore(14))
               }.id
 
               addStatusUpdates(userBPrisonAApplicationIds.first(), assessor)
@@ -889,7 +889,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 withCreatedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                 withSubmittedAt(OffsetDateTime.now().randomDateTimeBefore(14))
                 withReferringPrisonCode(caseAdminPrisonA.activeCaseloadId!!)
-                withConditionalReleaseDate(LocalDate.now().randomDateBefore())
+                withConditionalReleaseDate(LocalDate.now().randomDateBefore(14))
               }.id
 
               val pomUserPrisonB = nomisUserEntityFactory.produceAndPersist {
@@ -1012,7 +1012,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
                 withCrn(offenderDetails.otherIds.crn)
                 withData("{}")
                 withSubmittedAt(OffsetDateTime.now())
-                withConditionalReleaseDate(LocalDate.now().randomDateBefore())
+                withConditionalReleaseDate(LocalDate.now().randomDateBefore(14))
               }.id
 
               addStatusUpdates(submittedIds.first(), assessor)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -1612,7 +1612,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             it.extensions = extensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
 
             val firstDepartureUpdate = departureEntityFactory.produceAndPersist {
-              withDateTime(OffsetDateTime.now().randomDateTimeBefore())
+              withDateTime(OffsetDateTime.now().randomDateTimeBefore(14))
               withBooking(it)
               withYieldedDestinationProvider { destinationProviderEntityFactory.produceAndPersist() }
               withYieldedReason { departureReasonEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -1601,7 +1601,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
           bookings[2].let {
             val firstArrivalUpdate = arrivalEntityFactory.produceAndPersist {
               withBooking(it)
-              withArrivalDate(LocalDate.now().randomDateBefore())
+              withArrivalDate(LocalDate.now().randomDateBefore(14))
             }
             val secondArrivalUpdate = arrivalEntityFactory.produceAndPersist {
               withBooking(it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest.kt
@@ -27,7 +27,7 @@ class Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest : MigrationJobTe
           objectMapper.writeValueAsString(
             CAS3PersonDepartureUpdatedEvent(
               id = UUID.randomUUID(),
-              timestamp = Instant.now().randomDateTimeBefore(),
+              timestamp = Instant.now().randomDateTimeBefore(14),
               eventType = EventType.personDeparted,
               eventDetails = CAS3PersonDepartedEventDetailsFactory().produce(),
             ),
@@ -43,7 +43,7 @@ class Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest : MigrationJobTe
           objectMapper.writeValueAsString(
             CAS3PersonDepartureUpdatedEvent(
               id = UUID.randomUUID(),
-              timestamp = Instant.now().randomDateTimeBefore(),
+              timestamp = Instant.now().randomDateTimeBefore(14),
               eventType = EventType.personDepartureUpdated,
               eventDetails = CAS3PersonDepartedEventDetailsFactory().produce(),
             ),
@@ -59,7 +59,7 @@ class Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest : MigrationJobTe
           objectMapper.writeValueAsString(
             BookingChangedEnvelope(
               id = UUID.randomUUID(),
-              timestamp = Instant.now().randomDateTimeBefore(),
+              timestamp = Instant.now().randomDateTimeBefore(14),
               eventType = bookingChanged,
               eventDetails = BookingChangedFactory().produce(),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestBookingSearchResult.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestBookingSearchResult.kt
@@ -30,7 +30,7 @@ class TestBookingSearchResult : BookingSearchResult {
     )
 
   private var bookingStartDate: LocalDate = LocalDate.now().randomDateBefore(14)
-  private var bookingEndDate: LocalDate = LocalDate.now().randomDateAfter()
+  private var bookingEndDate: LocalDate = LocalDate.now().randomDateAfter(14)
   private var bookingCreatedAt: OffsetDateTime = OffsetDateTime.now().minusDays(30).randomDateTimeBefore(14)
   private var premisesId: UUID = UUID.randomUUID()
   private var premisesName: String = randomStringMultiCaseWithNumbers(6)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestBookingSearchResult.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestBookingSearchResult.kt
@@ -29,7 +29,7 @@ class TestBookingSearchResult : BookingSearchResult {
       ),
     )
 
-  private var bookingStartDate: LocalDate = LocalDate.now().randomDateBefore()
+  private var bookingStartDate: LocalDate = LocalDate.now().randomDateBefore(14)
   private var bookingEndDate: LocalDate = LocalDate.now().randomDateAfter()
   private var bookingCreatedAt: OffsetDateTime = OffsetDateTime.now().minusDays(30).randomDateTimeBefore(14)
   private var premisesId: UUID = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestBookingSearchResult.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestBookingSearchResult.kt
@@ -31,7 +31,7 @@ class TestBookingSearchResult : BookingSearchResult {
 
   private var bookingStartDate: LocalDate = LocalDate.now().randomDateBefore()
   private var bookingEndDate: LocalDate = LocalDate.now().randomDateAfter()
-  private var bookingCreatedAt: OffsetDateTime = OffsetDateTime.now().minusDays(30).randomDateTimeBefore()
+  private var bookingCreatedAt: OffsetDateTime = OffsetDateTime.now().minusDays(30).randomDateTimeBefore(14)
   private var premisesId: UUID = UUID.randomUUID()
   private var premisesName: String = randomStringMultiCaseWithNumbers(6)
   private var premisesAddressLine1: String = randomStringMultiCaseWithNumbers(6)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -421,7 +421,7 @@ class AssessmentTransformerTest {
         applicationId = UUID.randomUUID(),
         createdAt = OffsetDateTime.now().toTimestamp(),
         riskRatings = objectMapper.writeValueAsString(personRisks),
-        arrivalDate = OffsetDateTime.now().randomDateTimeBefore().toTimestamp(),
+        arrivalDate = OffsetDateTime.now().randomDateTimeBefore(14).toTimestamp(),
         completed = false,
         decision = "ACCEPTED",
         crn = randomStringMultiCaseWithNumbers(6),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -40,7 +40,7 @@ fun LocalDateTime.randomDateTimeAfter(maxDays: Int = 14): LocalDateTime = this.p
 fun LocalDateTime.randomDateTimeBefore(maxDays: Int = 14): LocalDateTime = this.minusDays(randomInt(1, maxDays).toLong())
 
 fun OffsetDateTime.randomDateTimeAfter(maxDays: Int = 14): OffsetDateTime = this.plusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
-fun OffsetDateTime.randomDateTimeBefore(maxDays: Int = 14): OffsetDateTime = this.minusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
+fun OffsetDateTime.randomDateTimeBefore(maxDays: Int): OffsetDateTime = this.minusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
 
 fun Instant.randomDateTimeAfter(maxDays: Int = 14): Instant = this.plus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)
 fun Instant.randomDateTimeBefore(maxDays: Int = 14): Instant = this.minus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -43,6 +43,6 @@ fun OffsetDateTime.randomDateTimeAfter(maxDays: Int): OffsetDateTime = this.plus
 fun OffsetDateTime.randomDateTimeBefore(maxDays: Int): OffsetDateTime = this.minusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
 
 fun Instant.randomDateTimeAfter(maxDays: Int = 14): Instant = this.plus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)
-fun Instant.randomDateTimeBefore(maxDays: Int = 14): Instant = this.minus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)
+fun Instant.randomDateTimeBefore(maxDays: Int): Instant = this.minus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)
 
 fun <T> randomOf(options: List<T>) = options[randomInt(0, options.size - 1)]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -42,7 +42,7 @@ fun LocalDateTime.randomDateTimeBefore(maxDays: Int = 14): LocalDateTime = this.
 fun OffsetDateTime.randomDateTimeAfter(maxDays: Int): OffsetDateTime = this.plusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
 fun OffsetDateTime.randomDateTimeBefore(maxDays: Int): OffsetDateTime = this.minusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
 
-fun Instant.randomDateTimeAfter(maxDays: Int = 14): Instant = this.plus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)
+fun Instant.randomDateTimeAfter(maxDays: Int): Instant = this.plus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)
 fun Instant.randomDateTimeBefore(maxDays: Int): Instant = this.minus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)
 
 fun <T> randomOf(options: List<T>) = options[randomInt(0, options.size - 1)]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -33,7 +33,7 @@ fun randomInt(min: Int, max: Int) = Random.nextInt(min, max)
 fun randomDouble(min: Double, max: Double) = Random.nextDouble(min, max)
 
 fun LocalDate.randomDateAfter(maxDays: Int = 14): LocalDate = this.plusDays(randomInt(1, maxDays).toLong())
-fun LocalDate.randomDateBefore(maxDays: Int = 14): LocalDate = this.minusDays(randomInt(1, maxDays).toLong())
+fun LocalDate.randomDateBefore(maxDays: Int): LocalDate = this.minusDays(randomInt(1, maxDays).toLong())
 fun LocalDate.randomDateAround(maxDays: Int): LocalDate = this.minusDays(maxDays.toLong()).randomDateAfter(maxDays * 2)
 
 fun LocalDateTime.randomDateTimeAfter(maxDays: Int): LocalDateTime = this.plusDays(randomInt(1, maxDays).toLong())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -36,7 +36,7 @@ fun LocalDate.randomDateAfter(maxDays: Int = 14): LocalDate = this.plusDays(rand
 fun LocalDate.randomDateBefore(maxDays: Int = 14): LocalDate = this.minusDays(randomInt(1, maxDays).toLong())
 fun LocalDate.randomDateAround(maxDays: Int = 14): LocalDate = this.minusDays(maxDays.toLong()).randomDateAfter(maxDays * 2)
 
-fun LocalDateTime.randomDateTimeAfter(maxDays: Int = 14): LocalDateTime = this.plusDays(randomInt(1, maxDays).toLong())
+fun LocalDateTime.randomDateTimeAfter(maxDays: Int): LocalDateTime = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDateTime.randomDateTimeBefore(maxDays: Int): LocalDateTime = this.minusDays(randomInt(1, maxDays).toLong())
 
 fun OffsetDateTime.randomDateTimeAfter(maxDays: Int): OffsetDateTime = this.plusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -39,7 +39,7 @@ fun LocalDate.randomDateAround(maxDays: Int = 14): LocalDate = this.minusDays(ma
 fun LocalDateTime.randomDateTimeAfter(maxDays: Int = 14): LocalDateTime = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDateTime.randomDateTimeBefore(maxDays: Int = 14): LocalDateTime = this.minusDays(randomInt(1, maxDays).toLong())
 
-fun OffsetDateTime.randomDateTimeAfter(maxDays: Int = 14): OffsetDateTime = this.plusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
+fun OffsetDateTime.randomDateTimeAfter(maxDays: Int): OffsetDateTime = this.plusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
 fun OffsetDateTime.randomDateTimeBefore(maxDays: Int): OffsetDateTime = this.minusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
 
 fun Instant.randomDateTimeAfter(maxDays: Int = 14): Instant = this.plus(randomInt(1, 60 * 24 * maxDays).toLong(), ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -34,7 +34,7 @@ fun randomDouble(min: Double, max: Double) = Random.nextDouble(min, max)
 
 fun LocalDate.randomDateAfter(maxDays: Int = 14): LocalDate = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDate.randomDateBefore(maxDays: Int = 14): LocalDate = this.minusDays(randomInt(1, maxDays).toLong())
-fun LocalDate.randomDateAround(maxDays: Int = 14): LocalDate = this.minusDays(maxDays.toLong()).randomDateAfter(maxDays * 2)
+fun LocalDate.randomDateAround(maxDays: Int): LocalDate = this.minusDays(maxDays.toLong()).randomDateAfter(maxDays * 2)
 
 fun LocalDateTime.randomDateTimeAfter(maxDays: Int): LocalDateTime = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDateTime.randomDateTimeBefore(maxDays: Int): LocalDateTime = this.minusDays(randomInt(1, maxDays).toLong())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -32,7 +32,7 @@ fun randomPostCode() = randomStringUpperCase(2) + randomNumberChars(1) + " " +
 fun randomInt(min: Int, max: Int) = Random.nextInt(min, max)
 fun randomDouble(min: Double, max: Double) = Random.nextDouble(min, max)
 
-fun LocalDate.randomDateAfter(maxDays: Int = 14): LocalDate = this.plusDays(randomInt(1, maxDays).toLong())
+fun LocalDate.randomDateAfter(maxDays: Int): LocalDate = this.plusDays(randomInt(1, maxDays).toLong())
 fun LocalDate.randomDateBefore(maxDays: Int): LocalDate = this.minusDays(randomInt(1, maxDays).toLong())
 fun LocalDate.randomDateAround(maxDays: Int): LocalDate = this.minusDays(maxDays.toLong()).randomDateAfter(maxDays * 2)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/RandomData.kt
@@ -37,7 +37,7 @@ fun LocalDate.randomDateBefore(maxDays: Int = 14): LocalDate = this.minusDays(ra
 fun LocalDate.randomDateAround(maxDays: Int = 14): LocalDate = this.minusDays(maxDays.toLong()).randomDateAfter(maxDays * 2)
 
 fun LocalDateTime.randomDateTimeAfter(maxDays: Int = 14): LocalDateTime = this.plusDays(randomInt(1, maxDays).toLong())
-fun LocalDateTime.randomDateTimeBefore(maxDays: Int = 14): LocalDateTime = this.minusDays(randomInt(1, maxDays).toLong())
+fun LocalDateTime.randomDateTimeBefore(maxDays: Int): LocalDateTime = this.minusDays(randomInt(1, maxDays).toLong())
 
 fun OffsetDateTime.randomDateTimeAfter(maxDays: Int): OffsetDateTime = this.plusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)
 fun OffsetDateTime.randomDateTimeBefore(maxDays: Int): OffsetDateTime = this.minusMinutes(randomInt(1, 60 * 24 * maxDays).toLong()).truncatedTo(ChronoUnit.SECONDS)


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/CAS2-505

Applications where the status is withdrawn, cancelled or awaiting arrival and created greater than 32 days in the past can be excluded from the applications list (previously 14 days).

VIEW recreated with 32 day INTERVAL period (previously 14).  This VIEW replaces the one created in [20240618100000__create_cas_2_summary_views_change_id_type.sql](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/resources/db/migration/all/20240618100000__create_cas_2_summary_views_change_id_type.sql).

Tests updated so that valid/unexpired dates are within the past 32 days (previously 14) and expired times are at least 33 days in the past.