### PR TITLE
Remove sentry exception.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1813,7 +1813,6 @@ class BookingService(
       extractEntityFromNestedAuthorisableValidatableActionResult(assessmentService.closeAssessment(user, assessmentId))
     } catch (exception: Exception) {
       log.error("Unable to close CAS3 assessment $assessmentId for booking ${booking.id} ", exception)
-      Sentry.captureException(RuntimeException("Unable to close CAS3 assessment $assessmentId for booking ${booking.id} ", exception))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -4207,9 +4207,6 @@ class BookingServiceTest {
     verify(exactly = 1) {
       mockAssessmentRepository.findByApplication_IdAndReallocatedAtNull(bookingEntity.application!!.id)
     }
-    verify(exactly = 1) {
-      Sentry.captureException(any())
-    }
   }
 
   @Test


### PR DESCRIPTION
A message is logged and a sentry exception is raised when the following scenario occurs:

1. The referral is moved to In Review and then Ready to place
2. They book a bedspace for them and it status will be provisional
3. They go to the referral and they Archive it
4. Then they go to the booking and they Confirm it

Ticket [CAS-452](https://dsdmoj.atlassian.net/browse/CAS-452) has been raised to investigate this scenario and what needs to happen when it occurs and will be worked on when brought into scope.

Propose to remove this Sentry exception because:

- The cas-events Slack channel will not be alerted when this occurs which means there is less chatter so we can focus on higher priority issues (we have been 'muting' this issue in the channel)
- A proper solution will be determined when the work is brought into scope
- The event is written to the logs as an error

[CAS-452]: https://dsdmoj.atlassian.net/browse/CAS-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ