### PR TITLE
APS-1122 - Spring Boot 3 - Use 2nd Level Cache for Ref Data Entities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.7.0")
   implementation("org.locationtech.jts:jts-core:1.19.0")
   implementation("org.hibernate:hibernate-spatial:6.4.4.Final")
+  implementation("org.hibernate.orm:hibernate-jcache")
   implementation("org.flywaydb:flyway-core")
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
   implementation("org.springframework.boot:spring-boot-starter-cache")
@@ -60,6 +61,9 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("io.sentry:sentry-spring-boot-starter-jakarta:7.11.0")
+  implementation("org.springframework.boot:spring-boot-starter-cache")
+
+  runtimeOnly("org.ehcache:ehcache")
 
   implementation(kotlin("reflect"))
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -21,6 +22,7 @@ interface ApAreaRepository : JpaRepository<ApAreaEntity, UUID> {
 
 @Entity
 @Table(name = "ap_areas")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class ApAreaEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -25,6 +26,7 @@ interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity,
 
 @Entity
 @Table(name = "cancellation_reasons")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class CancellationReasonEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import java.util.UUID
@@ -51,6 +52,7 @@ interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
 
 @Entity
 @Table(name = "characteristics")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class CharacteristicEntity(
   @Id
   var id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -24,6 +25,7 @@ interface DepartureReasonRepository : JpaRepository<DepartureReasonEntity, UUID>
 
 @Entity
 @Table(name = "departure_reasons")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class DepartureReasonEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DestinationProviderEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DestinationProviderEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -14,6 +15,7 @@ interface DestinationProviderRepository : JpaRepository<DestinationProviderEntit
 
 @Entity
 @Table(name = "destination_providers")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class DestinationProviderEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/JsonSchemaEntity.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Inheritance
 import jakarta.persistence.InheritanceType
 import jakarta.persistence.PrimaryKeyJoinColumn
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -24,6 +25,7 @@ interface JsonSchemaRepository : JpaRepository<JsonSchemaEntity, UUID> {
 @Table(name = "json_schemas")
 @DiscriminatorColumn(name = "type")
 @Inheritance(strategy = InheritanceType.JOINED)
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 abstract class JsonSchemaEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LocalAuthorityAreaEntity.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -14,6 +15,7 @@ interface LocalAuthorityAreaRepository : JpaRepository<LocalAuthorityAreaEntity,
 
 @Entity
 @Table(name = "local_authority_areas")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class LocalAuthorityAreaEntity(
   @Id
   var id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/LostBedReasonEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -16,6 +17,7 @@ interface LostBedReasonRepository : JpaRepository<LostBedReasonEntity, UUID> {
 
 @Entity
 @Table(name = "lost_bed_reasons")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class LostBedReasonEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -24,6 +25,7 @@ interface MoveOnCategoryRepository : JpaRepository<MoveOnCategoryEntity, UUID> {
 
 @Entity
 @Table(name = "move_on_categories")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class MoveOnCategoryEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalReasonEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -14,6 +15,7 @@ interface NonArrivalReasonRepository : JpaRepository<NonArrivalReasonEntity, UUI
 
 @Entity
 @Table(name = "non_arrival_reasons")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class NonArrivalReasonEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PostCodeDistrictEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PostCodeDistrictEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.locationtech.jts.geom.Point
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
@@ -16,6 +17,7 @@ interface PostcodeDistrictRepository : JpaRepository<PostCodeDistrictEntity, UUI
 
 @Entity
 @Table(name = "postcode_districts")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class PostCodeDistrictEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationAreaProbationRegionMappingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationAreaProbationRegionMappingEntity.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -16,6 +17,7 @@ interface ProbationAreaProbationRegionMappingRepository : JpaRepository<Probatio
 
 @Entity
 @Table(name = "probation_area_probation_region_mappings")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class ProbationAreaProbationRegionMappingEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationDeliveryUnitEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationDeliveryUnitEntity.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -22,6 +23,7 @@ interface ProbationDeliveryUnitRepository : JpaRepository<ProbationDeliveryUnitE
 
 @Entity
 @Table(name = "probation_delivery_units")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class ProbationDeliveryUnitEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationRegionEntity.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -16,6 +17,7 @@ interface ProbationRegionRepository : JpaRepository<ProbationRegionEntity, UUID>
 
 @Entity
 @Table(name = "probation_regions")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class ProbationRegionEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReferralRejectionReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReferralRejectionReasonEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -16,6 +17,7 @@ interface ReferralRejectionReasonRepository : JpaRepository<ReferralRejectionRea
 
 @Entity
 @Table(name = "referral_rejection_reasons")
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class ReferralRejectionReasonEntity(
   @Id
   val id: UUID,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,12 +32,26 @@ spring:
     locations: classpath:db/migration/all,classpath:db/migration/all-except-integration
     placeholderReplacement: true
 
+  cache:
+    # we explicitly define redis as the cache provided as we have
+    # ehcache on the classpath for JPA/hibernate, and spring will
+    # that by default instead
+    type: redis
+
   jpa:
     hibernate:
       ddl-auto: none
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        cache:
+          use_second_level_cache: true
+      javax.cache:
+        provider: org.ehcache.jsr107.EhcacheCachingProvider
+        uri: hibernate-ehcache.xml
+        persistence:
+          sharedCache:
+            mode: ENABLE_SELECTIVE
 
   data:
     redis:

--- a/src/main/resources/hibernate-ehcache.xml
+++ b/src/main/resources/hibernate-ehcache.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- note - this cache is managed by jpa/hibernate, not spring -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.ehcache.org/v3"
+        xmlns:jsr107="http://www.ehcache.org/v3/jsr107"
+        xsi:schemaLocation="
+            http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
+            http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
+
+    <service>
+        <jsr107:defaults
+                default-template="default"
+                enable-management="true"
+                enable-statistics="true"/>
+    </service>
+
+    <cache-template name="default">
+        <key-type>java.lang.Object</key-type>
+        <value-type>java.lang.Object</value-type>
+        <expiry>
+            <ttl unit="seconds">300</ttl>
+        </expiry>
+        <resources>
+            <!-- intellij warns that this tag is deprecated. It isn't, just the usage of size units in the value -->
+            <heap unit="MB">2</heap>
+        </resources>
+    </cache-template>
+
+</config>

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -19,6 +19,10 @@ spring:
     properties:
       hibernate:
         enable_lazy_load_no_trans: true
+        # disable cache during integration tests as it blocks us from
+        # dynamically adding test reference data
+        cache:
+          use_second_level_cache: false
     show-sql: true
   main:
     allow-bean-definition-overriding: true


### PR DESCRIPTION
This commit enables an in-memory (i.e. per container) second level hibernate cache.

This cache has only been applied to read-only reference data that is managed via the flyway schema migrations. This ensures that the cache will always be correct because a change in migration would come via a new release (all containers would be restarted, flushing the caches).

Note that this cache is managed by Hibernate, and is not linked to Spring’s Redis cache that we use for various function-level caches. This was a deliberate choice to keep this initial implementation simple.

All caches share the same default settings. For reference, this is show many rows exist in production for each cached entity:

ap_areas - 7
cancellation_reasons -  22
cas1_out_of_service_bed_reasons - 7
characteristics - 66
departure_reasons - 38
destination_providers - 30
json_schemas - 7
local_authority_areas - 408
lost_bed_reasons - 14
move_on_categories - 33
non_arrival_reasons - 6
postcode_districts - 2862
probation_area_probation_region_mappings - 19
probation_delivery_units - 108
probation_regions - 13
referral_rejection_reasons - 9

Given there are 16 caches and a max cache size of 2MB, this will require 32MB of heap. Given each contains has 2GB heap and typically use just over 1GB of memory, there should be sufficient head room for this.