### PR TITLE
APS-1294 Use correct default ap-and-delius-context config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -170,7 +170,7 @@ services:
   case-notes:
     base-url: http://localhost:9004
   ap-delius-context-api:
-    base-url: http://localhost:9004
+    base-url: http://localhost:8181
   ap-oasys-context-api:
     base-url: http://localhost:9004
   gov-uk-bank-holidays-api:


### PR DESCRIPTION
The default URL configurations in application.yml should match those used for local deployments.