### PR TITLE
APS-1244 - Create Booking Made Domain Event for CAS1 Space Bookings

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -57,6 +57,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-dev.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
+    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/manage/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -49,6 +49,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-preprod.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-preprod.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
+    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/manage/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -50,6 +50,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
+    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/manage/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -44,6 +44,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-test.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
+    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/manage/premises/#premisesId/bookings/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -37,11 +37,17 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
         d.assessmentId as assessmentId,
         d.bookingId as bookingId,
         d.triggerSource as triggerSource,
-        b.premises.id as premisesId,
+        CASE
+            WHEN b.id IS NOT NULL THEN b.premises.id
+            WHEN sb.id IS NOT NULL THEN sb.premises.id
+            ELSE NULL
+        END as premisesId,
         a.id as appealId,
+        d.cas1SpaceBookingId as cas1SpaceBookingId,
         u as triggeredByUser
       FROM DomainEventEntity d 
       LEFT OUTER JOIN BookingEntity b ON b.id = d.bookingId
+      LEFT OUTER JOIN Cas1SpaceBookingEntity sb ON sb.id = d.cas1SpaceBookingId
       LEFT OUTER JOIN AppealEntity a ON a.application.id = d.applicationId 
       LEFT OUTER JOIN UserEntity u ON u.id = d.triggeredByUserId
       WHERE d.applicationId = :applicationId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
@@ -15,6 +15,7 @@ interface DomainEventSummary {
   val bookingId: UUID?
   val premisesId: UUID?
   val appealId: UUID?
+  val cas1SpaceBookingId: UUID?
   val triggerSource: TriggerSourceType?
   val triggeredByUser: UserEntity?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -17,6 +17,7 @@ class ApplicationTimelineTransformer(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.assessment}") private val assessmentUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.frontend.cas1.space-booking-made}") private val cas1SpaceBookingUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.application-appeal}") private val appealUrlTemplate: UrlTemplate,
   private val domainEventDescriber: DomainEventDescriber,
   private val userTransformer: UserTransformer,
@@ -84,6 +85,20 @@ class ApplicationTimelineTransformer(
     }
   }
 
+  private fun cas1SpaceBookingUrlOrNull(domainEventSummary: DomainEventSummary) = domainEventSummary.cas1SpaceBookingId?.let {
+    domainEventSummary.premisesId?.let {
+      TimelineEventAssociatedUrl(
+        TimelineEventUrlType.cas1SpaceBooking,
+        cas1SpaceBookingUrlTemplate.resolve(
+          mapOf(
+            "premisesId" to domainEventSummary.premisesId.toString(),
+            "bookingId" to domainEventSummary.cas1SpaceBookingId.toString(),
+          ),
+        ),
+      )
+    }
+  }
+
   fun generateUrlsForTimelineEventType(domainEventSummary: DomainEventSummary): List<TimelineEventAssociatedUrl> {
     return when (domainEventSummary.type) {
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> listOfNotNull(
@@ -98,6 +113,7 @@ class ApplicationTimelineTransformer(
         applicationUrlOrNull(domainEventSummary),
         assessmentUrlOrNull(domainEventSummary),
         bookingUrlOrNull(domainEventSummary),
+        cas1SpaceBookingUrlOrNull(domainEventSummary),
       )
     }
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -246,6 +246,8 @@ url-templates:
     application-timeline: http://localhost:3000/applications/#applicationId?tab=timeline
     assessment: http://localhost:3000/assessments/#id
     booking: http://localhost:3000/premises/#premisesId/bookings/#bookingId
+    cas1:
+      space-booking-made: http://localhost:3000/manage/premises/#premisesId/bookings/#bookingId
     cas2:
       application: http://localhost:3000/applications/#id
       application-overview: http://localhost:3000/applications/#id/overview

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3713,6 +3713,7 @@ components:
         - booking
         - assessment
         - assessmentAppeal
+        - cas1SpaceBooking
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8173,6 +8173,7 @@ components:
         - booking
         - assessment
         - assessmentAppeal
+        - cas1SpaceBooking
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4665,6 +4665,7 @@ components:
         - booking
         - assessment
         - assessmentAppeal
+        - cas1SpaceBooking
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4304,6 +4304,7 @@ components:
         - booking
         - assessment
         - assessmentAppeal
+        - cas1SpaceBooking
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3804,6 +3804,7 @@ components:
         - booking
         - assessment
         - assessmentAppeal
+        - cas1SpaceBooking
     Cas2TimelineEvent:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -137,6 +137,7 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
               null,
               null,
               null,
+              null,
               it.triggerSource,
               user,
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ASSESSOR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_FUTURE_MANAGER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
@@ -179,7 +180,7 @@ class Cas1SpaceBookingTest {
     }
 
     @Test
-    fun `Booking a space returns OK with the correct data`() {
+    fun `Booking a space returns OK with the correct data and creates a domain event`() {
       `Given a User` { user, jwt ->
         `Given a Placement Request`(
           placementRequestAllocatedTo = user,
@@ -275,6 +276,8 @@ class Cas1SpaceBookingTest {
           assertThat(result.createdAt).satisfies(
             { it.isAfter(Instant.now().minusSeconds(10)) },
           )
+
+          domainEventAsserter.assertDomainEventOfTypeStored(placementRequest.application.id, DomainEventType.APPROVED_PREMISES_BOOKING_MADE)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -861,6 +861,7 @@ data class DomainEventSummaryImpl(
   override val bookingId: UUID?,
   override val premisesId: UUID?,
   override val appealId: UUID?,
+  override val cas1SpaceBookingId: UUID?,
   override val triggerSource: TriggerSourceType?,
   override val triggeredByUser: UserEntity?,
 ) : DomainEventSummary {
@@ -874,6 +875,7 @@ data class DomainEventSummaryImpl(
       bookingId = null,
       premisesId = null,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationTimelineTransformerTest.kt
@@ -31,10 +31,11 @@ class ApplicationTimelineTransformerTest {
   private val mockUserTransformer = mockk<UserTransformer>()
 
   private val applicationTimelineTransformer = ApplicationTimelineTransformer(
-    UrlTemplate("http://somehost:3000/applications/#id"),
-    UrlTemplate("http://somehost:3000/assessments/#id"),
-    UrlTemplate("http://somehost:3000/premises/#premisesId/bookings/#bookingId"),
-    UrlTemplate("http://somehost:3000/applications/#applicationId/appeals/#appealId"),
+    applicationUrlTemplate = UrlTemplate("http://somehost:3000/applications/#id"),
+    assessmentUrlTemplate = UrlTemplate("http://somehost:3000/assessments/#id"),
+    bookingUrlTemplate = UrlTemplate("http://somehost:3000/premises/#premisesId/bookings/#bookingId"),
+    cas1SpaceBookingUrlTemplate = UrlTemplate("http://somehost:3000/manage/premises/#premisesId/bookings/#bookingId"),
+    appealUrlTemplate = UrlTemplate("http://somehost:3000/applications/#applicationId/appeals/#appealId"),
     mockDomainEventDescriber,
     mockUserTransformer,
   )
@@ -48,6 +49,7 @@ class ApplicationTimelineTransformerTest {
     override val bookingId: UUID?,
     override val premisesId: UUID?,
     override val appealId: UUID?,
+    override val cas1SpaceBookingId: UUID?,
     override val triggerSource: TriggerSourceType?,
     override val triggeredByUser: UserEntity?,
   ) : DomainEventSummary
@@ -66,6 +68,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = userJpa,
     )
@@ -97,6 +100,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = userJpa,
     )
@@ -119,6 +123,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
     )
@@ -152,6 +157,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = null,
       appealId = appealId,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
     )
@@ -190,6 +196,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = null,
       premisesId = premisesId,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
     )
@@ -210,6 +217,39 @@ class ApplicationTimelineTransformerTest {
   }
 
   @Test
+  fun `transformDomainEventSummaryToTimelineEvent adds cas1SpaceBookingUrl if cas1 space booking id defined`() {
+    val spaceBookingId = UUID.randomUUID()
+    val premisesId = UUID.randomUUID()
+    val domainEvent = DomainEventSummaryImpl(
+      id = UUID.randomUUID().toString(),
+      type = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
+      occurredAt = OffsetDateTime.now(),
+      bookingId = null,
+      applicationId = null,
+      assessmentId = null,
+      premisesId = premisesId,
+      appealId = null,
+      cas1SpaceBookingId = spaceBookingId,
+      triggerSource = null,
+      triggeredByUser = null,
+    )
+
+    every { mockDomainEventDescriber.getDescription(domainEvent) } returns "Some event"
+
+    assertThat(applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)).isEqualTo(
+      TimelineEvent(
+        id = domainEvent.id,
+        type = TimelineEventType.approvedPremisesBookingMade,
+        occurredAt = domainEvent.occurredAt.toInstant(),
+        associatedUrls = listOf(
+          TimelineEventAssociatedUrl(TimelineEventUrlType.cas1SpaceBooking, "http://somehost:3000/manage/premises/$premisesId/bookings/$spaceBookingId"),
+        ),
+        content = "Some event",
+      ),
+    )
+  }
+
+  @Test
   fun `transformDomainEventSummaryToTimelineEvent adds assessmentUrl if assessment id defined`() {
     val assessmentId = UUID.randomUUID()
     val domainEvent = DomainEventSummaryImpl(
@@ -221,6 +261,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = null,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
     )
@@ -254,6 +295,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = null,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
     )
@@ -287,6 +329,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = null,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
     )
@@ -327,6 +370,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = premisesId,
       appealId = appealId,
+      cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
     )
@@ -361,6 +405,7 @@ class ApplicationTimelineTransformerTest {
       assessmentId = assessmentId,
       premisesId = null,
       appealId = null,
+      cas1SpaceBookingId = null,
       triggerSource = triggerSource,
       triggeredByUser = null,
     )


### PR DESCRIPTION
Whilst we reuse the same APPROVED_PREMISES_BOOKING_MADE domain event for space bookings, we are populating the domain_events.cas1_space_booking_Id instead of domain_events.cas1_booking_Id to allow us to easily differentiate between the two types when rendering the timeline

This commit also adds a cas1SpaceBooking timeline url type to allow the UI to differentiate between legacy bookings and cas 1 space bookings when linking to the corresponding view placement page

The screenshot below shows how a legacy booking and a cas1 space booking appear on the timeline. Note that view placement link for CAS1 space booking is incomplete. This requires a change in the UI to recognise the new URL type (via APS-1268)

![Screenshot 2024-09-05 at 12 17 51](https://github.com/user-attachments/assets/8a5df56f-5824-4fa0-9f20-70d9a54a1d38)
