### PR TITLE
CAS-640 Make premises notes nullable in bedspace search result

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -395,7 +395,7 @@ class TemporaryAccommodationBedSearchResult(
   bedName: String,
   roomCharacteristics: MutableList<CharacteristicNames>,
   val probationDeliveryUnitName: String,
-  val premisesNotes: String,
+  val premisesNotes: String?,
   val overlaps: MutableList<TemporaryAccommodationBedSearchResultOverlap>,
 ) : BedSearchResult(
   premisesId,


### PR DESCRIPTION
This [PR CAS-640](https://dsdmoj.atlassian.net/browse/CAS-640) is to make premises notes nullable in temporary accommodation bedspace search result