### PR TITLE
CAS-464 Extend bedspace search to include property attributes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
@@ -38,6 +38,8 @@ class BedSearchController(
         probationDeliveryUnit = bedSearchParameters.probationDeliveryUnit,
         startDate = bedSearchParameters.startDate,
         durationInDays = bedSearchParameters.durationDays,
+        filterBySharedProperty = bedSearchParameters.sharedProperty == true,
+        filterBySingleOccupancy = bedSearchParameters.singleOccupancy == true,
       )
       else -> throw RuntimeException("Unsupported BedSearchParameters type: ${bedSearchParameters::class.qualifiedName}")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -96,6 +96,8 @@ class BedSearchService(
     probationDeliveryUnit: String,
     startDate: LocalDate,
     durationInDays: Int,
+    filterBySharedProperty: Boolean,
+    filterBySingleOccupancy: Boolean,
   ): AuthorisableActionResult<ValidatableActionResult<List<TemporaryAccommodationBedSearchResult>>> {
     return AuthorisableActionResult.Success(
       validated {
@@ -114,6 +116,8 @@ class BedSearchService(
           startDate = startDate,
           endDate = endDate,
           probationRegionId = user.probationRegion.id,
+          filterBySharedProperty = filterBySharedProperty,
+          filterBySingleOccupancy = filterBySingleOccupancy,
         )
 
         val bedIds = candidateResults.map { it.bedId }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4194,6 +4194,12 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            sharedProperty:
+              type: boolean
+              description: Is a shared property
+            singleOccupancy:
+              type: boolean
+              description: Is the property for single occupancy
           required:
             - probationDeliveryUnit
     BedSearchResults:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8567,6 +8567,12 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            sharedProperty:
+              type: boolean
+              description: Is a shared property
+            singleOccupancy:
+              type: boolean
+              description: Is the property for single occupancy
           required:
             - probationDeliveryUnit
     BedSearchResults:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5014,6 +5014,12 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            sharedProperty:
+              type: boolean
+              description: Is a shared property
+            singleOccupancy:
+              type: boolean
+              description: Is the property for single occupancy
           required:
             - probationDeliveryUnit
     BedSearchResults:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4785,6 +4785,12 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            sharedProperty:
+              type: boolean
+              description: Is a shared property
+            singleOccupancy:
+              type: boolean
+              description: Is the property for single occupancy
           required:
             - probationDeliveryUnit
     BedSearchResults:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4285,6 +4285,12 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            sharedProperty:
+              type: boolean
+              description: Is a shared property
+            singleOccupancy:
+              type: boolean
+              description: Is the property for single occupancy
           required:
             - probationDeliveryUnit
     BedSearchResults:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
@@ -29,6 +30,7 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
   private var status: Yielded<PropertyStatus> = { randomOf(PropertyStatus.values().asList()) }
   private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>? = null
   private var turnaroundWorkingDayCount: Yielded<Int>? = null
+  private var characteristics: Yielded<MutableList<CharacteristicEntity>> = { mutableListOf() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -94,8 +96,8 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     this.turnaroundWorkingDayCount = { turnaroundWorkingDayCount }
   }
 
-  fun withYieldedRooms(probationRegion: Yielded<ProbationRegionEntity>) = apply {
-    this.probationRegion = probationRegion
+  fun withCharacteristics(characteristics: MutableList<CharacteristicEntity>) = apply {
+    this.characteristics = { characteristics }
   }
 
   fun withUnitTestControlTestProbationAreaAndLocalAuthority() = apply {
@@ -133,7 +135,7 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
     notes = this.notes(),
     emailAddress = this.emailAddress(),
     rooms = mutableListOf(),
-    characteristics = mutableListOf(),
+    characteristics = this.characteristics(),
     status = this.status(),
     probationDeliveryUnit = this.probationDeliveryUnit?.invoke(),
     turnaroundWorkingDayCount = this.turnaroundWorkingDayCount?.invoke() ?: 2,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -493,6 +493,8 @@ class BedSearchServiceTest {
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 0,
       probationDeliveryUnit = "PDU-1",
+      filterBySharedProperty = false,
+      filterBySingleOccupancy = false,
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -552,6 +554,8 @@ class BedSearchServiceTest {
         endDate = LocalDate.parse("2023-03-28"),
         probationDeliveryUnit = "PDU-1",
         probationRegionId = user.probationRegion.id,
+        filterBySharedProperty = false,
+        filterBySingleOccupancy = false,
       )
     } returns repositorySearchResults
 
@@ -564,6 +568,8 @@ class BedSearchServiceTest {
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
       probationDeliveryUnit = "PDU-1",
+      filterBySharedProperty = false,
+      filterBySingleOccupancy = false,
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -647,6 +653,8 @@ class BedSearchServiceTest {
         endDate = LocalDate.parse("2023-03-28"),
         probationDeliveryUnit = "PDU-1",
         probationRegionId = user.probationRegion.id,
+        filterBySharedProperty = false,
+        filterBySingleOccupancy = false,
       )
     } returns repositorySearchResults
 
@@ -737,6 +745,8 @@ class BedSearchServiceTest {
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
       probationDeliveryUnit = "PDU-1",
+      filterBySharedProperty = false,
+      filterBySingleOccupancy = false,
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue


### PR DESCRIPTION
This [PR CAS-464](https://dsdmoj.atlassian.net/browse/CAS-464) is to extend the current bedspace search to include filtering results by the following property attributes:
- Shared Property
- Single Occupancy

The change made is to create a CTE to return the premises Ids that match the filtering criteria. 

I added another condition in the where condition for Shared Property and Single Occupancy to include the properties that they don't have property attributes.  