### PR TITLE
[APS-1159] Iterate on CAS1 space search filtering

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -1,13 +1,20 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
@@ -17,6 +24,13 @@ import java.time.LocalDate
 class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var transformer: Cas1SpaceSearchResultsTransformer
+
+  @BeforeEach
+  fun setup() {
+    postCodeDistrictRepository.deleteAll()
+    roomRepository.deleteAll()
+    approvedPremisesRepository.deleteAll()
+  }
 
   @Test
   fun `Search for Spaces without JWT returns 401`() {
@@ -84,14 +98,244 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
     }
   }
 
-  private fun assertThatResultMatches(actual: Cas1SpaceSearchResult, expected: ApprovedPremisesEntity) {
+  @Disabled("Only male APs are currently supported in the CAS1 service")
+  @ParameterizedTest
+  @EnumSource
+  fun `Filtering APs by gender only returns APs supporting that gender`(gender: Gender) {
+    postCodeDistrictFactory.produceAndPersist {
+      withOutcode("SE1")
+      withLatitude(-0.07)
+      withLongitude(51.48)
+    }
+
+    `Given a User` { _, jwt ->
+      val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        // withGender(gender)
+      }
+
+      val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        // withGender(Gender.entries.first { it != gender })
+      }
+
+      val searchParameters = Cas1SpaceSearchParameters(
+        startDate = LocalDate.now(),
+        durationInDays = 14,
+        targetPostcodeDistrict = "SE1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = null,
+          spaceCharacteristics = null,
+          genders = listOf(gender),
+        ),
+      )
+
+      val response = webTestClient.post()
+        .uri("/cas1/spaces/search")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(searchParameters)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1SpaceSearchResults::class.java)
+
+      val results = response.responseBody.blockFirst()!!
+
+      assertThat(results.resultsCount).isEqualTo(5)
+      assertThat(results.searchCriteria).isEqualTo(searchParameters)
+
+      assertThatResultMatches(results.results[0], expectedPremises[0])
+      assertThatResultMatches(results.results[1], expectedPremises[1])
+      assertThatResultMatches(results.results[2], expectedPremises[2])
+      assertThatResultMatches(results.results[3], expectedPremises[3])
+      assertThatResultMatches(results.results[4], expectedPremises[4])
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource
+  fun `Filtering APs by AP type returns only APs of that type`(apType: ApType) {
+    postCodeDistrictFactory.produceAndPersist {
+      withOutcode("SE1")
+      withLatitude(-0.07)
+      withLongitude(51.48)
+    }
+
+    `Given a User` { _, jwt ->
+      val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        withCharacteristicsList(listOfNotNull(apType.asCharacteristicEntity()))
+      }
+
+      val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        withCharacteristicsList(listOfNotNull(ApType.entries.first { it != apType }.asCharacteristicEntity()))
+      }
+
+      val searchParameters = Cas1SpaceSearchParameters(
+        startDate = LocalDate.now(),
+        durationInDays = 14,
+        targetPostcodeDistrict = "SE1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = listOf(apType),
+          spaceCharacteristics = null,
+          genders = null,
+        ),
+      )
+
+      val response = webTestClient.post()
+        .uri("/cas1/spaces/search")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(searchParameters)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1SpaceSearchResults::class.java)
+
+      val results = response.responseBody.blockFirst()!!
+
+      assertThat(results.resultsCount).isEqualTo(5)
+      assertThat(results.searchCriteria).isEqualTo(searchParameters)
+
+      val expectedApType = if (apType == ApType.mhapElliottHouse) { ApType.mhapStJosephs } else { apType }
+
+      assertThatResultMatches(results.results[0], expectedPremises[0], expectedApType)
+      assertThatResultMatches(results.results[1], expectedPremises[1], expectedApType)
+      assertThatResultMatches(results.results[2], expectedPremises[2], expectedApType)
+      assertThatResultMatches(results.results[3], expectedPremises[3], expectedApType)
+      assertThatResultMatches(results.results[4], expectedPremises[4], expectedApType)
+    }
+  }
+
+  @Test
+  fun `Filtering APs by multiple AP types returns APs of any specified type`() {
+    postCodeDistrictFactory.produceAndPersist {
+      withOutcode("SE1")
+      withLatitude(-0.07)
+      withLongitude(51.48)
+    }
+
+    `Given a User` { _, jwt ->
+      val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(4) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        withCharacteristicsList(listOfNotNull(ApType.entries[it - 1].asCharacteristicEntity()))
+      }
+
+      val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        withCharacteristicsList(listOfNotNull(ApType.entries[5].asCharacteristicEntity()))
+      }
+
+      val searchParameters = Cas1SpaceSearchParameters(
+        startDate = LocalDate.now(),
+        durationInDays = 14,
+        targetPostcodeDistrict = "SE1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = ApType.entries.slice(0..3),
+          spaceCharacteristics = null,
+          genders = null,
+        ),
+      )
+
+      val response = webTestClient.post()
+        .uri("/cas1/spaces/search")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(searchParameters)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1SpaceSearchResults::class.java)
+
+      val results = response.responseBody.blockFirst()!!
+
+      assertThat(results.resultsCount).isEqualTo(4)
+      assertThat(results.searchCriteria).isEqualTo(searchParameters)
+
+      assertThatResultMatches(results.results[0], expectedPremises[0], ApType.normal)
+      assertThatResultMatches(results.results[1], expectedPremises[1], ApType.pipe)
+      assertThatResultMatches(results.results[2], expectedPremises[2], ApType.esap)
+      assertThatResultMatches(results.results[3], expectedPremises[3], ApType.rfap)
+    }
+  }
+
+  private fun assertThatResultMatches(
+    actual: Cas1SpaceSearchResult,
+    expected: ApprovedPremisesEntity,
+    expectedApType: ApType = ApType.normal,
+  ) {
     assertThat(actual.spacesAvailable).isEmpty()
     assertThat(actual.distanceInMiles).isGreaterThan(0f.toBigDecimal())
     assertThat(actual.premises).isNotNull
     assertThat(actual.premises!!.id).isEqualTo(expected.id)
     assertThat(actual.premises!!.apCode).isEqualTo(expected.apCode)
     assertThat(actual.premises!!.deliusQCode).isEqualTo(expected.qCode)
-    assertThat(actual.premises!!.apType).isEqualTo(ApType.normal)
+    assertThat(actual.premises!!.apType).isEqualTo(expectedApType)
     assertThat(actual.premises!!.name).isEqualTo(expected.name)
     assertThat(actual.premises!!.addressLine1).isEqualTo(expected.addressLine1)
     assertThat(actual.premises!!.addressLine2).isEqualTo(expected.addressLine2)
@@ -103,4 +347,213 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
     assertThat(actual.premises!!.totalSpaceCount).isEqualTo(expected.rooms.flatMap { it.beds }.count())
     assertThat(actual.premises!!.premisesCharacteristics).isEmpty()
   }
+
+  @ParameterizedTest
+  @EnumSource
+  fun `Filtering APs by characteristic only returns APs with that characteristic`(characteristic: Cas1SpaceCharacteristic) {
+    postCodeDistrictFactory.produceAndPersist {
+      withOutcode("SE1")
+      withLatitude(-0.07)
+      withLongitude(51.48)
+    }
+
+    `Given a User` { _, jwt ->
+      val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        withCharacteristicsList(listOf(characteristic.asCharacteristicEntity()))
+      }
+
+      expectedPremises.forEach {
+        roomEntityFactory.produceAndPersist {
+          withPremises(it)
+          withCharacteristicsList(listOf(characteristic.asCharacteristicEntity()))
+        }
+      }
+
+      val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        withCharacteristicsList(
+          listOf(
+            Cas1SpaceCharacteristic.entries.first { it != characteristic }.asCharacteristicEntity(),
+          ),
+        )
+      }
+
+      unexpectedPremises.forEach {
+        roomEntityFactory.produceAndPersist {
+          withPremises(it)
+          withCharacteristicsList(
+            listOf(
+              Cas1SpaceCharacteristic.entries.first { it != characteristic }.asCharacteristicEntity(),
+            ),
+          )
+        }
+      }
+
+      val searchParameters = Cas1SpaceSearchParameters(
+        startDate = LocalDate.now(),
+        durationInDays = 14,
+        targetPostcodeDistrict = "SE1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = null,
+          spaceCharacteristics = listOf(characteristic),
+          genders = null,
+        ),
+      )
+
+      val response = webTestClient.post()
+        .uri("/cas1/spaces/search")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(searchParameters)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1SpaceSearchResults::class.java)
+
+      val results = response.responseBody.blockFirst()!!
+
+      assertThat(results.resultsCount).isEqualTo(5)
+      assertThat(results.searchCriteria).isEqualTo(searchParameters)
+
+      assertThatResultMatches(results.results[0], expectedPremises[0])
+      assertThatResultMatches(results.results[1], expectedPremises[1])
+      assertThatResultMatches(results.results[2], expectedPremises[2])
+      assertThatResultMatches(results.results[3], expectedPremises[3])
+      assertThatResultMatches(results.results[4], expectedPremises[4])
+    }
+  }
+
+  @Test
+  fun `Filtering APs by multiple characteristics only returns APs with all characteristics`() {
+    postCodeDistrictFactory.produceAndPersist {
+      withOutcode("SE1")
+      withLatitude(-0.07)
+      withLongitude(51.48)
+    }
+
+    `Given a User` { _, jwt ->
+      val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        withCharacteristicsList(Cas1SpaceCharacteristic.entries.slice(1..3).map { it.asCharacteristicEntity() })
+      }
+
+      expectedPremises.forEach {
+        roomEntityFactory.produceAndPersist {
+          withPremises(it)
+          withCharacteristicsList(Cas1SpaceCharacteristic.entries.slice(1..3).map { it.asCharacteristicEntity() })
+        }
+      }
+
+      val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(4) {
+        withYieldedProbationRegion {
+          probationRegionEntityFactory.produceAndPersist {
+            withYieldedApArea {
+              apAreaEntityFactory.produceAndPersist()
+            }
+          }
+        }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((it * -0.01) - 0.08)
+        withLongitude((it * 0.01) + 51.49)
+        withCharacteristicsList(
+          listOf(
+            Cas1SpaceCharacteristic.entries[it].asCharacteristicEntity(),
+          ),
+        )
+      }
+
+      unexpectedPremises.forEach {
+        roomEntityFactory.produceAndPersist {
+          withPremises(it)
+          withCharacteristicsList(
+            it.characteristics,
+          )
+        }
+      }
+
+      val searchParameters = Cas1SpaceSearchParameters(
+        startDate = LocalDate.now(),
+        durationInDays = 14,
+        targetPostcodeDistrict = "SE1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = null,
+          spaceCharacteristics = Cas1SpaceCharacteristic.entries.slice(1..3),
+          genders = null,
+        ),
+      )
+
+      val response = webTestClient.post()
+        .uri("/cas1/spaces/search")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(searchParameters)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1SpaceSearchResults::class.java)
+
+      val results = response.responseBody.blockFirst()!!
+
+      assertThat(results.resultsCount).isEqualTo(5)
+      assertThat(results.searchCriteria).isEqualTo(searchParameters)
+
+      assertThatResultMatches(results.results[0], expectedPremises[0])
+      assertThatResultMatches(results.results[1], expectedPremises[1])
+      assertThatResultMatches(results.results[2], expectedPremises[2])
+      assertThatResultMatches(results.results[3], expectedPremises[3])
+      assertThatResultMatches(results.results[4], expectedPremises[4])
+    }
+  }
+
+  private fun ApType.asCharacteristicEntity() = when (this) {
+    ApType.normal -> null
+    ApType.pipe -> "isPIPE"
+    ApType.esap -> "isESAP"
+    ApType.rfap -> "isRecoveryFocussed"
+    ApType.mhapStJosephs, ApType.mhapElliottHouse -> "isSemiSpecialistMentalHealth"
+  }?.let {
+    characteristicRepository.findByPropertyName(it)
+  }
+
+  private fun Cas1SpaceCharacteristic.asCharacteristicEntity() = characteristicRepository.findByPropertyName(this.value)
+    ?: characteristicEntityFactory.produceAndPersist {
+      withName(this@asCharacteristicEntity.value)
+      withPropertyName(this@asCharacteristicEntity.value)
+      withServiceScope(ServiceName.approvedPremises.value)
+      withModelScope("*")
+    }
 }


### PR DESCRIPTION
> See [APS-1159 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-1159).

This PR formalises the behaviour of the CAS1 space search endpoint according to the document linked in https://dsdmoj.atlassian.net/browse/APS-1159.

This is done by introducing integration tests for each specific type of filter:
- A test for AP gender has been introduced, but is `@Disabled`, as currently CAS1 only supports APs for male offenders and the filter currently has no effect.
- A test for AP type and a test for multiple AP types has been introduced. This already behaves as expected except for an issue with `"MHAP"` not deserialising to an `ApprovedPremisesType` value - this has been altered to use `ApprovedPremisesType.MHAP_ST_JOSEPHS` as the exact MHAP information is not currently recoverable.
- A test for space characteristic and a test for multiple characterstics has been been introduced. The behaviour for this has been changed so that only spaces with all of the specified characteristics are returned, rather than spaces with any of the specified characteristics.