### PR TITLE
APS-1315 Capture CRU Management Area on Application Submission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -342,6 +342,7 @@ abstract class ApplicationEntity(
   abstract fun getRequiredQualifications(): List<UserQualification>
 }
 
+@SuppressWarnings("LongParameterList")
 @Entity
 @DiscriminatorValue("approved-premises")
 @Table(name = "approved_premises_applications")
@@ -389,6 +390,9 @@ class ApprovedPremisesApplicationEntity(
   @ManyToOne
   @JoinColumn(name = "ap_area_id")
   var apArea: ApAreaEntity?,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cas1_cru_management_area_id")
+  var cruManagementArea: Cas1CruManagementAreaEntity?,
   @OneToOne
   @JoinColumn(name = "applicant_cas1_application_user_details_id")
   var applicantUserDetails: Cas1ApplicationUserDetailsEntity?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -700,7 +700,7 @@ class ApplicationService(
     applicationId: UUID,
     submitApplication: SubmitApprovedPremisesApplication,
     username: String,
-    apAreaId: UUID?,
+    apAreaId: UUID,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     lockableApplicationRepository.acquirePessimisticLock(applicationId)
 
@@ -783,6 +783,7 @@ class ApplicationService(
 
     val now = OffsetDateTime.now(clock)
 
+    val apArea = apAreaRepository.findByIdOrNull(apAreaId)!!
     application.apply {
       isWomensApplication = submitApplication.isWomensApplication
       this.isEmergencyApplication = isEmergencyApplication
@@ -795,7 +796,7 @@ class ApplicationService(
       sentenceType = submitApplication.sentenceType.toString()
       situation = submitApplication.situation?.toString()
       inmateInOutStatusOnSubmission = inmateDetails?.custodyStatus?.name
-      apArea = apAreaRepository.findByIdOrNull(apAreaId)
+      this.apArea = apArea
       this.applicantUserDetails = upsertCas1ApplicationUserDetails(this.applicantUserDetails, submitApplication.applicantUserDetails)
       this.caseManagerIsNotApplicant = submitApplication.caseManagerIsNotApplicant
       this.caseManagerUserDetails = upsertCas1ApplicationUserDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -354,6 +354,7 @@ class ApplicationService(
       situation = null,
       inmateInOutStatusOnSubmission = null,
       apArea = null,
+      cruManagementArea = null,
       applicantUserDetails = null,
       caseManagerIsNotApplicant = null,
       caseManagerUserDetails = null,
@@ -797,6 +798,7 @@ class ApplicationService(
       situation = submitApplication.situation?.toString()
       inmateInOutStatusOnSubmission = inmateDetails?.custodyStatus?.name
       this.apArea = apArea
+      this.cruManagementArea = apArea.defaultCruManagementArea
       this.applicantUserDetails = upsertCas1ApplicationUserDetails(this.applicantUserDetails, submitApplication.applicantUserDetails)
       this.caseManagerIsNotApplicant = submitApplication.caseManagerIsNotApplicant
       this.caseManagerUserDetails = upsertCas1ApplicationUserDetails(

--- a/src/main/resources/db/migration/all/20240919144438__link_cas1_application_to_cru_management_area.sql
+++ b/src/main/resources/db/migration/all/20240919144438__link_cas1_application_to_cru_management_area.sql
@@ -1,0 +1,2 @@
+ALTER TABLE approved_premises_applications ADD cas1_cru_management_area_id uuid NULL;
+ALTER TABLE approved_premises_applications ADD CONSTRAINT approved_premises_applications_cas1_cru_management_areas_fk FOREIGN KEY (cas1_cru_management_area_id) REFERENCES cas1_cru_management_areas(id);

--- a/src/main/resources/db/migration/all/20240919144714__backfill_cas1_application_cru_management_area.sql
+++ b/src/main/resources/db/migration/all/20240919144714__backfill_cas1_application_cru_management_area.sql
@@ -1,0 +1,3 @@
+UPDATE approved_premises_applications apa
+SET cas1_cru_management_area_id = (SELECT default_cru1_management_area_id FROM ap_areas area WHERE area.id = apa.ap_area_id)
+WHERE apa.ap_area_id IS NOT NULL AND apa.cas1_cru_management_area_id IS NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2292,6 +2292,7 @@ components:
               type: string
               format: date
             apAreaId:
+              description: If the user's ap area id is incorrect, they can optionally override it for the application
               type: string
               format: uuid
             applicantUserDetails:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6758,6 +6758,7 @@ components:
               type: string
               format: date
             apAreaId:
+              description: If the user's ap area id is incorrect, they can optionally override it for the application
               type: string
               format: uuid
             applicantUserDetails:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3303,6 +3303,7 @@ components:
               type: string
               format: date
             apAreaId:
+              description: If the user's ap area id is incorrect, they can optionally override it for the application
               type: string
               format: uuid
             applicantUserDetails:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2883,6 +2883,7 @@ components:
               type: string
               format: date
             apAreaId:
+              description: If the user's ap area id is incorrect, they can optionally override it for the application
               type: string
               format: uuid
             applicantUserDetails:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2383,6 +2383,7 @@ components:
               type: string
               format: date
             apAreaId:
+              description: If the user's ap area id is incorrect, they can optionally override it for the application
               type: string
               format: uuid
             applicantUserDetails:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -62,6 +63,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var status: Yielded<ApprovedPremisesApplicationStatus> = { ApprovedPremisesApplicationStatus.STARTED }
   private var inmateInOutStatusOnSubmission: Yielded<String?> = { null }
   private var apArea: Yielded<ApAreaEntity?> = { null }
+  private var cruManagementArea: Yielded<Cas1CruManagementAreaEntity?> = { null }
   private var applicantUserDetails: Yielded<Cas1ApplicationUserDetailsEntity?> = { null }
   private var caseManagerIsNotApplicant: Yielded<Boolean?> = { null }
   private var caseManagerUserDetails: Yielded<Cas1ApplicationUserDetailsEntity?> = { null }
@@ -257,6 +259,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     situation = this.situation(),
     inmateInOutStatusOnSubmission = this.inmateInOutStatusOnSubmission(),
     apArea = this.apArea(),
+    cruManagementArea = this.cruManagementArea(),
     applicantUserDetails = this.applicantUserDetails(),
     caseManagerIsNotApplicant = this.caseManagerIsNotApplicant(),
     caseManagerUserDetails = this.caseManagerUserDetails(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1764,6 +1764,8 @@ class ApplicationServiceTest {
       assertThat(persistedApplication.caseManagerIsNotApplicant).isEqualTo(true)
       assertThat(persistedApplication.caseManagerUserDetails).isEqualTo(theCaseManagerUserDetailsEntity)
       assertThat(persistedApplication.noticeType).isEqualTo(Cas1ApplicationTimelinessCategory.standard)
+      assertThat(persistedApplication.apArea).isEqualTo(apArea)
+      assertThat(persistedApplication.cruManagementArea).isEqualTo(apArea.defaultCruManagementArea)
 
       verify { mockApplicationRepository.save(any()) }
       verify(exactly = 1) { mockAssessmentService.createApprovedPremisesAssessment(application) }


### PR DESCRIPTION
This PR adds a new 'default_cru1_management_area_id' column to approved_premises_application

Initially this will always be derived from the AP Area's default Management Area. In subsequent commits we will use the ‘Women’s Estate’ Management Area if the application is for a female.

This PR also backfills the management area for any submitted applications.