### PR TITLE
Start Cache Refresher once spring has started

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -47,6 +47,7 @@ seed:
 
 assign-default-region-to-users-with-unknown-region: true
 preemptive-cache-logging-enabled: true
+preemptive-cache-lock-duration-ms: 60000
 
 user-allocations:
   rules:


### PR DESCRIPTION
Before this commit the PreemptiveCacheRefresher would start cache refresh threads as soon as soon as it was constructed. This would lead to the cache refreshers starting their work before the spring application was ready to handle requests.

Issues with this approach have been noted in dev where we seed data during spring startup, leading to potential deadlocks on the database.

Furthermore, these threads don’t need to start ASAP, and should really wait until spring is ready.

This commit ensures the cache refreshers once spring has fully started