### PR TITLE
APS-1029:  Change to authorisation for task reallocation on CAS1 requests.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -358,7 +358,13 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_PREMISES_VIEW_SUMMARY,
     ),
   ),
-  CAS1_WORKFLOW_MANAGER(ServiceName.approvedPremises, ApprovedPremisesUserRole.workflowManager),
+  CAS1_WORKFLOW_MANAGER(
+    ServiceName.approvedPremises,
+    ApprovedPremisesUserRole.workflowManager,
+    listOf(
+      UserPermission.CAS1_VIEW_MANAGE_TASKS,
+    ),
+  ),
   CAS1_CRU_MEMBER(
     ServiceName.approvedPremises,
     ApprovedPremisesUserRole.cruMember,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -195,7 +195,7 @@ class UserAccessService(
 
   fun userCanReallocateTask(user: UserEntity): Boolean = when (requestContextService.getServiceForRequest()) {
     ServiceName.temporaryAccommodation -> user.hasRole(UserRole.CAS3_ASSESSOR)
-    ServiceName.approvedPremises -> user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
+    ServiceName.approvedPremises -> user.hasPermission(UserPermission.CAS1_VIEW_MANAGE_TASKS)
     else -> false
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -1317,7 +1317,7 @@ class UserAccessServiceTest {
   }
 
   @Test
-  fun `currentUserCanReallocateTask returns true if the current request has 'X-Service-Name' header with value 'approved-premises' and the user has the CAS1_WORKFLOW_MANAGER role`() {
+  fun `currentUserCanReallocateTask returns true if the current request has 'X-Service-Name' header with value 'approved-premises' and the user has a role with the CAS1_VIEW_MANAGE_TASKS permission`() {
     currentRequestIsFor(ServiceName.approvedPremises)
 
     user.addRoleForUnitTest(UserRole.CAS1_WORKFLOW_MANAGER)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -184,7 +184,11 @@ class UserTransformerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_JANITOR", "CAS1_APPEALS_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_CRU_MEMBER", "CAS1_FUTURE_MANAGER"], mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(
+      value = UserRole::class,
+      names = ["CAS1_JANITOR", "CAS1_APPEALS_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_CRU_MEMBER", "CAS1_FUTURE_MANAGER", "CAS1_WORKFLOW_MANAGER"],
+      mode = EnumSource.Mode.EXCLUDE,
+    )
     fun `transformJpaToApi CAS1 should return no permissions for Approved Premises roles which have no permissions defined`(role: UserRole) {
       val user = buildUserEntity(
         role = role,


### PR DESCRIPTION
Change to authorisation for task reallocation on CAS1 requests.
The check is now for presence of the permission CAS1_VIEW_MANAGE_TASKS rather than the role CAS1_WORKFLOW_MANAGER. 

The CAS1_VIEW_MANAGE_TASKS permission has been added to the CAS1_WORKFLOW_MANAGER role.