### PR TITLE
APS-1274 Harmonise OOSB Reasons across environments

### DIFF
--- a/src/main/resources/db/migration/all/20240909111543__harmonise_out_of_service_bed_reasons_across_all_envs.sql
+++ b/src/main/resources/db/migration/all/20240909111543__harmonise_out_of_service_bed_reasons_across_all_envs.sql
@@ -1,0 +1,28 @@
+
+INSERT INTO cas1_out_of_service_bed_reasons(id, created_at, name, is_active)
+SELECT '2f46e769-17a5-4b5c-b04a-a5a9a5b3f773',now(),'Planned Refurbishment',true
+WHERE NOT EXISTS ( SELECT id FROM cas1_out_of_service_bed_reasons WHERE id = '2f46e769-17a5-4b5c-b04a-a5a9a5b3f773');
+
+INSERT INTO cas1_out_of_service_bed_reasons(id, created_at, name, is_active)
+SELECT '34467c03-b919-4423-b4e2-e0dc92520a56',now(),'Damage by Resident',true
+WHERE NOT EXISTS ( SELECT id FROM cas1_out_of_service_bed_reasons WHERE id = '34467c03-b919-4423-b4e2-e0dc92520a56');
+
+INSERT INTO cas1_out_of_service_bed_reasons(id, created_at, name, is_active)
+SELECT '2e947d1a-c547-4a09-9b76-76a609771307',now(),'Accident/Flood/Fire',true
+WHERE NOT EXISTS ( SELECT id FROM cas1_out_of_service_bed_reasons WHERE id = '2e947d1a-c547-4a09-9b76-76a609771307');
+
+INSERT INTO cas1_out_of_service_bed_reasons(id, created_at, name, is_active)
+SELECT 'abd5af8d-8f8c-469a-8e22-85635f99ec0d',now(),'Staff Shortage/Illness',true
+WHERE NOT EXISTS ( SELECT id FROM cas1_out_of_service_bed_reasons WHERE id = 'abd5af8d-8f8c-469a-8e22-85635f99ec0d');
+
+INSERT INTO cas1_out_of_service_bed_reasons(id, created_at, name, is_active)
+SELECT 'ce0c151c-dda5-450c-8a7f-ca8895fecd04',now(),'Double Room with Single occupancy - risk',true
+WHERE NOT EXISTS ( SELECT id FROM cas1_out_of_service_bed_reasons WHERE id = 'ce0c151c-dda5-450c-8a7f-ca8895fecd04');
+
+INSERT INTO cas1_out_of_service_bed_reasons(id, created_at, name, is_active)
+SELECT '55594aa8-1ae1-4a3c-b6f3-7bb55ff14807',now(),'Double room with single occupancy - health',true
+WHERE NOT EXISTS ( SELECT id FROM cas1_out_of_service_bed_reasons WHERE id = '55594aa8-1ae1-4a3c-b6f3-7bb55ff14807');
+
+INSERT INTO cas1_out_of_service_bed_reasons(id, created_at, name, is_active)
+SELECT '6943e9e7-ffae-44ba-b2f4-bc299af8773c',now(),'Planned FM works required',true
+WHERE NOT EXISTS ( SELECT id FROM cas1_out_of_service_bed_reasons WHERE id = '6943e9e7-ffae-44ba-b2f4-bc299af8773c');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
@@ -11,6 +11,8 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `All available out-of-service bed reasons are returned`() {
+    cas1OutOfServiceBedReasonTestRepository.deleteAll()
+
     val activeReason1 = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist {
       withIsActive(true)
       withName("Active reason 1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1OutOfServiceBedReasonsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1OutOfServiceBedReasonsTest.kt
@@ -9,6 +9,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.Mi
 class MigrateCas1OutOfServiceBedReasonsTest : MigrationJobTestBase() {
   @Test
   fun `Job migrates expected set of lost bed reasons`() {
+    cas1OutOfServiceBedReasonTestRepository.deleteAll()
+
     val approvedPremisesLostBedReasons = lostBedReasonRepository
       .findAll()
       .filter { listOf("*", ServiceName.approvedPremises.value).contains(it.serviceScope) }


### PR DESCRIPTION
Before this commit the cas1_out_of_service_bed_reasons reference data was populated using the update_cas1_out_of_service_bed_reasons migration job, which copied the data from the lost beds reasons table.

This is awkward when testing locally because we have to remember to run the migration job step.

This commits adds a migration script that populates the update_cas1_out_of_service_bed_reasons, where they don’t already exist. This will have no affect on environments where this data is already populated (e.g. prod, preprod, dev)