### PR TITLE
decrease case-notes-api client timeout

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -262,7 +262,7 @@ preemptive-cache-lock-duration-ms: 1800000
 arrived-departed-domain-events-disabled: true
 
 upstream-timeout-ms: 10000
-case-notes-service-upstream-timeout-ms: 30000
+case-notes-service-upstream-timeout-ms: 25000
 
 web-clients:
   # 0.7MB


### PR DESCRIPTION
previously this was set to 30 seconds. given our API client timeout is also 30 seconds, this meant that we’d typically timeout the client before timing out calls to case notes. this commit changes the prison-api timeout to 25 seconds to ensure it will timeout before timing out the client