### PR TITLE
added inmate details to exclusion list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CacheRefreshExclusionsInmateDetailsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CacheRefreshExclusionsInmateDetailsEntity.kt
@@ -9,7 +9,7 @@ import javax.persistence.Id
 import javax.persistence.Table
 
 @Repository
-interface CacheRefreshExclusionsInmateDetailsRepository : JpaRepository<ExternalUserEntity, UUID> {
+interface CacheRefreshExclusionsInmateDetailsRepository : JpaRepository<CacheRefreshExclusionsInmateDetailsEntity, UUID> {
   @Query("SELECT DISTINCT(nomsNumber) FROM CacheRefreshExclusionsInmateDetailsEntity")
   fun getDistinctNomsNumbers(): List<String>
 }


### PR DESCRIPTION
There is a temporary step to add the noms number to the CacheRefreshExclusionsInmateDetailsRepository to prevent the repeat error message. This PR extends on an existing manual method, and checks for a 404 HttpStatus and also to see if we have multiple failed responses, and if so, adds an entry into the exclusions table, which will prevent their details trying to be refreshed.

We need to establish :
 a) what to do with CAS3 applcations when the NOMS number changes
 b) how to handle NOMS number changes without manual intervention
