### PR TITLE
APS-1193 - OOSB update shouldn’t check for booking conflicts

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
@@ -1467,7 +1467,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Update Out-Of-Service Beds returns 409 Conflict when a booking for the same bed overlaps`() {
+    fun `Update Out-Of-Service Beds succeeds even if overlapping with Booking`() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1528,11 +1528,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
           )
           .exchange()
           .expectStatus()
-          .is4xxClientError
-          .expectBody()
-          .jsonPath("title").isEqualTo("Conflict")
-          .jsonPath("status").isEqualTo(409)
-          .jsonPath("detail").isEqualTo("A booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingBooking.id}")
+          .isOk
       }
     }
 


### PR DESCRIPTION
Going forward we will not maintain the concept of a booking being assigned to a bed. Therefore, we should not check for such conflicts when updating an out of service bed (OOSB). Note that this is already the case when creating an OOSB.

This change is required to avoid unexpected errors in production related to bookings that _have_ been allocated to a bed in the legacy version of match and manage.