### PR TITLE
CAS-379 CAS3 allow turnaround to be zero

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -683,7 +683,7 @@ class BookingService(
     booking: BookingEntity,
     workingDays: Int,
   ) = validated {
-    if (workingDays <= 0) {
+    if (workingDays < 0) {
       "$.workingDays" hasValidationError "isNotAPositiveInteger"
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PremisesService.kt
@@ -284,7 +284,7 @@ class PremisesService(
       property hasValidationError err
     }
 
-    if (turnaroundWorkingDayCount != null && turnaroundWorkingDayCount <= 0) {
+    if (turnaroundWorkingDayCount != null && turnaroundWorkingDayCount < 0) {
       "$.turnaroundWorkingDayCount" hasValidationError "isNotAPositiveInteger"
     }
 
@@ -405,8 +405,16 @@ class PremisesService(
       entity
     }
 
-    if (turnaroundWorkingDayCount != null && premises is ApprovedPremisesEntity) {
-      validationErrors["$.turnaroundWorkingDayCount"] = "onlyAppliesToTemporaryAccommodationPremises"
+    if (turnaroundWorkingDayCount != null) {
+      when (premises) {
+        is TemporaryAccommodationPremisesEntity -> {
+          if (turnaroundWorkingDayCount < 0) {
+            validationErrors["$.turnaroundWorkingDayCount"] = "isNotAPositiveInteger"
+          }
+        }
+
+        else -> validationErrors["$.turnaroundWorkingDayCount"] = "onlyAppliesToTemporaryAccommodationPremises"
+      }
     }
 
     if (validationErrors.any()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
@@ -85,7 +85,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           NewTurnaround(
-            workingDays = 0,
+            workingDays = -1,
           ),
         )
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -6668,7 +6668,7 @@ class BookingServiceTest {
   }
 
   @Test
-  fun `createTurnaround returns FieldValidationError if the number of working days is not a positive integer`() {
+  fun `createTurnaround returns FieldValidationError if the number of working days is a negative integer`() {
     val premises = TemporaryAccommodationPremisesEntityFactory()
       .withProbationRegion(
         ProbationRegionEntityFactory()
@@ -6703,15 +6703,9 @@ class BookingServiceTest {
     every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
 
     val negativeDaysResult = bookingService.createTurnaround(booking, -1)
-    val zeroDaysResult = bookingService.createTurnaround(booking, 0)
 
     assertThat(negativeDaysResult).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
     assertThat((negativeDaysResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.workingDays", "isNotAPositiveInteger"),
-    )
-
-    assertThat(zeroDaysResult).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
-    assertThat((zeroDaysResult as ValidatableActionResult.FieldValidationError).validationMessages).contains(
       entry("$.workingDays", "isNotAPositiveInteger"),
     )
   }


### PR DESCRIPTION
This [PR CAS-379](https://dsdmoj.atlassian.net/browse/CAS-379) is to allow the value of zero days for turnaround when:
- Create/update a property
- Change the turnaround for a booking

It will return the same validation message type isNotAPositiveInteger when the value of turnaround days is negative integer