### PR TITLE
CAS-440 - Update to save assessments updates as domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/DomainEventUrlConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/DomainEventUrlConfig.kt
@@ -44,6 +44,7 @@ class DomainEventUrlConfig {
       DomainEventType.CAS3_REFERRAL_SUBMITTED -> cas3["referral-submitted-event-detail"]
       DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED -> cas3["person-departure-updated-event-detail"]
       DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED -> cas3["booking-cancelled-updated-event-detail"]
+      DomainEventType.CAS3_ASSESSMENT_UPDATED -> throw IllegalArgumentException("Don't emit for $domainEventType")
     } ?: throw IllegalStateException("Missing URL for $domainEventType")
 
     return template.resolve("eventId", eventId.toString())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -335,4 +335,10 @@ enum class DomainEventType(
     "A cancelled booking for a Transitional Accommodation premises has been updated",
     null,
   ),
+  CAS3_ASSESSMENT_UPDATED(
+    DomainEventCas.CAS3,
+    Cas3EventType.assessmentUpdated.value,
+    "A field has been updated on an assessment",
+    null,
+  ),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3AssessmentService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3AssessmentUpdatedField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
@@ -8,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.findAssessmentById
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
 import java.time.LocalDate
 import java.util.UUID
 
@@ -15,8 +17,9 @@ import java.util.UUID
 class Cas3AssessmentService(
   private val assessmentRepository: AssessmentRepository,
   private val userAccessService: UserAccessService,
+  private val domainEventService: DomainEventService,
+  private val domainEventBuilder: DomainEventBuilder,
 ) {
-
   @Suppress("ReturnCount")
   fun updateAssessment(
     user: UserEntity,
@@ -36,22 +39,60 @@ class Cas3AssessmentService(
       return CasResult.GeneralValidationError("Cannot update both dates")
     }
 
-    updateAssessment.releaseDate?.apply {
-      if (this.isAfter(assessment.currentAccommodationRequiredFromDate())) return notAfterValidationResult(assessment.currentAccommodationRequiredFromDate())
-      assessment.releaseDate = this
+    updateAssessment.releaseDate?.let { newReleaseDate ->
+      val currentAccommodationReqDate = assessment.currentAccommodationRequiredFromDate()
+
+      if (newReleaseDate.isAfter(currentAccommodationReqDate)) {
+        return notAfterValidationResult(currentAccommodationReqDate)
+      }
+
+      val domainEvent =
+        domainEventBuilder.buildAssessmentUpdatedDomainEvent(
+          assessment = assessment,
+          listOf(
+            CAS3AssessmentUpdatedField(
+              fieldName = "releaseDate",
+              updatedFrom = assessment.currentReleaseDate().toUiFormat(),
+              updatedTo = newReleaseDate.toUiFormat(),
+            ),
+          ),
+        )
+      domainEventService.saveAssessmentUpdatedEvent(domainEvent)
+      assessment.releaseDate = newReleaseDate
     }
 
-    updateAssessment.accommodationRequiredFromDate?.apply {
-      if (this.isBefore(assessment.currentReleaseDate())) return notBeforeValidationResult(assessment.currentReleaseDate())
-      assessment.accommodationRequiredFromDate = this
+    updateAssessment.accommodationRequiredFromDate?.let { newAccommodationRequiredFromDate ->
+      val currentReleaseDate = assessment.currentReleaseDate()
+
+      if (newAccommodationRequiredFromDate.isBefore(currentReleaseDate)) {
+        return notBeforeValidationResult(currentReleaseDate)
+      }
+
+      val domainEvent =
+        domainEventBuilder.buildAssessmentUpdatedDomainEvent(
+          assessment = assessment,
+          listOf(
+            CAS3AssessmentUpdatedField(
+              fieldName = "accommodationRequiredFromDate",
+              updatedFrom = assessment.currentAccommodationRequiredFromDate().toUiFormat(),
+              updatedTo = newAccommodationRequiredFromDate.toUiFormat(),
+            ),
+          ),
+        )
+      domainEventService.saveAssessmentUpdatedEvent(domainEvent)
+      assessment.accommodationRequiredFromDate = newAccommodationRequiredFromDate
     }
 
     return CasResult.Success(assessmentRepository.save(assessment))
   }
 
   private fun notBeforeValidationResult(existingDate: LocalDate) =
-    CasResult.GeneralValidationError<TemporaryAccommodationAssessmentEntity>("Accommodation required from date cannot be before release date: $existingDate")
+    CasResult.GeneralValidationError<TemporaryAccommodationAssessmentEntity>(
+      "Accommodation required from date cannot be before release date: $existingDate",
+    )
 
   private fun notAfterValidationResult(existingDate: LocalDate) =
-    CasResult.GeneralValidationError<TemporaryAccommodationAssessmentEntity>("Release date cannot be after accommodation required from date: $existingDate")
+    CasResult.GeneralValidationError<TemporaryAccommodationAssessmentEntity>(
+      "Release date cannot be after accommodation required from date: $existingDate",
+    )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/DomainEventBuilder.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3AssessmentUpdatedEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3AssessmentUpdatedField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3BookingCancelledEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3BookingCancelledEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas3.model.CAS3BookingCancelledUpdatedEvent
@@ -26,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import java.net.URI
@@ -40,7 +43,7 @@ class DomainEventBuilder(
 ) {
   fun getBookingCancelledDomainEvent(
     booking: BookingEntity,
-    user: UserEntity?,
+    user: UserEntity,
   ): DomainEvent<CAS3BookingCancelledEvent> {
     val domainEventId = UUID.randomUUID()
 
@@ -210,6 +213,27 @@ class DomainEventBuilder(
           applicationUrl = application.toUrl()!!,
         ),
       ),
+    )
+  }
+
+  fun buildAssessmentUpdatedDomainEvent(
+    assessment: TemporaryAccommodationAssessmentEntity,
+    updatedFields: List<CAS3AssessmentUpdatedField>,
+  ): DomainEvent<CAS3AssessmentUpdatedEvent> {
+    val id = UUID.randomUUID()
+    val now = Instant.now()
+    return DomainEvent(
+      id = id,
+      crn = assessment.application.crn,
+      occurredAt = now,
+      data = CAS3AssessmentUpdatedEvent(
+        id = id,
+        updatedFields = updatedFields,
+        eventType = EventType.assessmentUpdated,
+        timestamp = now,
+      ),
+      assessmentId = assessment.id,
+      nomsNumber = null,
     )
   }
 

--- a/src/main/resources/static/cas3-domain-events-api.yml
+++ b/src/main/resources/static/cas3-domain-events-api.yml
@@ -551,7 +551,30 @@ components:
         - personReference
         - applicationId
         - applicationUrl
-
+    CAS3AssessmentUpdatedEvent:
+      allOf:
+        - $ref: '#/components/schemas/CAS3Event'
+      type: object
+      properties:
+        updatedFields:
+          type: array
+          items:
+           $ref: '#/components/schemas/CAS3AssessmentUpdatedField'
+      required:
+        - updatedFields
+    CAS3AssessmentUpdatedField:
+      type: object
+      properties:
+        fieldName:
+          type: string
+        updatedFrom:
+          type: string
+        updatedTo:
+          type: string
+      required:
+        - fieldName
+        - updatedFrom
+        - updatedTo
     # Common domain schemas
     PersonReference:
       type: object
@@ -600,6 +623,7 @@ components:
         - accommodation.cas3.person.departed
         - accommodation.cas3.referral.submitted
         - accommodation.cas3.person.departed.updated
+        - accommodation.cas3.assessment.updated
       x-enum-varnames:
         - bookingCancelled
         - bookingCancelledUpdated
@@ -610,6 +634,7 @@ components:
         - personDeparted
         - referralSubmitted
         - personDepartureUpdated
+        - assessmentUpdated
     Problem:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -249,4 +249,8 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     prisonReleaseTypes = this.prisonReleaseTypes(),
     probationDeliveryUnit = this.probationDeliveryUnit(),
   )
+
+  fun withDefaults() = TemporaryAccommodationApplicationEntityFactory()
+    .withCreatedByUser(UserEntityFactory.DEFAULT)
+    .withProbationRegion(ProbationRegionEntityFactory().withDefaults().produce())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -2857,12 +2857,20 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("$.releaseDate").isEqualTo(newReleaseDate.toString())
           .jsonPath("$.accommodationRequiredFromDate").isEqualTo(accommodationDateFromApplication.toString())
+
+        val domainEvents =
+          domainEventRepository.findByAssessmentIdAndType(
+            assessmentId = assessment.id,
+            type = DomainEventType.CAS3_ASSESSMENT_UPDATED,
+          )
+
+        assertThat(domainEvents.size).isEqualTo(1)
       }
     }
   }
 
   @Test
-  fun `PUT Update accommodation required from date on temporary accommodation assessment `() {
+  fun `PUT Update accommodation required from date on temporary accommodation assessment`() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR, UserRole.CAS3_REPORTER)) { userEntity, jwt ->
       `Given an Offender` { offenderDetails, inmateDetails ->
 
@@ -2909,6 +2917,14 @@ class AssessmentTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("$.releaseDate").isEqualTo(releaseDateFromApplication.toString())
           .jsonPath("$.accommodationRequiredFromDate").isEqualTo(newAccommodationDate.toString())
+
+        val domainEvents =
+          domainEventRepository.findByAssessmentIdAndType(
+            assessmentId = assessment.id,
+            type = DomainEventType.CAS3_ASSESSMENT_UPDATED,
+          )
+
+        assertThat(domainEvents.size).isEqualTo(1)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
@@ -3,10 +3,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import java.util.UUID
 
 @Repository
 interface DomainEventTestRepository : JpaRepository<DomainEventEntity, UUID> {
   fun findFirstByOrderByCreatedAtDesc(): DomainEventEntity?
   fun findByApplicationId(applicationId: UUID): List<DomainEventEntity>
+  fun findByAssessmentIdAndType(assessmentId: UUID, type: DomainEventType): List<DomainEventEntity>
 }


### PR DESCRIPTION
This PR is the second phase in adding assessment updates, where a change will now be saved as a domain event that will **not** be emitted to delius. The next step is to add a migration script to back track any changes up to now, and then returning the domain events will be in an additional PR