### PR TITLE
APS-1346 Filter by CRU management area id.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -80,6 +80,7 @@ class PlacementRequestsController(
     arrivalDateEnd: LocalDate?,
     requestType: PlacementRequestRequestType?,
     apAreaId: UUID?,
+    cruManagementAreaId: UUID?,
     page: Int?,
     sortBy: PlacementRequestSortField?,
     sortDirection: SortDirection?,
@@ -100,6 +101,7 @@ class PlacementRequestsController(
         arrivalDateEnd = arrivalDateEnd,
         requestType = requestType,
         apAreaId = apAreaId,
+        cruManagementAreaId = cruManagementAreaId,
       ),
       PageCriteria(
         sortBy = sortBy ?: PlacementRequestSortField.createdAt,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -114,6 +114,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
         )
       )
       AND ((CAST(:apAreaId AS pg_catalog.uuid) IS NULL) OR area.id = :apAreaId)
+      AND ((CAST(:cruManagementAreaId AS pg_catalog.uuid) IS NULL) OR apa.cas1_cru_management_area_id = :cruManagementAreaId)
   """,
     nativeQuery = true,
   )
@@ -126,6 +127,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
     arrivalDateTo: LocalDate? = null,
     requestType: String? = null,
     apAreaId: UUID? = null,
+    cruManagementAreaId: UUID? = null,
     pageable: Pageable? = null,
   ): Page<PlacementRequestEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -107,6 +107,7 @@ class PlacementRequestService(
       arrivalDateTo = searchCriteria.arrivalDateEnd,
       requestType = searchCriteria.requestType?.name,
       apAreaId = searchCriteria.apAreaId,
+      cruManagementAreaId = searchCriteria.cruManagementAreaId,
       pageable = pageable,
     )
 
@@ -404,6 +405,7 @@ class PlacementRequestService(
     val arrivalDateEnd: LocalDate? = null,
     val requestType: PlacementRequestRequestType? = null,
     val apAreaId: UUID? = null,
+    val cruManagementAreaId: UUID? = null,
   )
 
   data class PlacementRequestAndCancellations(

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3190,7 +3190,15 @@ paths:
         - name: apAreaId
           in: query
           required: false
-          description: filter by approved premises area ID
+          description: filter by approved premises area ID.  Use cruManagementAreaId instead.
+          deprecated: true
+          schema:
+            type: string
+            format: uuid
+        - name: cruManagementAreaId
+          in: query
+          required: false
+          description: filter by CRU management area ID
           schema:
             type: string
             format: uuid

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3192,7 +3192,15 @@ paths:
         - name: apAreaId
           in: query
           required: false
-          description: filter by approved premises area ID
+          description: filter by approved premises area ID.  Use cruManagementAreaId instead.
+          deprecated: true
+          schema:
+            type: string
+            format: uuid
+        - name: cruManagementAreaId
+          in: query
+          required: false
+          description: filter by CRU management area ID
           schema:
             type: string
             format: uuid

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -225,6 +225,10 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.noticeType = { noticeType }
   }
 
+  fun withCruManagementArea(cruManagementArea: Cas1CruManagementAreaEntity?) = apply {
+    this.cruManagementArea = { cruManagementArea }
+  }
+
   override fun produce(): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = this.id(),
     crn = this.crn(),


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1346

We have several endpoints that allow filtering of results on AP Area ID. These need updating to support filtering on CRU Management Area ID instead. The option to filter on AP Area ID should be deprecated in favour of CRU Management Area

This PR updates `PlacementRequestsController.placementRequestsDashboardGet` (tested by `PlacementRequestsTest.Dashboard`). In the SQL this will work by filtering on the CRU Management Area linked to the application i.e. (`approved_premises_applications.cas1_cru_management_area_id`).

This is a back end change only and does not require any change to the front end (for now).  Therefore although we are passing `apAreaId` to the API, we are doing a SQL search joining on `cruManagementAreaId`.

Note that for AP Area we perform a join - this has been removed.