### PR TITLE
Disable pre-emptive cache refresh during tests

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -269,6 +269,7 @@ url-templates:
       application-overview: http://localhost:3000/applications/#id/overview
       submitted-application-overview: http://localhost:3000/assess/applications/#applicationId/overview
 
+preemptive-cache-enabled: true
 preemptive-cache-key-prefix: ""
 preemptive-cache-logging-enabled: false
 preemptive-cache-delay-ms: 10000

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/NoOpSentryService.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/NoOpSentryService.kt
@@ -17,12 +17,12 @@ class NoOpSentryService : SentryService {
   private val capturedErrors = mutableListOf<String>()
 
   override fun captureException(throwable: Throwable) {
-    log.info("Will capture exception in sentry", throwable)
+    log.info("Sentry Exception Captured", throwable)
     capturedExceptions.add(throwable)
   }
 
   override fun captureErrorMessage(message: String) {
-    log.info("Will capture message $message in sentry", message)
+    log.info("Sentry Message Captured : '$message'", message)
     capturedErrors.add(message)
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -177,8 +177,7 @@ url-templates:
       application-overview: http://cas2.frontend/applications/#id/overview
       submitted-application-overview: http://cas2.frontend/assess/applications/#applicationId/overview
 
-preemptive-cache-delay-ms: 250
-preemptive-cache-lock-duration-ms: 10000
+preemptive-cache-enabled: false
 
 arrived-departed-domain-events-disabled: false
 manual-bookings-domain-events-disabled: false


### PR DESCRIPTION
This isn’t required for testing and creates quite a bit of noise when the database is being reset at the same point in the time the refresh job runs.