### PR TITLE
added user id to CAS3 domain events

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -38,7 +38,7 @@ generic-service:
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
-    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,referralSubmitted,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
     DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -37,7 +37,7 @@ generic-service:
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
-    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted,bookingCancelledUpdated,personDepartureUpdated,personArrivedUpdated
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
     DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -29,7 +29,7 @@ generic-service:
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: false
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: false
-    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted,bookingCancelledUpdated,personDepartureUpdated,personArrivedUpdated
+    DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
     DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false
     DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -841,7 +841,7 @@ class BookingService(
 
   @Transactional
   fun createArrival(
-    user: UserEntity? = null,
+    user: UserEntity,
     booking: BookingEntity,
     arrivalDate: LocalDate,
     expectedDepartureDate: LocalDate,
@@ -884,7 +884,7 @@ class BookingService(
 
   @Transactional
   fun createCas3Arrival(
-    user: UserEntity? = null,
+    user: UserEntity,
     booking: BookingEntity,
     arrivalDate: LocalDate,
     expectedDepartureDate: LocalDate,
@@ -1340,7 +1340,7 @@ class BookingService(
   }
 
   fun createDeparture(
-    user: UserEntity?,
+    user: UserEntity,
     booking: BookingEntity,
     dateTime: OffsetDateTime,
     reasonId: UUID,
@@ -1523,7 +1523,7 @@ class BookingService(
     reasonId: UUID,
     moveOnCategoryId: UUID,
     notes: String?,
-    user: UserEntity?,
+    user: UserEntity,
   ) = validated<DepartureEntity> {
     if (booking.premises !is TemporaryAccommodationPremisesEntity) {
       throw RuntimeException("Only CAS3 bookings are supported")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -1807,7 +1807,7 @@ class BookingServiceTest {
 
     @Test
     fun `createArrival returns Success with correct result for CAS3 when validation passed and saves domain event without staff detail`() {
-      every { mockCas3DomainEventService.savePersonArrivedEvent(any(), null) } just Runs
+      every { mockCas3DomainEventService.savePersonArrivedEvent(any(), user) } just Runs
 
       val result = bookingService.createCas3Arrival(
         booking = bookingEntity,
@@ -1815,7 +1815,7 @@ class BookingServiceTest {
         expectedDepartureDate = LocalDate.parse("2022-08-29"),
         notes = "notes",
         keyWorkerStaffCode = null,
-        user = null,
+        user = user,
       )
 
       assertThat(result).isInstanceOf(ValidatableActionResult.Success::class.java)
@@ -1828,7 +1828,7 @@ class BookingServiceTest {
 
       verify(exactly = 1) { mockArrivalRepository.save(any()) }
       verify(exactly = 1) { mockBookingRepository.save(any()) }
-      verify(exactly = 1) { mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity, null) }
+      verify(exactly = 1) { mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity, user) }
     }
 
     private fun createTemporaryAccommodationBooking() = BookingEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventBuilderTest.kt
@@ -89,48 +89,6 @@ class DomainEventBuilderTest {
   }
 
   @Test
-  fun `getBookingCancelledDomainEvent transforms the booking information correctly without optional staff detail`() {
-    val cancellationReasonName = "Some cancellation reason"
-    val cancellationNotes = "Some notes about the cancellation"
-
-    val probationRegion = probationRegionEntity()
-
-    val premises = temporaryAccommodationPremisesEntity(probationRegion)
-
-    val user = userEntity(probationRegion)
-
-    val application = temporaryAccommodationApplicationEntity(user, probationRegion)
-
-    val booking = bookingEntity(premises, application)
-
-    val cancellationReason = cancellationReasonEntity(cancellationReasonName)
-
-    booking.cancellations += cancellationEntity(booking, cancellationReason, cancellationNotes)
-
-    val event = domainEventBuilder.getBookingCancelledDomainEvent(booking, null)
-
-    assertThat(event).matches {
-      val data = it.data.eventDetails
-
-      it.applicationId == application.id &&
-        it.bookingId == booking.id &&
-        it.crn == booking.crn &&
-        it.nomsNumber == booking.nomsNumber &&
-        data.personReference.crn == booking.crn &&
-        data.personReference.noms == booking.nomsNumber &&
-        data.bookingId == booking.id &&
-        data.bookingUrl.toString() == "http://api/premises/${premises.id}/bookings/${booking.id}" &&
-        data.cancellationReason == cancellationReasonName &&
-        data.notes == cancellationNotes &&
-        data.applicationId == application.id &&
-        data.applicationUrl.toString() == "http://api/applications/${application.id}" &&
-        data.cancelledAt == booking.cancellation?.date &&
-        data.cancelledBy == null &&
-        it.data.eventType == EventType.bookingCancelled
-    }
-  }
-
-  @Test
   fun `getBookingConfirmedDomainEvent transforms the booking information correctly`() {
     val expectedArrivalDateTime = Instant.parse("2023-07-15T00:00:00Z")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/DomainEventServiceTest.kt
@@ -45,8 +45,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEventServiceConfig
@@ -75,6 +77,9 @@ class DomainEventServiceTest {
   @MockK
   lateinit var domainEventServiceConfig: DomainEventServiceConfig
 
+  @MockK
+  lateinit var userService: UserService
+
   @InjectMockKs
   private lateinit var domainEventService: DomainEventService
 
@@ -94,6 +99,7 @@ class DomainEventServiceTest {
   fun setup() {
     every { domainEventServiceConfig.emitForEvent(any()) } returns true
     every { mockDomainEventUrlConfig.getUrlForDomainEventId(any(), any()) } returns detailUrl
+    every { userService.getUserForRequestOrNull() } returns user
   }
 
   @Test
@@ -355,7 +361,8 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -497,7 +504,8 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -570,7 +578,8 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -626,7 +635,8 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -771,7 +781,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -847,7 +858,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -906,7 +918,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1049,7 +1062,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1123,7 +1137,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1180,7 +1195,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1283,7 +1299,7 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id
         },
       )
     }
@@ -1357,7 +1373,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1414,7 +1431,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1528,7 +1546,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1613,7 +1632,7 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id
         },
       )
     }
@@ -1681,7 +1700,7 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id
         },
       )
     }
@@ -1718,7 +1737,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1773,7 +1793,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1810,7 +1831,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1908,7 +1930,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1946,7 +1969,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -1986,11 +2010,11 @@ class DomainEventServiceTest {
     val mockHmppsTopic = mockk<HmppsTopic>()
     every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
     every { hmppsQueueServiceMock.findByTopicId("domainevents") } returns mockHmppsTopic
-    every { domainEventBuilderMock.getBookingCancelledUpdatedDomainEvent(any(), null) } returns domainEventToSave
+    every { domainEventBuilderMock.getBookingCancelledUpdatedDomainEvent(any(), any()) } returns domainEventToSave
     every { mockHmppsTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
     every { mockHmppsTopic.snsClient.publish(any()) } returns PublishResult()
 
-    domainEventService.saveBookingCancelledUpdatedEvent(bookingEntity, null)
+    domainEventService.saveBookingCancelledUpdatedEvent(bookingEntity, user)
 
     verify(exactly = 1) {
       domainEventRepositoryMock.save(
@@ -2001,7 +2025,7 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id
         },
       )
     }
@@ -2055,7 +2079,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -2091,7 +2116,8 @@ class DomainEventServiceTest {
             it.crn == domainEventToSave.crn &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -2176,7 +2202,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber
           it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -2232,7 +2259,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }
@@ -2266,7 +2294,8 @@ class DomainEventServiceTest {
             it.nomsNumber == domainEventToSave.nomsNumber &&
             it.occurredAt.toInstant() == domainEventToSave.occurredAt &&
             it.data == objectMapper.writeValueAsString(domainEventToSave.data) &&
-            it.triggeredByUserId == null
+            it.triggeredByUserId == user.id &&
+            it.triggerSource == TriggerSourceType.USER
         },
       )
     }


### PR DESCRIPTION
- reordered the config for emitting messages so they are consistent between environments
- added user id to the CAS3 domain events
- made the userentity a non-nullable parameter, as we'll always have one (i think)
- removed test that's no longer needed