### PR TITLE
Remove direct usage of ApAreaEntityFactory in IT

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -42,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClie
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulRegistrationsCall
@@ -150,9 +151,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
       roles = listOf(UserRole.CAS1_ASSESSOR),
       probationRegion = probationRegionEntityFactory.produceAndPersist {
         withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist {
-            withName("Wales")
-          }
+          `Given an AP Area`(name = "Wales")
         }
       },
     )
@@ -607,7 +606,11 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        probationRegionEntityFactory.produceAndPersist {
+          withYieldedApArea {
+            `Given an AP Area`()
+          }
+        }
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
@@ -121,9 +122,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
           withPermissiveSchema()
         }
 
-        val probationRegion = probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        }
+        val probationRegion = `Given a Probation Region`()
 
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withProbationRegion(probationRegion)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -54,6 +54,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClie
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
@@ -281,9 +282,7 @@ class ApplicationTest : IntegrationTestBase() {
                 createTempApplicationEntity(applicationSchema, otherUser, offenderDetails, probationRegion, null)
 
               val otherProbationRegion = probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea {
-                  apAreaEntityFactory.produceAndPersist()
-                }
+                withYieldedApArea { `Given an AP Area`() }
               }
 
               val notInRegionApplication =
@@ -2147,8 +2146,7 @@ class ApplicationTest : IntegrationTestBase() {
 
             GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 
-            val apArea = apAreaEntityFactory.produceAndPersist {
-            }
+            val apArea = `Given an AP Area`()
 
             val probationRegion = probationRegionEntityFactory.produceAndPersist {
               withApArea(apArea)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelinessTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelinessTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelinessEntityRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
@@ -24,11 +25,7 @@ class ApplicationTimelinessTest : IntegrationTestBase() {
     }
 
     val user = userEntityFactory.produceAndPersist {
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
     }
 
     val month = 4

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 
 class BedDetailQueryTest : IntegrationTestBase() {
@@ -11,11 +12,7 @@ class BedDetailQueryTest : IntegrationTestBase() {
 
   @Test
   fun `summary works as expected`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedSearchRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomNumberChars
 import java.time.LocalDate
@@ -13,6 +16,15 @@ import java.time.LocalDate
 class BedSearchRepositoryTest : IntegrationTestBase() {
   @Autowired
   lateinit var bedSearchRepository: BedSearchRepository
+
+  lateinit var probationRegion: ProbationRegionEntity
+  lateinit var otherProbationRegion: ProbationRegionEntity
+
+  @BeforeEach
+  fun before() {
+    probationRegion = `Given a Probation Region`()
+    otherProbationRegion = `Given a Probation Region`()
+  }
 
   // Searching for a Bed returns Beds ordered by their distance from the postcode district that:
   // - Match all the characteristics at both Premises and Room level
@@ -33,12 +45,6 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withOutcode("AA11")
       withLatitude(postCodeDistrictLatLong.latitude)
       withLongitude(postCodeDistrictLatLong.longitude)
-    }
-
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
     }
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
@@ -439,18 +445,6 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
     val bedsThatShouldNotAppearInSearchResults = mutableListOf<BedEntity>()
     val bedsThatShouldAppearInSearchResults = mutableListOf<BedEntity>()
 
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
-
-    val otherProbationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
-
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
     val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
@@ -756,12 +750,6 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
     val bedsThatShouldNotAppearInSearchResults = mutableListOf<BedEntity>()
     val bedsThatShouldAppearInSearchResults = mutableListOf<BedEntity>()
 
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
-
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
     val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
@@ -953,12 +941,6 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
   fun `Searching for a Temporary Accommodation Bedspace in a Single Occupancy Property returns correct results`() {
     val bedsThatShouldNotAppearInSearchResults = mutableListOf<BedEntity>()
     val bedsThatShouldAppearInSearchResults = mutableListOf<BedEntity>()
-
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.hamcrest.Matchers
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesBedSearchParameters
@@ -16,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationBedSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationBedSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationBedSearchResultOverlap
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
@@ -34,6 +36,13 @@ import java.time.LocalDate
 import java.util.UUID
 @SuppressWarnings("LargeClass")
 class BedSearchTest : IntegrationTestBase() {
+
+  lateinit var probationRegion: ProbationRegionEntity
+
+  @BeforeEach
+  fun before() {
+    probationRegion = `Given a Probation Region`()
+  }
 
   @Nested
   inner class BedSearchForApprovedPremises {
@@ -90,12 +99,6 @@ class BedSearchTest : IntegrationTestBase() {
           withOutcode("AA11")
           withLatitude(postCodeDistrictLatLong.latitude)
           withLongitude(postCodeDistrictLatLong.longitude)
-        }
-
-        val probationRegion = probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea {
-            apAreaEntityFactory.produceAndPersist()
-          }
         }
 
         val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
@@ -176,12 +179,6 @@ class BedSearchTest : IntegrationTestBase() {
   inner class BedSearchForTemporaryAccommodationPremises {
     @Test
     fun `Searching for a Temporary Accommodation Bed returns 200 with correct body`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -241,12 +238,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed returns results that do not include beds with current turnarounds`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -300,12 +291,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed returns results when existing booking departure-date is same as search start-date`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -359,12 +344,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed returns results which include overlapping bookings for rooms in the same premises`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -476,12 +455,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed returns results which include overlapping bookings across multiple premises`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -619,12 +592,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed returns results which do not include non-overlapping bookings`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -701,12 +668,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed returns results which do not consider cancelled bookings as overlapping`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -790,12 +751,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bedspace in a Shared Property returns only bedspaces in shared properties`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -922,12 +877,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bedspace in a Single Occupancy Property returns only bedspaces in properties with single occupancy`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -1101,12 +1050,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed should return single bed when given premises has got 2 rooms where one with endDate and another room without enddate`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -1177,12 +1120,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed should return bed when given premises bedspace endDate after search end date`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }
@@ -1256,12 +1193,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed should return bed matches searching pdu`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withName(randomStringLowerCase(8))
         withProbationRegion(probationRegion)
@@ -1371,12 +1302,6 @@ class BedSearchTest : IntegrationTestBase() {
 
     @Test
     fun `Searching for a Temporary Accommodation Bed in multiple pdus should return bed matches searching pdus`() {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val pduOne = probationDeliveryUnitFactory.produceAndPersist {
         withName("Probation Delivery Unit One")
         withProbationRegion(probationRegion)
@@ -1535,12 +1460,6 @@ class BedSearchTest : IntegrationTestBase() {
       searchStartDate: LocalDate,
       bedEndDate: LocalDate,
     ): ProbationDeliveryUnitEntity {
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-
       val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
         withProbationRegion(probationRegion)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
@@ -19,11 +20,7 @@ class BedSummaryQueryTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import java.time.LocalDate
@@ -14,11 +15,7 @@ class BedSummaryTest : InitialiseDatabasePerClassTestBase() {
 
   @BeforeEach
   fun setup() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given Some Offenders`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addListCaseSummaryToBulkResponse
@@ -298,13 +299,7 @@ class BookingSearchTest : IntegrationTestBase() {
         }
 
         val unexpectedPremises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea {
-                apAreaEntityFactory.produceAndPersist()
-              }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
           withYieldedLocalAuthorityArea {
             localAuthorityEntityFactory.produceAndPersist()
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -19,7 +20,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewNonarrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulGetReferralDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
@@ -29,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -49,6 +53,13 @@ import java.util.UUID
 class BookingTest : IntegrationTestBase() {
   @Autowired
   lateinit var bookingTransformer: BookingTransformer
+
+  lateinit var probationRegion: ProbationRegionEntity
+
+  @BeforeEach
+  fun before() {
+    probationRegion = `Given a Probation Region`()
+  }
 
   @Nested
   inner class GetBooking {
@@ -76,11 +87,11 @@ class BookingTest : IntegrationTestBase() {
     fun `Get a booking returns OK with the correct body when user has one of roles MANAGER, MATCHER`(
       role: UserRole,
     ) {
-      `Given a User`(roles = listOf(role)) { userEntity, jwt ->
+      `Given a User`(roles = listOf(role)) { _, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+            withYieldedProbationRegion { probationRegion }
           }
 
           val keyWorker = ContextStaffMemberFactory().produce()
@@ -136,7 +147,7 @@ class BookingTest : IntegrationTestBase() {
         ) { offenderDetails, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+            withYieldedProbationRegion { probationRegion }
           }
 
           val keyWorker = ContextStaffMemberFactory().produce()
@@ -169,7 +180,7 @@ class BookingTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, inmateDetails ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+            withYieldedProbationRegion { probationRegion }
           }
 
           val keyWorker = ContextStaffMemberFactory().produce()
@@ -207,7 +218,7 @@ class BookingTest : IntegrationTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val keyWorker = ContextStaffMemberFactory().produce()
@@ -249,7 +260,7 @@ class BookingTest : IntegrationTestBase() {
         ) { offenderDetails, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+            withYieldedProbationRegion { probationRegion }
           }
 
           val keyWorker = ContextStaffMemberFactory().produce()
@@ -289,7 +300,7 @@ class BookingTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, inmateDetails ->
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+            withYieldedProbationRegion { probationRegion }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -335,14 +346,7 @@ class BookingTest : IntegrationTestBase() {
         `Given an Offender` { offenderDetails, inmateDetails ->
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withId(UUID.randomUUID())
-                withYieldedApArea {
-                  apAreaEntityFactory.produceAndPersist()
-                }
-              }
-            }
+            withYieldedProbationRegion { probationRegion }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -403,7 +407,7 @@ class BookingTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+        withYieldedProbationRegion { probationRegion }
       }
 
       webTestClient.get()
@@ -425,7 +429,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -492,7 +496,7 @@ class BookingTest : IntegrationTestBase() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          probationRegion
         }
       }
 
@@ -535,7 +539,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -581,12 +585,7 @@ class BookingTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bookings = bookingEntityFactory.produceAndPersistMultiple(5) {
@@ -636,7 +635,7 @@ class BookingTest : IntegrationTestBase() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
       withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+        probationRegion
       }
     }
 
@@ -667,7 +666,7 @@ class BookingTest : IntegrationTestBase() {
             val premises = approvedPremisesEntityFactory.produceAndPersist {
               withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
               withYieldedProbationRegion {
-                probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+                probationRegion
               }
             }
 
@@ -755,7 +754,7 @@ class BookingTest : IntegrationTestBase() {
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+              probationRegion
             }
           }
 
@@ -819,7 +818,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -906,7 +905,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -980,7 +979,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1054,7 +1053,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1128,7 +1127,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1216,7 +1215,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1301,7 +1300,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1401,7 +1400,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1467,7 +1466,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1527,7 +1526,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1562,7 +1561,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1607,7 +1606,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1663,7 +1662,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1727,7 +1726,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1802,7 +1801,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1857,7 +1856,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
           withTurnaroundWorkingDayCount(2)
         }
@@ -1914,7 +1913,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -1988,12 +1987,7 @@ class BookingTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -2051,7 +2045,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -2116,7 +2110,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -2183,11 +2177,7 @@ class BookingTest : IntegrationTestBase() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withQCode("QCODE")
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val room = roomEntityFactory.produceAndPersist {
@@ -2238,11 +2228,7 @@ class BookingTest : IntegrationTestBase() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withQCode("QCODE")
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val room = roomEntityFactory.produceAndPersist {
@@ -2300,11 +2286,7 @@ class BookingTest : IntegrationTestBase() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withQCode("QCODE")
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val room = roomEntityFactory.produceAndPersist {
@@ -2351,11 +2333,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withQCode("QCODE")
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2413,11 +2391,7 @@ class BookingTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -2476,11 +2450,7 @@ class BookingTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -2546,11 +2516,7 @@ class BookingTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -2618,12 +2584,7 @@ class BookingTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -2678,11 +2639,7 @@ class BookingTest : IntegrationTestBase() {
           approvedPremisesEntityFactory.produceAndPersist {
             withQCode("QCODE")
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { probationRegion }
           }
         }
         withServiceName(ServiceName.approvedPremises)
@@ -2733,11 +2690,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withQCode("QCODE")
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2810,11 +2763,7 @@ class BookingTest : IntegrationTestBase() {
           approvedPremisesEntityFactory.produceAndPersist {
             withQCode("QCODE")
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { probationRegion }
           }
         }
         withServiceName(ServiceName.approvedPremises)
@@ -2867,11 +2816,7 @@ class BookingTest : IntegrationTestBase() {
           withYieldedPremises {
             temporaryAccommodationPremisesEntityFactory.produceAndPersist {
               withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-              withYieldedProbationRegion {
-                probationRegionEntityFactory.produceAndPersist {
-                  withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-                }
-              }
+              withYieldedProbationRegion { probationRegion }
             }
           }
           withServiceName(ServiceName.temporaryAccommodation)
@@ -2928,11 +2873,7 @@ class BookingTest : IntegrationTestBase() {
           withYieldedPremises {
             temporaryAccommodationPremisesEntityFactory.produceAndPersist {
               withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-              withYieldedProbationRegion {
-                probationRegionEntityFactory.produceAndPersist {
-                  withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-                }
-              }
+              withYieldedProbationRegion { probationRegion }
             }
           }
           withServiceName(ServiceName.temporaryAccommodation)
@@ -2990,11 +2931,7 @@ class BookingTest : IntegrationTestBase() {
           withYieldedPremises {
             temporaryAccommodationPremisesEntityFactory.produceAndPersist {
               withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-              withYieldedProbationRegion {
-                probationRegionEntityFactory.produceAndPersist {
-                  withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-                }
-              }
+              withYieldedProbationRegion { probationRegion }
             }
           }
           withServiceName(ServiceName.temporaryAccommodation)
@@ -3059,9 +2996,7 @@ class BookingTest : IntegrationTestBase() {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         `Given a User`(roles = listOf(role)) { applicant, _ ->
           `Given an Offender` { offenderDetails, _ ->
-            val apArea = apAreaEntityFactory.produceAndPersist {
-              withEmailAddress("apAreaEmail@test.com")
-            }
+            val apArea = `Given an AP Area`(emailAddress = "apAreaEmail@test.com")
 
             val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
               withCrn(offenderDetails.otherIds.crn)
@@ -3076,7 +3011,7 @@ class BookingTest : IntegrationTestBase() {
                 approvedPremisesEntityFactory.produceAndPersist {
                   withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
                   withYieldedProbationRegion {
-                    probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+                    probationRegion
                   }
                 }
               }
@@ -3112,9 +3047,7 @@ class BookingTest : IntegrationTestBase() {
         `Given a User` { applicant, _ ->
           `Given a User` { placementApplicationCreator, _ ->
             `Given an Offender` { offenderDetails, _ ->
-              val apArea = apAreaEntityFactory.produceAndPersist {
-                withEmailAddress("apAreaEmail@test.com")
-              }
+              val apArea = `Given an AP Area`(emailAddress = "apAreaEmail@test.com")
 
               val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
                 withCrn(offenderDetails.otherIds.crn)
@@ -3159,7 +3092,7 @@ class BookingTest : IntegrationTestBase() {
                   approvedPremisesEntityFactory.produceAndPersist {
                     withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
                     withYieldedProbationRegion {
-                      probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+                      probationRegion
                     }
                   }
                 }
@@ -3233,12 +3166,7 @@ class BookingTest : IntegrationTestBase() {
         withYieldedPremises {
           temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withId(UUID.randomUUID())
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { probationRegion }
           }
         }
       }
@@ -3541,7 +3469,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -3603,7 +3531,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -3673,7 +3601,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -3734,7 +3662,7 @@ class BookingTest : IntegrationTestBase() {
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegion
           }
         }
 
@@ -3809,7 +3737,7 @@ class BookingTest : IntegrationTestBase() {
         withQCode("QCODE")
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          probationRegion
         }
       }
 
@@ -3843,7 +3771,7 @@ class BookingTest : IntegrationTestBase() {
         withQCode("QCODE")
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          probationRegion
         }
       }
 
@@ -3868,7 +3796,7 @@ class BookingTest : IntegrationTestBase() {
         withQCode("QCODE")
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          probationRegion
         }
       }
 
@@ -3911,7 +3839,7 @@ class BookingTest : IntegrationTestBase() {
         withQCode("QCODE")
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          probationRegion
         }
       }
 
@@ -3956,7 +3884,7 @@ class BookingTest : IntegrationTestBase() {
         withQCode("QCODE")
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          probationRegion
         }
       }
 
@@ -3998,12 +3926,7 @@ class BookingTest : IntegrationTestBase() {
         withYieldedPremises {
           temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withId(UUID.randomUUID())
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { probationRegion }
           }
         }
       }
@@ -4045,7 +3968,7 @@ class BookingTest : IntegrationTestBase() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          probationRegion
         }
       }
 
@@ -4088,7 +4011,7 @@ class BookingTest : IntegrationTestBase() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+          probationRegion
         }
       }
 
@@ -4158,7 +4081,7 @@ class BookingTest : IntegrationTestBase() {
           approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+              probationRegion
             }
           }
         }
@@ -4192,7 +4115,7 @@ class BookingTest : IntegrationTestBase() {
           temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+              probationRegion
             }
           }
         }
@@ -4248,7 +4171,7 @@ class BookingTest : IntegrationTestBase() {
             temporaryAccommodationPremisesEntityFactory.produceAndPersist {
               withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
               withYieldedProbationRegion {
-                probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+                probationRegion
               }
             }
           }
@@ -4294,11 +4217,7 @@ class BookingTest : IntegrationTestBase() {
           approvedPremisesEntityFactory.produceAndPersist {
             withQCode("QCODE")
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { probationRegion }
           }
         }
       }
@@ -4333,12 +4252,7 @@ class BookingTest : IntegrationTestBase() {
         withYieldedPremises {
           temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withId(UUID.randomUUID())
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { probationRegion }
           }
         }
         withServiceName(ServiceName.temporaryAccommodation)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulOffenderDetailsCall
@@ -80,11 +81,7 @@ class CacheClearTest : IntegrationTestBase() {
 
   private fun setupBookingForOffender(offenderDetails: OffenderDetailSummary) {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
       withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     }
 
@@ -127,9 +124,7 @@ class CacheClearTest : IntegrationTestBase() {
     approvedPremisesEntityFactory.produceAndPersist {
       withId(premisesId)
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
       withQCode(qCode)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CalendarRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CalendarRepositoryTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CalendarBedInfo
@@ -12,7 +13,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CalendarBooki
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CalendarLostBedInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.CalendarRepository
 import java.time.LocalDate
-import java.util.UUID
 
 class CalendarRepositoryTest : IntegrationTestBase() {
   @Autowired
@@ -24,14 +24,7 @@ class CalendarRepositoryTest : IntegrationTestBase() {
   fun createPremises() {
     premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withId(UUID.randomUUID())
-          withYieldedApArea {
-            apAreaEntityFactory.produceAndPersist()
-          }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CancellationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CancellationQueryTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
@@ -16,11 +17,7 @@ class CancellationQueryTest : IntegrationTestBase() {
     `Given a User` { user, _ ->
       `Given an Application`(createdByUser = user) { application ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withProbationRegion(
-            probationRegionEntityFactory.produceAndPersist {
-              withApArea(apAreaEntityFactory.produceAndPersist())
-            },
-          )
+          withProbationRegion(`Given a Probation Region`())
           withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
         }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CapacityTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -7,20 +8,27 @@ import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DateCapacity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import java.time.LocalDate
-import java.util.UUID
 
 class CapacityTest : IntegrationTestBase() {
+
+  lateinit var probationRegion: ProbationRegionEntity
+
+  @BeforeEach
+  fun before() {
+    probationRegion = `Given a Probation Region`()
+  }
+
   @Test
   fun `Get Capacity without JWT returns 401`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { probationRegion }
     }
 
     webTestClient.get()
@@ -48,11 +56,7 @@ class CapacityTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       bedEntityFactory.produceAndPersistMultiple(30) {
@@ -76,9 +80,7 @@ class CapacityTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       bedEntityFactory.produceAndPersistMultiple(30) {
@@ -111,9 +113,7 @@ class CapacityTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       bedEntityFactory.produceAndPersistMultiple(30) {
@@ -154,12 +154,7 @@ class CapacityTest : IntegrationTestBase() {
     `Given a User` { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas1TaskDueMigrationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas1TaskDueMigrationJobTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
@@ -84,11 +85,7 @@ class Cas1TaskDueMigrationJobTest : IntegrationTestBase() {
 
   private fun createPlacementApplication(): PlacementApplicationEntity {
     val user = userEntityFactory.produceAndPersist {
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
     }
 
     val assessment = createAssessment()
@@ -130,11 +127,7 @@ class Cas1TaskDueMigrationJobTest : IntegrationTestBase() {
 
   private fun createAssessment(): ApprovedPremisesAssessmentEntity {
     val user = userEntityFactory.produceAndPersist {
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
     }
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CharacteristicQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CharacteristicQueryTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 
 class CharacteristicQueryTest : IntegrationTestBase() {
@@ -11,11 +12,7 @@ class CharacteristicQueryTest : IntegrationTestBase() {
 
   @Test
   fun `findAllForRoomId returns all the characteristics for a roomId`() {
-    var probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DailyMetricsReportTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeBookedByFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.StaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -72,11 +73,7 @@ class DailyMetricsReportTest : IntegrationTestBase() {
       val year = 2023
 
       val user = userEntityFactory.produceAndPersist {
-        withProbationRegion(
-          probationRegionEntityFactory.produceAndPersist {
-            withApArea(apAreaEntityFactory.produceAndPersist())
-          },
-        )
+        withProbationRegion(`Given a Probation Region`())
       }
 
       val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeletePremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeletePremisesTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
@@ -124,11 +125,7 @@ class DeletePremisesTest : IntegrationTestBase() {
   }
 
   private fun createPremises() = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-    withProbationRegion(
-      probationRegionEntityFactory.produceAndPersist {
-        withApArea(apAreaEntityFactory.produceAndPersist())
-      },
-    )
+    withProbationRegion(`Given a Probation Region`())
 
     withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteRoomTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteRoomTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
@@ -102,11 +103,7 @@ class DeleteRoomTest : IntegrationTestBase() {
   private fun createRoom() = roomEntityFactory.produceAndPersist {
     withYieldedPremises {
       temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-        withProbationRegion(
-          probationRegionEntityFactory.produceAndPersist {
-            withApArea(apAreaEntityFactory.produceAndPersist())
-          },
-        )
+        withProbationRegion(`Given a Probation Region`())
         withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -105,6 +105,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruMana
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.toStaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.DomainEventAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.EmailNotificationAsserter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addStaffDetailResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MockFeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MutableClockConfiguration
@@ -850,7 +851,7 @@ abstract class IntegrationTestBase {
   fun mockStaffUserInfoCommunityApiCall(staffUserDetails: StaffUserDetails, createProbationRegionForStaffAreaCode: Boolean = true): StubMapping? {
     if (createProbationRegionForStaffAreaCode) {
       probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        withYieldedApArea { `Given an AP Area`() }
         withDeliusCode(staffUserDetails.probationArea.code)
       }
     }
@@ -858,9 +859,9 @@ abstract class IntegrationTestBase {
     ApDeliusContext_addStaffDetailResponse(staffDetail = staffUserDetails.toStaffDetail())
 
     return wiremockServer.stubFor(
-      WireMock.get(WireMock.urlEqualTo("/secure/staff/username/${staffUserDetails.username}"))
+      WireMock.get(urlEqualTo("/secure/staff/username/${staffUserDetails.username}"))
         .willReturn(
-          WireMock.aResponse()
+          aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(200)
             .withBody(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/LostBedsTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -9,9 +10,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewLostBedCanc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LostBedsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
@@ -23,13 +26,18 @@ class LostBedsTest : IntegrationTestBase() {
   @Autowired
   lateinit var lostBedsTransformer: LostBedsTransformer
 
+  lateinit var probationRegion: ProbationRegionEntity
+
+  @BeforeEach
+  fun before() {
+    probationRegion = `Given a Probation Region`()
+  }
+
   @Test
   fun `List Lost Beds without JWT returns 401`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { probationRegion }
     }
 
     webTestClient.get()
@@ -57,9 +65,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -108,9 +114,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -147,12 +151,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User` { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -185,9 +184,7 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Get Lost Bed without JWT returns 401`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { probationRegion }
     }
 
     val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -231,9 +228,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       webTestClient.get()
@@ -251,9 +246,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -290,9 +283,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -329,12 +320,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User` { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -369,9 +355,7 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Create Lost Beds without JWT returns 401`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { probationRegion }
     }
 
     val bed = bedEntityFactory.produceAndPersist {
@@ -400,13 +384,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val reason = lostBedReasonEntityFactory.produceAndPersist {
@@ -441,9 +419,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       bedEntityFactory.produceAndPersistMultiple(3) {
@@ -497,9 +473,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       bedEntityFactory.produceAndPersistMultiple(2) {
@@ -560,13 +534,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -618,14 +586,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User` { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -667,9 +628,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       bedEntityFactory.produceAndPersistMultiple(2) {
@@ -713,9 +672,7 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Update Lost Bed without JWT returns 401`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { probationRegion }
     }
 
     val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -783,9 +740,7 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Update Lost Bed for non-existent lost bed returns 404`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { probationRegion }
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -813,9 +768,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       bedEntityFactory.produceAndPersistMultiple(2) {
@@ -876,13 +829,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -939,14 +886,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User` { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -992,9 +932,7 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Cancel Lost Bed without JWT returns 401`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { probationRegion }
     }
 
     val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -1046,9 +984,7 @@ class LostBedsTest : IntegrationTestBase() {
   fun `Cancel Lost Bed for non-existent lost bed returns 404`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { probationRegion }
     }
 
     val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -1072,9 +1008,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(role)) { userEntity, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       bedEntityFactory.produceAndPersistMultiple(2) {
@@ -1123,13 +1057,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -1174,14 +1102,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User` { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -1225,9 +1146,7 @@ class LostBedsTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -1283,9 +1202,7 @@ class LostBedsTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -1352,9 +1269,7 @@ class LostBedsTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -1407,9 +1322,7 @@ class LostBedsTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -1475,13 +1388,7 @@ class LostBedsTest : IntegrationTestBase() {
     `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { probationRegion }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -1543,13 +1450,7 @@ class LostBedsTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea {
-                apAreaEntityFactory.produceAndPersist()
-              }
-            }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -1623,9 +1524,7 @@ class LostBedsTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -1685,9 +1584,7 @@ class LostBedsTest : IntegrationTestBase() {
       `Given an Offender` { offenderDetails, inmateDetails ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { probationRegion }
         }
 
         val bed = bedEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MoveBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/MoveBookingTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBedMove
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
@@ -20,9 +21,7 @@ class MoveBookingTest : InitialiseDatabasePerClassTestBase() {
   fun setup() {
     premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     booking = bookingEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -42,7 +42,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationClientResponseFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulRegistrationsCall
@@ -131,13 +133,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
     )
     assessorDetails = `Given a User`(
       roles = listOf(UserRole.CAS1_ASSESSOR),
-      probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist {
-            withName("Wales")
-          }
-        }
-      },
+      probationRegion = `Given a Probation Region`(apArea = `Given an AP Area`(name = "Wales")),
       staffUserDetailsConfigBlock = {
         withProbationAreaCode("N03")
       },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Submitted Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
@@ -427,11 +428,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
       `Given a User` { _, jwt ->
         `Given a Placement Application`(
           createdByUser = userEntityFactory.produceAndPersist {
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           },
           schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
@@ -589,11 +586,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
       `Given a User` { _, jwt ->
         `Given a Placement Application`(
           createdByUser = userEntityFactory.produceAndPersist {
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           },
           schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
@@ -1119,11 +1112,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
       val placementApplication = `Given a Placement Application`(
         allocatedToUser = allocatedToUser,
         createdByUser = userEntityFactory.produceAndPersist {
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         },
         schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
           withPermissiveSchema()
@@ -1206,11 +1195,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
       `Given a User` { _, jwt ->
         `Given a Placement Application`(
           createdByUser = userEntityFactory.produceAndPersist {
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-              }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           },
           schema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import java.time.LocalDate
@@ -70,11 +71,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     @BeforeEach
     fun setup() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withProbationRegion(
-          probationRegionEntityFactory.produceAndPersist {
-            withApArea(apAreaEntityFactory.produceAndPersist())
-          },
-        )
+        withProbationRegion(`Given a Probation Region`())
         withLocalAuthorityArea(
           localAuthorityEntityFactory.produceAndPersist(),
         )
@@ -262,11 +259,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
 
   private fun createPlacementRequests(count: Int, isWithdrawn: Boolean, isReallocated: Boolean, isParole: Boolean, crn: String? = null, name: String? = null, expectedArrival: LocalDate? = null, tier: String? = null): List<PlacementRequestEntity> {
     val user = userEntityFactory.produceAndPersist {
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
     }
 
     return List(count) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
@@ -30,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -50,6 +53,13 @@ class PlacementRequestsTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var realPlacementRequestRepository: PlacementRequestRepository
+
+  lateinit var probationRegion: ProbationRegionEntity
+
+  @BeforeEach
+  fun before() {
+    probationRegion = `Given a Probation Region`()
+  }
 
   @Nested
   inner class AllPlacementRequests {
@@ -292,11 +302,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
 
           fun matchPlacementRequest(placementRequest: PlacementRequestEntity) {
             val premises = approvedPremisesEntityFactory.produceAndPersist {
-              withProbationRegion(
-                probationRegionEntityFactory.produceAndPersist {
-                  withApArea(apAreaEntityFactory.produceAndPersist())
-                },
-              )
+              withProbationRegion(probationRegion)
               withLocalAuthorityArea(
                 localAuthorityEntityFactory.produceAndPersist(),
               )
@@ -1055,11 +1061,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
       return placementRequestFactory.produceAndPersist {
         withAllocatedToUser(
           userEntityFactory.produceAndPersist {
-            withProbationRegion(
-              probationRegionEntityFactory.produceAndPersist {
-                withApArea(apAreaEntityFactory.produceAndPersist())
-              },
-            )
+            withProbationRegion(probationRegion)
           },
         )
         withApplication(application)
@@ -1294,11 +1296,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
               crn = offenderDetails.otherIds.crn,
             ) { placementRequest, _ ->
               val premises = approvedPremisesEntityFactory.produceAndPersist {
-                withProbationRegion(
-                  probationRegionEntityFactory.produceAndPersist {
-                    withApArea(apAreaEntityFactory.produceAndPersist())
-                  },
-                )
+                withProbationRegion(probationRegion)
                 withLocalAuthorityArea(
                   localAuthorityEntityFactory.produceAndPersist(),
                 )
@@ -1380,9 +1378,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
               ) { placementRequest, _ ->
                 val premises = approvedPremisesEntityFactory.produceAndPersist {
                   withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion {
-                    probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-                  }
+                  withYieldedProbationRegion { probationRegion }
                 }
 
                 val room = roomEntityFactory.produceAndPersist {
@@ -1445,9 +1441,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                   ) { placementRequest, _ ->
                     val premises = approvedPremisesEntityFactory.produceAndPersist {
                       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                      withYieldedProbationRegion {
-                        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-                      }
+                      withYieldedProbationRegion { probationRegion }
                     }
 
                     val room = roomEntityFactory.produceAndPersist {
@@ -1545,9 +1539,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
               ) { placementRequest, _ ->
                 val premises = approvedPremisesEntityFactory.produceAndPersist {
                   withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion {
-                    probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-                  }
+                  withYieldedProbationRegion { probationRegion }
                 }
 
                 val room = roomEntityFactory.produceAndPersist {
@@ -1592,9 +1584,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
               ) { placementRequest, _ ->
                 val premises = approvedPremisesEntityFactory.produceAndPersist {
                   withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion {
-                    probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-                  }
+                  withYieldedProbationRegion { probationRegion }
                 }
 
                 webTestClient.post()
@@ -1632,9 +1622,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
               ) { placementRequest, _ ->
                 val premises = approvedPremisesEntityFactory.produceAndPersist {
                   withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion {
-                    probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-                  }
+                  withYieldedProbationRegion { probationRegion }
                 }
 
                 webTestClient.post()
@@ -1768,7 +1756,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
             assessmentAllocatedTo = user,
             createdByUser = user,
             crn = offenderDetails.otherIds.crn,
-            apArea = apAreaEntityFactory.produceAndPersist(),
+            apArea = `Given an AP Area`(),
           ) { placementRequest, _ ->
 
             webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import java.time.LocalDate
 import java.util.UUID
 class PremisesSummaryTest : IntegrationTestBase() {
@@ -31,12 +33,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
       // unexpectedCas3Premises that's in a different region
       temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val room = roomEntityFactory.produceAndPersist {
@@ -285,12 +282,10 @@ class PremisesSummaryTest : IntegrationTestBase() {
 
   @Test
   fun `Get all CAS1 Premises returns OK with correct body`() {
-    `Given a User` { _, jwt ->
+    `Given a User` { user, jwt ->
       val uuid = UUID.randomUUID()
-      val apArea = apAreaEntityFactory.produceAndPersist()
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withApArea(apArea)
-      }
+      val apArea = `Given an AP Area`()
+      val probationRegion = `Given a Probation Region`(apArea = apArea)
 
       val cas1Premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -354,8 +349,8 @@ class PremisesSummaryTest : IntegrationTestBase() {
   @Test
   fun `Get all CAS1 Premises filters by probation region`() {
     `Given a User` { _, jwt ->
-      val region1 = probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      val region2 = probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      val region1 = `Given a Probation Region`()
+      val region2 = `Given a Probation Region`()
 
       val region1Premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -383,9 +378,9 @@ class PremisesSummaryTest : IntegrationTestBase() {
   @Test
   fun `Get all CAS1 Premises filters by AP Area`() {
     `Given a User` { _, jwt ->
-      val apArea = apAreaEntityFactory.produceAndPersist()
-      val region1 = probationRegionEntityFactory.produceAndPersist { withApArea(apArea) }
-      val region2 = probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+      val apArea = `Given an AP Area`()
+      val region1 = `Given a Probation Region`(apArea = apArea)
+      val region2 = `Given a Probation Region`()
 
       val apAreaPremises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateRoom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addCaseSummaryToBulkResponse
@@ -289,9 +290,7 @@ class PremisesTest {
     fun `Trying to create a new premises with a non-unique name returns 400`() {
       temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withName("premises-name-conflict")
       }
 
@@ -611,9 +610,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
         val premisesToGet = premises[0]
 
@@ -889,10 +886,7 @@ class PremisesTest {
           withProbationRegion(user.probationRegion)
         }
 
-        val otherProbationRegion = probationRegionEntityFactory.produceAndPersist {
-          withId(UUID.randomUUID())
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
+        val otherProbationRegion = `Given a Probation Region`()
 
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -935,9 +929,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val premisesToGet = premises[0]
@@ -972,9 +964,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val premisesToGet = premises[0]
@@ -1007,9 +997,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(1) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val premisesToGet = premises[0]
@@ -1044,9 +1032,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val premisesToGet = premises[0]
@@ -1084,9 +1070,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val premisesToGet = premises[0]
@@ -1175,9 +1159,7 @@ class PremisesTest {
 
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(1) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val premisesToGet = premises[0]
@@ -1215,9 +1197,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
           withName("old-premises-name")
         }
 
@@ -1448,11 +1428,7 @@ class PremisesTest {
       }
 
       // Add some extra premises in both services for other regions that shouldn't be returned
-      val otherRegion = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
+      val otherRegion = `Given a Probation Region`()
 
       cas3Premises[otherRegion] = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1596,9 +1572,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }.onEach {
           addRoomsAndBeds(it, roomCount = 4, 5)
           addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
@@ -1623,9 +1597,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersistMultiple(5) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }.onEach {
           addRoomsAndBeds(it, roomCount = 4, 5)
           addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
@@ -1681,9 +1653,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val premisesToGet = premises[2]
@@ -1703,9 +1673,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist() {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }.also {
           addRoomsAndBeds(it, roomCount = 2, bedsPerRoom = 5)
           addRoomsAndBeds(it, roomCount = 1, bedsPerRoom = 1, isActive = false)
@@ -1745,9 +1713,7 @@ class PremisesTest {
 
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
           withQCode(qCode)
         }
 
@@ -1793,14 +1759,7 @@ class PremisesTest {
       `Given a User` { user, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea {
-                apAreaEntityFactory.produceAndPersist()
-              }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         webTestClient.get()
@@ -1821,9 +1780,7 @@ class PremisesTest {
 
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
           withQCode(qCode)
         }
 
@@ -1875,9 +1832,7 @@ class PremisesTest {
 
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
           withQCode(qCode)
         }
 
@@ -1942,9 +1897,7 @@ class PremisesTest {
     fun setup() {
       premises = approvedPremisesEntityFactory.produceAndPersist() {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       rooms = addRoomsAndBeds(premises, roomCount = 4, 5)
@@ -2195,9 +2148,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist() {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
         val rooms = roomEntityFactory.produceAndPersistMultiple(5) {
           withYieldedPremises { premises }
@@ -2225,12 +2176,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
         val rooms = roomEntityFactory.produceAndPersistMultiple(5) {
           withYieldedPremises { premises }
@@ -2257,9 +2203,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist() {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
         val rooms = roomEntityFactory.produceAndPersistMultiple(5) {
           withYieldedPremises { premises }
@@ -2302,9 +2246,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
@@ -2341,9 +2283,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         webTestClient.post()
@@ -2369,9 +2309,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
@@ -2410,9 +2348,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         webTestClient.post()
@@ -2439,9 +2375,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         webTestClient.post()
@@ -2468,9 +2402,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val characteristicId = characteristicEntityFactory.produceAndPersist {
@@ -2502,9 +2434,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val characteristicId = characteristicEntityFactory.produceAndPersist {
@@ -2536,12 +2466,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val characteristicIds = characteristicEntityFactory.produceAndPersistMultiple(5) {
@@ -2575,9 +2500,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2618,9 +2541,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2650,9 +2571,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val id = UUID.randomUUID()
@@ -2681,9 +2600,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2714,9 +2631,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2752,9 +2667,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2790,12 +2703,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2830,9 +2738,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2874,9 +2780,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2918,9 +2822,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -2962,9 +2864,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3013,9 +2913,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3067,9 +2965,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3121,9 +3017,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3175,9 +3069,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3229,9 +3121,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3287,9 +3177,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3354,9 +3242,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3418,9 +3304,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3481,9 +3365,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3528,9 +3410,7 @@ class PremisesTest {
         val bedEndDate = LocalDate.now()
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3582,9 +3462,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3610,9 +3488,7 @@ class PremisesTest {
     fun `Get Room by ID returns Not Found with correct body when Premises does not exist`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val room = roomEntityFactory.produceAndPersist {
@@ -3643,9 +3519,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val roomIdToRequest = UUID.randomUUID().toString()
@@ -3669,12 +3543,7 @@ class PremisesTest {
       `Given a User` { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3698,12 +3567,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {
@@ -3730,12 +3594,7 @@ class PremisesTest {
       `Given a User`(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withId(UUID.randomUUID())
-              withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val room = roomEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -19,11 +19,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.toStaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addStaffDetailResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.util.UUID
 
 class ProfileTest : IntegrationTestBase() {
@@ -39,9 +41,7 @@ class ProfileTest : IntegrationTestBase() {
       val email = "foo@bar.com"
       val telephoneNumber = "123445677"
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion()
 
       `Given a User`(
         id = id,
@@ -104,9 +104,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion()
 
       val userEntity = userEntityFactory.produceAndPersist {
         withId(id)
@@ -164,9 +162,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion()
 
       val userEntity = userEntityFactory.produceAndPersist {
         withId(id)
@@ -244,10 +240,7 @@ class ProfileTest : IntegrationTestBase() {
       val email = "foo@bar.com"
       val telephoneNumber = "123445677"
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withDeliusCode(deliusCode)
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion(deliusCode)
 
       probationAreaProbationRegionMappingFactory.produceAndPersist {
         withProbationRegion(region)
@@ -329,10 +322,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withDeliusCode(deliusCode)
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion(deliusCode)
 
       probationAreaProbationRegionMappingFactory.produceAndPersist {
         withProbationRegion(region)
@@ -424,10 +414,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withDeliusCode(deliusCode)
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion(deliusCode)
       probationAreaProbationRegionMappingFactory.produceAndPersist {
         withProbationRegion(region)
         withProbationAreaDeliusCode(deliusCode)
@@ -482,10 +469,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withDeliusCode(deliusCode)
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion(deliusCode)
 
       probationAreaProbationRegionMappingFactory.produceAndPersist {
         withProbationRegion(region)
@@ -546,10 +530,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withDeliusCode(deliusCode)
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion(deliusCode)
 
       probationAreaProbationRegionMappingFactory.produceAndPersist {
         withProbationRegion(region)
@@ -607,10 +588,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withDeliusCode(deliusCode)
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion(deliusCode)
 
       probationAreaProbationRegionMappingFactory.produceAndPersist {
         withProbationRegion(region)
@@ -669,10 +647,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withDeliusCode(deliusCode)
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion(deliusCode)
 
       probationAreaProbationRegionMappingFactory.produceAndPersist {
         withProbationRegion(region)
@@ -762,9 +737,7 @@ class ProfileTest : IntegrationTestBase() {
         roles = listOf("ROLE_PROBATION"),
       )
 
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = createProbationRegion()
 
       probationAreaProbationRegionMappingFactory.produceAndPersist {
         withProbationRegion(region)
@@ -866,5 +839,10 @@ class ProfileTest : IntegrationTestBase() {
           .jsonPath("detail").isEqualTo("Missing required header X-Service-Name")
       }
     }
+  }
+
+  fun IntegrationTestBase.createProbationRegion(deliusCode: String? = null) = probationRegionEntityFactory.produceAndPersist {
+    withDeliusCode(deliusCode ?: randomStringMultiCaseWithNumbers(10))
+    withYieldedApArea { `Given an AP Area`() }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
@@ -766,7 +767,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     probationRegionRepository.deleteAll()
 
     val probationRegions = probationRegionEntityFactory.produceAndPersistMultiple(10) {
-      withApArea(apAreaEntityFactory.produceAndPersist())
+      withApArea(`Given an AP Area`())
     }
     val expectedJson = objectMapper.writeValueAsString(
       probationRegions.map(probationRegionTransformer::transformJpaToApi),
@@ -791,7 +792,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     probationRegionRepository.deleteAll()
     apAreaRepository.deleteAll()
 
-    val apAreas = apAreaEntityFactory.produceAndPersistMultiple(10)
+    val apAreas = (1..10).map { `Given an AP Area`() }
     val expectedJson = objectMapper.writeValueAsString(
       apAreas.map(apAreaTransformer::transformJpaToApi),
     )
@@ -834,9 +835,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     probationDeliveryUnitRepository.deleteAll()
 
     val probationRegions = probationRegionEntityFactory.produceAndPersistMultiple(4) {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
+      withYieldedApArea { `Given an AP Area`() }
     }
 
     val probationDeliveryUnits = mutableListOf<ProbationDeliveryUnitEntity>()
@@ -867,9 +866,7 @@ class ReferenceDataTest : IntegrationTestBase() {
     probationDeliveryUnitRepository.deleteAll()
 
     val probationRegions = probationRegionEntityFactory.produceAndPersistMultiple(4) {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
+      withYieldedApArea { `Given an AP Area`() }
     }
 
     val probationDeliveryUnits = mutableListOf<ProbationDeliveryUnitEntity>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
@@ -721,13 +722,7 @@ class ReportsTest : IntegrationTestBase() {
 
           val unexpectedPremises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea {
-                  apAreaEntityFactory.produceAndPersist()
-                }
-              }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           // Unexpected bookings

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
@@ -257,23 +259,12 @@ open class SubjectAccessRequestServiceTestBase : IntegrationTestBase() {
 
   protected fun probationRegionEntity() = probationRegionEntityFactory.produceAndPersist {
     withName("Probation Region ${randomStringMultiCaseWithNumbers(5)}")
-    withApArea(
-      apAreaEntityFactory.produceAndPersist {
-        withName("Probation Area ${randomStringMultiCaseWithNumbers(5)}")
-      },
-    )
+    withApArea(`Given an AP Area`(name = "Probation Area ${randomStringMultiCaseWithNumbers(5)}"))
   }
 
   protected fun userEntity(): UserEntity =
     userEntityFactory.produceAndPersist {
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(
-            apAreaEntityFactory.produceAndPersist {
-            },
-          )
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
     }
 
   protected fun personRisks() =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
@@ -1367,9 +1368,7 @@ class TasksTest {
                   withPremises(
                     approvedPremisesEntityFactory.produceAndPersist {
                       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                      withYieldedProbationRegion {
-                        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-                      }
+                      withYieldedProbationRegion { `Given a Probation Region`() }
                     },
                   )
                 },
@@ -1564,9 +1563,7 @@ class TasksTest {
                   withPremises(
                     approvedPremisesEntityFactory.produceAndPersist {
                       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                      withYieldedProbationRegion {
-                        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-                      }
+                      withYieldedProbationRegion { `Given a Probation Region`() }
                     },
                   )
                 },
@@ -1582,9 +1579,7 @@ class TasksTest {
                   withPremises(
                     approvedPremisesEntityFactory.produceAndPersist {
                       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                      withYieldedProbationRegion {
-                        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-                      }
+                      withYieldedProbationRegion { `Given a Probation Region`() }
                     },
                   )
                 },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateSentenceTypeAndSituationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateSentenceTypeAndSituationJobTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.MigrationJobService
@@ -24,9 +25,7 @@ class UpdateSentenceTypeAndSituationJobTest : IntegrationTestBase() {
       withPermissiveSchema()
     }
 
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val user = userEntityFactory.produceAndPersist {
       withProbationRegion(probationRegion)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserAllocationsEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UserAllocationsEngineTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
@@ -45,13 +46,7 @@ class UserAllocationsEngineTest : InitialiseDatabasePerClassTestBase() {
     assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist()
     placementApplicationSchema = approvedPremisesPlacementApplicationJsonSchemaEntityFactory.produceAndPersist()
     premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea {
-            apAreaEntityFactory.produceAndPersist()
-          }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
       withYieldedLocalAuthorityArea {
         localAuthorityEntityFactory.produceAndPersist()
       }
@@ -558,11 +553,7 @@ class UserAllocationsEngineTest : InitialiseDatabasePerClassTestBase() {
   private fun createUser(deliusUsername: String, roles: List<UserRole>, qualifications: List<UserQualification>, isActive: Boolean = true): UserEntity {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(deliusUsername)
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
       withIsActive(isActive)
     }
 
@@ -585,11 +576,7 @@ class UserAllocationsEngineTest : InitialiseDatabasePerClassTestBase() {
 
   private fun createApplicationAndAssessment(): Pair<ApprovedPremisesApplicationEntity, ApprovedPremisesAssessmentEntity> {
     val user = userEntityFactory.produceAndPersist {
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -17,7 +17,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRolesAndQualifications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -103,9 +105,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
       roles = listOf("ROLE_PROBATION"),
     )
 
-    val region = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
+    val region = `Given a Probation Region`()
 
     userEntityFactory.produceAndPersist {
       withId(id)
@@ -154,11 +154,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
       roles = listOf("ROLE_PROBATION"),
     )
 
-    val apArea = apAreaEntityFactory.produceAndPersist()
-
-    val region = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apArea }
-    }
+    val region = `Given a Probation Region`()
 
     userEntityFactory.produceAndPersist {
       withId(id)
@@ -226,9 +222,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
       roles = listOf("ROLE_PROBATION"),
     )
 
-    val region = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
+    val region = `Given a Probation Region`()
 
     val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
       withDeliusCode(brought.code)
@@ -427,7 +421,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
         `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { userWithNoRole, _ ->
             `Given a User`(roles = listOf(role)) { requestUser, jwt ->
-              val apArea = apAreaEntityFactory.produceAndPersist()
+              val apArea = `Given an AP Area`()
               val probationRegion = probationRegionEntityFactory.produceAndPersist {
                 withApArea(apArea)
               }
@@ -474,9 +468,9 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
         `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { userWithNoRole, _ ->
             `Given a User`(roles = listOf(role)) { requestUser, jwt ->
-              val apArea = apAreaEntityFactory.produceAndPersist()
+              val apArea = `Given an AP Area`()
 
-              val probationRegionApArea = apAreaEntityFactory.produceAndPersist()
+              val probationRegionApArea = `Given an AP Area`()
               val probationRegion = probationRegionEntityFactory.produceAndPersist {
                 withApArea(probationRegionApArea)
               }
@@ -728,7 +722,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
         `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { userWithNoRole, _ ->
             `Given a User`(roles = listOf(role)) { requestUser, jwt ->
-              val apArea = apAreaEntityFactory.produceAndPersist()
+              val apArea = `Given an AP Area`()
               val probationRegion = probationRegionEntityFactory.produceAndPersist {
                 withApArea(apArea)
               }
@@ -775,9 +769,9 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
         `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
           `Given a User` { userWithNoRole, _ ->
             `Given a User`(roles = listOf(role)) { requestUser, jwt ->
-              val apArea = apAreaEntityFactory.produceAndPersist()
+              val apArea = `Given an AP Area`()
 
-              val probationRegionApArea = apAreaEntityFactory.produceAndPersist()
+              val probationRegionApArea = `Given an AP Area`()
               val probationRegion = probationRegionEntityFactory.produceAndPersist {
                 withApArea(probationRegionApArea)
               }
@@ -1197,15 +1191,13 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
         ApprovedPremisesUserRole.excludedFromMatchAllocation,
         ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation,
       )
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-      }
+      val region = `Given a Probation Region`()
 
       userEntityFactory.produceAndPersist {
         withId(id)
         withIsActive(false)
         withYieldedProbationRegion { region }
-        withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
+        withYieldedApArea { `Given an AP Area`() }
       }
 
       `Given a User`(roles = listOf(role)) { _, jwt ->
@@ -1322,12 +1314,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     fun `Deleting a user with an approved role deletes successfully`(role: UserRole) {
       userEntityFactory.produceAndPersist {
         withId(id)
-
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       `Given a User`(roles = listOf(role)) { _, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -14,7 +14,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawables
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulGetReferralDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -1505,9 +1507,7 @@ class WithdrawalTest : IntegrationTestBase() {
       withAddedAt(OffsetDateTime.now())
     }
 
-    val apArea = apAreaEntityFactory.produceAndPersist {
-      withEmailAddress("apAreaEmail@test.com")
-    }
+    val apArea = `Given an AP Area`(emailAddress = "apAreaEmail@test.com")
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn(offenderDetails.otherIds.crn)
@@ -1669,7 +1669,7 @@ class WithdrawalTest : IntegrationTestBase() {
   ): BookingEntity {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } } }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     val booking = bookingEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarifi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
@@ -235,9 +236,7 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
 
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     val room = roomEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationReportTest.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TeamFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
@@ -203,11 +204,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
           withSurname("Juderson")
         },
         probationRegion = probationRegionEntityFactory.produceAndPersist() {
-          withApArea(
-            apAreaEntityFactory.produceAndPersist() {
-              withName("Ap Area 1")
-            },
-          )
+          withApArea(`Given an AP Area`(name = "Ap Area 1"))
         },
       )
 
@@ -408,12 +405,8 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
           withForenames("Assessor")
           withSurname("Assessing")
         },
-        probationRegion = probationRegionEntityFactory.produceAndPersist() {
-          withApArea(
-            apAreaEntityFactory.produceAndPersist() {
-              withName("Ap Area 4")
-            },
-          )
+        probationRegion = probationRegionEntityFactory.produceAndPersist {
+          withApArea(`Given an AP Area`(name = "Ap Area 4"))
         },
       )
 
@@ -870,9 +863,7 @@ class Cas1ApplicationReportTest : InitialiseDatabasePerClassTestBase() {
 
     clock.setNow(submittedAt)
 
-    val apArea = apAreaEntityFactory.produceAndPersist {
-      withName(apAreaName)
-    }
+    val apArea = `Given an AP Area`(name = apAreaName)
 
     cas1SimpleApiClient.applicationSubmit(
       this,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesReportTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1Pla
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1PlacementMatchingOutcomesReportTest.Constants.REPORT_YEAR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
@@ -26,7 +27,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUtcOffsetDateTime
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import java.util.UUID
 
 class Cas1PlacementMatchingOutcomesReportTest : IntegrationTestBase() {
 
@@ -481,13 +481,6 @@ class Cas1PlacementMatchingOutcomesReportTest : IntegrationTestBase() {
 
   private fun premises() = approvedPremisesEntityFactory.produceAndPersist {
     withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-    withYieldedProbationRegion {
-      probationRegionEntityFactory.produceAndPersist {
-        withId(UUID.randomUUID())
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
-    }
+    withYieldedProbationRegion { `Given a Probation Region`() }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1PlacementMatchingOutcomesV2ReportTest.Constants.REPORT_MONTH
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1PlacementMatchingOutcomesV2ReportTest.Constants.REPORT_YEAR
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
@@ -454,9 +455,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     cas1SimpleApiClient.bookingForPlacementRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ASSESSOR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_FUTURE_MANAGER
@@ -26,11 +27,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
     @BeforeAll
     fun setupTestData() {
       val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist() {
-            withName("The ap area name")
-          }
-        }
+        withYieldedApArea { `Given an AP Area`(name = "The ap area name") }
       }
 
       premises = approvedPremisesEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -64,13 +65,7 @@ class Cas1SpaceBookingTest {
     fun `Booking a space for an unknown placement request returns 400 Bad Request`() {
       `Given a User` { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea {
-                apAreaEntityFactory.produceAndPersist()
-              }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
           withYieldedLocalAuthorityArea {
             localAuthorityEntityFactory.produceAndPersist()
           }
@@ -146,13 +141,7 @@ class Cas1SpaceBookingTest {
           createdByUser = user,
         ) { placementRequest, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea {
-                  apAreaEntityFactory.produceAndPersist()
-                }
-              }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
             withYieldedLocalAuthorityArea {
               localAuthorityEntityFactory.produceAndPersist()
             }
@@ -225,13 +214,7 @@ class Cas1SpaceBookingTest {
           placementRequestRepository.saveAndFlush(placementRequest)
 
           val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea {
-                  apAreaEntityFactory.produceAndPersist()
-                }
-              }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
             withYieldedLocalAuthorityArea {
               localAuthorityEntityFactory.produceAndPersist()
             }
@@ -313,11 +296,7 @@ class Cas1SpaceBookingTest {
 
     @BeforeAll
     fun setupTestData() {
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
+      val region = `Given a Probation Region`()
 
       premisesWithNoBooking = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedProbationRegion { region }
@@ -669,11 +648,7 @@ class Cas1SpaceBookingTest {
 
     @BeforeAll
     fun setupTestData() {
-      val region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
+      val region = `Given a Probation Region`()
 
       premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedProbationRegion { region }
@@ -808,11 +783,7 @@ class Cas1SpaceBookingTest {
 
     @BeforeAll
     fun setupTestData() {
-      region = probationRegionEntityFactory.produceAndPersist {
-        withYieldedApArea {
-          apAreaEntityFactory.produceAndPersist()
-        }
-      }
+      region = `Given a Probation Region`()
 
       premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedProbationRegion { region }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
@@ -51,13 +52,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
 
     `Given a User` { _, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -110,13 +105,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
 
     `Given a User` { _, jwt ->
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -126,13 +115,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -185,13 +168,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
 
     `Given a User` { _, jwt ->
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -201,13 +178,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -261,13 +232,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
 
     `Given a User` { _, jwt ->
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(4) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -277,13 +242,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -359,13 +318,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
 
     `Given a User` { _, jwt ->
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -382,13 +335,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -455,13 +402,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
 
     `Given a User` { _, jwt ->
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }
@@ -478,13 +419,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(4) {
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
         withYieldedLocalAuthorityArea {
           localAuthorityEntityFactory.produceAndPersist()
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/LostBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/LostBedsTest.kt
@@ -11,7 +11,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateLostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -32,9 +34,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     fun `Get All Lost Beds without JWT returns 401`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       webTestClient.get()
@@ -62,9 +62,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -115,9 +113,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     fun `Get Lost Bed without JWT returns 401`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -161,9 +157,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         webTestClient.get()
@@ -181,9 +175,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -222,9 +214,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     fun `Create Lost Beds without JWT returns 401`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -253,13 +243,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea {
-                apAreaEntityFactory.produceAndPersist()
-              }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val reason = lostBedReasonEntityFactory.produceAndPersist {
@@ -294,9 +278,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(3) {
@@ -350,9 +332,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(2) {
@@ -413,9 +393,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(2) {
@@ -461,9 +439,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -516,9 +492,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -586,9 +560,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     fun `Update Lost Bed without JWT returns 401`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -656,9 +628,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     fun `Update Lost Bed for non-existent lost bed returns 404`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -686,9 +656,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(2) {
@@ -749,13 +717,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea {
-                apAreaEntityFactory.produceAndPersist()
-              }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -817,13 +779,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { offenderDetails, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea {
-                  apAreaEntityFactory.produceAndPersist()
-                }
-              }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -897,9 +853,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -959,9 +913,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -1036,9 +988,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     fun `Cancel Lost Bed without JWT returns 401`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val lostBeds = lostBedsEntityFactory.produceAndPersist {
@@ -1090,9 +1040,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
     fun `Cancel Lost Bed for non-existent lost bed returns 404`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -1117,7 +1065,7 @@ class LostBedsTest : InitialiseDatabasePerClassTestBase() {
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { `Given an AP Area`() } }
           }
         }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
@@ -6,13 +6,14 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
 
 class MigrateCas1UserApAreaTest : MigrationJobTestBase() {
 
   @Test
   fun `Populate ap area and team codes`() {
-    val apArea = apAreaEntityFactory.produceAndPersist()
+    val apArea = `Given an AP Area`()
 
     val probationRegion = probationRegionEntityFactory.produceAndPersist {
       withDefaults()
@@ -43,7 +44,7 @@ class MigrateCas1UserApAreaTest : MigrationJobTestBase() {
 
   @Test
   fun `If staff details not found for user (404), fall back to probation region ap area and set team codes to an empty list`() {
-    val apArea = apAreaEntityFactory.produceAndPersist()
+    val apArea = `Given an AP Area`()
 
     val probationRegion = probationRegionEntityFactory.produceAndPersist {
       withDefaults()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Temporality
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas1OutOfServiceBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
@@ -112,9 +113,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -162,9 +161,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -232,9 +229,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -247,9 +242,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val otherBed = bedEntityFactory.produceAndPersist {
@@ -311,9 +304,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -326,9 +317,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val otherBed = bedEntityFactory.produceAndPersist {
@@ -395,9 +384,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       private fun initialiseOosBedsForAllTemporalities(user: UserEntity) {
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(2) {
@@ -569,9 +556,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -584,9 +569,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
         val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val otherBed = bedEntityFactory.produceAndPersist {
@@ -658,9 +641,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -719,9 +700,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Get All Out-Of-Service Beds On Premises without JWT returns 401`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       webTestClient.get()
@@ -749,9 +728,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -814,9 +791,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User` { user, _ ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
@@ -866,9 +841,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         webTestClient.get()
@@ -886,9 +859,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
@@ -933,9 +904,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Create Out-Of-Service Beds without JWT returns 401`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -964,13 +933,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea {
-                apAreaEntityFactory.produceAndPersist()
-              }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
@@ -1003,9 +966,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(3) {
@@ -1082,9 +1043,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(2) {
@@ -1168,9 +1127,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(2) {
@@ -1221,9 +1178,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -1280,9 +1235,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -1404,9 +1357,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User` { user, _ ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
@@ -1480,9 +1431,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Update Out-Of-Service Bed for non-existent out-of-service bed returns 404`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -1510,9 +1459,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(2) {
@@ -1624,13 +1571,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist {
-              withYieldedApArea {
-                apAreaEntityFactory.produceAndPersist()
-              }
-            }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val bed = bedEntityFactory.produceAndPersist {
@@ -1691,13 +1632,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { offenderDetails, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea {
-                  apAreaEntityFactory.produceAndPersist()
-                }
-              }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -1822,9 +1757,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -1893,9 +1826,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         `Given an Offender` { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-            }
+            withYieldedProbationRegion { `Given a Probation Region`() }
           }
 
           val bed = bedEntityFactory.produceAndPersist {
@@ -2052,9 +1983,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User` { user, _ ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
@@ -2112,9 +2041,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Cancel Out-Of-Service Bed for non-existent out-of-service bed returns 404`() {
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
@@ -2138,9 +2065,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       `Given a User`(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-          }
+          withYieldedProbationRegion { `Given a Probation Region`() }
         }
 
         bedEntityFactory.produceAndPersistMultiple(2) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/ApStaffUsersSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/ApStaffUsersSeedJobTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
@@ -50,9 +51,7 @@ class APStaffUsersSeedJobTest : SeedTestBase() {
 
   @Test
   fun `Attempting to seed a real but currently unknown user succeeds`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val probationRegionDeliusMapping = probationAreaProbationRegionMappingFactory.produceAndPersist {
       withProbationRegion(probationRegion)
@@ -94,11 +93,7 @@ class APStaffUsersSeedJobTest : SeedTestBase() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("PRE-EXISTING-USER")
       withUpdatedAt(OffsetDateTime.now().minusDays(3))
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     val roleEntities = listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS1_WORKFLOW_MANAGER).map { role ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesBookingCancellationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesBookingCancellationTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
@@ -42,14 +43,7 @@ class SeedApprovedPremisesBookingCancellationTest : SeedTestBase() {
     `Given an Offender` { offenderDetails, _ ->
       val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val bed = bedEntityFactory.produceAndPersist {
@@ -96,14 +90,7 @@ class SeedApprovedPremisesBookingCancellationTest : SeedTestBase() {
     `Given an Offender` { offenderDetails, _ ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegionEntityFactory.produceAndPersist {
-            withId(UUID.randomUUID())
-            withYieldedApArea {
-              apAreaEntityFactory.produceAndPersist()
-            }
-          }
-        }
+        withYieldedProbationRegion { `Given a Probation Region`() }
       }
 
       val bed = bedEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesRoomsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesRoomsTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesRoomsSeedCsvRow
@@ -26,11 +27,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
   fun `Attempting to create an AP room with an incorrectly service-scoped characteristic logs an error`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withApCode("NEABC")
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
       withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     }
 
@@ -69,11 +66,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
   fun `Attempting to create an AP room with an incorrectly model-scoped characteristic logs an error`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withApCode("NEABC")
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
       withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     }
 
@@ -201,11 +194,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
 
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withApCode("NEABC")
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
       withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     }
 
@@ -270,11 +259,7 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
 
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withApCode("NEABC")
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
       withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedApprovedPremisesTest.kt
@@ -11,6 +11,7 @@ import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.PrecisionModel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesSeedCsvRow
@@ -53,9 +54,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create an Approved Premises with an invalid Local Authority Area logs an error`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     withCsv(
       "invalid-local-authority",
@@ -83,9 +82,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create an Approved Premises with an incorrectly service-scoped characteristic logs an error`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
@@ -123,9 +120,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create an Approved Premises with an incorrectly model-scoped characteristic logs an error`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
@@ -219,9 +214,7 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
   @Test
   fun `Creating a new Approved Premises persists correctly`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
@@ -278,13 +271,9 @@ class SeedApprovedPremisesTest : SeedTestBase() {
 
   @Test
   fun `Updating an existing Approved Premises persists correctly`() {
-    val originalProbationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val originalProbationRegion = `Given a Probation Region`()
 
-    val updatedProbationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val updatedProbationRegion = `Given a Probation Region`()
 
     val originalLocalAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingAdhocPropertyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingAdhocPropertyTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import java.util.UUID
@@ -36,11 +37,7 @@ class SeedCas1BookingAdhocPropertyTest : SeedTestBase() {
   @Test
   fun `Bookings adhoc statuses are updated`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
       withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     }
     val booking1 = bookingEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Applicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APOASysContext_mockSuccessfulNeedsDetailsCall
@@ -38,11 +39,7 @@ class SeedCas1DuplicateApplicationTest : SeedTestBase() {
           withApplicationSchema(jsonSchemaService.getNewestSchema(ApprovedPremisesApplicationJsonSchemaEntity::class.java))
           withSubmittedAt(OffsetDateTime.now())
           withNomsNumber(offenderDetails.otherIds.nomsNumber)
-          withApArea(
-            apAreaEntityFactory.produceAndPersist {
-              withEmailAddress("apAreaEmail@test.com")
-            },
-          )
+          withApArea(`Given an AP Area`(emailAddress = "apAreaEmail@test.com"))
           withIsEmergencyApplication(true)
           withReleaseType("licence")
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
@@ -94,11 +95,7 @@ class SeedCas1LinkBookingToPlacementRequestTest : SeedTestBase() {
     val booking = bookingEntityFactory.produceAndPersist {
       withPremises(
         approvedPremisesEntityFactory.produceAndPersist {
-          withProbationRegion(
-            probationRegionEntityFactory.produceAndPersist {
-              withApArea(apAreaEntityFactory.produceAndPersist())
-            },
-          )
+          withProbationRegion(`Given a Probation Region`())
           withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
         },
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
@@ -5,6 +5,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Approved Premises Bed`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
@@ -78,13 +79,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
   @Test
   fun `Logs an error if no bed exists with the given ID`() {
     val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea {
-            apAreaEntityFactory.produceAndPersist()
-          }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
       withYieldedLocalAuthorityArea {
         localAuthorityEntityFactory.produceAndPersist()
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -170,9 +171,7 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
       withAddedAt(OffsetDateTime.now())
     }
 
-    val apArea = apAreaEntityFactory.produceAndPersist {
-      withEmailAddress("apAreaEmail@test.com")
-    }
+    val apArea = `Given an AP Area`(emailAddress = "apAreaEmail@test.com")
 
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn(offenderDetails.otherIds.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed.Se
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed.SeedCasUpdateEventNumberTest.CONSTANTS.OLD_EVENT_NUMBER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed.SeedCasUpdateEventNumberTest.CONSTANTS.OLD_OFFENCE_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -290,7 +291,7 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
           },
         )
         withSubmittedAt(OffsetDateTime.now())
-        withApArea(apAreaEntityFactory.produceAndPersist())
+        withApArea(`Given an AP Area`())
         withReleaseType("licence")
         withEventNumber(OLD_EVENT_NUMBER)
         withOffenceId(OLD_OFFENCE_ID)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
@@ -2022,7 +2023,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withYieldedProbationRegion {
               probationRegionEntityFactory.produceAndPersist {
                 withYieldedApArea {
-                  apAreaEntityFactory.produceAndPersist()
+                  `Given an AP Area`()
                 }
               }
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABed.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABed.kt
@@ -7,11 +7,7 @@ fun IntegrationTestBase.`Given an Approved Premises Bed`(
   block: (bed: BedEntity) -> Unit,
 ) {
   val premises = approvedPremisesEntityFactory.produceAndPersist {
-    withProbationRegion(
-      probationRegionEntityFactory.produceAndPersist {
-        withApArea(apAreaEntityFactory.produceAndPersist())
-      },
-    )
+    withProbationRegion(`Given a Probation Region`())
     withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -33,7 +33,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
   noticeType: Cas1ApplicationTimelinessCategory? = null,
   isWithdrawn: Boolean = false,
 ): PlacementApplicationEntity {
-  val userApArea = apAreaEntityFactory.produceAndPersist()
+  val userApArea = `Given an AP Area`()
 
   val assessmentAllocatedToUser = userEntityFactory.produceAndPersist {
     withYieldedProbationRegion {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAProbationRegion.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAProbationRegion.kt
@@ -10,7 +10,7 @@ fun IntegrationTestBase.`Given a Probation Region`(
   name: String? = null,
   apArea: ApAreaEntity? = null,
   deliusCode: String? = null,
-  block: (probationRegion: ProbationRegionEntity) -> Unit,
+  block: ((probationRegion: ProbationRegionEntity) -> Unit)? = null,
 ): ProbationRegionEntity {
   val probationRegion = probationRegionEntityFactory.produceAndPersist {
     withId(id)
@@ -21,7 +21,7 @@ fun IntegrationTestBase.`Given a Probation Region`(
       withApArea(apArea)
     } else {
       withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
+        `Given an AP Area`()
       }
     }
     if (deliusCode != null) {
@@ -29,7 +29,9 @@ fun IntegrationTestBase.`Given a Probation Region`(
     }
   }
 
-  block(probationRegion)
+  if (block != null) {
+    block(probationRegion)
+  }
 
   return probationRegion
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -37,11 +37,7 @@ fun IntegrationTestBase.`Given a User`(
 
   val yieldedProbationRegion = probationRegion
     ?: probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist {
-          withName(apAreaName)
-        }
-      }
+      withYieldedApArea { `Given an AP Area`(name = apAreaName) }
     }
 
   val user = userEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApArea.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApArea.kt
@@ -6,10 +6,16 @@ import java.util.UUID
 
 fun IntegrationTestBase.`Given an AP Area`(
   id: UUID = UUID.randomUUID(),
+  name: String? = null,
+  emailAddress: String? = null,
 ): ApAreaEntity {
-  val probationRegion = apAreaEntityFactory.produceAndPersist {
+  return apAreaEntityFactory.produceAndPersist {
     withId(id)
+    if (name != null) {
+      withName(name)
+    }
+    if (emailAddress != null) {
+      withEmailAddress(emailAddress)
+    }
   }
-
-  return probationRegion
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateAllUsersFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateAllUsersFromCommunityApiMigrationTest.kt
@@ -6,6 +6,7 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.toStaffDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addStaffDetailResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
@@ -13,9 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.Co
 class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
   @Test
   fun `All users are updated from Community API with a 50ms artificial delay`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val userOne = userEntityFactory.produceAndPersist {
       withDeliusUsername("USER1")
@@ -59,9 +58,7 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
 
   @Test
   fun `Failure to update individual user does not stop processing`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val userOne = userEntityFactory.produceAndPersist {
       withDeliusUsername("USER1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateUsersPduFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateUsersPduFromCommunityApiMigrationTest.kt
@@ -6,6 +6,7 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -15,9 +16,7 @@ import java.time.LocalDate
 class UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
   @Test
   fun `All users pdu are updated from Community API with a 50ms artificial delay`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     probationDeliveryUnitFactory.produceAndPersist {
       withDeliusCode("PDUCODE1")
@@ -215,9 +214,7 @@ class UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
 
   @Test
   fun `Failure to update individual user does not stop processing`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val probationDeliveryUnitTwo = probationDeliveryUnitFactory.produceAndPersist {
       withDeliusCode("PDUCODE2")
@@ -289,9 +286,7 @@ class UpdateUsersPduFromCommunityApiMigrationTest : MigrationJobTestBase() {
 
   @Test
   fun `When probation delivery unit not exist in CAS does not stop processing other users`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     probationDeliveryUnitFactory.produceAndPersist {
       withDeliusCode("PDUCODE1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/ApAreaMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/ApAreaMigrationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.midlandsApplicationIds
@@ -24,8 +25,8 @@ class ApAreaMigrationTest : IntegrationTestBase() {
     probationRegionRepository.deleteAll()
     apAreaRepository.deleteAll()
 
-    val apArea1 = apAreaEntityFactory.produceAndPersist()
-    val apArea2 = apAreaEntityFactory.produceAndPersist()
+    val apArea1 = `Given an AP Area`()
+    val apArea2 = `Given an AP Area`()
 
     val probationRegion1 = probationRegionEntityFactory.produceAndPersist {
       withApArea(apArea1)
@@ -35,15 +36,9 @@ class ApAreaMigrationTest : IntegrationTestBase() {
       withApArea(apArea2)
     }
 
-    val midlandsApArea = apAreaEntityFactory.produceAndPersist {
-      withName("Midlands")
-    }
-    val southEastAndEasternApArea = apAreaEntityFactory.produceAndPersist {
-      withName("South East & Eastern")
-    }
-    val northEastApArea = apAreaEntityFactory.produceAndPersist {
-      withName("North East")
-    }
+    val midlandsApArea = `Given an AP Area`(name = "Midlands")
+    val southEastAndEasternApArea = `Given an AP Area`(name = "South East & Eastern")
+    val northEastApArea = `Given an AP Area`(name = "North East")
 
     val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
       withPermissiveSchema()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1ManagerToFutureManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1ManagerToFutureManagerTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -67,11 +68,7 @@ class MigrateCas1ManagerToFutureManagerTest : MigrationJobTestBase() {
   fun createUserWithRoles(username: String, roles: List<UserRole>): UserEntity {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername(username)
-      withProbationRegion(
-        probationRegionEntityFactory.produceAndPersist {
-          withApArea(apAreaEntityFactory.produceAndPersist())
-        },
-      )
+      withProbationRegion(`Given a Probation Region`())
     }
     roles.forEach {
       userRoleAssignmentEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1OutOfServiceBedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1OutOfServiceBedsTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
@@ -23,11 +24,7 @@ class MigrateCas1OutOfServiceBedsTest : MigrationJobTestBase() {
 
   @BeforeEach
   fun setup() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea {
-        apAreaEntityFactory.produceAndPersist()
-      }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1TruncateOosbTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/MigrateCas1TruncateOosbTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
@@ -24,9 +25,7 @@ class MigrateCas1TruncateOosbTest : MigrationJobTestBase() {
 
     val premises = approvedPremisesEntityFactory.produceAndPersist {
       withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     val bedNoEndDate = createBed(premises, endDate = null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateApplicationOffenderNameJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateApplicationOffenderNameJobTest.kt
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addListCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
@@ -28,9 +29,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
         withPermissiveSchema()
       }
 
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withApArea(apAreaEntityFactory.produceAndPersist())
-      }
+      val probationRegion = `Given a Probation Region`()
 
       val user = userEntityFactory.produceAndPersist {
         withProbationRegion(probationRegion)
@@ -80,9 +79,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
         withPermissiveSchema()
       }
 
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withApArea(apAreaEntityFactory.produceAndPersist())
-      }
+      val probationRegion = `Given a Probation Region`()
 
       val user = userEntityFactory.produceAndPersist {
         withProbationRegion(probationRegion)
@@ -134,9 +131,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
         withPermissiveSchema()
       }
 
-      val probationRegion = probationRegionEntityFactory.produceAndPersist {
-        withApArea(apAreaEntityFactory.produceAndPersist())
-      }
+      val probationRegion = `Given a Probation Region`()
 
       val user = userEntityFactory.produceAndPersist {
         withProbationRegion(probationRegion)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationBedspaceTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationBedspaceSeedCsvRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -37,9 +38,7 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
 
   @Test
   fun `Creating a new Temporary Accommodation Bedspace persists correctly`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
@@ -76,9 +75,7 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
 
   @Test
   fun `Updating an existing Temporary Accommodation Bedspace persists correctly`() {
-    val originalProbationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val originalProbationRegion = `Given a Probation Region`()
 
     val originalLocalAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationPremisesTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationPremisesSeedCsvRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -37,9 +38,7 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create a Temporary Accommodation Premises with an invalid Local Authority Area logs an error`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     withCsv(
       "invalid-local-authority-ta",
@@ -65,9 +64,7 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
 
   @Test
   fun `Creating a new Temporary Accommodation Premises persists correctly`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
       withProbationRegion(probationRegion)
@@ -108,17 +105,13 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
 
   @Test
   fun `Updating an existing Temporary Accommodation Premises persists correctly`() {
-    val originalProbationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val originalProbationRegion = `Given a Probation Region`()
 
     val originalProbationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
       withProbationRegion(originalProbationRegion)
     }
 
-    val updatedProbationRegion = probationRegionEntityFactory.produceAndPersist {
-      withApArea(apAreaEntityFactory.produceAndPersist())
-    }
+    val updatedProbationRegion = `Given a Probation Region`()
 
     val updateProbationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
       withProbationRegion(updatedProbationRegion)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UpdateNomsNumberSeedRow
@@ -38,7 +39,7 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
           withPermissiveSchema()
         },
       )
-      withApArea(apAreaEntityFactory.produceAndPersist())
+      withApArea(`Given an AP Area`())
       withCrn(CRN)
       withNomsNumber(OLD_NOMS)
     }
@@ -51,7 +52,7 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
           withPermissiveSchema()
         },
       )
-      withApArea(apAreaEntityFactory.produceAndPersist())
+      withApArea(`Given an AP Area`())
       withCrn(CRN)
       withNomsNumber(NEW_NOMS)
     }
@@ -64,7 +65,7 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
           withPermissiveSchema()
         },
       )
-      withApArea(apAreaEntityFactory.produceAndPersist())
+      withApArea(`Given an AP Area`())
       withCrn(OTHER_CRN)
       withNomsNumber(OTHER_NOMS)
     }
@@ -74,7 +75,7 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
         approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { `Given an AP Area`() } }
           }
         },
       )
@@ -87,7 +88,7 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
         approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { apAreaEntityFactory.produceAndPersist() } }
+            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { `Given an AP Area`() } }
           }
         },
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateUsersFromApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateUsersFromApiTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.toStaffDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addStaffDetailResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
@@ -23,11 +24,7 @@ class SeedUpdateUsersFromApiTest : SeedTestBase() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername(USERNAME)
       withEmail("oldemail@localhost")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     val staffUserDetails = StaffUserDetailsFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockNotFoundOffenderDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockSuccessfulStaffUserDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
@@ -48,9 +49,7 @@ class SeedUsersTest : SeedTestBase() {
 
   @Test
   fun `Attempting to seed a real but currently unknown user succeeds`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val probationRegionDeliusMapping = probationAreaProbationRegionMappingFactory.produceAndPersist {
       withProbationRegion(probationRegion)
@@ -96,11 +95,7 @@ class SeedUsersTest : SeedTestBase() {
   fun `Attempting to assign roles to a currently known user succeeds`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("KNOWN-USER")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     withCsv(
@@ -134,11 +129,7 @@ class SeedUsersTest : SeedTestBase() {
   fun `Attempting to assign a non-existent role logs an error`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("known-user")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     withCsv(
@@ -169,11 +160,7 @@ class SeedUsersTest : SeedTestBase() {
   fun `Attempting to assign a non-existent qualification logs an error`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("known-user")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     withCsv(
@@ -203,11 +190,7 @@ class SeedUsersTest : SeedTestBase() {
   fun `Attempting to assign legacy roles to a user succeeds`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("KNOWN-USER")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     withCsv(
@@ -245,11 +228,7 @@ class SeedUsersTest : SeedTestBase() {
   fun `Service specific user seed jobs only overwrite roles for that service`() {
     val user = userEntityFactory.produceAndPersist {
       withDeliusUsername("MULTI-SERVICE-USER")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     val roles = listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS3_ASSESSOR).map { role ->
@@ -287,9 +266,7 @@ class SeedUsersTest : SeedTestBase() {
 
   @Test
   fun `Seeding same users multiple times works every time for base user seed job`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val probationRegionDeliusMapping = probationAreaProbationRegionMappingFactory.produceAndPersist {
       withProbationRegion(probationRegion)
@@ -368,9 +345,7 @@ class SeedUsersTest : SeedTestBase() {
 
   @Test
   fun `Seeding same users multiple times works every time for AP user seed job`() {
-    val probationRegion = probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-    }
+    val probationRegion = `Given a Probation Region`()
 
     val probationRegionDeliusMapping = probationAreaProbationRegionMappingFactory.produceAndPersist {
       withProbationRegion(probationRegion)
@@ -451,11 +426,7 @@ class SeedUsersTest : SeedTestBase() {
   fun `Attempting to assign new role CAS3_REPORTER to a currently known user succeeds`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("KNOWN-USER")
-      withYieldedProbationRegion {
-        probationRegionEntityFactory.produceAndPersist {
-          withYieldedApArea { apAreaEntityFactory.produceAndPersist() }
-        }
-      }
+      withYieldedProbationRegion { `Given a Probation Region`() }
     }
 
     withCsv(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -47,8 +48,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
         `Given an Offender` { offenderDetails2, _ ->
           crn1 = offenderDetails.otherIds.crn
           crn2 = offenderDetails2.otherIds.crn
-
-          apArea = apAreaEntityFactory.produceAndPersist()
+          apArea = `Given an AP Area`()
 
           val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()


### PR DESCRIPTION
Instead of using factories directly in tests we should, where possible, use the ‘Given’ functions as these reduce the amount of duplicated boiler plate code.

This commit uses `Given an AP Area` function whereever an ap area is required in tests. This is in preparation for adding a new mandatory field to AP Area.