### PR TITLE
APS-1314 Add CRU Management Area to user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -40,6 +40,9 @@ data class ApAreaEntity(
   val notifyReplyToEmailId: String?,
   /**
    * Used to determine a user's [Cas1CruManagementAreaEntity] if no override is specified
+   *
+   * Also used to determine which management area an application is linked to on submission,
+   * based upon the user's AP Area
    */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "default_cru1_management_area_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -292,9 +292,21 @@ data class UserEntity(
   var probationRegion: ProbationRegionEntity,
   @ManyToOne(fetch = FetchType.LAZY)
   var probationDeliveryUnit: ProbationDeliveryUnitEntity?,
+  /**
+   * The geographical area the user belongs to.
+   */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "ap_area_id")
   var apArea: ApAreaEntity?,
+  /**
+   * Used by CRU Members only to determine which tasks/applications they should work on.
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cas1_cru_management_area_id")
+  var cruManagementArea: Cas1CruManagementAreaEntity?,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cas1_cru_management_area_override_id")
+  var cruManagementAreaOverride: Cas1CruManagementAreaEntity?,
   @Convert(converter = StringListConverter::class)
   var teamCodes: List<String>?,
   val createdAt: OffsetDateTime?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -343,9 +343,11 @@ class UserService(
     }
 
     if (forService == ServiceName.approvedPremises) {
-      user.apArea =
-        cas1ApAreaMappingService.determineApArea(user.probationRegion, staffDetail.teamCodes(), staffDetail.username)
+      val apArea = cas1ApAreaMappingService.determineApArea(user.probationRegion, staffDetail.teamCodes(), staffDetail.username)
+      user.apArea = apArea
+      user.cruManagementArea = apArea.defaultCruManagementArea
     }
+
     return userRepository.save(user)
   }
 
@@ -376,7 +378,9 @@ class UserService(
     }
 
     if (forService == ServiceName.approvedPremises) {
-      user.apArea = cas1ApAreaMappingService.determineApArea(user.probationRegion, deliusUser)
+      val apArea = cas1ApAreaMappingService.determineApArea(user.probationRegion, deliusUser)
+      user.apArea = apArea
+      user.cruManagementArea = apArea.defaultCruManagementArea
     }
 
     return userRepository.save(user)
@@ -466,6 +470,8 @@ class UserService(
         },
         isActive = true,
         apArea = apArea,
+        cruManagementArea = apArea.defaultCruManagementArea,
+        cruManagementAreaOverride = null,
         teamCodes = staffUserDetails.getTeamCodes(),
         createdAt = OffsetDateTime.now(),
         updatedAt = null,

--- a/src/main/resources/db/migration/all/20240923113600__add_cru_management_fields_to_user.sql
+++ b/src/main/resources/db/migration/all/20240923113600__add_cru_management_fields_to_user.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users ADD cas1_cru_management_area_id uuid NULL;
+ALTER TABLE users ADD CONSTRAINT users_cas1_cru_management_area_id_fk FOREIGN KEY (cas1_cru_management_area_id) REFERENCES cas1_cru_management_areas(id);
+
+ALTER TABLE users ADD cas1_cru_management_area_override_id uuid NULL;
+ALTER TABLE users ADD CONSTRAINT users_cas1_cru_management_area_override_id_fk FOREIGN KEY (cas1_cru_management_area_override_id) REFERENCES cas1_cru_management_areas(id);

--- a/src/main/resources/db/migration/all/20240923152108__backfill_user_cru_management_area.sql
+++ b/src/main/resources/db/migration/all/20240923152108__backfill_user_cru_management_area.sql
@@ -1,0 +1,3 @@
+UPDATE users u
+SET cas1_cru_management_area_id = (SELECT default_cru1_management_area_id FROM ap_areas area WHERE area.id = u.ap_area_id)
+WHERE u.ap_area_id IS NOT NULL AND u.cas1_cru_management_area_id IS NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -50,6 +51,8 @@ class UserEntityFactory : Factory<UserEntity> {
   private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>? = null
   private var isActive: Yielded<Boolean> = { true }
   private var apArea: Yielded<ApAreaEntity?> = { null }
+  private var cruManagementArea: Yielded<Cas1CruManagementAreaEntity?> = { null }
+  private var cruManagementAreaOverride: Yielded<Cas1CruManagementAreaEntity?> = { null }
   private var teamCodes: Yielded<List<String>?> = { null }
   private var createdAt: Yielded<OffsetDateTime?> = { null }
   private var updatedAt: Yielded<OffsetDateTime?> = { null }
@@ -166,6 +169,8 @@ class UserEntityFactory : Factory<UserEntity> {
     probationDeliveryUnit = this.probationDeliveryUnit?.invoke(),
     isActive = this.isActive(),
     apArea = this.apArea(),
+    cruManagementArea = this.cruManagementArea(),
+    cruManagementAreaOverride = this.cruManagementAreaOverride(),
     teamCodes = this.teamCodes(),
     createdAt = this.createdAt(),
     updatedAt = this.updatedAt(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationAreaProbationRegionMappingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
@@ -199,7 +200,8 @@ class UserServiceTest {
         .withProbationAreaDeliusCode("AREACODE")
         .produce()
 
-      val apArea = ApAreaEntityFactory().produce()
+      val apAreaDefaultCruManagementArea = Cas1CruManagementAreaEntityFactory().produce()
+      val apArea = ApAreaEntityFactory().withDefaultCruManagementArea(apAreaDefaultCruManagementArea).produce()
 
       every { mockCas1ApAreaMappingService.determineApArea(probationRegion, deliusUser) } returns apArea
 
@@ -218,6 +220,7 @@ class UserServiceTest {
       assertThat(result.user.name).isEqualTo("Jim Jimmerson")
       assertThat(result.user.teamCodes).isEqualTo(listOf("TC1", "TC2"))
       assertThat(result.user.apArea).isEqualTo(apArea)
+      assertThat(result.user.cruManagementArea).isEqualTo(apAreaDefaultCruManagementArea)
       assertThat(result.user.probationDeliveryUnit?.deliusCode).isEqualTo(pduDeliusCode)
       assertThat(result.user.createdAt).isWithinTheLastMinute()
 
@@ -864,7 +867,8 @@ class UserServiceTest {
       every { mockUserRepository.save(any()) } returnsArgument 0
       every { mockProbationDeliveryUnitRepository.findByDeliusCode(any()) } returns pdu
 
-      val newApAreaForCas1 = ApAreaEntityFactory().produce()
+      val newApAreaDefaultCruManagementArea = Cas1CruManagementAreaEntityFactory().produce()
+      val newApAreaForCas1 = ApAreaEntityFactory().withDefaultCruManagementArea(newApAreaDefaultCruManagementArea).produce()
       if (serviceName == ServiceName.approvedPremises) {
         every {
           mockCas1ApAreaMappingService.determineApArea(probationRegion, user.teamCodes!!, user.deliusUsername)
@@ -895,8 +899,10 @@ class UserServiceTest {
 
       if (serviceName == ServiceName.approvedPremises) {
         assertThat(entity.apArea).isEqualTo(newApAreaForCas1)
+        assertThat(entity.cruManagementArea).isEqualTo(newApAreaDefaultCruManagementArea)
       } else {
         assertThat(entity.apArea).isNull()
+        assertThat(entity.cruManagementArea).isNull()
       }
     }
 
@@ -1050,7 +1056,8 @@ class UserServiceTest {
           .produce()
       }
 
-      val newApAreaForCas1 = ApAreaEntityFactory().produce()
+      val newApAreaDefaultCruManagementArea = Cas1CruManagementAreaEntityFactory().produce()
+      val newApAreaForCas1 = ApAreaEntityFactory().withDefaultCruManagementArea(newApAreaDefaultCruManagementArea).produce()
       if (forService == ServiceName.approvedPremises) {
         every { mockCas1ApAreaMappingService.determineApArea(probationRegion, deliusUser) } returns newApAreaForCas1
       }
@@ -1075,8 +1082,10 @@ class UserServiceTest {
 
       if (forService == ServiceName.approvedPremises) {
         assertThat(entity.apArea).isEqualTo(newApAreaForCas1)
+        assertThat(entity.cruManagementArea).isEqualTo(newApAreaDefaultCruManagementArea)
       } else {
         assertThat(entity.apArea).isNull()
+        assertThat(entity.cruManagementArea).isNull()
       }
 
       verify(exactly = 1) { mockCommunityApiClient.getStaffUserDetails(username) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedRevisionTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedRevisionTransformerTest.kt
@@ -5,13 +5,10 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApprovedPremisesUserFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionChangeType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
@@ -49,23 +46,7 @@ class Cas1OutOfServiceBedRevisionTransformerTest {
     isActive = true,
   )
 
-  private val expectedUser = ApprovedPremisesUser(
-    qualifications = listOf(),
-    roles = listOf(),
-    apArea = ApArea(
-      id = UUID.randomUUID(),
-      identifier = "APA",
-      name = "AP Area",
-    ),
-    service = ServiceName.approvedPremises.value,
-    id = UUID.randomUUID(),
-    name = "Some User",
-    deliusUsername = "SOMEUSER",
-    region = ProbationRegion(
-      id = UUID.randomUUID(),
-      name = "Some Probation Region",
-    ),
-  )
+  private val expectedUser = ApprovedPremisesUserFactory().produce()
 
   @BeforeEach
   fun setup() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
@@ -8,20 +8,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Temporality
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApprovedPremisesUserFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedCancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedRevisionTransformer
@@ -93,23 +90,7 @@ class Cas1OutOfServiceBedTransformerTest {
     val historyItem = Cas1OutOfServiceBedRevision(
       id = UUID.randomUUID(),
       updatedAt = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres().toInstant(),
-      updatedBy = ApprovedPremisesUser(
-        qualifications = listOf(),
-        roles = listOf(),
-        apArea = ApArea(
-          id = UUID.randomUUID(),
-          identifier = "APAREA",
-          name = "An AP Area",
-        ),
-        service = ServiceName.approvedPremises.value,
-        id = UUID.randomUUID(),
-        name = "Some User",
-        deliusUsername = "SOMEUSER",
-        region = ProbationRegion(
-          id = UUID.randomUUID(),
-          name = "A Probation Region",
-        ),
-      ),
+      updatedBy = ApprovedPremisesUserFactory().produce(),
       revisionType = listOf(Cas1OutOfServiceBedRevisionType.created),
     )
 
@@ -182,23 +163,7 @@ class Cas1OutOfServiceBedTransformerTest {
     val historyItem = Cas1OutOfServiceBedRevision(
       id = UUID.randomUUID(),
       updatedAt = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres().toInstant(),
-      updatedBy = ApprovedPremisesUser(
-        qualifications = listOf(),
-        roles = listOf(),
-        apArea = ApArea(
-          id = UUID.randomUUID(),
-          identifier = "APAREA",
-          name = "An AP Area",
-        ),
-        service = ServiceName.approvedPremises.value,
-        id = UUID.randomUUID(),
-        name = "Some User",
-        deliusUsername = "SOMEUSER",
-        region = ProbationRegion(
-          id = UUID.randomUUID(),
-          name = "A Probation Region",
-        ),
-      ),
+      updatedBy = ApprovedPremisesUserFactory().produce(),
       revisionType = listOf(Cas1OutOfServiceBedRevisionType.created),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -8,15 +8,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummaryDiscriminator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPersonSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -26,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApprovedPremisesUserFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingAtPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -124,23 +122,7 @@ class Cas1SpaceBookingTransformerTest {
         serviceScope = "the service",
       )
 
-      val expectedUser = ApprovedPremisesUser(
-        qualifications = listOf(),
-        roles = listOf(),
-        apArea = ApArea(
-          id = UUID.randomUUID(),
-          identifier = "SOMEAPA",
-          name = "Some AP Area",
-        ),
-        service = ServiceName.approvedPremises.value,
-        id = spaceBooking.createdBy.id,
-        name = spaceBooking.createdBy.name,
-        deliusUsername = spaceBooking.createdBy.deliusUsername,
-        region = ProbationRegion(
-          id = UUID.randomUUID(),
-          name = "Some Probation Region",
-        ),
-      )
+      val expectedUser = ApprovedPremisesUserFactory().produce()
 
       val otherBookings = listOf(
         Cas1SpaceBookingAtPremisesImpl(


### PR DESCRIPTION
This PR adds two new fields to the users table:

* cas1_cru_management_area_id
* cas1_cru_management_area_override_id

The former will always be updated when ap area is updated, using the ap areas default management area value.

This commit also backfills the cas1_cru_management_area_id value for existing users.

The latter will be configurable via an API call to be added in a subsquent commit.