### PR TITLE
CAS-463 Extend bedsearch to search up to 5 PDUs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
@@ -36,6 +36,7 @@ class BedSearchController(
       is TemporaryAccommodationBedSearchParameters -> bedSearchService.findTemporaryAccommodationBeds(
         user = user,
         probationDeliveryUnit = bedSearchParameters.probationDeliveryUnit,
+        probationDeliveryUnits = bedSearchParameters.probationDeliveryUnits,
         startDate = bedSearchParameters.startDate,
         durationInDays = bedSearchParameters.durationDays,
         propertyBedAttributes = bedSearchParameters.attributes,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationDeliveryUnitEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ProbationDeliveryUnitEntity.kt
@@ -18,6 +18,8 @@ interface ProbationDeliveryUnitRepository : JpaRepository<ProbationDeliveryUnitE
 
   fun findByNameAndProbationRegion_Id(name: String, probationRegionId: UUID): ProbationDeliveryUnitEntity?
 
+  fun findByName(name: String): ProbationDeliveryUnitEntity?
+
   fun findByDeliusCode(deliusCode: String): ProbationDeliveryUnitEntity?
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedSearchResultTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedSearchResultTransformer.kt
@@ -71,6 +71,7 @@ class BedSearchResultTransformer {
         },
         addressLine2 = result.premisesAddressLine2,
         town = result.premisesTown,
+        probationDeliveryUnitName = result.probationDeliveryUnitName,
         bedCount = result.premisesBedCount,
       ),
       room = BedSearchResultRoomSummary(

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4210,13 +4210,17 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            probationDeliveryUnits:
+              type: array
+              description: The list of pdus Ids to search within
+              items:
+                type: string
+                format: uuid
             attributes:
               type: array
               description: Bedspace and property attributes to filter on
               items:
                 $ref: "_shared.yml#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnit
     BedSearchResults:
       type: object
       properties:
@@ -4313,6 +4317,8 @@ components:
         town:
           type: string
         postcode:
+          type: string
+        probationDeliveryUnitName:
           type: string
         characteristics:
           type: array

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8676,13 +8676,17 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            probationDeliveryUnits:
+              type: array
+              description: The list of pdus Ids to search within
+              items:
+                type: string
+                format: uuid
             attributes:
               type: array
               description: Bedspace and property attributes to filter on
               items:
                 $ref: "#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnit
     BedSearchResults:
       type: object
       properties:
@@ -8779,6 +8783,8 @@ components:
         town:
           type: string
         postcode:
+          type: string
+        probationDeliveryUnitName:
           type: string
         characteristics:
           type: array

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5197,13 +5197,17 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            probationDeliveryUnits:
+              type: array
+              description: The list of pdus Ids to search within
+              items:
+                type: string
+                format: uuid
             attributes:
               type: array
               description: Bedspace and property attributes to filter on
               items:
                 $ref: "#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnit
     BedSearchResults:
       type: object
       properties:
@@ -5300,6 +5304,8 @@ components:
         town:
           type: string
         postcode:
+          type: string
+        probationDeliveryUnitName:
           type: string
         characteristics:
           type: array

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4801,13 +4801,17 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            probationDeliveryUnits:
+              type: array
+              description: The list of pdus Ids to search within
+              items:
+                type: string
+                format: uuid
             attributes:
               type: array
               description: Bedspace and property attributes to filter on
               items:
                 $ref: "#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnit
     BedSearchResults:
       type: object
       properties:
@@ -4904,6 +4908,8 @@ components:
         town:
           type: string
         postcode:
+          type: string
+        probationDeliveryUnitName:
           type: string
         characteristics:
           type: array

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4301,13 +4301,17 @@ components:
             probationDeliveryUnit:
               type: string
               description: The pdu to search within
+            probationDeliveryUnits:
+              type: array
+              description: The list of pdus Ids to search within
+              items:
+                type: string
+                format: uuid
             attributes:
               type: array
               description: Bedspace and property attributes to filter on
               items:
                 $ref: "#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnit
     BedSearchResults:
       type: object
       properties:
@@ -4404,6 +4408,8 @@ components:
         town:
           type: string
         postcode:
+          type: string
+        probationDeliveryUnitName:
           type: string
         characteristics:
           type: array

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationBedSearchResultFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationBedSearchResultFactory.kt
@@ -17,6 +17,7 @@ class TemporaryAccommodationBedSearchResultFactory : Factory<TemporaryAccommodat
   private var premisesAddressLine2: Yielded<String?> = { null }
   private var premisesTown: Yielded<String?> = { null }
   private var premisesPostcode: Yielded<String> = { randomStringUpperCase(6) }
+  private var probationDeliveryUnitName: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var premisesCharacteristics: Yielded<MutableList<CharacteristicNames>> = { mutableListOf() }
   private var roomId: Yielded<UUID> = { UUID.randomUUID() }
   private var roomName: Yielded<String> = { randomStringUpperCase(6) }
@@ -48,6 +49,10 @@ class TemporaryAccommodationBedSearchResultFactory : Factory<TemporaryAccommodat
 
   fun withPremisesPostcode(premisesPostcode: String) = apply {
     this.premisesPostcode = { premisesPostcode }
+  }
+
+  fun withProbationDeliveryUnitName(probationDeliveryUnitName: String) = apply {
+    this.probationDeliveryUnitName = { probationDeliveryUnitName }
   }
 
   fun withPremisesCharacteristics(premisesCharacteristics: MutableList<CharacteristicNames>) = apply {
@@ -89,6 +94,7 @@ class TemporaryAccommodationBedSearchResultFactory : Factory<TemporaryAccommodat
     premisesAddressLine2 = this.premisesAddressLine2(),
     premisesTown = this.premisesTown(),
     premisesPostcode = this.premisesPostcode(),
+    probationDeliveryUnitName = this.probationDeliveryUnitName(),
     premisesCharacteristics = this.premisesCharacteristics(),
     roomId = this.roomId(),
     roomName = this.roomName(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
@@ -734,7 +734,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
     bedsThatShouldNotAppearInSearchResults += bedOneInRoomInPremisesInOtherProbationRegion
 
     val results = bedSearchRepository.findTemporaryAccommodationBeds(
-      probationDeliveryUnit = searchPdu.name,
+      probationDeliveryUnits = listOf(searchPdu.id),
       startDate = LocalDate.parse("2023-03-09"),
       endDate = LocalDate.parse("2023-03-15"),
       probationRegionId = probationRegion.id,
@@ -931,7 +931,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
     bedsThatShouldNotAppearInSearchResults += bedOneInRoomOneInNonActivePremises
 
     val results = bedSearchRepository.findTemporaryAccommodationBeds(
-      probationDeliveryUnit = searchPdu.name,
+      probationDeliveryUnits = listOf(searchPdu.id),
       startDate = LocalDate.parse("2024-08-29"),
       endDate = LocalDate.parse("2024-09-15"),
       probationRegionId = probationRegion.id,
@@ -1129,7 +1129,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
     bedsThatShouldNotAppearInSearchResults += bedOneInRoomOneInNonActivePremises
 
     val results = bedSearchRepository.findTemporaryAccommodationBeds(
-      probationDeliveryUnit = searchPdu.name,
+      probationDeliveryUnits = listOf(searchPdu.id),
       startDate = LocalDate.parse("2024-08-29"),
       endDate = LocalDate.parse("2024-09-15"),
       probationRegionId = probationRegion.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -236,6 +236,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premises.name,
                       addressLine1 = premises.addressLine1,
                       postcode = premises.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premises.addressLine2,
                       town = premises.town,
@@ -472,6 +473,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premises.name,
                       addressLine1 = premises.addressLine1,
                       postcode = premises.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premises.addressLine2,
                       town = premises.town,
@@ -616,6 +618,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premisesOne.name,
                       addressLine1 = premisesOne.addressLine1,
                       postcode = premisesOne.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premisesOne.addressLine2,
                       town = premisesOne.town,
@@ -646,6 +649,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premisesTwo.name,
                       addressLine1 = premisesTwo.addressLine1,
                       postcode = premisesTwo.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premisesTwo.addressLine2,
                       town = premisesTwo.town,
@@ -753,6 +757,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premises.name,
                       addressLine1 = premises.addressLine1,
                       postcode = premises.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premises.addressLine2,
                       town = premises.town,
@@ -776,6 +781,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premises.name,
                       addressLine1 = premises.addressLine1,
                       postcode = premises.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premises.addressLine2,
                       town = premises.town,
@@ -885,6 +891,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premises.name,
                       addressLine1 = premises.addressLine1,
                       postcode = premises.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premises.addressLine2,
                       town = premises.town,
@@ -908,6 +915,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premises.name,
                       addressLine1 = premises.addressLine1,
                       postcode = premises.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premises.addressLine2,
                       town = premises.town,
@@ -1030,6 +1038,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premisesOne.name,
                       addressLine1 = premisesOne.addressLine1,
                       postcode = premisesOne.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(
                         CharacteristicPair(
                           propertyName = sharedPropertyPropertyName,
@@ -1058,6 +1067,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premisesThree.name,
                       addressLine1 = premisesThree.addressLine1,
                       postcode = premisesThree.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(
                         CharacteristicPair(
                           propertyName = sharedPropertyPropertyName,
@@ -1187,6 +1197,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premisesOne.name,
                       addressLine1 = premisesOne.addressLine1,
                       postcode = premisesOne.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(
                         CharacteristicPair(
                           propertyName = singleOccupancyPropertyName,
@@ -1219,6 +1230,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premisesTwo.name,
                       addressLine1 = premisesTwo.addressLine1,
                       postcode = premisesTwo.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(
                         CharacteristicPair(
                           propertyName = singleOccupancyPropertyName,
@@ -1369,6 +1381,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premises.name,
                       addressLine1 = premises.addressLine1,
                       postcode = premises.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premises.addressLine2,
                       town = premises.town,
@@ -1458,6 +1471,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premises.name,
                       addressLine1 = premises.addressLine1,
                       postcode = premises.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premises.addressLine2,
                       town = premises.town,
@@ -1601,6 +1615,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premisesOne.name,
                       addressLine1 = premisesOne.addressLine1,
                       postcode = premisesOne.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premisesOne.addressLine2,
                       town = premisesOne.town,
@@ -1624,6 +1639,7 @@ class BedSearchTest : IntegrationTestBase() {
                       name = premisesOne.name,
                       addressLine1 = premisesOne.addressLine1,
                       postcode = premisesOne.postcode,
+                      probationDeliveryUnitName = searchPdu.name,
                       characteristics = listOf(),
                       addressLine2 = premisesOne.addressLine2,
                       town = premisesOne.town,
@@ -1637,6 +1653,169 @@ class BedSearchTest : IntegrationTestBase() {
                     bed = BedSearchResultBedSummary(
                       id = bedTwo.id,
                       name = bedTwo.name,
+                    ),
+                    serviceName = ServiceName.temporaryAccommodation,
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a Temporary Accommodation Bed in multiple pdus should return bed matches searching pdus`() {
+      val probationRegion = probationRegionEntityFactory.produceAndPersist {
+        withYieldedApArea {
+          apAreaEntityFactory.produceAndPersist()
+        }
+      }
+
+      val pduOne = probationDeliveryUnitFactory.produceAndPersist {
+        withName(randomStringLowerCase(8))
+        withProbationRegion(probationRegion)
+      }
+
+      val pduTwo = probationDeliveryUnitFactory.produceAndPersist {
+        withName(randomStringLowerCase(8))
+        withProbationRegion(probationRegion)
+      }
+
+      val pduThree = probationDeliveryUnitFactory.produceAndPersist {
+        withName(randomStringLowerCase(8))
+        withProbationRegion(probationRegion)
+      }
+
+      `Given a User`(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val searchStartDate = LocalDate.parse("2024-08-12")
+        val durationDays = 7
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+        val premisesOne = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+          withProbationRegion(probationRegion)
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(pduOne)
+          withProbationRegion(probationRegion)
+          withStatus(PropertyStatus.active)
+        }
+
+        val (roomOnePremisesOne, bedOnePremisesOne) = createBedspace(premisesOne)
+        val (roomTwoPremisesOne, bedTwoPremisesOne) = createBedspace(premisesOne)
+
+        val premisesTwo = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+          withProbationRegion(probationRegion)
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(pduTwo)
+          withProbationRegion(probationRegion)
+          withStatus(PropertyStatus.active)
+        }
+
+        val (roomOnePremisesTwo, bedOnePremisesTwo) = createBedspace(premisesTwo)
+
+        val premisesThree = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+          withProbationRegion(probationRegion)
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(pduThree)
+          withProbationRegion(probationRegion)
+          withStatus(PropertyStatus.active)
+        }
+
+        val (roomOnePremisesThree, bedOnePremisesThree) = createBedspace(premisesThree)
+
+        webTestClient.post()
+          .uri("/beds/search")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            TemporaryAccommodationBedSearchParameters(
+              startDate = searchStartDate,
+              durationDays = durationDays,
+              serviceName = "temporary-accommodation",
+              probationDeliveryUnit = null,
+              probationDeliveryUnits = listOf(pduOne.id, pduThree.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              BedSearchResults(
+                resultsRoomCount = 3,
+                resultsPremisesCount = 2,
+                resultsBedCount = 3,
+                results = listOf(
+                  TemporaryAccommodationBedSearchResult(
+                    premises = BedSearchResultPremisesSummary(
+                      id = premisesOne.id,
+                      name = premisesOne.name,
+                      addressLine1 = premisesOne.addressLine1,
+                      postcode = premisesOne.postcode,
+                      probationDeliveryUnitName = pduOne.name,
+                      characteristics = listOf(),
+                      addressLine2 = premisesOne.addressLine2,
+                      town = premisesOne.town,
+                      bedCount = 2,
+                    ),
+                    room = BedSearchResultRoomSummary(
+                      id = roomOnePremisesOne.id,
+                      name = roomOnePremisesOne.name,
+                      characteristics = listOf(),
+                    ),
+                    bed = BedSearchResultBedSummary(
+                      id = bedOnePremisesOne.id,
+                      name = bedOnePremisesOne.name,
+                    ),
+                    serviceName = ServiceName.temporaryAccommodation,
+                    overlaps = listOf(),
+                  ),
+                  TemporaryAccommodationBedSearchResult(
+                    premises = BedSearchResultPremisesSummary(
+                      id = premisesOne.id,
+                      name = premisesOne.name,
+                      addressLine1 = premisesOne.addressLine1,
+                      postcode = premisesOne.postcode,
+                      probationDeliveryUnitName = pduOne.name,
+                      characteristics = listOf(),
+                      addressLine2 = premisesOne.addressLine2,
+                      town = premisesOne.town,
+                      bedCount = 2,
+                    ),
+                    room = BedSearchResultRoomSummary(
+                      id = roomTwoPremisesOne.id,
+                      name = roomTwoPremisesOne.name,
+                      characteristics = listOf(),
+                    ),
+                    bed = BedSearchResultBedSummary(
+                      id = bedTwoPremisesOne.id,
+                      name = bedTwoPremisesOne.name,
+                    ),
+                    serviceName = ServiceName.temporaryAccommodation,
+                    overlaps = listOf(),
+                  ),
+                  TemporaryAccommodationBedSearchResult(
+                    premises = BedSearchResultPremisesSummary(
+                      id = premisesThree.id,
+                      name = premisesThree.name,
+                      addressLine1 = premisesThree.addressLine1,
+                      postcode = premisesThree.postcode,
+                      probationDeliveryUnitName = pduThree.name,
+                      characteristics = listOf(),
+                      addressLine2 = premisesThree.addressLine2,
+                      town = premisesThree.town,
+                      bedCount = 1,
+                    ),
+                    room = BedSearchResultRoomSummary(
+                      id = roomOnePremisesThree.id,
+                      name = roomOnePremisesThree.name,
+                      characteristics = listOf(),
+                    ),
+                    bed = BedSearchResultBedSummary(
+                      id = bedOnePremisesThree.id,
+                      name = bedOnePremisesThree.name,
                     ),
                     serviceName = ServiceName.temporaryAccommodation,
                     overlaps = listOf(),


### PR DESCRIPTION
This [PR CAS-463](https://dsdmoj.atlassian.net/browse/CAS-463) is to extend the current functionality of bedspace search to be a able to search bedspaces in up to 5 Pdus. We need to maintain the current functionality by allowing to pass the Pdu name util the UI work is done. Changes are:
- Maintain the current property `probationDeliveryUnit` and make it not required as it will be replaced with a new parameter `probationDeliveryUnits` that  will allow to pass a list of Pdus (this property will be removed after the UI work is done)
- New property `probationDeliveryUnits` which allow to pass a list of Pdu Ids (this will be changed to required after the UI work is done)
- Include the PDU information for each bedspace in the search results response