### PR TITLE
Remove unused test users

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -78,16 +78,6 @@ class Cas1AutoScript(
   private fun usersToSeed(): List<SeedUser> {
     return listOf(
       SeedUser(
-        username = "SHEILAHANCOCKNPS",
-        roles = listOf(UserRole.CAS1_CRU_MEMBER),
-        documentation = "Used for local E2E, with name 'E2E CRU Member",
-      ),
-      SeedUser(
-        username = "APPROVEDPREMISESTESTUSER",
-        roles = listOf(UserRole.CAS1_FUTURE_MANAGER),
-        documentation = "Used for E2E testing in local environment",
-      ),
-      SeedUser(
         username = "JIMSNOWLDAP",
         roles = listOf(
           UserRole.CAS1_ASSESSOR,

--- a/src/main/resources/db/migration/local+dev+test/20240913092812__remove_unused_test_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/20240913092812__remove_unused_test_users.sql
@@ -1,0 +1,4 @@
+-- ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'bernard.beaks', 2500057096),
+-- ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'panesar.jaspal', 2500054544);
+DELETE FROM user_role_assignments WHERE user_id IN ('695ba399-c407-4b66-aafc-e8835d72b8a7','045b71d3-9845-49b3-a79b-c7799a6bc7bc');
+DELETE FROM users WHERE id IN ('695ba399-c407-4b66-aafc-e8835d72b8a7','045b71d3-9845-49b3-a79b-c7799a6bc7bc');

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -2,14 +2,11 @@
 
 --These are randomly generated names
 
-INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probation_region_id, delius_staff_code, ap_area_id) VALUES
-    ('aa30f20a-84e3-4baa-bef0-3c9bd51879ad', 'Default User', 'JIMSNOWLDAP', 2500041001, '43606be0-9836-441d-9bc1-5586de9ac931', 'STAFFCODE', '2cc6bc0f-58cf-4d82-99dd-dfc67b7f5c33'), -- Premises & AP: South West
-    ('9807de9d-05b3-49e2-84b8-529790a299cc', 'C. Load-Tester', 'CAS-LOAD-TESTER', 2500041004, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: Kent, Surrey & Sussex
-    ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Assessor', 'TEMPORARY-ACCOMMODATION-E2E-TESTER', 2500041003, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: Kent, Surrey & Sussex
-    ('7e36a89e-c69e-48b1-a5cf-a7c8949f432a', 'T. Referrer', 'TEMPORARY-ACCOMMODATION-E2E-REFERRER', 2500510725, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: Kent, Surrey & Sussex
-    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE', '6025b8c6-883f-4300-bc26-2b01fbd6e272'), -- Premises & AP: North East
-    ('695ba399-c407-4b66-aafc-e8835d72b8a7', 'Bernard Beaks', 'BERNARD.BEAKS', 2500057096, 'ca979718-b15d-4318-9944-69aaff281cad', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227'), -- Premises & AP: East of England
-    ('045b71d3-9845-49b3-a79b-c7799a6bc7bc', 'Panesar Jaspal', 'PANESAR.JASPAL', 2500054544, 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'STAFFCODE', '56d78348-64d4-4af2-a13c-e5c0d4d30dd0') -- Premises & AP: Wales
+INSERT INTO "users" (id, name, delius_username, delius_staff_identifier, probation_region_id, delius_staff_code, ap_area_id, created_at) VALUES
+    ('aa30f20a-84e3-4baa-bef0-3c9bd51879ad', 'Default User', 'JIMSNOWLDAP', 2500041001, '43606be0-9836-441d-9bc1-5586de9ac931', 'STAFFCODE', '2cc6bc0f-58cf-4d82-99dd-dfc67b7f5c33', now()), -- Premises & AP: South West
+    ('0621c5b0-0028-40b7-87fb-53ec65704314', 'T. Assessor', 'TEMPORARY-ACCOMMODATION-E2E-TESTER', 2500041003, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227', now()), -- Premises & AP: Kent, Surrey & Sussex
+    ('7e36a89e-c69e-48b1-a5cf-a7c8949f432a', 'T. Referrer', 'TEMPORARY-ACCOMMODATION-E2E-REFERRER', 2500510725, 'db82d408-d440-4eb5-960b-119cb33427cd', 'STAFFCODE', '858a01cf-9fd1-482c-a983-1a74713f9227', now()), -- Premises & AP: Kent, Surrey & Sussex
+    ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 2500043547, 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE', '6025b8c6-883f-4300-bc26-2b01fbd6e272', now()) -- Premises & AP: North East
 ON CONFLICT (id) DO NOTHING;
 
 UPDATE
@@ -53,66 +50,6 @@ FROM
 WHERE
   "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
   AND ("role" = 'CAS3_ASSESSOR' OR "role" = 'CAS3_REPORTER')
-ON CONFLICT (id)
-DO
-  NOTHING;
-
--- Copy all roles from JIMSNOWLDAP to TESTER.TESTY
-INSERT INTO
-  "user_role_assignments" ("id", "role", "user_id")
-SELECT
-  gen_random_uuid() AS id,
-  role AS role,
-  (SELECT id FROM users where delius_username='TESTER.TESTY') AS user_id
-FROM
-  "user_role_assignments"
-WHERE
-  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-ON CONFLICT (id)
-DO
-  NOTHING;
-
--- Copy all roles from JIMSNOWLDAP to BERNARD.BEAKS
-INSERT INTO
-  "user_role_assignments" ("id", "role", "user_id")
-SELECT
-  gen_random_uuid() AS id,
-  role AS role,
-  (SELECT id FROM users where delius_username='BERNARD.BEAKS') AS user_id
-FROM
-  "user_role_assignments"
-WHERE
-  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-ON CONFLICT (id)
-DO
-  NOTHING;
-
--- Copy all roles from JIMSNOWLDAP to PANESAR.JASPAL
-INSERT INTO
-  "user_role_assignments" ("id", "role", "user_id")
-SELECT
-  gen_random_uuid() AS id,
-  role AS role,
-  (SELECT id FROM users where delius_username='PANESAR.JASPAL') AS user_id
-FROM
-  "user_role_assignments"
-WHERE
-  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-ON CONFLICT (id)
-DO
-  NOTHING;
-
--- Copy all roles from JIMSNOWLDAP to CAS-LOAD-TESTER
-INSERT INTO
-  "user_role_assignments" ("id", "role", "user_id")
-SELECT
-  gen_random_uuid() AS id,
-  role AS role,
-  (SELECT id FROM users where delius_username='CAS-LOAD-TESTER') AS user_id
-FROM
-  "user_role_assignments"
-WHERE
-  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
 ON CONFLICT (id)
 DO
   NOTHING;


### PR DESCRIPTION
Overtime we have collated several test users are deployed to local environments (and sometimes also dev/test).

This commit removes all test users that are not currently used for either manual or automated testing.

This commit removes these users completely (deletes them)

bernard.beaks
panesar.jaspal

These users will not be added to any new environment:

SHEILAHANCOCKNPS
APPROVEDPREMISESTESTUSER
CAS-LOAD-TESTER