### PR TITLE
APS-1171 Acquire lock when allocating assessments

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ script/development_database
 Then in the "Gradle" panel (`View->Tool Windows->Gradle` if not visible), expand `approved-premises-api`, `Tasks`, 
 `application` and right click on `bootRunLocal` and select either Run or Debug.
 
+Note that setting a breakpoint will block the handling of any subsequent web requests (don't use breakpoints to test what happens when subsequent request are received that are in contention).
+
 ### Linting
 
 There is a linting check stage in the pipeline, so to ensure this passes run the linting check locally before pushing:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRef
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -88,6 +89,7 @@ class AssessmentService(
   private val assessmentListener: AssessmentListener,
   private val assessmentClarificationNoteListener: AssessmentClarificationNoteListener,
   private val clock: Clock,
+  private val lockableAssessmentRepository: LockableAssessmentRepository,
 ) {
 
   fun getVisibleAssessmentSummariesForUserCAS1(
@@ -630,6 +632,8 @@ class AssessmentService(
     assigneeUser: UserEntity,
     id: UUID,
   ): AuthorisableActionResult<ValidatableActionResult<AssessmentEntity>> {
+    lockableAssessmentRepository.acquirePessimisticLock(id)
+
     val currentAssessment = assessmentRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -61,6 +61,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
@@ -114,6 +116,7 @@ class AssessmentServiceTest {
   private val cas1PlacementRequestEmailService = mockk<Cas1PlacementRequestEmailService>()
   private val assessmentListener = mockk<AssessmentListener>()
   private val assessmentClarificationNoteListener = mockk<AssessmentClarificationNoteListener>()
+  private val lockableAssessmentRepository = mockk<LockableAssessmentRepository>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -138,6 +141,7 @@ class AssessmentServiceTest {
     assessmentListener,
     assessmentClarificationNoteListener,
     Clock.systemDefaultZone(),
+    lockableAssessmentRepository,
   )
 
   @Test
@@ -1839,6 +1843,7 @@ class AssessmentServiceTest {
         submittedAt = OffsetDateTime.now()
       }
 
+      every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
       val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
@@ -1857,6 +1862,7 @@ class AssessmentServiceTest {
         roles = mutableListOf()
       }
 
+      every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
       val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
@@ -1879,6 +1885,7 @@ class AssessmentServiceTest {
         this.isWithdrawn = true
       }
 
+      every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
       val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
@@ -1918,6 +1925,7 @@ class AssessmentServiceTest {
         apType = ApprovedPremisesType.PIPE
       }
 
+      every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
       val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
@@ -1936,6 +1944,7 @@ class AssessmentServiceTest {
         reallocatedAt = OffsetDateTime.now()
       }
 
+      every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
       val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
@@ -1978,6 +1987,7 @@ class AssessmentServiceTest {
             .produce()
         }.produce()
 
+      every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
       every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -2066,6 +2076,7 @@ class AssessmentServiceTest {
             .produce()
         }.produce()
 
+      every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
       every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesAssessmentJsonSchemaEntity(
@@ -2154,6 +2165,8 @@ class AssessmentServiceTest {
       )
       .produce()
 
+    every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity((previousAssessment.id))
+
     every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
     val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
@@ -2200,6 +2213,7 @@ class AssessmentServiceTest {
       )
       .produce()
 
+    every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
     every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
     every { jsonSchemaServiceMock.getNewestSchema(TemporaryAccommodationAssessmentJsonSchemaEntity::class.java) } returns TemporaryAccommodationAssessmentJsonSchemaEntity(
@@ -2371,6 +2385,7 @@ class AssessmentServiceTest {
       assessmentListener,
       assessmentClarificationNoteListener,
       Clock.systemDefaultZone(),
+      lockableAssessmentRepository,
     )
 
     private val user = UserEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDec
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
@@ -91,6 +92,7 @@ class AcceptAssessmentTest {
   private val cas1AssessmentDomainEventServiceMock = mockk<Cas1AssessmentDomainEventService>()
   private val assessmentListener = mockk<AssessmentListener>()
   private val assessmentClarificationNoteListener = mockk<AssessmentClarificationNoteListener>()
+  private val lockableAssessmentRepository = mockk<LockableAssessmentRepository>()
 
   private val assessmentService = AssessmentService(
     userServiceMock,
@@ -115,6 +117,7 @@ class AcceptAssessmentTest {
     assessmentListener,
     assessmentClarificationNoteListener,
     Clock.systemDefaultZone(),
+    lockableAssessmentRepository,
   )
 
   lateinit var user: UserEntity


### PR DESCRIPTION
We have observed issues in production where a user clicks on the ‘reallocate’ button multiple times for a given task if the backend is being slow to respond. This results in multiple copies of the assessment being created in the backend.

Whilst we have double click protection on the reallocate button this has a debounce setting of 1 second, so doesn’t block users from click the button multiple times over a longer period.

Previously we’ve used Optimistic Locking to solve these issues (i.e. @Version attribute on Entities). Whilst this helps us ensure the database is consistent (i.e. we don’t end up with multiple assessments) this will result in a generic assessment being returned to the user, and an alert being raised in sentry. A pessmistic lock acquired before reallocation results in a neater error for the user (a message saying the task has already been allocated), and no alert is raised in the backend. We already have presidence for use of a pessmistic lock on application submission.

Note that there is a better solution to problem of duplicate assessments that requires a redesign of the datamodel, but doesn’t require any sort of locking (which is preferred if possible). This is discussed here - https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4996136966/CAS1+Proposal+Introduce+Task+Entity