### PR TITLE
APS-1286 - Add cancellation fields to space booking data model

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -122,4 +122,10 @@ data class Cas1SpaceBookingEntity(
   val keyWorkerStaffCode: String?,
   val keyWorkerName: String?,
   val keyWorkerAssignedAt: Instant?,
+  var cancellationOccurredAt: LocalDate?,
+  var cancellationRecordedAt: Instant?,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cancellation_reason_id")
+  var cancellationReason: CancellationReasonEntity?,
+  var cancellationReasonNotes: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -36,6 +36,7 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
       INNER JOIN approved_premises_applications apa ON b.approved_premises_application_id = apa.id
       WHERE 
       b.premises_id = :premisesId AND 
+      b.cancellation_occurred_at IS NULL AND 
       b.actual_departure_date_time IS NULL AND
       (
         :residency IS NULL OR (
@@ -67,7 +68,10 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
       b.canonical_arrival_date as canonicalArrivalDate,
       b.canonical_departure_date as canonicalDepartureDate
       FROM cas1_space_bookings b
-      WHERE b.premises_id = :premisesId AND b.crn = :crn
+      WHERE 
+      b.premises_id = :premisesId AND 
+      b.crn = :crn AND
+      b.cancellation_occurred_at IS NULL 
     """,
     nativeQuery = true,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -126,6 +126,10 @@ data class Cas1SpaceBookingEntity(
   val keyWorkerStaffCode: String?,
   val keyWorkerName: String?,
   val keyWorkerAssignedAt: Instant?,
+  /**
+   * Users are asked to specify when a cancelled occurred which may not necessarily
+   * be the same as when it was recorded in the system
+   */
   var cancellationOccurredAt: LocalDate?,
   var cancellationRecordedAt: Instant?,
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -88,6 +88,10 @@ class Cas1SpaceBookingService(
         keyWorkerStaffCode = null,
         keyWorkerName = null,
         keyWorkerAssignedAt = null,
+        cancellationOccurredAt = null,
+        cancellationRecordedAt = null,
+        cancellationReason = null,
+        cancellationReasonNotes = null,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1KeyWorkerAllocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
@@ -21,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
 class Cas1SpaceBookingTransformer(
   private val personTransformer: PersonTransformer,
   private val spaceBookingRequirementsTransformer: Cas1SpaceBookingRequirementsTransformer,
+  private val cancellationReasonTransformer: CancellationReasonTransformer,
   private val userTransformer: UserTransformer,
 ) {
   fun transformJpaToApi(
@@ -57,6 +60,7 @@ class Cas1SpaceBookingTransformer(
       canonicalArrivalDate = jpa.canonicalArrivalDate,
       canonicalDepartureDate = jpa.canonicalDepartureDate,
       otherBookingsInPremisesForCrn = otherBookingsAtPremiseForCrn.map { it.toSpaceBookingDate() },
+      cancellation = jpa.extractCancellation(),
     )
   }
 
@@ -79,6 +83,22 @@ class Cas1SpaceBookingTransformer(
           name = name,
         ),
         allocatedAt = assignedAt.toLocalDate(),
+      )
+    } else {
+      null
+    }
+  }
+
+  private fun Cas1SpaceBookingEntity.extractCancellation(): Cas1SpaceBookingCancellation? {
+    val occurredAt = cancellationOccurredAt
+    val recordedAt = cancellationRecordedAt
+    val reason = cancellationReason
+    return if (occurredAt != null && recordedAt != null && reason != null) {
+      Cas1SpaceBookingCancellation(
+        occurredAt = occurredAt,
+        recordedAt = recordedAt,
+        reason = cancellationReasonTransformer.transformJpaToApi(reason),
+        reasonNotes = cancellationReasonNotes,
       )
     } else {
       null

--- a/src/main/resources/db/migration/all/20240911103906__add_cancellation_columns_to_cas1_space_booking.sql
+++ b/src/main/resources/db/migration/all/20240911103906__add_cancellation_columns_to_cas1_space_booking.sql
@@ -1,0 +1,6 @@
+ALTER TABLE cas1_space_bookings ADD cancellation_occurred_at date NULL;
+ALTER TABLE cas1_space_bookings ADD cancellation_recorded_at timestamptz NULL;
+ALTER TABLE cas1_space_bookings ADD cancellation_reason_id UUID NULL;
+ALTER TABLE cas1_space_bookings ADD cancellation_reason_notes text NULL;
+
+ALTER TABLE cas1_space_bookings ADD FOREIGN KEY (cancellation_reason_id) REFERENCES cancellation_reasons(id);

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -299,6 +299,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceBookingDates'
+        cancellation:
+          $ref: '#/components/schemas/Cas1SpaceBookingCancellation'
       required:
         - id
         - applicationId
@@ -382,6 +384,23 @@ components:
       required:
         - keyWorker
         - allocatedAt
+    Cas1SpaceBookingCancellation:
+      type: object
+      properties:
+        occurredAt:
+          type: string
+          format: date
+        recordedAt:
+          type: string
+          format: date-time
+        reason:
+          $ref: '_shared.yml#/components/schemas/CancellationReason'
+        reason_notes:
+          type: string
+      required:
+        - occurredAt
+        - recordedAt
+        - reason
     Cas1NewArrival:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6409,6 +6409,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceBookingDates'
+        cancellation:
+          $ref: '#/components/schemas/Cas1SpaceBookingCancellation'
       required:
         - id
         - applicationId
@@ -6492,6 +6494,23 @@ components:
       required:
         - keyWorker
         - allocatedAt
+    Cas1SpaceBookingCancellation:
+      type: object
+      properties:
+        occurredAt:
+          type: string
+          format: date
+        recordedAt:
+          type: string
+          format: date-time
+        reason:
+          $ref: '#/components/schemas/CancellationReason'
+        reason_notes:
+          type: String
+      required:
+        - occurredAt
+        - recordedAt
+        - reason
     Cas1NewArrival:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6506,7 +6506,7 @@ components:
         reason:
           $ref: '#/components/schemas/CancellationReason'
         reason_notes:
-          type: String
+          type: string
       required:
         - occurredAt
         - recordedAt

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -30,6 +31,10 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var keyWorkerStaffCode: Yielded<String?> = { null }
   private var keyWorkerName: Yielded<String?> = { null }
   private var keyWorkerAssignedAt: Yielded<Instant?> = { null }
+  private var cancellationOccurredAt: Yielded<LocalDate?> = { null }
+  private var cancellationRecordedAt: Yielded<Instant?> = { null }
+  private var cancellationReason: Yielded<CancellationReasonEntity?> = { null }
+  private var cancellationReasonNotes: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -129,6 +134,22 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.keyWorkerAssignedAt = { keyWorkerAssignedAt }
   }
 
+  fun withCancellationOccurredAt(occurredAt: LocalDate?) = apply {
+    this.cancellationOccurredAt = { occurredAt }
+  }
+
+  fun withCancellationRecordedAt(recordedAt: Instant?) = apply {
+    this.cancellationRecordedAt = { recordedAt }
+  }
+
+  fun withCancellationReason(reason: CancellationReasonEntity?) = apply {
+    this.cancellationReason = { reason }
+  }
+
+  fun withCancellationReasonNotes(reasonNotes: String?) = apply {
+    this.cancellationReasonNotes = { reasonNotes }
+  }
+
   override fun produce() = Cas1SpaceBookingEntity(
     id = this.id(),
     premises = this.premises(),
@@ -146,5 +167,9 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     keyWorkerName = this.keyWorkerName(),
     keyWorkerAssignedAt = this.keyWorkerAssignedAt(),
     application = this.application(),
+    cancellationOccurredAt = cancellationOccurredAt(),
+    cancellationRecordedAt = cancellationRecordedAt(),
+    cancellationReason = cancellationReason(),
+    cancellationReasonNotes = cancellationReasonNotes(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -299,6 +299,7 @@ class Cas1SpaceBookingTest {
     lateinit var currentSpaceBooking2: Cas1SpaceBookingEntity
     lateinit var currentSpaceBooking3: Cas1SpaceBookingEntity
     lateinit var upcomingSpaceBooking: Cas1SpaceBookingEntity
+    lateinit var upcomingCancelledSpaceBooking: Cas1SpaceBookingEntity
     lateinit var departedSpaceBooking: Cas1SpaceBookingEntity
 
     @BeforeAll
@@ -382,6 +383,20 @@ class Cas1SpaceBookingTest {
         withKeyworkerName(null)
         withKeyworkerStaffCode(null)
         withKeyworkerAssignedAt(null)
+      }
+
+      upcomingCancelledSpaceBooking = createSpaceBooking(crn = "CRN_UPCOMING_CANCELLED", firstName = "up", lastName = "coming", tier = "U") {
+        withPremises(premisesWithBookings)
+        withExpectedArrivalDate(LocalDate.parse("2023-01-01"))
+        withExpectedDepartureDate(LocalDate.parse("2023-02-01"))
+        withActualArrivalDateTime(null)
+        withActualDepartureDateTime(null)
+        withCanonicalArrivalDate(LocalDate.parse("2023-01-01"))
+        withCanonicalDepartureDate(LocalDate.parse("2023-02-01"))
+        withKeyworkerName(null)
+        withKeyworkerStaffCode(null)
+        withKeyworkerAssignedAt(null)
+        withCancellationOccurredAt(LocalDate.now())
       }
     }
 
@@ -639,6 +654,7 @@ class Cas1SpaceBookingTest {
 
     lateinit var spaceBooking: Cas1SpaceBookingEntity
     lateinit var otherSpaceBookingAtPremises: Cas1SpaceBookingEntity
+    lateinit var otherSpaceBookingAtPremisesCancelled: Cas1SpaceBookingEntity
     lateinit var otherSpaceBookingAtPremisesDifferentCrn: Cas1SpaceBookingEntity
     lateinit var otherSpaceBookingNotAtPremises: Cas1SpaceBookingEntity
 
@@ -696,6 +712,17 @@ class Cas1SpaceBookingTest {
         withCreatedBy(user)
         withCanonicalArrivalDate(LocalDate.parse("2031-05-29"))
         withCanonicalDepartureDate(LocalDate.parse("2031-06-29"))
+      }
+
+      otherSpaceBookingAtPremisesCancelled = cas1SpaceBookingEntityFactory.produceAndPersist {
+        withCrn(offender.otherIds.crn)
+        withPremises(premises)
+        withPlacementRequest(placementRequest)
+        withApplication(placementRequest.application)
+        withCreatedBy(user)
+        withCanonicalArrivalDate(LocalDate.parse("2031-05-29"))
+        withCanonicalDepartureDate(LocalDate.parse("2031-06-29"))
+        withCancellationOccurredAt(LocalDate.parse("2020-01-01"))
       }
 
       otherSpaceBookingNotAtPremises = cas1SpaceBookingEntityFactory.produceAndPersist {


### PR DESCRIPTION
This PR also excludes cancelled space bookings when listing placements for a premises