### PR TITLE
APS-1173 - Acquire lock when allocating placement apps

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockablePlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
@@ -53,6 +54,7 @@ class PlacementApplicationService(
   private val cas1PlacementApplicationDomainEventService: Cas1PlacementApplicationDomainEventService,
   private val taskDeadlineService: TaskDeadlineService,
   private val clock: Clock,
+  private val lockablePlacementApplicationRepository: LockablePlacementApplicationRepository,
 ) {
 
   var log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -118,6 +120,8 @@ class PlacementApplicationService(
     assigneeUser: UserEntity,
     id: UUID,
   ): AuthorisableActionResult<ValidatableActionResult<PlacementApplicationEntity>> {
+    lockablePlacementApplicationRepository.acquirePessimisticLock(id)
+
     val currentPlacementApplication = placementApplicationRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockablePlacementApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
@@ -71,6 +72,7 @@ class PlacementApplicationServiceTest {
   private val cas1PlacementApplicationEmailService = mockk<Cas1PlacementApplicationEmailService>()
   private val cas1PlacementApplicationDomainEventService = mockk<Cas1PlacementApplicationDomainEventService>()
   private val taskDeadlineServiceMock = mockk<TaskDeadlineService>()
+  private val lockablePlacementApplicationRepository = mockk<LockablePlacementApplicationRepository>()
 
   private val placementApplicationService = PlacementApplicationService(
     placementApplicationRepository,
@@ -84,6 +86,7 @@ class PlacementApplicationServiceTest {
     cas1PlacementApplicationDomainEventService,
     taskDeadlineServiceMock,
     Clock.systemDefaultZone(),
+    lockablePlacementApplicationRepository,
   )
 
   @Nested
@@ -495,6 +498,7 @@ class PlacementApplicationServiceTest {
 
       val dueAt = OffsetDateTime.now()
 
+      every { lockablePlacementApplicationRepository.acquirePessimisticLock(previousPlacementApplication.id) } returns null
       every { taskDeadlineServiceMock.getDeadline(any<PlacementApplicationEntity>()) } returns dueAt
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
@@ -566,6 +570,7 @@ class PlacementApplicationServiceTest {
 
       val dueAt = OffsetDateTime.now()
 
+      every { lockablePlacementApplicationRepository.acquirePessimisticLock(previousPlacementApplication.id) } returns null
       every { taskDeadlineServiceMock.getDeadline(any<PlacementApplicationEntity>()) } returns dueAt
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
@@ -614,6 +619,7 @@ class PlacementApplicationServiceTest {
 
     @Test
     fun `Reallocating a placement application that doesnt exist returns not found`() {
+      every { lockablePlacementApplicationRepository.acquirePessimisticLock(previousPlacementApplication.id) } returns null
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns null
 
       val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)
@@ -627,6 +633,7 @@ class PlacementApplicationServiceTest {
         decision = PlacementApplicationDecision.ACCEPTED
       }
 
+      every { lockablePlacementApplicationRepository.acquirePessimisticLock(previousPlacementApplication.id) } returns null
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
       val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)
@@ -645,6 +652,7 @@ class PlacementApplicationServiceTest {
         reallocatedAt = OffsetDateTime.now()
       }
 
+      every { lockablePlacementApplicationRepository.acquirePessimisticLock(previousPlacementApplication.id) } returns null
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
       val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)
@@ -660,6 +668,7 @@ class PlacementApplicationServiceTest {
 
     @Test
     fun `Reallocating a placement application when user to assign to is not a MATCHER or ASSESSOR returns a field validation error`() {
+      every { lockablePlacementApplicationRepository.acquirePessimisticLock(previousPlacementApplication.id) } returns null
       every { placementApplicationRepository.findByIdOrNull(previousPlacementApplication.id) } returns previousPlacementApplication
 
       val result = placementApplicationService.reallocateApplication(assigneeUser, previousPlacementApplication.id)


### PR DESCRIPTION
We have observed issues in production where a user clicks on the ‘reallocate’ button multiple times for a given task if the backend is being slow to respond. This results in multiple copies of the assessment being created in the backend.

Whilst we have double click protection on the reallocate button this has a debounce setting of 1 second, so doesn’t block users from click the button multiple times over a longer period.

Previously we’ve used Optimistic Locking to solve these issues (i.e. @Version attribute on Entities). Whilst this helps us ensure the database is consistent (i.e. we don’t end up with multiple assessments) this will result in a generic assessment being returned to the user, and an alert being raised in sentry. A pessimistic lock acquired before reallocation results in a neater error for the user (a message saying the task has already been allocated), and no alert is raised in the backend. We already have presidence for use of a pessmistic lock on application submission.

We use the pattern already established by LockableApplicationRepository to acquire a lock

Note that there is a better solution to problem of duplicate assessments that requires a redesign of the datamodel, but doesn’t require any sort of locking (which is preferred if possible). This is discussed here - https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4996136966/CAS1+Proposal+Introduce+Task+Entity.