### PR TITLE
Deprecate ActionResult types

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
@@ -25,6 +25,7 @@ class ValidatedScope<EntityType> {
   infix fun UUID.hasConflictError(message: String) = ValidatableActionResult.ConflictError<EntityType>(this, message)
 }
 
+@Deprecated("Use of ValidatableActionResult is deprecated. Callers should use CasResult and validatedCasResult", ReplaceWith("validatedCasResult"))
 inline fun <EntityType> validated(scope: ValidatedScope<EntityType>.() -> ValidatableActionResult<EntityType>): ValidatableActionResult<EntityType> {
   return scope(ValidatedScope())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/AuthorisableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/AuthorisableActionResult.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.results
 
+@Deprecated("The ValidatableActionResult and AuthorisableActionResult have been replaced by CasResult, which effectively flattens these two classes into one")
 sealed interface AuthorisableActionResult<EntityType> {
+  @Deprecated("Replaced by CasResult.Success", ReplaceWith("uk.gov.justice.digital.hmpps.approvedpremisesapi.CasResult.Success"))
   data class Success<EntityType>(val entity: EntityType) : AuthorisableActionResult<EntityType>
+
+  @Deprecated("Replaced by CasResult.Unauthorised", ReplaceWith("uk.gov.justice.digital.hmpps.approvedpremisesapi.CasResult.Unauthorised"))
   class Unauthorised<EntityType> : AuthorisableActionResult<EntityType>
+
+  @Deprecated("Replaced by CasResult.NotFound", ReplaceWith("uk.gov.justice.digital.hmpps.approvedpremisesapi.CasResult.NotFound"))
   class NotFound<EntityType>(val entityType: String? = null, val id: String? = null) : AuthorisableActionResult<EntityType>
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/ValidatableActionResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/ValidatableActionResult.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.results
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import java.util.UUID
 
+@Deprecated("The ValidatableActionResult and AuthorisableActionResult have been replaced by CasResult, which effectively flattens these two classes into one")
 sealed interface ValidatableActionResult<EntityType> {
   fun <T> translateError(): ValidatableActionResult<T> = when (this) {
     is Success -> throw RuntimeException("Cannot translate Success")
@@ -11,17 +12,17 @@ sealed interface ValidatableActionResult<EntityType> {
     is ConflictError -> ConflictError(this.conflictingEntityId, this.message)
   }
 
+  @Deprecated("Replaced by CasResult.Success", ReplaceWith("uk.gov.justice.digital.hmpps.approvedpremisesapi.CasResult.Success"))
   data class Success<EntityType>(val entity: EntityType) : ValidatableActionResult<EntityType>
   sealed interface ValidatableActionResultError<EntityType> : ValidatableActionResult<EntityType>
+
+  @Deprecated("Replaced by CasResult.FieldValidationError", ReplaceWith("uk.gov.justice.digital.hmpps.approvedpremisesapi.CasResult.FieldValidationError"))
   data class FieldValidationError<EntityType>(val validationMessages: ValidationErrors) :
     ValidatableActionResultError<EntityType>
-  data class GeneralValidationError<EntityType>(val message: String) : ValidatableActionResultError<EntityType>
-  data class ConflictError<EntityType>(val conflictingEntityId: UUID, val message: String) : ValidatableActionResultError<EntityType>
-}
 
-fun extractMessage(validatableActionResult: ValidatableActionResult<*>): String? = when (validatableActionResult) {
-  is ValidatableActionResult.Success -> null
-  is ValidatableActionResult.FieldValidationError -> validatableActionResult.validationMessages.toString()
-  is ValidatableActionResult.GeneralValidationError -> validatableActionResult.message
-  is ValidatableActionResult.ConflictError -> validatableActionResult.message
+  @Deprecated("Replaced by CasResult.GeneralValidationError", ReplaceWith("uk.gov.justice.digital.hmpps.approvedpremisesapi.CasResult.GeneralValidationError"))
+  data class GeneralValidationError<EntityType>(val message: String) : ValidatableActionResultError<EntityType>
+
+  @Deprecated("Replaced by CasResult.ConflictError", ReplaceWith("uk.gov.justice.digital.hmpps.approvedpremisesapi.CasResult.ConflictError"))
+  data class ConflictError<EntityType>(val conflictingEntityId: UUID, val message: String) : ValidatableActionResultError<EntityType>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/EntityUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/EntityUtils.kt
@@ -8,12 +8,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 
+@Deprecated("Update calling code to use CasResult", ReplaceWith("extractEntityFromCasResult"))
 fun <EntityType> extractEntityFromAuthorisableActionResult(result: AuthorisableActionResult<EntityType>) = when (result) {
   is AuthorisableActionResult.Success -> result.entity
   is AuthorisableActionResult.NotFound -> throw NotFoundProblem(result.id.toString(), result.entityType.toString())
   is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
 }
 
+@Deprecated("Update calling code to use CasResult", ReplaceWith("extractEntityFromCasResult"))
 fun <EntityType> extractEntityFromValidatableActionResult(result: ValidatableActionResult<EntityType>) = when (result) {
   is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = result.message)
   is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = result.validationMessages)
@@ -21,18 +23,17 @@ fun <EntityType> extractEntityFromValidatableActionResult(result: ValidatableAct
   is ValidatableActionResult.Success -> result.entity
 }
 
+@Deprecated("Update calling code to use CasResult", ReplaceWith("extractEntityFromCasResult"))
 fun <EntityType> ensureEntityFromNestedAuthorisableValidatableActionResultIsSuccess(result: AuthorisableActionResult<ValidatableActionResult<EntityType>>) {
   extractEntityFromNestedAuthorisableValidatableActionResult(result)
 }
 
-fun <EntityType> ensureEntityFromAuthorisableActionResultIsSuccess(result: AuthorisableActionResult<EntityType>) {
-  extractEntityFromAuthorisableActionResult(result)
-}
-
+@Deprecated("Update calling code to use CasResult", ReplaceWith("extractEntityFromCasResult"))
 fun <EntityType> ensureEntityFromValidatableActionResultIsSuccess(result: ValidatableActionResult<EntityType>) {
   extractEntityFromValidatableActionResult(result)
 }
 
+@Deprecated("Update calling code to use CasResult", ReplaceWith("extractEntityFromCasResult"))
 fun <EntityType> extractEntityFromNestedAuthorisableValidatableActionResult(result: AuthorisableActionResult<ValidatableActionResult<EntityType>>): EntityType {
   val validatableResult = extractEntityFromAuthorisableActionResult(result)
   return extractEntityFromValidatableActionResult(validatableResult)


### PR DESCRIPTION
CasResult should be used in instead of these types, simplifying both the production and handling of Service Results