### PR TITLE
APS-1230 - Add endpoint to get user summaries and lazy load user relationships

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -64,6 +64,29 @@ class UsersController(
       userTransformer.transformJpaToApi(user, ServiceName.approvedPremises)
     }
 
+  override fun usersSummaryGet(
+    xServiceName: ServiceName,
+    roles: List<ApprovedPremisesUserRole>?,
+    qualifications: List<UserQualification>?,
+    probationRegionId: UUID?,
+    apAreaId: UUID?,
+    page: Int?,
+    sortBy: UserSortField?,
+    sortDirection: SortDirection?,
+  ) =
+    getUsers(
+      xServiceName,
+      roles,
+      qualifications,
+      probationRegionId,
+      apAreaId,
+      page,
+      sortBy,
+      sortDirection,
+    ) { user ->
+      userTransformer.transformJpaToSummaryApi(user)
+    }
+
   private fun <T> getUsers(
     xServiceName: ServiceName,
     roles: List<ApprovedPremisesUserRole>?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRolesAndQualifications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -49,17 +50,38 @@ class UsersController(
     page: Int?,
     sortBy: UserSortField?,
     sortDirection: SortDirection?,
-  ): ResponseEntity<List<User>> {
+  ) =
+    getUsers(
+      xServiceName,
+      roles,
+      qualifications,
+      probationRegionId,
+      apAreaId,
+      page,
+      sortBy,
+      sortDirection,
+    ) { user ->
+      userTransformer.transformJpaToApi(user, ServiceName.approvedPremises)
+    }
+
+  private fun <T> getUsers(
+    xServiceName: ServiceName,
+    roles: List<ApprovedPremisesUserRole>?,
+    qualifications: List<UserQualification>?,
+    probationRegionId: UUID?,
+    apAreaId: UUID?,
+    page: Int?,
+    sortBy: UserSortField?,
+    sortDirection: SortDirection?,
+    resultTransformer: (UserEntity) -> T,
+  ): ResponseEntity<List<T>> {
     if (!userAccessService.currentUserCanManageUsers(xServiceName)) {
       throw ForbiddenProblem()
     }
 
-    var roles = roles?.map(UserRole::valueOf)
-    var qualifications = qualifications?.map(::transformApiQualification)
-
     val (users, metadata) = userService.getUsersWithQualificationsAndRoles(
-      qualifications,
-      roles,
+      qualifications?.map(::transformApiQualification),
+      roles?.map(UserRole::valueOf),
       sortBy,
       sortDirection,
       page,
@@ -70,13 +92,13 @@ class UsersController(
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),
     ).body(
-      users.map { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) },
+      users.map { resultTransformer(it) },
     )
   }
 
   override fun usersIdPut(
     xServiceName: ServiceName,
-    id: java.util.UUID,
+    id: UUID,
     userRolesAndQualifications: UserRolesAndQualifications,
   ): ResponseEntity<User> {
     if (!userAccessService.currentUserCanManageUsers(xServiceName)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -15,6 +15,7 @@ import javax.persistence.Convert
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
@@ -273,11 +274,11 @@ data class UserEntity(
   var roles: MutableList<UserRoleAssignmentEntity>,
   @OneToMany(mappedBy = "user")
   val qualifications: MutableList<UserQualificationAssignmentEntity>,
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   var probationRegion: ProbationRegionEntity,
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   var probationDeliveryUnit: ProbationDeliveryUnitEntity?,
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "ap_area_id")
   var apArea: ApAreaEntity?,
   @Convert(converter = StringListConverter::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProfileRespons
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationUserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserWithWorkload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
@@ -45,6 +46,12 @@ class UserTransformer(
       apArea = jpa.apArea?.let { apAreaTransformer.transformJpaToApi(it) },
     )
   }
+
+  fun transformJpaToSummaryApi(jpa: UserEntity) =
+    UserSummary(
+      id = jpa.id,
+      name = jpa.name,
+    )
 
   fun transformJpaToApi(jpa: UserEntity, serviceName: ServiceName) = when (serviceName) {
     ServiceName.approvedPremises -> ApprovedPremisesUser(

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3004,6 +3004,17 @@ components:
         - name
         - deliusUsername
         - region
+    UserSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
     UserWithWorkload:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3949,7 +3949,7 @@ paths:
     get:
       tags:
         - Auth
-      summary: Returns a list of users
+      summary: Returns a list of users. If only the user's ID and Name are required, use /users/summary
       parameters:
         - in: query
           name: roles
@@ -4122,6 +4122,93 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+  /users/summary:
+    get:
+      tags:
+        - Auth
+      summary: Returns a list of user summaries (i.e. id and name only)
+      parameters:
+        - in: query
+          name: roles
+          required: false
+          description: Only return users with the provided role(s)
+          schema:
+            type: array
+            items:
+              $ref: '_shared.yml#/components/schemas/ApprovedPremisesUserRole'
+        - in: query
+          name: qualifications
+          required: false
+          description: Only return users with the provided qualification(s)
+          schema:
+            type: array
+            items:
+              $ref: '_shared.yml#/components/schemas/UserQualification'
+        - name: probationRegionId
+          in: query
+          description: Probation region ID to filter results by
+          schema:
+            type: string
+            format: uuid
+        - name: apAreaId
+          in: query
+          description: Approved premises area ID to filter results by
+          schema:
+            type: string
+            format: uuid
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '_shared.yml#/components/schemas/ServiceName'
+        - name: page
+          in: query
+          description: Page number of results to return. If blank, returns all results
+          schema:
+            type: integer
+        - name: sortBy
+          in: query
+          description: Which field to sort the results by. If blank, will sort by createdAt
+          schema:
+            $ref: '_shared.yml#/components/schemas/UserSortField'
+        - name: sortDirection
+          in: query
+          description: The direction to sort the results by. If blank, will sort in descending order
+          schema:
+            $ref: '_shared.yml#/components/schemas/SortDirection'
+      responses:
+        200:
+          description: successfully retrieved users
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/UserSummary'
+          headers:
+            X-Pagination-CurrentPage:
+              schema:
+                type: integer
+              description: The current page number
+            X-Pagination-TotalPages:
+              schema:
+                type: integer
+              description: The total number of pages
+            X-Pagination-TotalResults:
+              schema:
+                type: integer
+              description: The total number of results
+            X-Pagination-PageSize:
+              schema:
+                type: integer
+              description: The size of each page
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3951,7 +3951,7 @@ paths:
     get:
       tags:
         - Auth
-      summary: Returns a list of users
+      summary: Returns a list of users. If only the user's ID and Name are required, use /users/summary
       parameters:
         - in: query
           name: roles
@@ -4124,6 +4124,93 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /users/summary:
+    get:
+      tags:
+        - Auth
+      summary: Returns a list of user summaries (i.e. id and name only)
+      parameters:
+        - in: query
+          name: roles
+          required: false
+          description: Only return users with the provided role(s)
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ApprovedPremisesUserRole'
+        - in: query
+          name: qualifications
+          required: false
+          description: Only return users with the provided qualification(s)
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/UserQualification'
+        - name: probationRegionId
+          in: query
+          description: Probation region ID to filter results by
+          schema:
+            type: string
+            format: uuid
+        - name: apAreaId
+          in: query
+          description: Approved premises area ID to filter results by
+          schema:
+            type: string
+            format: uuid
+        - name: X-Service-Name
+          in: header
+          required: true
+          description: Filters the user details to those relevant to the specified service.
+          schema:
+            $ref: '#/components/schemas/ServiceName'
+        - name: page
+          in: query
+          description: Page number of results to return. If blank, returns all results
+          schema:
+            type: integer
+        - name: sortBy
+          in: query
+          description: Which field to sort the results by. If blank, will sort by createdAt
+          schema:
+            $ref: '#/components/schemas/UserSortField'
+        - name: sortDirection
+          in: query
+          description: The direction to sort the results by. If blank, will sort in descending order
+          schema:
+            $ref: '#/components/schemas/SortDirection'
+      responses:
+        200:
+          description: successfully retrieved users
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserSummary'
+          headers:
+            X-Pagination-CurrentPage:
+              schema:
+                type: integer
+              description: The current page number
+            X-Pagination-TotalPages:
+              schema:
+                type: integer
+              description: The total number of pages
+            X-Pagination-TotalResults:
+              schema:
+                type: integer
+              description: The total number of results
+            X-Pagination-PageSize:
+              schema:
+                type: integer
+              description: The size of each page
         401:
           $ref: '#/components/responses/401Response'
         403:
@@ -7377,6 +7464,17 @@ components:
         - name
         - deliusUsername
         - region
+    UserSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
     UserWithWorkload:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3824,6 +3824,17 @@ components:
         - name
         - deliusUsername
         - region
+    UserSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
     UserWithWorkload:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3595,6 +3595,17 @@ components:
         - name
         - deliusUsername
         - region
+    UserSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
     UserWithWorkload:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3095,6 +3095,17 @@ components:
         - name
         - deliusUsername
         - region
+    UserSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
     UserWithWorkload:
       allOf:
         - $ref: '#/components/schemas/User'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -71,6 +71,25 @@ class UserTransformerTest {
   }
 
   @Nested
+  inner class TransformJapToSummaryApi {
+
+    @Test
+    fun `successfully transform user`() {
+      val id = randomUUID()
+      val user = UserEntityFactory()
+        .withDefaults()
+        .withId(id)
+        .withName("the name")
+        .produce()
+
+      val result = userTransformer.transformJpaToSummaryApi(user)
+
+      assertThat(result.id).isEqualTo(id)
+      assertThat(result.name).isEqualTo("the name")
+    }
+  }
+
+  @Nested
   inner class TransformJpaToApi {
 
     @Test


### PR DESCRIPTION
Add users summary endpoint. This endpoint is identical to /users, but it returns a light weight response, meaning no additional SQL queries are requried for each user in the list.

After implementing /users/summaries it was observed that we were making two additional database calls for each user being listed due to eager loading. This commit converts these relationships to be lazy loaded