### PR TITLE
clean up data in wrong format

### DIFF
--- a/src/main/resources/db/migration/all/2024091112120000__remove_records_with_incorrect_formatting.sql
+++ b/src/main/resources/db/migration/all/2024091112120000__remove_records_with_incorrect_formatting.sql
@@ -1,0 +1,1 @@
+delete from domain_events where type = 'CAS3_ASSESSMENT_UPDATED';


### PR DESCRIPTION
This is to remove the few entries in the domain events table that have the incorrect date format. They're now to be stored as local date, rather than in UI format