### PR TITLE
Add columns to cas1_space_bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -27,6 +27,9 @@ data class Cas1SpaceBookingEntity(
   @JoinColumn(name = "premises_id")
   val premises: ApprovedPremisesEntity,
   @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "approved_premises_application_id")
+  val application: ApprovedPremisesApplicationEntity?,
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "placement_request_id")
   val placementRequest: PlacementRequestEntity,
   @ManyToOne(fetch = FetchType.LAZY)
@@ -41,5 +44,6 @@ data class Cas1SpaceBookingEntity(
   val canonicalDepartureDate: LocalDate,
   val crn: String,
   val keyWorkerStaffCode: String?,
+  val keyWorkerName: String?,
   val keyWorkerAssignedAt: Instant?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -62,6 +62,7 @@ class Cas1SpaceBookingService(
       Cas1SpaceBookingEntity(
         id = UUID.randomUUID(),
         premises = premises,
+        application = placementRequest.application,
         placementRequest = placementRequest,
         createdBy = createdBy,
         createdAt = OffsetDateTime.now(),
@@ -73,6 +74,7 @@ class Cas1SpaceBookingService(
         canonicalDepartureDate = departureDate,
         crn = placementRequest.application.crn,
         keyWorkerStaffCode = null,
+        keyWorkerName = null,
         keyWorkerAssignedAt = null,
       ),
     )

--- a/src/main/resources/db/migration/all/20240830155841__add_colomns_to_cas1_space_booking.sql
+++ b/src/main/resources/db/migration/all/20240830155841__add_colomns_to_cas1_space_booking.sql
@@ -1,0 +1,4 @@
+ALTER TABLE cas1_space_bookings ADD key_worker_name TEXT NULL;
+ALTER TABLE cas1_space_bookings ADD approved_premises_application_id UUID NULL;
+
+ALTER TABLE cas1_space_bookings ADD FOREIGN KEY (approved_premises_application_id) REFERENCES approved_premises_applications(id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
@@ -15,6 +16,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var premises: Yielded<ApprovedPremisesEntity> = { ApprovedPremisesEntityFactory().withDefaults().produce() }
   private var placementRequest: Yielded<PlacementRequestEntity> = { PlacementRequestEntityFactory().withDefaults().produce() }
+  private var application: Yielded<ApprovedPremisesApplicationEntity?> = { null }
   private var createdBy: Yielded<UserEntity> = { UserEntityFactory().withDefaults().produce() }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
   private var arrivalDate: Yielded<LocalDate> = { LocalDate.now() }
@@ -25,6 +27,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private val canonicalDepartureDate = { LocalDate.now() }
   private val crn = { randomStringUpperCase(6) }
   private val keyWorkerStaffCode = { null }
+  private val keyWorkerName = { null }
   private val keyWorkerAssignedAt = { null }
 
   fun withId(id: UUID) = apply {
@@ -93,7 +96,8 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     canonicalDepartureDate = this.canonicalDepartureDate(),
     crn = this.crn(),
     keyWorkerStaffCode = this.keyWorkerStaffCode(),
+    keyWorkerName = this.keyWorkerName(),
     keyWorkerAssignedAt = this.keyWorkerAssignedAt(),
-
+    application = this.application(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -226,6 +226,7 @@ class Cas1SpaceBookingServiceTest {
       val persistedBooking = persistedBookingCaptor.captured
       assertThat(persistedBooking.premises).isEqualTo(premises)
       assertThat(persistedBooking.placementRequest).isEqualTo(placementRequest)
+      assertThat(persistedBooking.application).isEqualTo(application)
       assertThat(persistedBooking.createdAt).isWithinTheLastMinute()
       assertThat(persistedBooking.createdBy).isEqualTo(user)
       assertThat(persistedBooking.expectedArrivalDate).isEqualTo(arrivalDate)


### PR DESCRIPTION
application id will be required for manual bookings (i.e. those not linked to a placement_request)

key worker name is required to support filtering in queries