### PR TITLE
APS-1279: Correct wording on validation error message

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -252,7 +252,7 @@ class BookingService(
           "$.premisesId" hasValidationError "mustBeAnApprovedPremises"
         }
       } else {
-        return@validated generalError("You must specify either a bedId or a premisesId")
+        return@validated generalError("You must identify the AP Area and Premises name")
       }
 
       if (validationErrors.any()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -6021,7 +6021,7 @@ class BookingServiceTest {
       assertThat(result.entity is ValidatableActionResult.GeneralValidationError).isTrue
       val error = result.entity as ValidatableActionResult.GeneralValidationError
 
-      assertThat(error.message).isEqualTo("You must specify either a bedId or a premisesId")
+      assertThat(error.message).isEqualTo("You must identify the AP Area and Premises name")
     }
 
     @Test


### PR DESCRIPTION
Correct wording on validation error message when creating a booking from a placement request