### PR TITLE
CAS-541 Booking gap report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingGapReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingGapReportRepository.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
+
+import org.springframework.jdbc.core.ColumnMapRowMapper
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+
+val GAP_RANGES_QUERY = """
+with bed_bookings as (select
+    probation_regions.name as probation_region,
+    probation_delivery_units.name as pdu_name,
+    premises.name as premises_name,
+    rooms.name as room_name,
+    range_agg(daterange(arrival_date, departure_date,'[]')) as booked_days,
+    lower(range_agg(daterange(arrival_date, departure_date))) as date_min
+from bookings
+   left join premises on premises.id = bookings.premises_id
+   left join probation_regions on probation_regions.id = premises.probation_region_id
+   left join temporary_accommodation_premises on temporary_accommodation_premises.premises_id = bookings.premises_id
+   left join probation_delivery_units on probation_delivery_units.id = temporary_accommodation_premises.probation_delivery_unit_id
+   left join beds on beds.id = bookings.bed_id
+   left join rooms on rooms.id = beds.room_id
+   left join confirmations on confirmations.booking_id = bookings.id
+   left join cancellations on  cancellations.booking_id = bookings.id
+where bookings.service = 'temporary-accommodation' and cancellations.id is null
+group by probation_region, pdu_name, premises_name, room_name
+order by probation_region, pdu_name, premises_name, room_name),
+booking_gaps as (select
+    probation_region,
+    pdu_name,
+    premises_name,
+    room_name,
+    unnest(multirange(daterange(date_min, current_date)) - booked_days) as gap
+from bed_bookings) 
+select
+    probation_region,
+    pdu_name,
+    premises_name,
+    room_name,
+    gap::text,
+    upper(gap) - lower(gap) as gap_days
+from booking_gaps
+""".trimIndent()
+
+@Repository
+class Cas3BookingGapReportRepository(
+  val jdbcTemplate: NamedParameterJdbcTemplate,
+) {
+
+  fun generateBookingGapRangesReport(): MutableList<MutableMap<String, Any>> {
+    return jdbcTemplate.query(GAP_RANGES_QUERY.trimIndent(), ColumnMapRowMapper())
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ReportService.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingGapReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUsageReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
@@ -45,6 +46,7 @@ class Cas3ReportService(
   private val bedUsageRepository: BedUsageRepository,
   private val bedUtilisationReportRepository: BedUtilisationReportRepository,
   @Value("\${cas3-report.crn-search-limit:500}") private val numberOfCrn: Int,
+  private val cas3BookingGapReportRepository: Cas3BookingGapReportRepository,
 ) {
 
   fun createCas3ApplicationReferralsReport(
@@ -168,6 +170,11 @@ class Cas3ReportService(
         outputStream = outputStream,
         factory = WorkbookFactory.create(true),
       )
+  }
+
+  fun createBookingGapRangesReport(): MutableList<MutableMap<String, Any>> {
+    return cas3BookingGapReportRepository
+      .generateBookingGapRangesReport()
   }
 
   private fun splitAndRetrievePersonInfoReportData(crns: Set<String>): Map<String, PersonInformationReportData> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ProbationRegionTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ProbationRegionTestRepository.kt
@@ -6,4 +6,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 import java.util.UUID
 
 @Repository
-interface ProbationRegionTestRepository : JpaRepository<ProbationRegionEntity, UUID>
+interface ProbationRegionTestRepository : JpaRepository<ProbationRegionEntity, UUID> {
+  fun findByName(name: String): ProbationRegionEntity?
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingGapReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.TransitionalAccommodationReferralReportProperties
@@ -41,6 +42,7 @@ class Cas3ReportServiceTest {
   private val mockBookingRepository = mockk<BookingRepository>()
   private val mockBedUsageRepository = mockk<BedUsageRepository>()
   private val mockBedUtilisationReportRepository = mockk<BedUtilisationReportRepository>()
+  private val mockCas3BookingGapReportRepository = mockk<Cas3BookingGapReportRepository>()
 
   private val cas3ReportService = Cas3ReportService(
     mockOffenderService,
@@ -54,6 +56,7 @@ class Cas3ReportServiceTest {
     mockBedUsageRepository,
     mockBedUtilisationReportRepository,
     2,
+    mockCas3BookingGapReportRepository,
   )
 
   @Test
@@ -109,6 +112,7 @@ class Cas3ReportServiceTest {
       mockBedUsageRepository,
       mockBedUtilisationReportRepository,
       3,
+      mockCas3BookingGapReportRepository,
     )
 
     cas3ReportServiceWithThreeMonths.createCas3ApplicationReferralsReport(properties, ByteArrayOutputStream())


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/CAS-541

Initial work to generate a bookings gap report.

### Background

There is no requirement for this to become a downloadable report as yet.  The scope of the ticket was to generate an initial first pass of a booking gap report which we can pass to the HPT team to get some feedback.  An integration test has been added however if this report is to become a formal report accesses via the UI additional test coverage will be required (along with unit tests).

The report is a list of gap ranges for each room, of every premises, in every region for all dates.  Each row contains the details of a single gap, showing the date when the gap occurred (inclusive dates).  The report also contains the number of days the room was empty (calculated from the gap date range) and the number of turnaround working days associated with the premises.  The turnaround working days have not been subtracted from the total number of gap days since this would require an additional more complex calculation to determine the number of working days between a date range which would make the SQL more complex.  An interim solution would be just to subtract the number of turnaround days from the number of days in the gap range (and therefore ignore weekends and assume all the days in the gap range are working days) which can be calculated by the HPT team if required.

Presently the report contains the following columns:

- probation_region
- pdu_name
- premises_name
- room_name
- gap (inclusive date range)
- gap_days (number of days in the gap range, includes working days and weekends)

Desired Outcome (slight change to requirements in the ticket, based on feedback from Central HPT)

- A script to generate a custom booking report that shows gap days between booking for bedspaces
- The report should also show gap days in a given month for any HPT region
- The generated report should be in CSV format
- Likely to be a SQL script generated by a dev to begin with - to establish wether we can generate useful metrics. From there we may think about building this functionality out further and making it a report.
- The first iteration should be all properties in all regions, for all months

### SQL breakdown

There is an internal query which creates an array of date ranges representing all bookings by room_name:

```
with bed_bookings as (select
.
range_agg(daterange(arrival_date, departure_date, '[]')) as booked_days,
lower(range_agg(daterange(arrival_date, departure_date))) as date_min
.
from bookings where
.
group by probation_region, pdu_name, premises_name, room_name
.
```
For example, this may result in these bookings for a specific room: {[2024-06-06,2024-07-10),[2024-07-29,2024-09-01)}.  date_min is the earliest booking start date for a particular room, 2024-06-06 in this case.

The external query selects the data from `bed_bookings` and calculates the gaps between the bookings.  It does this by:

1. Calculating a date range from which we want to subtract the bookings using `date_min` and `current_date()`.
2. Converting the date range to a multirange
3. Subtracts the booking range array from `[date_min, current_date()]`.
4. Unnests this array of date ranges into individual gaps in `[gap_start_date, gap_end_date format]`.  One gap per row, for every room, every property, every region.

What is left is the date ranges which represent gaps between bookings between `date_min` and `current_date`.

`unnest(multirange(daterange(date_min, current_date)) - booked_days) as gap
`

If we consider the above booking dates and if today is 19/09/24:
date_min = 2024-06-06
current_date = 2024-09-19

gap = {[2024-06-06, 2024-09-19]} - {[2024-06-06, 2024-07-10),[2024-07-29, 2024-09-01)}
gap = {[2024-06-07, 2024-07-28], [2024-09-02, 2024-09-19]}


### Turnaround days
Each booking has a defined turnaround period (defined as working days), which defaults to 2.  It is very complicated to account for turnaround days when building this report for the following reasons:

1. For a specific booking there can be a number of different turnaround dates defined in the database (though only one will be the most recent).
5. There is no FK - PK relationship between bookings and turnarounds tables.  Therefore it is straightforward to determine the most recent number of turnaround days for a specific booking.  To do this it requires partitioning the turnaround table by `booking_id`, ordering by descending `created_at` dates, using `row_number()` and selecting those with a rank of 1.  The using this table in the join with bookings table on booking_id, something akin to this:

```
with current_turnarounds as (
  select booking_id, working_day_count from (
    select booking_id, created_at, working_day_count, row_number() over (partition by booking_id order by created_at desc) as rank
    from turnarounds) s1
  where rank = 1),
```

6. Turnaround days can be added on the beginning or the end of a booking which will affect the gap calculation i.e. if we have a booking between 04/02/24-11/02/24 and 16/02/24-30/02/24 the gap could be 4 days, 2 days or 0 days, depending on whether the gap is before or after each booking.
7. Similarly if we are displaying gaps between bookings it doesn't make sense to show the turnaround days as an additional column since these are related to bookings and not gaps.  It is not as straightforward as taking turnaround days off of the number of gap days.
8. Turnaround days are working days only and it is not straightforward to account for these in SQL when determining the gaps between bookings.

Because of these reasons turnaround days have not been considered as part of this initial example report which is to be supplied to the HPT team for feedback.  The effort of defining requirements and doing the work outweighs the benefit of the HPT receiving the report sooner.  As it stands, a default number of 2 turnaround days can be assumed for now and if assumed to be either weekdays or weekends it can be simply taken away from the gap days or now.  Should there be a requirement to consider turnaround days in any more detail than this, then we will have to revisit the above.

An alternative solution might involve adding on the turnaround week days to the booking end dates and then using the process above to determine gaps between bookings, this could result in negative gap ranges (i.e. 10/02/24-09/02/24) which will need to be accounted for.  In any case this approach would have to be agreed.

Any further complications might require that we consider removing this logic from SQL to Kotlin (possibly using dataframes).

### Generating the Report

Run the GAP_RANGES_QUERY in Cas3BookingGapReportRepository.kt directly against the database and download the resultset as CSV.