### PR TITLE
CAS-451 Setting Java heap memory to match prod configuration

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,6 +9,7 @@ generic-service:
     tlsSecretName: hmpps-approved-premises-api-preprod-cert
 
   env:
+    JAVA_OPTS: "-Xmx2000m"
     SPRING_PROFILES_ACTIVE: preprod
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.nonprod.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
This [PR CAS-451](https://dsdmoj.atlassian.net/browse/CAS-451) is to set Java heap memory to match prod configuration