### PR TITLE
CAS-547 Remove crn parameter from assessment api endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -60,7 +60,6 @@ class AssessmentController(
     sortDirection: SortDirection?,
     sortBy: AssessmentSortField?,
     statuses: List<AssessmentStatus>?,
-    crn: String?,
     crnOrName: String?,
     page: Int?,
     perPage: Int?,
@@ -75,7 +74,7 @@ class AssessmentController(
       ServiceName.temporaryAccommodation -> {
         val (summaries, metadata) = assessmentService.getAssessmentSummariesForUserCAS3(
           user,
-          crn ?: crnOrName,
+          crnOrName,
           xServiceName,
           domainSummaryStatuses,
           PageCriteria(resolvedSortBy, resolvedSortDirection, page, perPage),

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3591,12 +3591,6 @@ paths:
             type: array
             items:
               $ref: "_shared.yml#/components/schemas/AssessmentStatus"
-        - name: crn
-          in: query
-          description: If provided, return only results for the given CRN
-          required: false
-          schema:
-            type: string
         - name: crnOrName
           in: query
           description: Filters results using an exact match or CRN, or partial match on name

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3593,12 +3593,6 @@ paths:
             type: array
             items:
               $ref: "#/components/schemas/AssessmentStatus"
-        - name: crn
-          in: query
-          description: If provided, return only results for the given CRN
-          required: false
-          schema:
-            type: string
         - name: crnOrName
           in: query
           description: Filters results using an exact match or CRN, or partial match on name


### PR DESCRIPTION
This [PR CAS-547](https://dsdmoj.atlassian.net/browse/CAS-547) is to remove the crn parameter from the assessment end point as it was replaced by the new parameter crnOrName