### PR TITLE
APS-1268 - Add CAS1 specific premises summary endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.PremisesCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+import java.util.UUID
+
+@Service
+class Cas1PremisesController(
+  val userAccessService: UserAccessService,
+  val cas1PremisesService: Cas1PremisesService,
+) : PremisesCas1Delegate {
+
+  override fun premisesPremisesIdGet(premisesId: UUID): ResponseEntity<Cas1PremisesSummary> {
+    userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PREMISES_VIEW_SUMMARY)
+
+    return ResponseEntity
+      .ok()
+      .body(extractEntityFromCasResult(cas1PremisesService.getPremisesSummary(premisesId)))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -355,6 +355,7 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_VIEW_OUT_OF_SERVICE_BEDS,
       UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE,
       UserPermission.CAS1_SPACE_BOOKING_LIST,
+      UserPermission.CAS1_PREMISES_VIEW_SUMMARY,
     ),
   ),
   CAS1_WORKFLOW_MANAGER(ServiceName.approvedPremises, ApprovedPremisesUserRole.workflowManager),
@@ -478,6 +479,7 @@ enum class UserPermission {
   CAS1_VIEW_MANAGE_TASKS,
   CAS1_VIEW_OUT_OF_SERVICE_BEDS,
   CAS1_SPACE_BOOKING_LIST,
+  CAS1_PREMISES_VIEW_SUMMARY,
 }
 
 interface UserWorkload {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ForbiddenProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ForbiddenProblem.kt
@@ -4,7 +4,13 @@ import org.zalando.problem.AbstractThrowableProblem
 import org.zalando.problem.Exceptional
 import org.zalando.problem.Status
 
-class ForbiddenProblem : AbstractThrowableProblem(null, "Forbidden", Status.FORBIDDEN, "You are not authorized to access this endpoint") {
+class ForbiddenProblem(detail: String? = null) :
+  AbstractThrowableProblem(
+    null,
+    "Forbidden",
+    Status.FORBIDDEN,
+    "You are not authorized to access this endpoint" + if (detail != null) { " $detail" } else { "" },
+  ) {
   override fun getCause(): Exceptional? {
     return null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -15,9 +15,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import java.util.UUID
 
@@ -27,6 +29,12 @@ class UserAccessService(
   private val offenderService: OffenderService,
   private val requestContextService: RequestContextService,
 ) {
+  fun ensureCurrentUserHasPermission(permission: UserPermission) {
+    if (!userService.getUserForRequest().hasPermission(permission)) {
+      throw ForbiddenProblem("Permission ${permission.name} is required")
+    }
+  }
+
   fun currentUserCanAccessRegion(probationRegionId: UUID?) =
     userCanAccessRegion(userService.getUserForRequest(), probationRegionId)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import java.util.UUID
+
+@Service
+class Cas1PremisesService(
+  val premisesRepository: PremisesRepository,
+  val premisesService: PremisesService,
+) {
+  fun getPremisesSummary(premisesId: UUID): CasResult<Cas1PremisesSummary> {
+    val premise = premisesRepository.findByIdOrNull(premisesId)
+    if (premise !is ApprovedPremisesEntity) return CasResult.NotFound("premises", premisesId.toString())
+
+    return CasResult.Success(
+      Cas1PremisesSummary(
+        id = premisesId,
+        name = premise.name,
+        apCode = premise.apCode,
+        postcode = premise.postcode,
+        bedCount = premisesService.getBedCount(premise),
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -132,6 +132,7 @@ class UserTransformer(
         UserPermission.CAS1_VIEW_MANAGE_TASKS -> ApiUserPermission.viewManageTasks
         UserPermission.CAS1_VIEW_OUT_OF_SERVICE_BEDS -> ApiUserPermission.viewOutOfServiceBeds
         UserPermission.CAS1_SPACE_BOOKING_LIST -> ApiUserPermission.spaceBookingList
+        UserPermission.CAS1_PREMISES_VIEW_SUMMARY -> ApiUserPermission.premisesViewSummary
       }
     }
   }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3135,6 +3135,7 @@ components:
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
         - cas1_space_booking_list
+        - cas1_premises_view_summary
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -81,6 +81,7 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
+
   /premises/{premisesId}/lost-beds:
     post:
       deprecated: true
@@ -308,6 +309,7 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
+
   /premises/{premisesId}/out-of-service-beds:
     post:
       tags:
@@ -525,6 +527,38 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
+
+  /premises/{premisesId}:
+    get:
+      tags:
+        - premises
+      summary: Returns premises information
+      parameters:
+        - name: premisesId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremisesSummary'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings:
     get:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -39,6 +39,25 @@ components:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/CharacteristicPair'
+    Cas1PremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        apCode:
+          type: string
+          example: NEHOPE1
+        postcode:
+          type: string
+          example: LS1 3AD
+        bedCount:
+          type: integer
+          description: The total number of spaces in this premises
+          example: 22
     Cas1SpaceCharacteristic:
       type: string
       description: All of the characteristics of both premises and rooms

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7595,6 +7595,7 @@ components:
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
         - cas1_space_booking_list
+        - cas1_premises_view_summary
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -83,6 +83,7 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+
   /premises/{premisesId}/lost-beds:
     post:
       deprecated: true
@@ -310,6 +311,7 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+
   /premises/{premisesId}/out-of-service-beds:
     post:
       tags:
@@ -527,6 +529,38 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
+
+  /premises/{premisesId}:
+    get:
+      tags:
+        - premises
+      summary: Returns premises information
+      parameters:
+        - name: premisesId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas1PremisesSummary'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings:
     get:
@@ -3955,6 +3989,7 @@ components:
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
         - cas1_space_booking_list
+        - cas1_premises_view_summary
     TemporaryAccommodationUserRole:
       type: string
       enum:
@@ -5978,6 +6013,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CharacteristicPair'
+    Cas1PremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        apCode:
+          type: string
+          example: NEHOPE1
+        postcode:
+          type: string
+          example: LS1 3AD
+        bedCount:
+          type: integer
+          description: The total number of spaces in this premises
+          example: 22
     Cas1SpaceCharacteristic:
       type: string
       description: All of the characteristics of both premises and rooms

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3726,6 +3726,7 @@ components:
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
         - cas1_space_booking_list
+        - cas1_premises_view_summary
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3226,6 +3226,7 @@ components:
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
         - cas1_space_booking_list
+        - cas1_premises_view_summary
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationPremisesEntityFactory.kt
@@ -32,6 +32,11 @@ class TemporaryAccommodationPremisesEntityFactory : Factory<TemporaryAccommodati
   private var turnaroundWorkingDayCount: Yielded<Int>? = null
   private var characteristics: Yielded<MutableList<CharacteristicEntity>> = { mutableListOf() }
 
+  fun withDefaults() = apply {
+    withProbationRegion(ProbationRegionEntityFactory().withDefaults().produce())
+    withLocalAuthorityArea(LocalAuthorityAreaEntityFactory().produce())
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+
+class Cas1PremisesTest : IntegrationTestBase() {
+
+  @Nested
+  inner class GetPremisesSummary : InitialiseDatabasePerClassTestBase() {
+
+    lateinit var premises: ApprovedPremisesEntity
+
+    @BeforeAll
+    fun setupTestData() {
+      val region = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea {
+          apAreaEntityFactory.produceAndPersist()
+        }
+      }
+
+      premises = approvedPremisesEntityFactory.produceAndPersist {
+        withName("the premises name")
+        withYieldedProbationRegion { region }
+        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      }
+    }
+
+    @Test
+    fun `Returns 403 Forbidden if user does not have correct role`() {
+      val (_, jwt) = `Given a User`(roles = listOf(UserRole.CAS1_ASSESSOR))
+
+      webTestClient.get()
+        .uri("/cas1/premises/${premises.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `Returns premises summary`() {
+      val (_, jwt) = `Given a User`(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
+
+      val summary = webTestClient.get()
+        .uri("/cas1/premises/${premises.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1PremisesSummary::class.java).responseBody.blockFirst()!!
+
+      assertThat(summary.name).isEqualTo("the premises name")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremiseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremiseServiceTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1PremiseServiceTest {
+
+  @MockK
+  lateinit var premisesRepository: PremisesRepository
+
+  @MockK
+  lateinit var premisesService: PremisesService
+
+  @InjectMockKs
+  lateinit var service: Cas1PremisesService
+
+  companion object CONSTANTS {
+    val PREMISES_ID = UUID.randomUUID()
+  }
+
+  @Nested
+  inner class GetPremisesSummary {
+
+    @Test
+    fun `premises not found return error`() {
+      every { premisesRepository.findByIdOrNull(PREMISES_ID) } returns null
+
+      val result = service.getPremisesSummary(PREMISES_ID)
+
+      assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
+    }
+
+    @Test
+    fun `premises not cas1 return error`() {
+      every { premisesRepository.findByIdOrNull(PREMISES_ID) } returns
+        TemporaryAccommodationPremisesEntityFactory()
+          .withDefaults()
+          .produce()
+
+      val result = service.getPremisesSummary(PREMISES_ID)
+
+      assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
+    }
+
+    @Test
+    fun `success`() {
+      val premises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .withId(PREMISES_ID)
+        .withName("the name")
+        .withApCode("the ap code")
+        .withPostcode("LE11 1PO")
+        .produce()
+
+      every { premisesRepository.findByIdOrNull(PREMISES_ID) } returns premises
+
+      every { premisesService.getBedCount(premises) } returns 56
+
+      val result = service.getPremisesSummary(PREMISES_ID)
+
+      assertThat(result).isInstanceOf(CasResult.Success::class.java)
+      result as CasResult.Success
+
+      val premisesSummary = result.value
+      assertThat(premisesSummary.id).isEqualTo(premises.id)
+      assertThat(premisesSummary.name).isEqualTo("the name")
+      assertThat(premisesSummary.apCode).isEqualTo("the ap code")
+      assertThat(premisesSummary.postcode).isEqualTo("LE11 1PO")
+      assertThat(premisesSummary.bedCount).isEqualTo(56)
+    }
+  }
+}


### PR DESCRIPTION
This is similar to the existing /premises/{premisesId}/summary, but only returns the fields currently being shown on the CAS1 premises UI (i.e. it doesn’t include bookings, which will instead be provided by /premises/{premisesId}/space-bookings)