### PR TITLE
CAS-464 extend bedspace search to receive a list of attributes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
@@ -38,8 +38,7 @@ class BedSearchController(
         probationDeliveryUnit = bedSearchParameters.probationDeliveryUnit,
         startDate = bedSearchParameters.startDate,
         durationInDays = bedSearchParameters.durationDays,
-        filterBySharedProperty = bedSearchParameters.sharedProperty == true,
-        filterBySingleOccupancy = bedSearchParameters.singleOccupancy == true,
+        propertyBedAttributes = bedSearchParameters.attributes,
       )
       else -> throw RuntimeException("Unsupported BedSearchParameters type: ${bedSearchParameters::class.qualifiedName}")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchAttributes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
@@ -96,8 +97,7 @@ class BedSearchService(
     probationDeliveryUnit: String,
     startDate: LocalDate,
     durationInDays: Int,
-    filterBySharedProperty: Boolean,
-    filterBySingleOccupancy: Boolean,
+    propertyBedAttributes: List<BedSearchAttributes>?,
   ): AuthorisableActionResult<ValidatableActionResult<List<TemporaryAccommodationBedSearchResult>>> {
     return AuthorisableActionResult.Success(
       validated {
@@ -116,8 +116,8 @@ class BedSearchService(
           startDate = startDate,
           endDate = endDate,
           probationRegionId = user.probationRegion.id,
-          filterBySharedProperty = filterBySharedProperty,
-          filterBySingleOccupancy = filterBySingleOccupancy,
+          filterBySharedProperty = propertyBedAttributes?.contains(BedSearchAttributes.sharedProperty) ?: false,
+          filterBySingleOccupancy = propertyBedAttributes?.contains(BedSearchAttributes.singleOccupancy) ?: false,
         )
 
         val bedIds = candidateResults.map { it.bedId }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4207,12 +4207,11 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
-            sharedProperty:
-              type: boolean
-              description: Is a shared property
-            singleOccupancy:
-              type: boolean
-              description: Is the property for single occupancy
+            attributes:
+              type: array
+              description: Bedspace and property attributes to filter on
+              items:
+                $ref: "_shared.yml#/components/schemas/BedSearchAttributes"
           required:
             - probationDeliveryUnit
     BedSearchResults:
@@ -5107,3 +5106,8 @@ components:
       enum:
         - male
         - female
+    BedSearchAttributes:
+      type: string
+      enum:
+        - sharedProperty
+        - singleOccupancy

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8667,12 +8667,11 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
-            sharedProperty:
-              type: boolean
-              description: Is a shared property
-            singleOccupancy:
-              type: boolean
-              description: Is the property for single occupancy
+            attributes:
+              type: array
+              description: Bedspace and property attributes to filter on
+              items:
+                $ref: "#/components/schemas/BedSearchAttributes"
           required:
             - probationDeliveryUnit
     BedSearchResults:
@@ -9567,3 +9566,8 @@ components:
       enum:
         - male
         - female
+    BedSearchAttributes:
+      type: string
+      enum:
+        - sharedProperty
+        - singleOccupancy

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5110,12 +5110,11 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
-            sharedProperty:
-              type: boolean
-              description: Is a shared property
-            singleOccupancy:
-              type: boolean
-              description: Is the property for single occupancy
+            attributes:
+              type: array
+              description: Bedspace and property attributes to filter on
+              items:
+                $ref: "#/components/schemas/BedSearchAttributes"
           required:
             - probationDeliveryUnit
     BedSearchResults:
@@ -6010,6 +6009,11 @@ components:
       enum:
         - male
         - female
+    BedSearchAttributes:
+      type: string
+      enum:
+        - sharedProperty
+        - singleOccupancy
     Cas1PremisesSearchResultSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4798,12 +4798,11 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
-            sharedProperty:
-              type: boolean
-              description: Is a shared property
-            singleOccupancy:
-              type: boolean
-              description: Is the property for single occupancy
+            attributes:
+              type: array
+              description: Bedspace and property attributes to filter on
+              items:
+                $ref: "#/components/schemas/BedSearchAttributes"
           required:
             - probationDeliveryUnit
     BedSearchResults:
@@ -5698,3 +5697,8 @@ components:
       enum:
         - male
         - female
+    BedSearchAttributes:
+      type: string
+      enum:
+        - sharedProperty
+        - singleOccupancy

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4298,12 +4298,11 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
-            sharedProperty:
-              type: boolean
-              description: Is a shared property
-            singleOccupancy:
-              type: boolean
-              description: Is the property for single occupancy
+            attributes:
+              type: array
+              description: Bedspace and property attributes to filter on
+              items:
+                $ref: "#/components/schemas/BedSearchAttributes"
           required:
             - probationDeliveryUnit
     BedSearchResults:
@@ -5198,3 +5197,8 @@ components:
       enum:
         - male
         - female
+    BedSearchAttributes:
+      type: string
+      enum:
+        - sharedProperty
+        - singleOccupancy

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesBedSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesBedSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchAttributes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchResultBedSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchResultPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchResultRoomSummary
@@ -1009,8 +1010,7 @@ class BedSearchTest : IntegrationTestBase() {
               durationDays = 84,
               serviceName = "temporary-accommodation",
               probationDeliveryUnit = searchPdu.name,
-              sharedProperty = true,
-              singleOccupancy = false,
+              attributes = listOf(BedSearchAttributes.sharedProperty),
             ),
           )
           .exchange()
@@ -1167,8 +1167,7 @@ class BedSearchTest : IntegrationTestBase() {
               durationDays = 84,
               serviceName = "temporary-accommodation",
               probationDeliveryUnit = searchPdu.name,
-              sharedProperty = false,
-              singleOccupancy = true,
+              attributes = listOf(BedSearchAttributes.singleOccupancy),
             ),
           )
           .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -493,8 +493,7 @@ class BedSearchServiceTest {
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 0,
       probationDeliveryUnit = "PDU-1",
-      filterBySharedProperty = false,
-      filterBySingleOccupancy = false,
+      propertyBedAttributes = null,
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -568,8 +567,7 @@ class BedSearchServiceTest {
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
       probationDeliveryUnit = "PDU-1",
-      filterBySharedProperty = false,
-      filterBySingleOccupancy = false,
+      propertyBedAttributes = null,
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue
@@ -745,8 +743,7 @@ class BedSearchServiceTest {
       startDate = LocalDate.parse("2023-03-22"),
       durationInDays = 7,
       probationDeliveryUnit = "PDU-1",
-      filterBySharedProperty = false,
-      filterBySingleOccupancy = false,
+      propertyBedAttributes = null,
     )
 
     assertThat(authorisableResult is AuthorisableActionResult.Success).isTrue


### PR DESCRIPTION
This [PR CAS-464](https://dsdmoj.atlassian.net/browse/CAS-464) is to extend the  bedspace search Api endpoint to accept a list of property and bedspace attributes for filtering. The current values will be:
-  sharedProperty
- singleOccupancy