### PR TITLE
APS-1259 - Add AP Area to Cas1PremiseSummary API Model

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremisesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.util.UUID
 
@@ -14,6 +15,7 @@ import java.util.UUID
 class Cas1PremisesController(
   val userAccessService: UserAccessService,
   val cas1PremisesService: Cas1PremisesService,
+  val cas1PremisesTransformer: Cas1PremisesTransformer,
 ) : PremisesCas1Delegate {
 
   override fun getPremisesById(premisesId: UUID): ResponseEntity<Cas1PremisesSummary> {
@@ -21,6 +23,10 @@ class Cas1PremisesController(
 
     return ResponseEntity
       .ok()
-      .body(extractEntityFromCasResult(cas1PremisesService.getPremisesSummary(premisesId)))
+      .body(
+        cas1PremisesTransformer.toPremiseSummary(
+          extractEntityFromCasResult(cas1PremisesService.getPremisesSummary(premisesId)),
+        ),
+      )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
@@ -15,7 +14,7 @@ class Cas1PremisesService(
   val premisesService: PremisesService,
   val cas1OutOfServiceBedService: Cas1OutOfServiceBedService,
 ) {
-  fun getPremisesSummary(premisesId: UUID): CasResult<Cas1PremisesSummary> {
+  fun getPremisesSummary(premisesId: UUID): CasResult<Cas1PremisesSummaryInfo> {
     val premise = premisesRepository.findByIdOrNull(premisesId)
     if (premise !is ApprovedPremisesEntity) return CasResult.NotFound("premises", premisesId.toString())
 
@@ -23,15 +22,19 @@ class Cas1PremisesService(
     val outOfServiceBedsCount = cas1OutOfServiceBedService.getActiveOutOfServiceBedsCountForPremisesId(premisesId)
 
     return CasResult.Success(
-      Cas1PremisesSummary(
-        id = premisesId,
-        name = premise.name,
-        apCode = premise.apCode,
-        postcode = premise.postcode,
+      Cas1PremisesSummaryInfo(
+        entity = premise,
         bedCount = bedCount,
         availableBeds = bedCount - outOfServiceBedsCount,
         outOfServiceBeds = outOfServiceBedsCount,
       ),
     )
   }
+
+  data class Cas1PremisesSummaryInfo(
+    val entity: ApprovedPremisesEntity,
+    val bedCount: Int,
+    val availableBeds: Int,
+    val outOfServiceBeds: Int,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesTransformer.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
+
+@Service
+class Cas1PremisesTransformer(
+  val apAreaTransformer: ApAreaTransformer,
+) {
+  fun toPremiseSummary(premisesSummaryInfo: Cas1PremisesService.Cas1PremisesSummaryInfo): Cas1PremisesSummary {
+    val entity = premisesSummaryInfo.entity
+    return Cas1PremisesSummary(
+      id = entity.id,
+      name = entity.name,
+      apCode = entity.apCode,
+      postcode = entity.postcode,
+      bedCount = premisesSummaryInfo.bedCount,
+      availableBeds = premisesSummaryInfo.availableBeds,
+      outOfServiceBeds = premisesSummaryInfo.outOfServiceBeds,
+      apArea = apAreaTransformer.transformJpaToApi(entity.probationRegion.apArea!!),
+    )
+  }
+}

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -54,6 +54,8 @@ components:
         postcode:
           type: string
           example: LS1 3AD
+        apArea:
+          $ref: '_shared.yml#/components/schemas/ApArea'
         bedCount:
           type: integer
           description: The total number of spaces in this premises
@@ -66,6 +68,15 @@ components:
           type: integer
           description: The total number of out of service beds
           example: 2
+      required:
+        - id
+        - name
+        - apCode
+        - postcode
+        - apArea
+        - bedCount
+        - availableBeds
+        - outOfServiceBeds
     Cas1SpaceCharacteristic:
       type: string
       description: All of the characteristics of both premises and rooms

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6164,6 +6164,8 @@ components:
         postcode:
           type: string
           example: LS1 3AD
+        apArea:
+          $ref: '#/components/schemas/ApArea'
         bedCount:
           type: integer
           description: The total number of spaces in this premises
@@ -6176,6 +6178,15 @@ components:
           type: integer
           description: The total number of out of service beds
           example: 2
+      required:
+        - id
+        - name
+        - apCode
+        - postcode
+        - apArea
+        - bedCount
+        - availableBeds
+        - outOfServiceBeds
     Cas1SpaceCharacteristic:
       type: string
       description: All of the characteristics of both premises and rooms

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -27,7 +27,9 @@ class Cas1PremisesTest : IntegrationTestBase() {
     fun setupTestData() {
       val region = probationRegionEntityFactory.produceAndPersist {
         withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
+          apAreaEntityFactory.produceAndPersist() {
+            withName("The ap area name")
+          }
         }
       }
 
@@ -105,6 +107,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
       assertThat(summary.bedCount).isEqualTo(5)
       assertThat(summary.availableBeds).isEqualTo(4)
       assertThat(summary.outOfServiceBeds).isEqualTo(1)
+      assertThat(summary.apArea.name).isEqualTo("The ap area name")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
@@ -81,14 +81,11 @@ class Cas1PremisesServiceTest {
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
       result as CasResult.Success
 
-      val premisesSummary = result.value
-      assertThat(premisesSummary.id).isEqualTo(premises.id)
-      assertThat(premisesSummary.name).isEqualTo("the name")
-      assertThat(premisesSummary.apCode).isEqualTo("the ap code")
-      assertThat(premisesSummary.postcode).isEqualTo("LE11 1PO")
-      assertThat(premisesSummary.bedCount).isEqualTo(56)
-      assertThat(premisesSummary.availableBeds).isEqualTo(52)
-      assertThat(premisesSummary.outOfServiceBeds).isEqualTo(4)
+      val premisesSummaryInfo = result.value
+      assertThat(premisesSummaryInfo.entity).isEqualTo(premises)
+      assertThat(premisesSummaryInfo.bedCount).isEqualTo(56)
+      assertThat(premisesSummaryInfo.outOfServiceBeds).isEqualTo(4)
+      assertThat(premisesSummaryInfo.availableBeds).isEqualTo(52)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesTransformerTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremisesTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PremisesServiceTest.CONSTANTS.PREMISES_ID
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1PremisesTransformerTest {
+
+  @MockK
+  lateinit var apAreaTransformer: ApAreaTransformer
+
+  @InjectMockKs
+  lateinit var transformer: Cas1PremisesTransformer
+
+  companion object CONSTANTS {
+    val PREMISES_ID: UUID = UUID.randomUUID()
+  }
+
+  @Nested
+  inner class ToPremisesSummary {
+
+    @Test
+    fun `success`() {
+      val apArea = ApAreaEntityFactory().produce()
+
+      val probationRegion = ProbationRegionEntityFactory()
+        .withDefaults()
+        .withApArea(apArea)
+        .produce()
+
+      val premises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .withId(PREMISES_ID)
+        .withName("the name")
+        .withApCode("the ap code")
+        .withPostcode("LE11 1PO")
+        .withProbationRegion(probationRegion)
+        .produce()
+
+      val expectedApArea = ApArea(UUID.randomUUID(), "id", "name")
+      every { apAreaTransformer.transformJpaToApi(apArea) } returns expectedApArea
+
+      val result = transformer.toPremiseSummary(
+        Cas1PremisesService.Cas1PremisesSummaryInfo(
+          entity = premises,
+          bedCount = 10,
+          outOfServiceBeds = 2,
+          availableBeds = 8,
+        ),
+      )
+
+      assertThat(result.id).isEqualTo(premises.id)
+      assertThat(result.name).isEqualTo("the name")
+      assertThat(result.apCode).isEqualTo("the ap code")
+      assertThat(result.postcode).isEqualTo("LE11 1PO")
+      assertThat(result.bedCount).isEqualTo(10)
+      assertThat(result.availableBeds).isEqualTo(8)
+      assertThat(result.outOfServiceBeds).isEqualTo(2)
+      assertThat(result.apArea).isEqualTo(expectedApArea)
+    }
+  }
+}


### PR DESCRIPTION
This commit also:

* Refactors the getPremiseSummary code to use a transformer to map from the entity model into the API Model
* Makes all fields on Cas1PremiseSummary mandatory