### PR TITLE
APS-1264 - send placement request booking email to placement request creator

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -92,14 +92,11 @@ class Cas1BookingEmailService(
   }
 
   fun buildCommonPersonalisation(application: ApplicationEntity, booking: BookingEntity): Map<String, Any> {
-    val applicationSubmittedByUser = application.createdByUser
-
     val lengthOfStayDays = booking.arrivalDate.getDaysUntilInclusive(booking.departureDate).size
     val lengthOfStayWeeks = lengthOfStayDays.toDouble() / DAYS_IN_WEEK
     val lengthOfStayWeeksWholeNumber = (lengthOfStayDays.toDouble() % DAYS_IN_WEEK) == 0.0
 
     return mapOf(
-      "name" to applicationSubmittedByUser.name,
       "apName" to booking.premises.name,
       "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
       "applicationTimelineUrl" to applicationTimelineUrlTemplate.resolve("applicationId", application.id.toString()),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -31,14 +31,17 @@ class Cas1BookingEmailService(
       booking,
     )
 
-    if (applicationSubmittedByUser.email != null) {
-      emailNotifier.sendEmail(
-        recipientEmailAddress = applicationSubmittedByUser.email!!,
-        templateId = notifyConfig.templates.bookingMade,
-        personalisation = emailPersonalisation,
-        application = application,
-      )
-    }
+    val applicants = setOfNotNull(
+      applicationSubmittedByUser.email,
+      booking.placementRequest?.placementApplication?.createdByUser?.email,
+    )
+
+    emailNotifier.sendEmails(
+      recipientEmailAddresses = applicants,
+      templateId = notifyConfig.templates.bookingMade,
+      personalisation = emailPersonalisation,
+      application = application,
+    )
 
     if (booking.premises.emailAddress != null) {
       emailNotifier.sendEmail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -39,6 +39,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
 
   fun withDefaults() = apply {
     this.createdByUser = { UserEntityFactory().withDefaultProbationRegion().produce() }
+    this.application = { ApprovedPremisesApplicationEntityFactory().withDefaults().produce() }
   }
 
   fun withId(id: UUID) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -96,7 +96,6 @@ class Cas1BookingEmailServiceTest {
         PREMISES_EMAIL,
         notifyConfig.templates.bookingMadePremises,
         mapOf(
-          "name" to applicant.name,
           "apName" to PREMISES_NAME,
           "applicationUrl" to "http://frontend/applications/${application.id}",
           "bookingUrl" to "http://frontend/premises/${premises.id}/bookings/${booking.id}",
@@ -130,7 +129,6 @@ class Cas1BookingEmailServiceTest {
       mockEmailNotificationService.assertEmailRequestCount(2)
 
       val personalisation = mapOf(
-        "name" to applicant.name,
         "apName" to PREMISES_NAME,
         "applicationUrl" to "http://frontend/applications/${application.id}",
         "bookingUrl" to "http://frontend/premises/${premises.id}/bookings/${booking.id}",


### PR DESCRIPTION
If the user who created a request for placement on the application did not originally created the application, they should also receive a booking made email