### PR TITLE
APS-1284 - Allow call to /swagger-ui.html

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -45,6 +45,7 @@ class OAuth2ResourceServerSecurityConfiguration {
       csrf { disable() }
 
       authorizeHttpRequests {
+        authorize(HttpMethod.GET, "/swagger-ui.html", permitAll)
         authorize(HttpMethod.GET, "/health/**", permitAll)
         authorize(HttpMethod.GET, "/swagger-ui/**", permitAll)
         authorize(HttpMethod.GET, "/v3/api-docs/swagger-config", permitAll)


### PR DESCRIPTION
We often receive an AuthenticationCredentialsNotFoundException for GET /swagger-ui.html. This is a legitimate call which should redirect to swagger-ui/index.html. Therefore, this request should be allowed