### PR TITLE
APS-9191 Only CAS1_REPORT_VIEWER can view CAS1 reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
@@ -8,8 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.ContentType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.generateStreamingResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.LostBedReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
@@ -42,9 +42,7 @@ class Cas1ReportsController(
       throw NotAllowedProblem("This endpoint only supports CAS1")
     }
 
-    if (!userAccessService.currentUserCanViewReport()) {
-      throw ForbiddenProblem()
-    }
+    userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_REPORTS_VIEW)
 
     validateMonth(month)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -403,7 +403,13 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
   ),
   CAS1_APPLICANT(ServiceName.approvedPremises, ApprovedPremisesUserRole.applicant),
   CAS1_ADMIN(ServiceName.approvedPremises, ApprovedPremisesUserRole.roleAdmin),
-  CAS1_REPORT_VIEWER(ServiceName.approvedPremises, ApprovedPremisesUserRole.reportViewer),
+  CAS1_REPORT_VIEWER(
+    ServiceName.approvedPremises,
+    ApprovedPremisesUserRole.reportViewer,
+    listOf(
+      UserPermission.CAS1_REPORTS_VIEW,
+    ),
+  ),
   CAS1_EXCLUDED_FROM_ASSESS_ALLOCATION(ServiceName.approvedPremises, ApprovedPremisesUserRole.excludedFromAssessAllocation),
   CAS1_EXCLUDED_FROM_MATCH_ALLOCATION(ServiceName.approvedPremises, ApprovedPremisesUserRole.excludedFromMatchAllocation),
   CAS1_EXCLUDED_FROM_PLACEMENT_APPLICATION_ALLOCATION(ServiceName.approvedPremises, ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation),
@@ -514,6 +520,7 @@ enum class UserPermission {
   CAS1_SPACE_BOOKING_VIEW,
   CAS1_PREMISES_VIEW_SUMMARY,
   CAS1_APPLICATION_WITHDRAW_OTHERS,
+  CAS1_REPORTS_VIEW,
   CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -152,7 +152,6 @@ class UserAccessService(
   fun userCanViewReport(user: UserEntity) =
     when (requestContextService.getServiceForRequest()) {
       ServiceName.temporaryAccommodation -> user.hasAnyRole(UserRole.CAS3_ASSESSOR, CAS3_REPORTER)
-      ServiceName.approvedPremises -> user.hasAnyRole(UserRole.CAS1_REPORT_VIEWER, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ADMIN)
       else -> false
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -137,6 +137,7 @@ class UserTransformer(
         UserPermission.CAS1_PREMISES_VIEW_SUMMARY -> ApiUserPermission.premisesViewSummary
         UserPermission.CAS1_APPLICATION_WITHDRAW_OTHERS -> ApiUserPermission.applicationWithdrawOthers
         UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS -> ApiUserPermission.requestForPlacementWithdrawOthers
+        UserPermission.CAS1_REPORTS_VIEW -> ApiUserPermission.reportsView
       }
     }
   }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3140,6 +3140,7 @@ components:
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary
+        - cas1_reports_view
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7606,6 +7606,7 @@ components:
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary
+        - cas1_reports_view
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4127,6 +4127,7 @@ components:
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary
+        - cas1_reports_view
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3731,6 +3731,7 @@ components:
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary
+        - cas1_reports_view
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3231,6 +3231,7 @@ components:
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary
+        - cas1_reports_view
     TemporaryAccommodationUserRole:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReportsTest.kt
@@ -17,9 +17,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ADMIN
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_ASSESSOR
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_CRU_MEMBER
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_REPORT_VIEWER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas1OutOfServiceBedReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService
@@ -33,7 +32,7 @@ class Cas1ReportsTest : IntegrationTestBase() {
 
   @Test
   fun `Get report returns 400 if query parameters are missing`() {
-    `Given a User`(roles = listOf(CAS1_ADMIN)) { _, jwt ->
+    `Given a User`(roles = listOf(CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
         .uri("/cas1/reports/$cas1Report")
         .header("Authorization", "Bearer $jwt")
@@ -49,7 +48,7 @@ class Cas1ReportsTest : IntegrationTestBase() {
   @ParameterizedTest
   @ValueSource(ints = [0, 13])
   fun `Get report returns 400 if month provided is invalid`(month: Int) {
-    `Given a User`(roles = listOf(CAS1_ADMIN)) { _, jwt ->
+    `Given a User`(roles = listOf(CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
         .uri("/cas1/reports/$cas1Report?year=2024&month=$month")
         .header("Authorization", "Bearer $jwt")
@@ -64,7 +63,7 @@ class Cas1ReportsTest : IntegrationTestBase() {
 
   @Test
   fun `Get report returns 405 Not Allowed if serviceName header is not approvedPremises`() {
-    `Given a User`(roles = listOf(CAS3_ASSESSOR)) { _, jwt ->
+    `Given a User`(roles = listOf(CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
         .uri("/cas1/reports/$cas1Report?year=2023&month=4")
         .header("Authorization", "Bearer $jwt")
@@ -79,7 +78,7 @@ class Cas1ReportsTest : IntegrationTestBase() {
 
   @Test
   fun `Get report returns 403 Forbidden if user does not have CAS1 report access`() {
-    `Given a User`(roles = listOf(CAS3_ASSESSOR)) { _, jwt ->
+    `Given a User`(roles = listOf(CAS1_CRU_MEMBER)) { _, jwt ->
       webTestClient.get()
         .uri("/cas1/reports/$cas1Report?year=2023&month=4")
         .header("Authorization", "Bearer $jwt")
@@ -92,7 +91,7 @@ class Cas1ReportsTest : IntegrationTestBase() {
 
   @Test
   fun `Get report returns Server Error if report specified is invalid`() {
-    `Given a User`(roles = listOf(CAS1_ADMIN)) { _, jwt ->
+    `Given a User`(roles = listOf(CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
         .uri("/cas1/reports/doesnotexist")
         .header("Authorization", "Bearer $jwt")
@@ -106,7 +105,7 @@ class Cas1ReportsTest : IntegrationTestBase() {
   @ParameterizedTest
   @EnumSource(value = Cas1ReportName::class)
   fun `Get report returns OK response if user role is valid and parameters are valid `(reportName: Cas1ReportName) {
-    `Given a User`(roles = listOf(CAS1_ADMIN)) { _, jwt ->
+    `Given a User`(roles = listOf(CAS1_REPORT_VIEWER)) { _, jwt ->
       webTestClient.get()
         .uri("/cas1/reports/$reportName?year=2024&month=1")
         .header("Authorization", "Bearer $jwt")
@@ -126,7 +125,7 @@ class Cas1ReportsTest : IntegrationTestBase() {
 
     @Test
     fun `Get out-of-service beds report returns OK with correct body`() {
-      `Given a User`(roles = listOf(UserRole.CAS1_REPORT_VIEWER)) { userEntity, jwt ->
+      `Given a User`(roles = listOf(CAS1_REPORT_VIEWER)) { userEntity, jwt ->
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -1253,16 +1253,6 @@ class UserAccessServiceTest {
     assertThat(userAccessService.currentUserCanViewReport()).isFalse
   }
 
-  @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_REPORT_VIEWER", "CAS1_ADMIN"])
-  fun `currentUserCanViewReport returns returns true if the current request has 'X-Service-Name' header with value 'approved-premises' and the user has the correct role`(role: UserRole) {
-    currentRequestIsFor(ServiceName.approvedPremises)
-
-    user.addRoleForUnitTest(role)
-
-    assertThat(userAccessService.currentUserCanViewReport()).isTrue
-  }
-
   @Test
   fun `userCanReallocateTask returns true if the current request has 'X-Service-Name' header with value 'temporary-accommodation' and the user has the CAS3_ASSESSOR role`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -188,7 +188,18 @@ class UserTransformerTest {
     @ParameterizedTest
     @EnumSource(
       value = UserRole::class,
-      names = ["CAS1_JANITOR", "CAS1_APPEALS_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_CRU_MEMBER", "CAS1_FUTURE_MANAGER", "CAS1_WORKFLOW_MANAGER", "CAS1_MANAGER", "CAS1_LEGACY_MANAGER"],
+      names = [
+        "CAS1_JANITOR",
+        "CAS1_APPEALS_MANAGER",
+        "CAS1_ASSESSOR",
+        "CAS1_MATCHER",
+        "CAS1_CRU_MEMBER",
+        "CAS1_FUTURE_MANAGER",
+        "CAS1_WORKFLOW_MANAGER",
+        "CAS1_MANAGER",
+        "CAS1_LEGACY_MANAGER",
+        "CAS1_REPORT_VIEWER",
+      ],
       mode = EnumSource.Mode.EXCLUDE,
     )
     fun `transformJpaToApi CAS1 should return no permissions for Approved Premises roles which have no permissions defined`(role: UserRole) {


### PR DESCRIPTION
This change limits viewing reports to the CAS1_REPORT_VIEWER role by introducing a CAS1_REPORTS_VIEW permission