### PR TITLE
APS-1180 - The MDC Filter was unnecessarily loading the user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
@@ -39,7 +39,7 @@ class MDCHandlerInterceptor(
 
     Sentry.configureScope { scope: IScope -> scope.setTag("request.serviceName", request.getHeader("X-Service-Name") ?: "Not specified") }
 
-    MDC.put("request.user", userService.getUserForRequestOrNull()?.deliusUsername ?: "Anonymous")
+    MDC.put("request.user", userService.getDeliusUserNameForRequestOrNull() ?: "Anonymous")
   }
 
   private fun HttpServletRequest.getPathPattern() =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -88,9 +88,11 @@ class UserService(
     return userResponse
   }
 
+  fun getDeliusUserNameForRequestOrNull(): String? =
+    httpAuthService.getDeliusPrincipalOrNull()?.name
+
   fun getUserForRequestOrNull(): UserEntity? {
-    val deliusPrincipal = httpAuthService.getDeliusPrincipalOrNull() ?: return null
-    val username = deliusPrincipal.name
+    val username = getDeliusUserNameForRequestOrNull() ?: return null
 
     return userRepository.findByDeliusUsername(username.uppercase())
   }


### PR DESCRIPTION
The MDCHandlerInterceptor only required access to the delius username, but the function it used to access this on UserService was loading the whole user from the database, triggering 3 SQL queries.

This was also operating outside of our exception handler, meaning we weren’t returning a 503 if we had database connection issues.