### PR TITLE
APS-1285 Add exception handler for NoResourceFoundException

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -18,6 +18,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 import org.springframework.web.util.ContentCachingRequestWrapper
 import org.zalando.problem.Problem
 import org.zalando.problem.Status
@@ -46,6 +47,10 @@ class ExceptionHandling(
 
     if (throwable is AccessDeniedException) {
       return ForbiddenProblem()
+    }
+
+    if (throwable is NoResourceFoundException) {
+      return NotFoundResourceProblem()
     }
 
     if (throwable is MissingRequestHeaderException) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundResourceProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundResourceProblem.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import org.zalando.problem.AbstractThrowableProblem
+import org.zalando.problem.Exceptional
+import org.zalando.problem.Status
+
+class NotFoundResourceProblem : AbstractThrowableProblem(null, "Not Found", Status.NOT_FOUND, "Resource not found") {
+  override fun getCause(): Exceptional? {
+    return null
+  }
+}


### PR DESCRIPTION
We currently receive Sentry Alerts for NoResourceFoundException errors because our custom exception handler doesn’t know how to deal with this exception (note, this exception has only started appearing since upgrading to spring boot 3).

This PR adds exception handling for NoResourceFoundException, ensuring we no longer receive sentry alerts for these issues. Note that a WARN is still logged.