### PR TITLE
APS-1335 - Assign CAS1_PREMISES_VIEW_SUMMARY to relevant role

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -398,6 +398,7 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_APPLICATION_WITHDRAW_OTHERS,
       UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
       UserPermission.CAS1_VIEW_MANAGE_TASKS,
+      UserPermission.CAS1_PREMISES_VIEW_SUMMARY,
     ),
   ),
   CAS1_CRU_MEMBER(
@@ -410,6 +411,7 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_BOOKING_CHANGE_DATES,
       UserPermission.CAS1_BOOKING_WITHDRAW,
       UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE,
+      UserPermission.CAS1_PREMISES_VIEW_SUMMARY,
       UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
       UserPermission.CAS1_VIEW_CRU_DASHBOARD,
       UserPermission.CAS1_VIEW_MANAGE_TASKS,
@@ -446,6 +448,7 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_BOOKING_CREATE,
       UserPermission.CAS1_BOOKING_WITHDRAW,
       UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE,
+      UserPermission.CAS1_PREMISES_VIEW_SUMMARY,
       UserPermission.CAS1_PROCESS_AN_APPEAL,
       UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
       UserPermission.CAS1_VIEW_ASSIGNED_ASSESSMENTS,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.bookingCreate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.bookingWithdraw
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.outOfServiceBedCreate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.premisesViewSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.processAnAppeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.requestForPlacementWithdrawOthers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission.viewAssignedAssessments
@@ -236,6 +237,7 @@ class UserTransformerTest {
           assessAppealedApplication,
           bookingCreate,
           bookingWithdraw,
+          premisesViewSummary,
           processAnAppeal,
           outOfServiceBedCreate,
           requestForPlacementWithdrawOthers,
@@ -260,7 +262,7 @@ class UserTransformerTest {
         userTransformer.transformJpaToApi(user, approvedPremises) as ApprovedPremisesUser
 
       assertThat(result.version).isNotNull()
-      assertThat(result.version).isEqualTo(2087183858)
+      assertThat(result.version).isEqualTo(-950936260)
     }
 
     @Test


### PR DESCRIPTION
As the /cas1/premises/{premiseId} endpoint is going to be used for premise summaries, we need to ensure that all roles that access this page have the neccessary permissions