### PR TITLE
CAS-598 Fix issue to generate bedspace usage report for all regions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUsageRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUsageRepository.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import java.util.UUID
+
+interface BedUsageRepository : JpaRepository<BedEntity, UUID> {
+
+  @Query(
+    """
+    SELECT b.*
+    FROM beds b 
+    INNER JOIN rooms r ON b.room_id = r.id
+    INNER JOIN premises p ON r.premises_id = p.id
+    WHERE p.service = 'temporary-accommodation'
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBedspaces(
+    probationRegionId: UUID?,
+  ): List<BedEntity>
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
@@ -8,12 +8,12 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.TransitionalAccommodationReferralReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUsageRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BookingsReportRepository
@@ -39,7 +39,7 @@ class Cas3ReportServiceTest {
   private val mockBookingTransformer = mockk<BookingTransformer>()
   private val mockWorkingDayService = mockk<WorkingDayService>()
   private val mockBookingRepository = mockk<BookingRepository>()
-  private val mockBedRepository = mockk<BedRepository>()
+  private val mockBedUsageRepository = mockk<BedUsageRepository>()
   private val mockBedUtilisationReportRepository = mockk<BedUtilisationReportRepository>()
 
   private val cas3ReportService = Cas3ReportService(
@@ -51,7 +51,7 @@ class Cas3ReportServiceTest {
     mockBookingTransformer,
     mockWorkingDayService,
     mockBookingRepository,
-    mockBedRepository,
+    mockBedUsageRepository,
     mockBedUtilisationReportRepository,
     2,
   )
@@ -106,7 +106,7 @@ class Cas3ReportServiceTest {
       mockBookingTransformer,
       mockWorkingDayService,
       mockBookingRepository,
-      mockBedRepository,
+      mockBedUsageRepository,
       mockBedUtilisationReportRepository,
       3,
     )


### PR DESCRIPTION
This [PR CAS-589](https://dsdmoj.atlassian.net/browse/CAS-598) is to fix an issue when generate the bedspace usage report for all regions. It reduce the number of bedspaces to include only bedspaces for temporary accommodation service and filter it by region