### PR TITLE
APS-1314 - Return User's CRU Management Area details in the API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -315,7 +315,6 @@ data class UserEntity(
 ) {
   fun hasRole(userRole: UserRole) = roles.any { it.role == userRole }
   fun hasAnyRole(vararg userRoles: UserRole) = userRoles.any(::hasRole)
-  fun hasAnyRole(userRoles: List<UserRole>) = userRoles.any(::hasRole)
   fun hasQualification(userQualification: UserQualification) =
     qualifications.any { it.qualification === userQualification }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3091,12 +3091,26 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            cruManagementArea:
+              description: CRU Management Area to use. This will be the same as cruManagementAreaDefault unless cruManagementAreaOverride is defined
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaDefault:
+              description: The CRU Management Area used if no override is defined. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaOverride:
+              description: The CRU Management Area manually set on this user. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
             version:
               type: integer
           required:
             - qualifications
             - roles
             - apArea
+            - cruManagementArea
+            - cruManagementAreaDefault
     UserRolesAndQualifications:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7569,12 +7569,26 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            cruManagementArea:
+              description: CRU Management Area to use. This will be the same as cruManagementAreaDefault unless cruManagementAreaOverride is defined
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaDefault:
+              description: The CRU Management Area used if no override is defined. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaOverride:
+              description: The CRU Management Area manually set on this user. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
             version:
               type: integer
           required:
             - qualifications
             - roles
             - apArea
+            - cruManagementArea
+            - cruManagementAreaDefault
     UserRolesAndQualifications:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4230,12 +4230,26 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            cruManagementArea:
+              description: CRU Management Area to use. This will be the same as cruManagementAreaDefault unless cruManagementAreaOverride is defined
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaDefault:
+              description: The CRU Management Area used if no override is defined. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaOverride:
+              description: The CRU Management Area manually set on this user. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
             version:
               type: integer
           required:
             - qualifications
             - roles
             - apArea
+            - cruManagementArea
+            - cruManagementAreaDefault
     UserRolesAndQualifications:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3682,12 +3682,26 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            cruManagementArea:
+              description: CRU Management Area to use. This will be the same as cruManagementAreaDefault unless cruManagementAreaOverride is defined
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaDefault:
+              description: The CRU Management Area used if no override is defined. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaOverride:
+              description: The CRU Management Area manually set on this user. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
             version:
               type: integer
           required:
             - qualifications
             - roles
             - apArea
+            - cruManagementArea
+            - cruManagementAreaDefault
     UserRolesAndQualifications:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3182,12 +3182,26 @@ components:
                 $ref: '#/components/schemas/ApprovedPremisesUserPermission'
             apArea:
               $ref: '#/components/schemas/ApArea'
+            cruManagementArea:
+              description: CRU Management Area to use. This will be the same as cruManagementAreaDefault unless cruManagementAreaOverride is defined
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaDefault:
+              description: The CRU Management Area used if no override is defined. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaOverride:
+              description: The CRU Management Area manually set on this user. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
             version:
               type: integer
           required:
             - qualifications
             - roles
             - apArea
+            - cruManagementArea
+            - cruManagementAreaDefault
     UserRolesAndQualifications:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/UserEntityFactory.kt
@@ -150,6 +150,14 @@ class UserEntityFactory : Factory<UserEntity> {
     this.apArea = { apArea }
   }
 
+  fun withCruManagementArea(cruManagementArea: Cas1CruManagementAreaEntity?) = apply {
+    this.cruManagementArea = { cruManagementArea }
+  }
+
+  fun withCruManagementAreaOverride(cruManagementAreaOverride: Cas1CruManagementAreaEntity?) = apply {
+    this.cruManagementAreaOverride = { cruManagementAreaOverride }
+  }
+
   fun withTeamCodes(teamCodes: List<String>) = apply {
     this.teamCodes = { teamCodes }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApprovedPremisesUserFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/ApprovedPremisesUserFactory.kt
@@ -5,6 +5,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -21,6 +22,13 @@ class ApprovedPremisesUserFactory : Factory<ApprovedPremisesUser> {
       randomStringMultiCaseWithNumbers(20),
     )
   }
+  private var cruManagementArea: Yielded<NamedId> = {
+    NamedId(UUID.randomUUID(), randomStringUpperCase(6))
+  }
+  private var cruManagementAreaDefault: Yielded<NamedId> = {
+    NamedId(UUID.randomUUID(), randomStringUpperCase(6))
+  }
+  private var cruManagementAreaOverride: Yielded<NamedId?> = { null }
   private var service: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
@@ -83,6 +91,9 @@ class ApprovedPremisesUserFactory : Factory<ApprovedPremisesUser> {
     qualifications = this.qualifications(),
     roles = this.roles(),
     apArea = this.apArea(),
+    cruManagementArea = this.cruManagementArea(),
+    cruManagementAreaDefault = this.cruManagementAreaDefault(),
+    cruManagementAreaOverride = this.cruManagementAreaOverride(),
     service = this.service(),
     id = this.id(),
     name = this.name(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonalTimelineTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimeline
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonalTimeline
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
@@ -133,6 +134,8 @@ class PersonalTimelineTest : IntegrationTestBase() {
             inmateDetail = inmateDetails,
           )
 
+          val apArea = userEntity.apArea!!
+
           webTestClient.get()
             .uri("/people/${offenderDetails.otherIds.crn}/timeline")
             .header("Authorization", "Bearer $jwt")
@@ -155,9 +158,9 @@ class PersonalTimelineTest : IntegrationTestBase() {
                         roles = emptyList(),
                         permissions = emptyList(),
                         apArea = ApArea(
-                          id = userEntity.apArea!!.id,
-                          identifier = userEntity.apArea!!.identifier,
-                          name = userEntity.apArea!!.name,
+                          id = apArea.id,
+                          identifier = apArea.identifier,
+                          name = apArea.name,
                         ),
                         service = "CAS1",
                         id = userEntity.id,
@@ -171,6 +174,15 @@ class PersonalTimelineTest : IntegrationTestBase() {
                         telephoneNumber = userEntity.telephoneNumber,
                         isActive = userEntity.isActive,
                         version = 993,
+                        cruManagementArea = NamedId(
+                          id = userEntity.cruManagementArea!!.id,
+                          name = userEntity.cruManagementArea!!.name,
+                        ),
+                        cruManagementAreaDefault = NamedId(
+                          id = apArea.defaultCruManagementArea.id,
+                          name = apArea.defaultCruManagementArea.name,
+                        ),
+                        cruManagementAreaOverride = null,
                       ),
                       timelineEvents = listOf(
                         TimelineEvent(
@@ -259,6 +271,8 @@ class PersonalTimelineTest : IntegrationTestBase() {
             inmateDetail = null,
           )
 
+          val apArea = userEntity.apArea!!
+
           webTestClient.get()
             .uri("/people/${offenderDetails.otherIds.crn}/timeline")
             .header("Authorization", "Bearer $jwt")
@@ -281,9 +295,9 @@ class PersonalTimelineTest : IntegrationTestBase() {
                         roles = emptyList(),
                         permissions = emptyList(),
                         apArea = ApArea(
-                          id = userEntity.apArea!!.id,
-                          identifier = userEntity.apArea!!.identifier,
-                          name = userEntity.apArea!!.name,
+                          id = apArea.id,
+                          identifier = apArea.identifier,
+                          name = apArea.name,
                         ),
                         service = "CAS1",
                         id = userEntity.id,
@@ -297,6 +311,15 @@ class PersonalTimelineTest : IntegrationTestBase() {
                         telephoneNumber = userEntity.telephoneNumber,
                         isActive = userEntity.isActive,
                         version = 993,
+                        cruManagementArea = NamedId(
+                          id = userEntity.cruManagementArea!!.id,
+                          name = userEntity.cruManagementArea!!.name,
+                        ),
+                        cruManagementAreaDefault = NamedId(
+                          id = apArea.defaultCruManagementArea.id,
+                          name = apArea.defaultCruManagementArea.name,
+                        ),
+                        cruManagementAreaOverride = null,
                       ),
                       timelineEvents = listOf(
                         TimelineEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -17,13 +17,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS1 CRU Management Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an CAS1 CRU Management Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.CommunityAPI_mockOffenderUserAccessCall
@@ -652,8 +652,8 @@ class PlacementRequestsTest : IntegrationTestBase() {
       `Given a User`(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         `Given an Offender` { offenderDetails, inmateDetails ->
 
-          val cruArea1 = `Given an CAS1 CRU Management Area`()
-          val cruArea2 = `Given an CAS1 CRU Management Area`()
+          val cruArea1 = `Given a CAS1 CRU Management Area`()
+          val cruArea2 = `Given a CAS1 CRU Management Area`()
 
           createPlacementRequest(offenderDetails, user, cruManagementArea = cruArea1)
           val placementRequestA1 = createPlacementRequest(offenderDetails, user, cruManagementArea = cruArea2)
@@ -783,8 +783,8 @@ class PlacementRequestsTest : IntegrationTestBase() {
         `Given an Offender` { offender1Details, inmate1Details ->
           `Given an Offender` { offender2Details, _ ->
 
-            val cruArea1 = `Given an CAS1 CRU Management Area`()
-            val cruArea2 = `Given an CAS1 CRU Management Area`()
+            val cruArea1 = `Given a CAS1 CRU Management Area`()
+            val cruArea2 = `Given a CAS1 CRU Management Area`()
 
             createPlacementRequest(offender1Details, user, expectedArrival = LocalDate.of(2022, 1, 1), tier = RiskTierLevel.a2)
             createPlacementRequest(offender1Details, user, expectedArrival = LocalDate.of(2022, 1, 5), tier = RiskTierLevel.a1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ProfileTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProfileResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -77,6 +78,15 @@ class ProfileTest : IntegrationTestBase() {
                 service = "CAS1",
                 isActive = true,
                 apArea = ApArea(userApArea.id, userApArea.identifier, userApArea.name),
+                cruManagementArea = NamedId(
+                  id = userEntity.cruManagementArea!!.id,
+                  name = userEntity.cruManagementArea!!.name,
+                ),
+                cruManagementAreaDefault = NamedId(
+                  id = userApArea.defaultCruManagementArea.id,
+                  name = userApArea.defaultCruManagementArea.name,
+                ),
+                cruManagementAreaOverride = null,
                 permissions = listOf(
                   ApprovedPremisesUserPermission.assessApplication,
                   ApprovedPremisesUserPermission.assessAppealedApplication,
@@ -281,6 +291,15 @@ class ProfileTest : IntegrationTestBase() {
                   service = "CAS1",
                   isActive = true,
                   apArea = ApArea(userApArea.id, userApArea.identifier, userApArea.name),
+                  cruManagementArea = NamedId(
+                    id = userEntity.cruManagementArea!!.id,
+                    name = userEntity.cruManagementArea!!.name,
+                  ),
+                  cruManagementAreaDefault = NamedId(
+                    id = userApArea.defaultCruManagementArea.id,
+                    name = userApArea.defaultCruManagementArea.name,
+                  ),
+                  cruManagementAreaOverride = null,
                   permissions = listOf(
                     ApprovedPremisesUserPermission.assessApplication,
                     ApprovedPremisesUserPermission.assessAppealedApplication,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskWrapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS1 CRU Management Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
@@ -38,7 +39,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Approved Premises`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Assessment for Temporary Accommodation`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an CAS1 CRU Management Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
@@ -610,8 +610,8 @@ class TasksTest {
             `Given an Offender` { offenderDetails, _ ->
               this.jwt = jwt
 
-              cruArea = `Given an CAS1 CRU Management Area`()
-              val cruArea2 = `Given an CAS1 CRU Management Area`()
+              cruArea = `Given a CAS1 CRU Management Area`()
+              val cruArea2 = `Given a CAS1 CRU Management Area`()
 
               val offenderSummaries = getOffenderSummaries(offenderDetails)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRolesAndQualifications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserTeamMembershipFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS1 CRU Management Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
@@ -429,11 +430,13 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
               val userOne = userEntityFactory.produceAndPersist {
                 withProbationRegion(probationRegion)
                 withApArea(apArea)
+                withCruManagementArea(`Given a CAS1 CRU Management Area`())
               }
 
               val userTwo = userEntityFactory.produceAndPersist {
                 withProbationRegion(probationRegion)
                 withApArea(apArea)
+                withCruManagementArea(`Given a CAS1 CRU Management Area`())
               }
 
               webTestClient.get()
@@ -478,11 +481,13 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
               val userOne = userEntityFactory.produceAndPersist {
                 withProbationRegion(probationRegion)
                 withApArea(apArea)
+                withCruManagementArea(`Given a CAS1 CRU Management Area`())
               }
 
               val userTwo = userEntityFactory.produceAndPersist {
                 withProbationRegion(probationRegion)
                 withApArea(apArea)
+                withCruManagementArea(`Given a CAS1 CRU Management Area`())
               }
 
               webTestClient.get()
@@ -1193,12 +1198,11 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
       )
       val region = `Given a Probation Region`()
 
-      userEntityFactory.produceAndPersist {
-        withId(id)
-        withIsActive(false)
-        withYieldedProbationRegion { region }
-        withYieldedApArea { `Given an AP Area`() }
-      }
+      `Given a User`(
+        id = id,
+        isActive = false,
+        probationRegion = region,
+      )
 
       `Given a User`(roles = listOf(role)) { _, jwt ->
         webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -43,6 +43,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1Pla
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1PlacementMatchingOutcomesV2ReportTest.Constants.REPORT_YEAR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse
@@ -450,7 +451,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       staffUserDetailsConfigBlock = {
         withUsername(matcherUsername)
       },
-      apAreaName = matcherApAreaName,
+      probationRegion = `Given a Probation Region`(apArea = `Given an AP Area`(name = matcherApAreaName)),
     ).second
 
     val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -481,7 +482,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       staffUserDetailsConfigBlock = {
         withUsername(matcherUsername)
       },
-      apAreaName = matcherApAreaName,
+      probationRegion = `Given a Probation Region`(apArea = `Given an AP Area`(name = matcherApAreaName)),
     ).second
 
     cas1SimpleApiClient.placementRequestBookingNotMade(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1UsersTest.kt
@@ -201,7 +201,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `Updating a user returns OK with correct body when user has an approved role`(role: UserRole) {
-      val id = UUID.randomUUID()
       val qualifications = listOf(APIUserQualification.emergency, APIUserQualification.pipe)
       val roles = listOf(
         ApprovedPremisesUserRole.assessor,
@@ -210,14 +209,8 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         ApprovedPremisesUserRole.excludedFromMatchAllocation,
         ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation,
       )
-      val region = `Given a Probation Region`()
-
-      userEntityFactory.produceAndPersist {
-        withId(id)
-        withIsActive(false)
-        withYieldedProbationRegion { region }
-        withYieldedApArea { `Given an AP Area`() }
-      }
+      
+      val id = `Given a User`().first.id
 
       `Given a User`(roles = listOf(role)) { _, jwt ->
         webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1CruManagementArea.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1CruManagementArea.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 
-fun IntegrationTestBase.`Given an CAS1 CRU Management Area`(): Cas1CruManagementAreaEntity {
+fun IntegrationTestBase.`Given a CAS1 CRU Management Area`(): Cas1CruManagementAreaEntity {
   return cas1CruManagementAreaEntityFactory.produceAndPersist()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -37,14 +37,9 @@ fun IntegrationTestBase.`Given a Placement Application`(
 ): PlacementApplicationEntity {
   val userApArea = `Given an AP Area`()
 
-  val assessmentAllocatedToUser = userEntityFactory.produceAndPersist {
-    withYieldedProbationRegion {
-      probationRegionEntityFactory.produceAndPersist {
-        withApArea(userApArea)
-      }
-    }
-    withApArea(userApArea)
-  }
+  val (assessmentAllocatedToUser) = `Given a User`(
+    probationRegion = `Given a Probation Region`(apArea = userApArea),
+  )
 
   val assessmentCreatedByUser = userEntityFactory.produceAndPersist {
     withYieldedProbationRegion {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.util.UUID
 
 @SuppressWarnings("LongParameterList")
@@ -25,7 +24,6 @@ fun IntegrationTestBase.`Given a User`(
   probationRegion: ProbationRegionEntity? = null,
   isActive: Boolean = true,
   mockStaffUserDetailsCall: Boolean = true,
-  apAreaName: String = randomStringMultiCaseWithNumbers(8),
 ): Pair<UserEntity, String> {
   val staffUserDetailsFactory = StaffUserDetailsFactory()
 
@@ -35,10 +33,10 @@ fun IntegrationTestBase.`Given a User`(
 
   val staffUserDetails = staffUserDetailsFactory.produce()
 
-  val yieldedProbationRegion = probationRegion
-    ?: probationRegionEntityFactory.produceAndPersist {
-      withYieldedApArea { `Given an AP Area`(name = apAreaName) }
-    }
+  val resolvedProbationRegion = probationRegion ?: probationRegionEntityFactory.produceAndPersist {
+    withYieldedApArea { `Given an AP Area`() }
+  }
+  val apArea = resolvedProbationRegion.apArea!!
 
   val user = userEntityFactory.produceAndPersist {
     withId(id)
@@ -48,12 +46,9 @@ fun IntegrationTestBase.`Given a User`(
     withTelephoneNumber(staffUserDetails.telephoneNumber)
     withName("${staffUserDetails.staff.forenames} ${staffUserDetails.staff.surname}")
     withIsActive(isActive)
-    withYieldedProbationRegion {
-      yieldedProbationRegion
-    }
-    withYieldedApArea {
-      yieldedProbationRegion.apArea!!
-    }
+    withYieldedProbationRegion { resolvedProbationRegion }
+    withYieldedApArea { apArea }
+    withCruManagementArea(apArea.defaultCruManagementArea)
   }
 
   roles.forEach { role ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApArea.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApArea.kt
@@ -17,6 +17,6 @@ fun IntegrationTestBase.`Given an AP Area`(
     if (emailAddress != null) {
       withEmailAddress(emailAddress)
     }
-    withDefaultCruManagementArea(`Given an CAS1 CRU Management Area`())
+    withDefaultCruManagementArea(`Given a CAS1 CRU Management Area`())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -44,7 +44,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserWithWorklo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_APPEALS_MANAGER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_JANITOR
@@ -123,12 +125,20 @@ class UserTransformerTest {
     }
 
     @Test
-    fun `transformJpaToApi CAS1 Should successfully transfer user entity with role CAS1_MATCHER to matcher`() {
-      val apAreaEntity = ApAreaEntityFactory().produce()
+    fun `transformJpaToApi CAS1 should map successfully`() {
+      val cruManagementArea = Cas1CruManagementAreaEntityFactory().produce()
+      val defaultCruManagementArea = Cas1CruManagementAreaEntityFactory().produce()
+      val overriddenCruManagementArea = Cas1CruManagementAreaEntityFactory().produce()
+
+      val apAreaEntity = ApAreaEntityFactory()
+        .withDefaultCruManagementArea(defaultCruManagementArea)
+        .produce()
 
       val user = buildUserEntity(
         role = CAS1_MATCHER,
         apArea = apAreaEntity,
+        cruManagementArea = cruManagementArea,
+        cruManagementAreaOverride = overriddenCruManagementArea,
       )
 
       every { apAreaTransformer.transformJpaToApi(apAreaEntity) } returns apArea
@@ -139,6 +149,12 @@ class UserTransformerTest {
       assertThat(result.service).isEqualTo("CAS1")
       verify(exactly = 1) { probationRegionTransformer.transformJpaToApi(any()) }
       assertThat(result.apArea).isEqualTo(apArea)
+      assertThat(result.cruManagementArea.id).isEqualTo(cruManagementArea.id)
+      assertThat(result.cruManagementArea.name).isEqualTo(cruManagementArea.name)
+      assertThat(result.cruManagementAreaDefault.id).isEqualTo(defaultCruManagementArea.id)
+      assertThat(result.cruManagementAreaDefault.name).isEqualTo(defaultCruManagementArea.name)
+      assertThat(result.cruManagementAreaOverride!!.id).isEqualTo(overriddenCruManagementArea.id)
+      assertThat(result.cruManagementAreaOverride!!.name).isEqualTo(overriddenCruManagementArea.name)
     }
 
     @Test
@@ -146,6 +162,7 @@ class UserTransformerTest {
       val user = buildUserEntity(
         role = CAS1_MATCHER,
         apArea = ApAreaEntityFactory().produce(),
+        cruManagementArea = Cas1CruManagementAreaEntityFactory().produce(),
       )
       user.addRoleForUnitTest(CAS1_MATCHER)
       user.addRoleForUnitTest(CAS1_MATCHER)
@@ -173,6 +190,7 @@ class UserTransformerTest {
       val user = buildUserEntity(
         role = role,
         apArea = ApAreaEntityFactory().produce(),
+        cruManagementArea = Cas1CruManagementAreaEntityFactory().produce(),
       )
 
       every { apAreaTransformer.transformJpaToApi(any()) } returns apArea
@@ -210,6 +228,7 @@ class UserTransformerTest {
       val user = buildUserEntity(
         role = role,
         apArea = ApAreaEntityFactory().produce(),
+        cruManagementArea = Cas1CruManagementAreaEntityFactory().produce(),
       )
 
       every { apAreaTransformer.transformJpaToApi(any()) } returns apArea
@@ -225,6 +244,7 @@ class UserTransformerTest {
       val user = buildUserEntity(
         role = CAS1_JANITOR,
         apArea = ApAreaEntityFactory().produce(),
+        cruManagementArea = Cas1CruManagementAreaEntityFactory().produce(),
       )
       user.addRoleForUnitTest(CAS1_APPEALS_MANAGER)
 
@@ -262,6 +282,7 @@ class UserTransformerTest {
       val user = buildUserEntity(
         role = CAS1_JANITOR,
         apArea = ApAreaEntityFactory().produce(),
+        cruManagementArea = Cas1CruManagementAreaEntityFactory().produce(),
       )
 
       every { apAreaTransformer.transformJpaToApi(any()) } returns apArea
@@ -383,6 +404,7 @@ class UserTransformerTest {
       val user = buildUserEntity(
         role = CAS1_MATCHER,
         apArea = apAreaEntity,
+        cruManagementArea = Cas1CruManagementAreaEntityFactory().produce(),
       )
 
       every { apAreaTransformer.transformJpaToApi(apAreaEntity) } returns apArea
@@ -403,6 +425,8 @@ class UserTransformerTest {
     role: UserRole,
     apArea: ApAreaEntity? = null,
     updatedAt: OffsetDateTime? = null,
+    cruManagementArea: Cas1CruManagementAreaEntity? = null,
+    cruManagementAreaOverride: Cas1CruManagementAreaEntity? = null,
   ) = UserEntityFactory()
     .withId(randomUUID())
     .withName("username")
@@ -412,6 +436,8 @@ class UserTransformerTest {
     .withIsActive(true)
     .withProbationRegion(buildProbationRegionEntity())
     .withApArea(apArea)
+    .withCruManagementArea(cruManagementArea)
+    .withCruManagementAreaOverride(cruManagementAreaOverride)
     .withUpdatedAt(updatedAt)
     .produce()
     .addRoleForUnitTest(role)


### PR DESCRIPTION
This commit adds CRU Management Area fields to the ApprovedPremisesUser API Model to support:

* Determining which CRU Management Area the user is in (when retrieved via /profile/v2)
* Logic to determine/set/get override configuration for the user management page

This commit is quite large because i had fix existing test data where entries in the users table were created for CAS1 testing and the CRU Management Area was not set, something which wouldn’t be the case in production (it’s logically mandatory for CAS1 users)