### PR TITLE
CAS-545 Extend bookings Api to search bookings by name or CRN

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchResults
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -43,17 +42,17 @@ class BookingsController(
   }
 
   override fun bookingsSearchGet(
-    xServiceName: ServiceName,
     status: BookingStatus?,
     sortOrder: SortOrder?,
     sortField: BookingSearchSortField?,
     page: Int?,
     crn: String?,
+    crnOrName: String?,
   ): ResponseEntity<BookingSearchResults> {
     val sortOrder = sortOrder ?: SortOrder.ascending
     val sortField = sortField ?: BookingSearchSortField.bookingCreatedAt
 
-    val (results, metadata) = bookingSearchService.findBookings(xServiceName, status, sortOrder, sortField, page, crn)
+    val (results, metadata) = bookingSearchService.findBookings(status, sortOrder, sortField, page, crnOrName ?: crn)
 
     return ResponseEntity.ok()
       .headers(metadata?.toHeaders())

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2502,15 +2502,15 @@ paths:
           description: Page number of results to return. If blank, returns all results
           schema:
             type: integer
-        - name: X-Service-Name
-          in: header
-          required: true
-          description: Filters the bookings to those relevant to the specified service.
-          schema:
-            $ref: '_shared.yml#/components/schemas/ServiceName'
         - name: crn
           in: query
           description: If provided, return only results for the given CRN
+          required: false
+          schema:
+            type: string
+        - name: crnOrName
+          in: query
+          description: Filters bookings using exact or partial match on name or exact CRN match
           required: false
           schema:
             type: string

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2504,15 +2504,15 @@ paths:
           description: Page number of results to return. If blank, returns all results
           schema:
             type: integer
-        - name: X-Service-Name
-          in: header
-          required: true
-          description: Filters the bookings to those relevant to the specified service.
-          schema:
-            $ref: '#/components/schemas/ServiceName'
         - name: crn
           in: query
           description: If provided, return only results for the given CRN
+          required: false
+          schema:
+            type: string
+        - name: crnOrName
+          in: query
+          description: Filters bookings using exact or partial match on name or exact CRN match
           required: false
           schema:
             type: string


### PR DESCRIPTION
This [PR CAS-545](https://dsdmoj.atlassian.net/browse/CAS-545) is to extend the booking search to be enabled to search by name or crn. This includes:
- Extend the current Api end point to have a `crnOrName` new parameter. The current parameter `crn` will be removed from the endpoint when the UI work is done
- When search by CRN should match the search term. In case of name can be full/partial match.
- Refactor the code by removing the ApprovedPremises service related code as it not longer be use by the service 