### PR TITLE
CAS-451 Setting memory resource to match prod configuration

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,13 @@
 generic-service:
   serviceAccountName: hmpps-community-accommodation-api-service-account
 
+  resources:
+    limits:
+      memory: 3Gi
+    requests:
+      memory: 2.5Gi
+
+
   ingress:
     host: approved-premises-api-preprod.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-approved-premises-api-preprod-cert


### PR DESCRIPTION
This [PR CAS-451](https://dsdmoj.atlassian.net/browse/CAS-451) is to set memory resource to match prod configuration