### PR TITLE
CAS1 - Add ability to withdraw all entities to JANITOR and CRU_MEMBER

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -379,6 +379,9 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
     ServiceName.approvedPremises,
     ApprovedPremisesUserRole.workflowManager,
     listOf(
+      UserPermission.CAS1_BOOKING_WITHDRAW,
+      UserPermission.CAS1_APPLICATION_WITHDRAW_OTHERS,
+      UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
       UserPermission.CAS1_VIEW_MANAGE_TASKS,
     ),
   ),
@@ -386,11 +389,13 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
     ServiceName.approvedPremises,
     ApprovedPremisesUserRole.cruMember,
     listOf(
+      UserPermission.CAS1_APPLICATION_WITHDRAW_OTHERS,
       UserPermission.CAS1_ADHOC_BOOKING_CREATE,
       UserPermission.CAS1_BOOKING_CREATE,
       UserPermission.CAS1_BOOKING_CHANGE_DATES,
       UserPermission.CAS1_BOOKING_WITHDRAW,
       UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE,
+      UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
       UserPermission.CAS1_VIEW_CRU_DASHBOARD,
       UserPermission.CAS1_VIEW_MANAGE_TASKS,
       UserPermission.CAS1_VIEW_OUT_OF_SERVICE_BEDS,
@@ -416,10 +421,12 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
     ApprovedPremisesUserRole.janitor,
     listOf(
       UserPermission.CAS1_ADHOC_BOOKING_CREATE,
+      UserPermission.CAS1_APPLICATION_WITHDRAW_OTHERS,
       UserPermission.CAS1_BOOKING_CREATE,
       UserPermission.CAS1_BOOKING_WITHDRAW,
       UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE,
       UserPermission.CAS1_PROCESS_AN_APPEAL,
+      UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
       UserPermission.CAS1_VIEW_ASSIGNED_ASSESSMENTS,
       UserPermission.CAS1_VIEW_CRU_DASHBOARD,
       UserPermission.CAS1_VIEW_MANAGE_TASKS,
@@ -506,6 +513,8 @@ enum class UserPermission {
   CAS1_SPACE_BOOKING_LIST,
   CAS1_SPACE_BOOKING_VIEW,
   CAS1_PREMISES_VIEW_SUMMARY,
+  CAS1_APPLICATION_WITHDRAW_OTHERS,
+  CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
 }
 
 interface UserWorkload {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -90,7 +90,7 @@ class UserAccessService(
    * It doesn't consider if the booking is in a cancellable state
    */
   fun userMayCancelBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_WORKFLOW_MANAGER)
+    is ApprovedPremisesEntity -> user.hasPermission(UserPermission.CAS1_BOOKING_WITHDRAW)
     is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
     else -> false
   }
@@ -241,7 +241,7 @@ class UserAccessService(
   fun userMayWithdrawApplication(user: UserEntity, application: ApplicationEntity): Boolean = when (application) {
     is ApprovedPremisesApplicationEntity ->
       application.createdByUser == user || (
-        application.isSubmitted() && user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
+        application.isSubmitted() && user.hasPermission(UserPermission.CAS1_APPLICATION_WITHDRAW_OTHERS)
         )
     else -> false
   }
@@ -253,7 +253,7 @@ class UserAccessService(
    */
   fun userMayWithdrawPlacementRequest(user: UserEntity, placementRequest: PlacementRequestEntity) =
     placementRequest.application.createdByUser == user ||
-      user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER)
+      user.hasPermission(UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS)
 
   /**
    * This function only checks if the user has the correct permissions to withdraw the given placement application.
@@ -262,12 +262,7 @@ class UserAccessService(
    */
   fun userMayWithdrawPlacementApplication(user: UserEntity, placementApplication: PlacementApplicationEntity) =
     placementApplication.createdByUser == user ||
-      (placementApplication.isSubmitted() && user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER))
-}
-
-enum class ApprovedPremisesApplicationAccessLevel {
-  ALL,
-  TEAM,
+      (placementApplication.isSubmitted() && user.hasPermission(UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS))
 }
 
 enum class TemporaryAccommodationApplicationAccessLevel {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -135,6 +135,8 @@ class UserTransformer(
         UserPermission.CAS1_SPACE_BOOKING_LIST -> ApiUserPermission.spaceBookingList
         UserPermission.CAS1_SPACE_BOOKING_VIEW -> ApiUserPermission.spaceBookingView
         UserPermission.CAS1_PREMISES_VIEW_SUMMARY -> ApiUserPermission.premisesViewSummary
+        UserPermission.CAS1_APPLICATION_WITHDRAW_OTHERS -> ApiUserPermission.applicationWithdrawOthers
+        UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS -> ApiUserPermission.requestForPlacementWithdrawOthers
       }
     }
   }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3122,6 +3122,7 @@ components:
       type: string
       enum:
         - cas1_adhoc_booking_create
+        - cas1_application_withdraw_others
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -3135,6 +3136,7 @@ components:
         - cas1_view_cru_dashboard
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
+        - cas1_request_for_placement_withdraw_others
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7588,6 +7588,7 @@ components:
       type: string
       enum:
         - cas1_adhoc_booking_create
+        - cas1_application_withdraw_others
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -7601,6 +7602,7 @@ components:
         - cas1_view_cru_dashboard
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
+        - cas1_request_for_placement_withdraw_others
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4109,6 +4109,7 @@ components:
       type: string
       enum:
         - cas1_adhoc_booking_create
+        - cas1_application_withdraw_others
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -4122,6 +4123,7 @@ components:
         - cas1_view_cru_dashboard
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
+        - cas1_request_for_placement_withdraw_others
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3713,6 +3713,7 @@ components:
       type: string
       enum:
         - cas1_adhoc_booking_create
+        - cas1_application_withdraw_others
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -3726,6 +3727,7 @@ components:
         - cas1_view_cru_dashboard
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
+        - cas1_request_for_placement_withdraw_others
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3213,6 +3213,7 @@ components:
       type: string
       enum:
         - cas1_adhoc_booking_create
+        - cas1_application_withdraw_others
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -3226,6 +3227,7 @@ components:
         - cas1_view_cru_dashboard
         - cas1_view_manage_tasks
         - cas1_view_out_of_service_beds
+        - cas1_request_for_placement_withdraw_others
         - cas1_space_booking_list
         - cas1_space_booking_view
         - cas1_premises_view_summary

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomEmailAddress
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
@@ -32,7 +31,6 @@ class UserEntityFactory : Factory<UserEntity> {
   private var deliusStaffIdentifier: Yielded<Long> = { randomInt(1000, 10000).toLong() }
   private var applications: Yielded<MutableList<ApplicationEntity>> = { mutableListOf() }
   private var qualifications: Yielded<MutableList<UserQualificationAssignmentEntity>> = { mutableListOf() }
-  private var permissions: Yielded<MutableList<UserPermission>> = { mutableListOf() }
   private var probationRegion: Yielded<ProbationRegionEntity>? = null
   private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>? = null
   private var isActive: Yielded<Boolean> = { true }
@@ -71,10 +69,6 @@ class UserEntityFactory : Factory<UserEntity> {
 
   fun withQualifications(qualifications: MutableList<UserQualificationAssignmentEntity>) = apply {
     this.qualifications = { qualifications }
-  }
-
-  fun withPermissions(permissions: MutableList<UserPermission>) = apply {
-    this.permissions = { permissions }
   }
 
   fun withEmail(email: String?) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -3050,7 +3050,11 @@ class BookingTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER"], mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(
+      value = UserRole::class,
+      names = ["CAS1_WORKFLOW_MANAGER", "CAS1_CRU_MEMBER", "CAS1_JANITOR"],
+      mode = EnumSource.Mode.EXCLUDE,
+    )
     fun `Create Cancellation with invalid role returns 401`(role: UserRole) {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         `Given a User`(roles = listOf(role)) { applicant, _ ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -13,11 +13,13 @@ import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.adhocBookingCreate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.applicationWithdrawOthers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.assessAppealedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.bookingCreate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.bookingWithdraw
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.outOfServiceBedCreate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.processAnAppeal
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.requestForPlacementWithdrawOthers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.viewAssignedAssessments
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.viewCruDashboard
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.viewManageTasks
@@ -216,15 +218,16 @@ class UserTransformerTest {
       val result =
         userTransformer.transformJpaToApi(user, approvedPremises) as ApprovedPremisesUser
 
-      assertThat(result.permissions).size().isEqualTo(10)
       assertThat(result.permissions).hasSameElementsAs(
         listOf(
           adhocBookingCreate,
+          applicationWithdrawOthers,
           assessAppealedApplication,
           bookingCreate,
           bookingWithdraw,
           processAnAppeal,
           outOfServiceBedCreate,
+          requestForPlacementWithdrawOthers,
           viewAssignedAssessments,
           viewCruDashboard,
           viewManageTasks,
@@ -246,7 +249,7 @@ class UserTransformerTest {
         userTransformer.transformJpaToApi(user, approvedPremises) as ApprovedPremisesUser
 
       assertThat(result.version).isNotNull()
-      assertThat(result.version).isEqualTo(-159026997)
+      assertThat(result.version).isEqualTo(2087183858)
     }
 
     @Test


### PR DESCRIPTION
Prior to this commit roles were used to determine if various CAS1 entities could be withdrawn. We now use permissions

This commit also adds the ability for JANITOR and CRU_MEMBER to withdrawal all entity types.