### PR TITLE
CAS-586 Fix issues in booking tabs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -58,7 +58,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toPageableOrAllPages
 import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -108,8 +107,8 @@ class AssessmentService(
     return Pair(response.content, getMetadata(response, pageCriteria))
   }
 
-  private fun buildPageable(pageCriteria: PageCriteria<AssessmentSortField>) = pageCriteria.toPageableOrAllPages {
-    when (pageCriteria.sortBy) {
+  private fun buildPageable(pageCriteria: PageCriteria<AssessmentSortField>) = pageCriteria.toPageableOrAllPages(
+    sortByConverter = when (pageCriteria.sortBy) {
       AssessmentSortField.assessmentStatus -> "status"
       AssessmentSortField.assessmentArrivalDate -> "arrivalDate"
       AssessmentSortField.assessmentCreatedAt -> "createdAt"
@@ -117,8 +116,8 @@ class AssessmentService(
       AssessmentSortField.personCrn -> "crn"
       AssessmentSortField.personName -> "personName"
       AssessmentSortField.applicationProbationDeliveryUnitName -> "probationDeliveryUnit"
-    }
-  }
+    },
+  )
 
   fun getAssessmentSummariesForUserCAS3(
     user: UserEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingSearchService.kt
@@ -137,12 +137,12 @@ class BookingSearchService(
 
   private fun convertSortFieldToDBField(sortField: BookingSearchSortField) =
     when (sortField) {
-      BookingSearchSortField.bookingEndDate -> "departure_date"
-      BookingSearchSortField.bookingStartDate -> "arrival_date"
-      BookingSearchSortField.bookingCreatedAt -> "created_at"
-      BookingSearchSortField.personCrn -> "crn"
-      BookingSearchSortField.personName -> "personName"
-      else -> "created_at"
+      BookingSearchSortField.bookingEndDate -> listOf("departure_date", "personName")
+      BookingSearchSortField.bookingStartDate -> listOf("arrival_date", "personName")
+      BookingSearchSortField.bookingCreatedAt -> listOf("created_at")
+      BookingSearchSortField.personCrn -> listOf("crn")
+      BookingSearchSortField.personName -> listOf("personName")
+      else -> listOf("created_at")
     }
 
   private fun sortBookingResultByPersonName(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -42,7 +42,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toPageable
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -87,7 +86,7 @@ class PlacementRequestService(
     searchCriteria: AllActiveSearchCriteria,
     pageCriteria: PageCriteria<PlacementRequestSortField>,
   ): Pair<List<PlacementRequestEntity>, PaginationMetadata?> {
-    val pageable = pageCriteria.toPageable {
+    val pageable = pageCriteria.toPageable(
       when (pageCriteria.sortBy) {
         PlacementRequestSortField.applicationSubmittedAt -> "application.submitted_at"
         PlacementRequestSortField.createdAt -> "created_at"
@@ -96,8 +95,8 @@ class PlacementRequestService(
         PlacementRequestSortField.requestType -> "request_type"
         PlacementRequestSortField.personName -> "person_name"
         PlacementRequestSortField.personRisksTier -> "person_risks_tier"
-      }
-    }
+      },
+    )
 
     val response = placementRequestRepository.allForDashboard(
       status = searchCriteria.status,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -28,7 +28,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toPageable
 import java.util.UUID
 import javax.transaction.Transactional
 
@@ -106,7 +105,7 @@ class TaskService(
     pageCriteria: PageCriteria<TaskSortField>,
     taskTypes: List<TaskEntityType>,
   ): Page<Task> {
-    val pageable = pageCriteria.toPageable {
+    val pageable = pageCriteria.toPageable(
       when (pageCriteria.sortBy) {
         TaskSortField.createdAt -> "created_at"
         TaskSortField.dueAt -> "due_at"
@@ -115,8 +114,8 @@ class TaskService(
         TaskSortField.completedAt -> "completed_at"
         TaskSortField.taskType -> "type"
         TaskSortField.decision -> "decision"
-      }
-    }
+      },
+    )
 
     val allocatedFilter = filterCriteria.allocatedFilter
 


### PR DESCRIPTION
This [PR CAS-586](https://dsdmoj.atlassian.net/browse/CAS-586) is to fix an issues in bookings tabs. 

The issue happened when there are multiple bookings with the same arrival or departure dates and there are greater than the search result page size. Order by start/end dates asc/desc will result in: 
- Bookings are not showing in the bookings tab as expected
- Booking is showing multiple times in different pages

The PageRequest start returning duplicated booking or miss a booking in the search result. 

To fix this issue I change the booking sort to support sorting by multiple columns. And change the booking results to sort by start/end date and then by offender name this make sure that the search result don't show the booking in different pages and show all the bookings expected in the search result. 