### PR TITLE
APS-1264 send booking made email to pr creator

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -307,7 +307,11 @@ class BookingService(
         user = user,
         placementRequest = placementRequest,
       )
-      cas1BookingEmailService.bookingMade(placementRequest.application, booking)
+      cas1BookingEmailService.bookingMade(
+        application = placementRequest.application,
+        booking = booking,
+        placementApplication = placementRequest.placementApplication,
+      )
 
       return@validated success(booking)
     }
@@ -458,7 +462,11 @@ class BookingService(
         )
 
         if (onlineApplication != null) {
-          cas1BookingEmailService.bookingMade(onlineApplication, booking)
+          cas1BookingEmailService.bookingMade(
+            application = onlineApplication,
+            booking = booking,
+            placementApplication = null,
+          )
         }
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Constants.DAYS_IN_WEEK
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
@@ -23,7 +24,11 @@ class Cas1BookingEmailService(
   @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,
 ) {
 
-  fun bookingMade(application: ApprovedPremisesApplicationEntity, booking: BookingEntity) {
+  fun bookingMade(
+    application: ApprovedPremisesApplicationEntity,
+    booking: BookingEntity,
+    placementApplication: PlacementApplicationEntity?,
+  ) {
     val applicationSubmittedByUser = application.createdByUser
 
     val emailPersonalisation = buildCommonPersonalisation(
@@ -33,7 +38,7 @@ class Cas1BookingEmailService(
 
     val applicants = setOfNotNull(
       applicationSubmittedByUser.email,
-      booking.placementRequest?.placementApplication?.createdByUser?.email,
+      placementApplication?.createdByUser?.email,
     )
 
     emailNotifier.sendEmails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1350,7 +1350,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
   @Nested
   inner class CreateBookingFromPlacementRequest {
     @Test
-    fun `Create a Booking from a Placement Request without a JWT returns 401`() {
+    fun `Create a Booking from PR without a JWT returns 401`() {
       webTestClient.post()
         .uri("/placement-requests/62faf6f4-1dac-4139-9a18-09c1b2852a0f/booking")
         .bodyValue(
@@ -1366,7 +1366,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Creating a Booking from a Placement Request creates a domain event and sends booking made emails`() {
+    fun `Create a Booking from a PR creates a domain event and sends booking made emails`() {
       `Given a User` { user, jwt ->
         `Given a User` { applicant, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -1428,10 +1428,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Creating a Booking from a Placement Request that is not allocated to the User returns a 403`() {
-      `Given a User` { user, jwt ->
+    fun `Create a Booking from a PR allocated to another user returns a 403`() {
+      `Given a User` { _, jwt ->
         `Given a User` { otherUser, _ ->
-          `Given an Offender` { offenderDetails, inmateDetails ->
+          `Given an Offender` { offenderDetails, _ ->
             `Given an Application`(createdByUser = otherUser) {
               `Given a Placement Request`(
                 placementRequestAllocatedTo = otherUser,
@@ -1460,7 +1460,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Creating a Booking from a Placement Request that is allocated to the User returns a 200 and sends email`() {
+    fun `Create a Booking from a PR for bed id returns a 200`() {
       `Given a User` { user, jwt ->
         `Given a User` { applicant, _ ->
           `Given an Offender` { offenderDetails, _ ->
@@ -1507,10 +1507,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Creating a Booking from a Placement Request that is allocated to the User and a premisesId is specified returns a 200`() {
+    fun `Create a Booking from a PR for premises id returns a 200`() {
       `Given a User` { user, jwt ->
         `Given a User` { otherUser, _ ->
-          `Given an Offender` { offenderDetails, inmateDetails ->
+          `Given an Offender` { offenderDetails, _ ->
             `Given an Application`(createdByUser = otherUser) {
               `Given a Placement Request`(
                 placementRequestAllocatedTo = user,
@@ -1547,10 +1547,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Creating a Booking from a Placement Request that is not allocated to the User and the user is a Workflow Manager returns a 200`() {
+    fun `Create a Booking from a PR allocated to other user and current user is a Workflow Manager returns a 200`() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given a User` { otherUser, _ ->
-          `Given an Offender` { offenderDetails, inmateDetails ->
+          `Given an Offender` { offenderDetails, _ ->
             `Given an Application`(createdByUser = otherUser) {
               `Given a Placement Request`(
                 placementRequestAllocatedTo = user,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -18,7 +18,7 @@ import java.time.OffsetDateTime
 fun IntegrationTestBase.`Given a Placement Application`(
   assessmentDecision: AssessmentDecision = AssessmentDecision.ACCEPTED,
   createdByUser: UserEntity,
-  schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity,
+  schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity? = null,
   crn: String = randomStringMultiCaseWithNumbers(8),
   allocatedToUser: UserEntity? = null,
   submittedAt: OffsetDateTime? = null,
@@ -69,7 +69,11 @@ fun IntegrationTestBase.`Given a Placement Application`(
     withCreatedByUser(createdByUser)
     withAllocatedToUser(allocatedToUser)
     withApplication(application)
-    withSchemaVersion(schema)
+    withSchemaVersion(
+      schema ?: approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+        withPermissiveSchema()
+      },
+    )
     withSubmittedAt(submittedAt)
     withDecision(decision)
     withDecisionMadeAt(decisionMadeAt)
@@ -82,10 +86,11 @@ fun IntegrationTestBase.`Given a Placement Application`(
   }
 }
 
+@SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.`Given a Placement Application`(
   assessmentDecision: AssessmentDecision = AssessmentDecision.ACCEPTED,
   createdByUser: UserEntity,
-  schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity,
+  schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity? = null,
   crn: String = randomStringMultiCaseWithNumbers(8),
   allocatedToUser: UserEntity? = null,
   submittedAt: OffsetDateTime? = null,
@@ -98,7 +103,9 @@ fun IntegrationTestBase.`Given a Placement Application`(
   val placementApplication = `Given a Placement Application`(
     assessmentDecision = assessmentDecision,
     createdByUser = createdByUser,
-    schema = schema,
+    schema = schema ?: approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    },
     crn = crn,
     allocatedToUser = allocatedToUser,
     submittedAt = submittedAt,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -177,6 +177,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   duration: Int? = null,
   applicationSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
   assessmentSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
+  placementApplication: PlacementApplicationEntity? = null,
   block: (placementRequest: PlacementRequestEntity, application: ApplicationEntity) -> Unit,
 ) {
   val result = `Given a Placement Request`(
@@ -194,6 +195,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
     duration = duration,
     applicationSubmittedAt = applicationSubmittedAt,
     assessmentSubmittedAt = assessmentSubmittedAt,
+    placementApplication = placementApplication,
   )
 
   block(result.first, result.second)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -4328,7 +4328,7 @@ class BookingServiceTest {
       every { mockBookingRepository.save(any()) } answers { bookingEntity }
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
       every { mockCas1BookingDomainEventService.adhocBookingMade(any(), any(), any(), any(), any()) } just Runs
-      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any(), any()) } just Runs
     }
 
     @Test
@@ -4507,7 +4507,7 @@ class BookingServiceTest {
         )
       }
 
-      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(application, booking) }
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(application, booking, placementApplication = null) }
     }
 
     @ParameterizedTest
@@ -4554,7 +4554,7 @@ class BookingServiceTest {
         )
       }
 
-      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(existingApplication, booking) }
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(existingApplication, booking, placementApplication = null) }
     }
 
     @Test
@@ -4601,7 +4601,7 @@ class BookingServiceTest {
         )
       }
 
-      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(existingApplication, booking) }
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(existingApplication, booking, placementApplication = null) }
     }
 
     @ParameterizedTest
@@ -6402,7 +6402,7 @@ class BookingServiceTest {
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
       every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
-      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -6456,7 +6456,7 @@ class BookingServiceTest {
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
       every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
-      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -6535,7 +6535,7 @@ class BookingServiceTest {
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
       every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
-      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -6600,7 +6600,7 @@ class BookingServiceTest {
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockPlacementRequestRepository.save(any()) } answers { it.invocation.args[0] as PlacementRequestEntity }
       every { mockCas1BookingDomainEventService.bookingMade(any(), any(), any(), any()) } just Runs
-      every { mockCas1BookingEmailService.bookingMade(any(), any()) } just Runs
+      every { mockCas1BookingEmailService.bookingMade(any(), any(), any()) } just Runs
 
       val authorisableResult = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = workflowManager,
@@ -6663,7 +6663,13 @@ class BookingServiceTest {
     }
 
     private fun assertEmailsSent(application: ApprovedPremisesApplicationEntity, booking: BookingEntity) {
-      verify(exactly = 1) { mockCas1BookingEmailService.bookingMade(application, booking) }
+      verify(exactly = 1) {
+        mockCas1BookingEmailService.bookingMade(
+          application = application,
+          booking = booking,
+          placementApplication = null,
+        )
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -93,7 +93,11 @@ class Cas1BookingEmailServiceTest {
         departureDate = LocalDate.of(2023, 2, 14),
       )
 
-      service.bookingMade(application, booking)
+      service.bookingMade(
+        application = application,
+        booking = booking,
+        placementApplication = null,
+      )
 
       mockEmailNotificationService.assertEmailRequestCount(1)
       mockEmailNotificationService.assertEmailRequested(
@@ -128,7 +132,11 @@ class Cas1BookingEmailServiceTest {
         departureDate = LocalDate.of(2023, 2, 14),
       )
 
-      service.bookingMade(application, booking)
+      service.bookingMade(
+        application = application,
+        booking = booking,
+        placementApplication = null,
+      )
 
       mockEmailNotificationService.assertEmailRequestCount(2)
 
@@ -172,7 +180,11 @@ class Cas1BookingEmailServiceTest {
         departureDate = LocalDate.of(2023, 2, 27),
       )
 
-      service.bookingMade(application, booking)
+      service.bookingMade(
+        application = application,
+        booking = booking,
+        placementApplication = null,
+      )
 
       mockEmailNotificationService.assertEmailRequestCount(2)
 
@@ -211,22 +223,25 @@ class Cas1BookingEmailServiceTest {
         departureDate = LocalDate.of(2023, 2, 14),
       )
 
-      booking.placementRequest = PlacementRequestEntityFactory()
+      val placementApplication = PlacementApplicationEntityFactory()
         .withDefaults()
-        .withPlacementApplication(
-          PlacementApplicationEntityFactory()
-            .withDefaults()
-            .withCreatedByUser(
-              UserEntityFactory()
-                .withUnitTestControlProbationRegion()
-                .withEmail(PLACEMENT_APPLICATION_CREATOR_EMAIL)
-                .produce(),
-            )
+        .withCreatedByUser(
+          UserEntityFactory()
+            .withUnitTestControlProbationRegion()
+            .withEmail(PLACEMENT_APPLICATION_CREATOR_EMAIL)
             .produce(),
         )
         .produce()
 
-      service.bookingMade(application, booking)
+      booking.placementRequest = PlacementRequestEntityFactory()
+        .withDefaults()
+        .produce()
+
+      service.bookingMade(
+        application = application,
+        booking = booking,
+        placementApplication = placementApplication,
+      )
 
       mockEmailNotificationService.assertEmailRequestCount(3)
 


### PR DESCRIPTION
a change was made on https://github.com/ministryofjustice/hmpps-approved-premises-api/commit/e8c803178839a27feec829a36edc2ecd803b1c95 to sending booking emails to placement request creators, if it’s a different user to the application creator. This change did not work because it assumed the relationship between booking and placement request was populated when the code was called, which was not the case.

This commit reworks the functionality in Cas1BookingEmailService, updating the function to be explicitly provided with the placement request (PlacementApplicationEntity). It also adds an integration test for this scenario.