### PR TITLE
CAS-412 return pdu and enable sort by pdu

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -39,7 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentCl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.sort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.sortByName
 import java.util.UUID
 import javax.transaction.Transactional
 
@@ -82,7 +82,7 @@ class AssessmentController(
         )
         val transformSummaries = when (sortBy) {
           AssessmentSortField.assessmentDueAt -> throw BadRequestProblem(errorDetail = "Sorting by due date is not supported for CAS3")
-          AssessmentSortField.personName -> transformDomainToApi(user, summaries, user.hasQualification(UserQualification.LAO)).sort(resolvedSortDirection, sortBy)
+          AssessmentSortField.personName -> transformDomainToApi(user, summaries, user.hasQualification(UserQualification.LAO)).sortByName(resolvedSortDirection)
           else -> transformDomainToApi(user, summaries)
         }
         Pair(transformSummaries, metadata)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -122,11 +122,13 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
                   WHEN a.decision='ACCEPTED' AND aa.completed_at is null THEN 'READY_TO_PLACE'
                   WHEN a.decision is null AND a.allocated_to_user_id is not null THEN 'IN_REVIEW'
                   WHEN a.decision is null AND a.allocated_to_user_id is null THEN 'UNALLOCATED'
-             END  as status
+             END  as status,
+             pdu.name as probationDeliveryUnitName
         from temporary_accommodation_assessments aa
              join assessments a on aa.assessment_id = a.id
              join applications ap on a.application_id = ap.id
              left outer join temporary_accommodation_applications taa on ap.id = taa.id
+             left outer join probation_delivery_units pdu on taa.probation_delivery_unit_id = pdu.id
        where taa.probation_region_id = ?1
              and (?2 is null OR ap.crn = ?2 OR lower(taa.name) LIKE CONCAT('%', lower(?2),'%'))
              and a.reallocated_at is null
@@ -148,6 +150,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
                join assessments a on aa.assessment_id = a.id
                join applications ap on a.application_id = ap.id
                left outer join temporary_accommodation_applications taa on ap.id = taa.id
+               left outer join probation_delivery_units pdu on taa.probation_delivery_unit_id = pdu.id
          where taa.probation_region_id = ?1
                and (?2 is null OR ap.crn = ?2)
                and a.reallocated_at is null
@@ -362,6 +365,7 @@ interface DomainAssessmentSummary {
   val crn: String
   val status: DomainAssessmentSummaryStatus?
   val dueAt: Timestamp?
+  val probationDeliveryUnitName: String?
 }
 
 enum class DomainAssessmentSummaryStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -150,7 +150,6 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
                join assessments a on aa.assessment_id = a.id
                join applications ap on a.application_id = ap.id
                left outer join temporary_accommodation_applications taa on ap.id = taa.id
-               left outer join probation_delivery_units pdu on taa.probation_delivery_unit_id = pdu.id
          where taa.probation_region_id = ?1
                and (?2 is null OR ap.crn = ?2)
                and a.reallocated_at is null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -114,7 +114,7 @@ class AssessmentService(
       AssessmentSortField.assessmentDueAt -> "dueAt"
       AssessmentSortField.personCrn -> "crn"
       AssessmentSortField.personName -> "personName"
-      AssessmentSortField.applicationProbationDeliveryUnit -> "probationDeliveryUnit"
+      AssessmentSortField.applicationProbationDeliveryUnitName -> "probationDeliveryUnit"
     }
 
     return getPageableOrAllPages(pageCriteria.withSortBy(sortFieldString))
@@ -134,7 +134,7 @@ class AssessmentService(
           AssessmentSortField.assessmentArrivalDate -> "arrivalDate"
           AssessmentSortField.assessmentCreatedAt -> "createdAt"
           AssessmentSortField.personCrn -> "crn"
-          AssessmentSortField.applicationProbationDeliveryUnit -> "probationDeliveryUnitName"
+          AssessmentSortField.applicationProbationDeliveryUnitName -> "probationDeliveryUnitName"
           else -> "arrivalDate"
         }
         val response = assessmentRepository.findTemporaryAccommodationAssessmentSummariesForRegionAndCrnAndStatus(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -114,6 +114,7 @@ class AssessmentService(
       AssessmentSortField.assessmentDueAt -> "dueAt"
       AssessmentSortField.personCrn -> "crn"
       AssessmentSortField.personName -> "personName"
+      AssessmentSortField.applicationProbationDeliveryUnit -> "probationDeliveryUnit"
     }
 
     return getPageableOrAllPages(pageCriteria.withSortBy(sortFieldString))
@@ -133,6 +134,7 @@ class AssessmentService(
           AssessmentSortField.assessmentArrivalDate -> "arrivalDate"
           AssessmentSortField.assessmentCreatedAt -> "createdAt"
           AssessmentSortField.personCrn -> "crn"
+          AssessmentSortField.applicationProbationDeliveryUnit -> "probationDeliveryUnitName"
           else -> "arrivalDate"
         }
         val response = assessmentRepository.findTemporaryAccommodationAssessmentSummariesForRegionAndCrnAndStatus(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -147,6 +147,7 @@ class AssessmentTransformer(
           )
         },
         person = personTransformer.transformModelToPersonApi(personInfo),
+        probationDeliveryUnitName = ase.probationDeliveryUnitName,
       )
 
       else -> throw RuntimeException("Unsupported type: ${ase.type}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/AssessmentUtils.kt
@@ -1,25 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationAssessmentSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 
-fun List<AssessmentSummary>.sort(sortDirection: SortDirection, sortField: AssessmentSortField): List<AssessmentSummary> {
+@SuppressWarnings("CyclomaticComplexMethod", "ThrowsCount")
+fun List<AssessmentSummary>.sortByName(sortDirection: SortDirection): List<AssessmentSummary> {
   val comparator = Comparator<AssessmentSummary> { a, b ->
-    val ascendingCompare = when (sortField) {
-      AssessmentSortField.personName -> compareValues((a.person as? FullPerson)?.name, (b.person as? FullPerson)?.name)
-      AssessmentSortField.personCrn -> compareValues(a.person.crn, b.person.crn)
-      AssessmentSortField.assessmentArrivalDate -> compareValues(a.arrivalDate, b.arrivalDate)
-      AssessmentSortField.assessmentStatus -> when {
-        a is TemporaryAccommodationAssessmentSummary && b is TemporaryAccommodationAssessmentSummary -> compareValues(a.status, b.status)
-        else -> throw RuntimeException("Cannot compare values of types ${a::class.qualifiedName} and ${b::class.qualifiedName} due to incomparable status types.")
-      }
-      AssessmentSortField.assessmentCreatedAt -> compareValues(a.createdAt, b.createdAt)
-      AssessmentSortField.assessmentDueAt -> throw BadRequestProblem(errorDetail = "Sorting by due date is not supported for CAS3")
-    }
+    val ascendingCompare = compareValues((a.person as? FullPerson)?.name, (b.person as? FullPerson)?.name)
 
     when (sortDirection) {
       SortDirection.asc, null -> ascendingCompare

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2891,6 +2891,8 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            probationDeliveryUnitName:
+              type: string
           required:
             - status
     AssessmentSortField:
@@ -2902,6 +2904,7 @@ components:
         - status
         - createdAt
         - dueAt
+        - probationDeliveryUnit
       x-enum-varnames:
         - personName
         - personCrn
@@ -2909,6 +2912,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
+        - applicationProbationDeliveryUnit
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2904,7 +2904,7 @@ components:
         - status
         - createdAt
         - dueAt
-        - probationDeliveryUnit
+        - probationDeliveryUnitName
       x-enum-varnames:
         - personName
         - personCrn
@@ -2912,7 +2912,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
-        - applicationProbationDeliveryUnit
+        - applicationProbationDeliveryUnitName
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7264,6 +7264,8 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            probationDeliveryUnitName:
+              type: string
           required:
             - status
     AssessmentSortField:
@@ -7275,6 +7277,7 @@ components:
         - status
         - createdAt
         - dueAt
+        - probationDeliveryUnit
       x-enum-varnames:
         - personName
         - personCrn
@@ -7282,6 +7285,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
+        - applicationProbationDeliveryUnit
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7277,7 +7277,7 @@ components:
         - status
         - createdAt
         - dueAt
-        - probationDeliveryUnit
+        - probationDeliveryUnitName
       x-enum-varnames:
         - personName
         - personCrn
@@ -7285,7 +7285,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
-        - applicationProbationDeliveryUnit
+        - applicationProbationDeliveryUnitName
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3557,7 +3557,7 @@ components:
         - status
         - createdAt
         - dueAt
-        - probationDeliveryUnit
+        - probationDeliveryUnitName
       x-enum-varnames:
         - personName
         - personCrn
@@ -3565,7 +3565,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
-        - applicationProbationDeliveryUnit
+        - applicationProbationDeliveryUnitName
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3544,6 +3544,8 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            probationDeliveryUnitName:
+              type: string
           required:
             - status
     AssessmentSortField:
@@ -3555,6 +3557,7 @@ components:
         - status
         - createdAt
         - dueAt
+        - probationDeliveryUnit
       x-enum-varnames:
         - personName
         - personCrn
@@ -3562,6 +3565,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
+        - applicationProbationDeliveryUnit
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3482,6 +3482,8 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            probationDeliveryUnitName:
+              type: string
           required:
             - status
     AssessmentSortField:
@@ -3493,6 +3495,7 @@ components:
         - status
         - createdAt
         - dueAt
+        - probationDeliveryUnit
       x-enum-varnames:
         - personName
         - personCrn
@@ -3500,6 +3503,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
+        - applicationProbationDeliveryUnit
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3495,7 +3495,7 @@ components:
         - status
         - createdAt
         - dueAt
-        - probationDeliveryUnit
+        - probationDeliveryUnitName
       x-enum-varnames:
         - personName
         - personCrn
@@ -3503,7 +3503,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
-        - applicationProbationDeliveryUnit
+        - applicationProbationDeliveryUnitName
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2982,6 +2982,8 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            probationDeliveryUnitName:
+              type: string
           required:
             - status
     AssessmentSortField:
@@ -2993,6 +2995,7 @@ components:
         - status
         - createdAt
         - dueAt
+        - probationDeliveryUnit
       x-enum-varnames:
         - personName
         - personCrn
@@ -3000,6 +3003,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
+        - applicationProbationDeliveryUnit
     AssessmentDecision:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2995,7 +2995,7 @@ components:
         - status
         - createdAt
         - dueAt
-        - probationDeliveryUnit
+        - probationDeliveryUnitName
       x-enum-varnames:
         - personName
         - personCrn
@@ -3003,7 +3003,7 @@ components:
         - assessmentStatus
         - assessmentCreatedAt
         - assessmentDueAt
-        - applicationProbationDeliveryUnit
+        - applicationProbationDeliveryUnitName
     AssessmentDecision:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -200,6 +200,10 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.prisonReleaseTypes = { prisonReleaseTypes }
   }
 
+  fun withProbationDeliveryUnit(probationDeliveryUnit: ProbationDeliveryUnitEntity?) = apply {
+    this.probationDeliveryUnit = { probationDeliveryUnit }
+  }
+
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
     id = this.id(),
     crn = this.crn(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -1217,7 +1217,6 @@ class AssessmentTest : IntegrationTestBase() {
       `Given a User` { user, jwt ->
         `Given Some Offenders` { offenderSequence ->
           val offenders = offenderSequence.take(5).toList()
-
           data class AssessmentParams(
             val assessment: TemporaryAccommodationAssessmentEntity,
             val offenderDetails: OffenderDetailSummary,
@@ -1305,7 +1304,7 @@ class AssessmentTest : IntegrationTestBase() {
               ExpectedResponse.Error(HttpStatus.BAD_REQUEST, "Sorting by due date is not supported for CAS3")
             }
 
-            AssessmentSortField.applicationProbationDeliveryUnit -> {
+            AssessmentSortField.applicationProbationDeliveryUnitName -> {
               ExpectedResponse.OK(
                 assessments
                   .sortedWith(
@@ -3558,6 +3557,12 @@ class AssessmentTest : IntegrationTestBase() {
         allocated = assessment.allocatedToUser != null,
         status = status,
         dueAt = assessment.dueAt?.toTimestamp(),
+
+        /*
+        If assessment.application is not TemporaryAccommodationApplicationEntity this returns null due to cast failing.
+        If assessment.application is not null but probationDeliveryUnit is null, then null is also returned,
+        which makes sense for applications for which the PDU hasn't been specified (and would therefore need to be null
+         */
         probationDeliveryUnitName = (assessment.application as? TemporaryAccommodationApplicationEntity)?.probationDeliveryUnit?.name,
       )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -392,6 +392,7 @@ class AssessmentTransformerTest {
         allocated = true,
         status = null,
         dueAt = null,
+        probationDeliveryUnitName = null,
       )
 
       every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
@@ -428,6 +429,7 @@ class AssessmentTransformerTest {
         allocated = true,
         status = DomainAssessmentSummaryStatus.AWAITING_RESPONSE,
         dueAt = Timestamp.from(Instant.now()),
+        probationDeliveryUnitName = null,
       )
 
       every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
@@ -459,5 +461,6 @@ class AssessmentTransformerTest {
     override val crn: String,
     override val status: DomainAssessmentSummaryStatus?,
     override val dueAt: Timestamp?,
+    override val probationDeliveryUnitName: String?,
   ) : DomainAssessmentSummary
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -392,7 +392,7 @@ class AssessmentTransformerTest {
         allocated = true,
         status = null,
         dueAt = null,
-        probationDeliveryUnitName = null,
+        probationDeliveryUnitName = "test pdu name",
       )
 
       every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
@@ -407,6 +407,7 @@ class AssessmentTransformerTest {
       assertThat(apiSummary.decision).isNull()
       assertThat(apiSummary.risks).isNull()
       assertThat(apiSummary.person).isNotNull
+      assertThat(apiSummary.probationDeliveryUnitName).isEqualTo("test pdu name")
     }
   }
 


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/CAS-412

In order to display PDUs for referrals list, and sort those lists by PDUs, the GET /assessments API endpoint needs to:

- Return the PDU name alongside the existing data for each referral (this should be the PDU of the application)

- Enable new sort field by PDU (alphabetical sort on PDU name)