### PR TITLE
Convert eager load to lazy for performance

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.OneToOne
@@ -27,11 +28,11 @@ data class PlacementDateEntity(
 
   val createdAt: OffsetDateTime,
 
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "placement_application_id")
   val placementApplication: PlacementApplicationEntity,
 
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "placement_request_id")
   var placementRequest: PlacementRequestEntity? = null,
 
@@ -49,8 +50,6 @@ data class PlacementDateEntity(
 
     if (id != other.id) return false
     if (createdAt != other.createdAt) return false
-    if (placementApplication.id != other.placementApplication.id) return false
-    if (placementRequest != other.placementRequest) return false
     if (expectedArrival != other.expectedArrival) return false
     if (duration != other.duration) return false
 
@@ -60,8 +59,6 @@ data class PlacementDateEntity(
   override fun hashCode(): Int {
     var result = id.hashCode()
     result = 31 * result + createdAt.hashCode()
-    result = 31 * result + placementApplication.id.hashCode()
-    result = 31 * result + (placementRequest?.hashCode() ?: 0)
     result = 31 * result + expectedArrival.hashCode()
     result = 31 * result + duration
     return result

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -155,7 +155,7 @@ data class PlacementRequestEntity(
   @JoinColumn(name = "application_id")
   val application: ApprovedPremisesApplicationEntity,
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "assessment_id")
   val assessment: AssessmentEntity,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.hibernate.Hibernate
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -894,7 +895,7 @@ class AssessmentService(
   }
 
   fun updateCas1AssessmentWithdrawn(assessmentId: UUID, withdrawingUser: UserEntity) {
-    val assessment = assessmentRepository.findByIdOrNull(assessmentId)
+    val assessment = Hibernate.unproxy(assessmentRepository.findByIdOrNull(assessmentId))
     if (assessment is ApprovedPremisesAssessmentEntity) {
       val isPendingAssessment = assessment.isPendingAssessment()
 


### PR DESCRIPTION
This commit updates some @ManyToOne and @OneToOne relationships to use eager loading to reduce the number of unneccessary database calls in production.

Placement Application - Typically this is viewed for a specific application, in which case application information isn’t required. Loading application information can lead to a cascade of eager loads.

Placement Date Entity - the relationships now marked as eager were only used in the hashcode/equals generation, which was unneccessary given that the ID uniquely identifies an instance

Placement Request Entity - the assessment property is not typically required but eagerly loaded. This is now lazy