### PR TITLE
APS-1288 - Send booking withdrawn email to placement app creator

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -1138,6 +1138,7 @@ class BookingService(
       cas1BookingEmailService.bookingWithdrawn(
         application = it,
         booking = booking,
+        placementApplication = booking.placementRequest?.placementApplication,
         withdrawalTriggeredBy = withdrawalContext.withdrawalTriggeredBy,
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -61,6 +61,7 @@ class Cas1BookingEmailService(
   fun bookingWithdrawn(
     application: ApprovedPremisesApplicationEntity,
     booking: BookingEntity,
+    placementApplication: PlacementApplicationEntity?,
     withdrawalTriggeredBy: WithdrawalTriggeredBy,
   ) {
     val allPersonalisation =
@@ -72,9 +73,10 @@ class Cas1BookingEmailService(
     val interestedParties =
       (
         application.interestedPartiesEmailAddresses() +
+          setOfNotNull(placementApplication?.createdByUser?.email) +
           setOfNotNull(booking.premises.emailAddress) +
           setOfNotNull(application.apArea?.emailAddress)
-        )
+        ).toSet()
 
     emailNotifier.sendEmails(
       recipientEmailAddresses = interestedParties,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -69,34 +69,19 @@ class Cas1BookingEmailService(
     allPersonalisation += "region" to booking.premises.probationRegion.name
     allPersonalisation["withdrawnBy"] = withdrawalTriggeredBy.getName()
 
-    val template = notifyConfig.templates.bookingWithdrawnV2
+    val interestedParties =
+      (
+        application.interestedPartiesEmailAddresses() +
+          setOfNotNull(booking.premises.emailAddress) +
+          setOfNotNull(application.apArea?.emailAddress)
+        )
 
     emailNotifier.sendEmails(
-      recipientEmailAddresses = application.interestedPartiesEmailAddresses(),
-      templateId = template,
+      recipientEmailAddresses = interestedParties,
+      templateId = notifyConfig.templates.bookingWithdrawnV2,
       personalisation = allPersonalisation,
       application = application,
     )
-
-    val premises = booking.premises
-    premises.emailAddress?.let { email ->
-      emailNotifier.sendEmail(
-        recipientEmailAddress = email,
-        templateId = template,
-        personalisation = allPersonalisation,
-        application = application,
-      )
-    }
-
-    val area = application.apArea
-    area?.emailAddress?.let { cruEmail ->
-      emailNotifier.sendEmail(
-        recipientEmailAddress = cruEmail,
-        templateId = template,
-        personalisation = allPersonalisation,
-        application = application,
-      )
-    }
   }
 
   fun buildCommonPersonalisation(application: ApplicationEntity, booking: BookingEntity): Map<String, Any> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -58,6 +58,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
@@ -2518,7 +2519,7 @@ class BookingServiceTest {
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
       every { mockApplicationService.updateApprovedPremisesApplicationStatus(any(), any()) } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, null, WithdrawalTriggeredByUser(user)) } returns Unit
 
       val cancelledAt = LocalDate.parse("2022-08-25")
       val notes = "notes"
@@ -2589,11 +2590,22 @@ class BookingServiceTest {
         .withSubmittedAt(OffsetDateTime.now())
         .produce()
 
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withDefaults()
+        .produce()
+
       val bookingEntity = BookingEntityFactory()
         .withPremises(premises)
         .withApplication(application)
         .withCrn(application.crn)
+        .withPlacementRequest(
+          PlacementRequestEntityFactory()
+            .withDefaults()
+            .withPlacementApplication(placementApplication)
+            .produce(),
+        )
         .produce()
+
       every { mockCancellationReasonRepository.findByIdOrNull(reasonId) } returns reason
       every { mockCancellationRepository.save(any()) } answers { it.invocation.args[0] as CancellationEntity }
       every { mockDomainEventService.saveBookingCancelledEvent(any()) } just Runs
@@ -2614,7 +2626,7 @@ class BookingServiceTest {
 
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
       every { mockApplicationService.updateApprovedPremisesApplicationStatus(any(), any()) } returns Unit
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, placementApplication, WithdrawalTriggeredByUser(user)) } returns Unit
 
       val cancelledAt = LocalDate.parse("2022-08-25")
       val notes = "notes"
@@ -2634,7 +2646,7 @@ class BookingServiceTest {
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
 
-      verify(exactly = 1) { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) }
+      verify(exactly = 1) { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, placementApplication, WithdrawalTriggeredByUser(user)) }
     }
 
     @Test
@@ -2954,7 +2966,7 @@ class BookingServiceTest {
         )
       } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, null, WithdrawalTriggeredByUser(user)) } returns Unit
 
       val cancelledBooking1 = BookingEntityFactory()
         .withPremises(premises)
@@ -3049,7 +3061,7 @@ class BookingServiceTest {
         )
       } returns Unit
 
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, null, WithdrawalTriggeredByUser(user)) } returns Unit
 
       val cancelledBooking1 = BookingEntityFactory()
         .withPremises(premises)
@@ -3126,7 +3138,7 @@ class BookingServiceTest {
           ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT,
         )
       } returns Unit
-      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, WithdrawalTriggeredByUser(user)) } returns Unit
+      every { mockCas1BookingEmailService.bookingWithdrawn(application, bookingEntity, null, WithdrawalTriggeredByUser(user)) } returns Unit
 
       every { mockBookingRepository.findAllByApplication(application) } returns emptyList()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
+// TOdO: add tests in here for placement app email
 class Cas1BookingEmailServiceTest {
 
   private object TestConstants {
@@ -297,7 +298,12 @@ class Cas1BookingEmailServiceTest {
         caseManagerNotApplicant = true,
       )
 
-      service.bookingWithdrawn(application, booking, WithdrawalTriggeredByUser(withdrawingUser))
+      service.bookingWithdrawn(
+        application = application,
+        booking = booking,
+        placementApplication = null,
+        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawingUser),
+      )
 
       val expectedPersonalisation = mapOf(
         "apName" to PREMISES_NAME,
@@ -362,7 +368,12 @@ class Cas1BookingEmailServiceTest {
         departureDate = LocalDate.of(2023, 2, 14),
       )
 
-      service.bookingWithdrawn(application, booking, WithdrawalTriggeredByUser(withdrawingUser))
+      service.bookingWithdrawn(
+        application = application,
+        booking = booking,
+        placementApplication = null,
+        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawingUser),
+      )
 
       mockEmailNotificationService.assertNoEmailsRequested()
     }
@@ -382,7 +393,12 @@ class Cas1BookingEmailServiceTest {
         caseManagerNotApplicant = true,
       )
 
-      service.bookingWithdrawn(application, booking, WithdrawalTriggeredBySeedJob)
+      service.bookingWithdrawn(
+        application = application,
+        booking = booking,
+        placementApplication = null,
+        withdrawalTriggeredBy = WithdrawalTriggeredBySeedJob,
+      )
 
       val expectedPersonalisation = mapOf(
         "apName" to PREMISES_NAME,


### PR DESCRIPTION
This commit ensure that booking withdrawn emails for a given request for placement are sent to the person who created that request for placement, if not the same as the application’s creator.