### PR TITLE
CAS-637 Remove CRN from booking Api endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
@@ -46,13 +46,12 @@ class BookingsController(
     sortOrder: SortOrder?,
     sortField: BookingSearchSortField?,
     page: Int?,
-    crn: String?,
     crnOrName: String?,
   ): ResponseEntity<BookingSearchResults> {
     val sortOrder = sortOrder ?: SortOrder.ascending
     val sortField = sortField ?: BookingSearchSortField.bookingCreatedAt
 
-    val (results, metadata) = bookingSearchService.findBookings(status, sortOrder, sortField, page, crnOrName ?: crn)
+    val (results, metadata) = bookingSearchService.findBookings(status, sortOrder, sortField, page, crnOrName)
 
     return ResponseEntity.ok()
       .headers(metadata?.toHeaders())

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2502,12 +2502,6 @@ paths:
           description: Page number of results to return. If blank, returns all results
           schema:
             type: integer
-        - name: crn
-          in: query
-          description: If provided, return only results for the given CRN
-          required: false
-          schema:
-            type: string
         - name: crnOrName
           in: query
           description: Filters bookings using exact or partial match on name or exact CRN match

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2504,12 +2504,6 @@ paths:
           description: Page number of results to return. If blank, returns all results
           schema:
             type: integer
-        - name: crn
-          in: query
-          description: If provided, return only results for the given CRN
-          required: false
-          schema:
-            type: string
         - name: crnOrName
           in: query
           description: Filters bookings using exact or partial match on name or exact CRN match

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -58,9 +58,8 @@ class BookingSearchTest : IntegrationTestBase() {
     }
   }
 
-  @ParameterizedTest
-  @CsvSource("crn", "crnOrName")
-  fun `Searching for Temporary Accommodation bookings correctly filtered single booking for a specific crn`(queryParameter: String) {
+  @Test
+  fun `Searching for Temporary Accommodation bookings correctly filtered single booking for a specific crn`() {
     `Given a User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, _ ->
         val crn = "S121978"
@@ -69,14 +68,13 @@ class BookingSearchTest : IntegrationTestBase() {
           createTestTemporaryAccommodationBookings(userEntity.probationRegion, 1, 1, crn)
         val expectedResponse = getExpectedResponseWithoutPersonName(expectedBookingSearchResult, crn)
 
-        callApiAndAssertResponse("/bookings/search?$queryParameter=$crn", jwt, expectedResponse, true)
+        callApiAndAssertResponse("/bookings/search?crnOrName=$crn", jwt, expectedResponse, true)
       }
     }
   }
 
-  @ParameterizedTest
-  @CsvSource("crn", "crnOrName")
-  fun `Searching for Temporary Accommodation bookings correctly filtered multiple booking for a specific crn`(queryParameter: String) {
+  @Test
+  fun `Searching for Temporary Accommodation bookings correctly filtered multiple booking for a specific crn`() {
     `Given a User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, _ ->
         val crn = "S121978"
@@ -85,20 +83,20 @@ class BookingSearchTest : IntegrationTestBase() {
         createTestTemporaryAccommodationBookings(userEntity.probationRegion, 1, 1, crn)
         val expectedResponse = getExpectedResponse(expectedBookingInSearchResult, offenderDetails)
 
-        callApiAndAssertResponse("/bookings/search?$queryParameter=${offenderDetails.otherIds.crn}", jwt, expectedResponse, true)
+        callApiAndAssertResponse("/bookings/search?crnOrName=${offenderDetails.otherIds.crn}", jwt, expectedResponse, true)
       }
     }
   }
 
   @ParameterizedTest
-  @CsvSource("crn,S121978", "crnOrName,PersonName")
-  fun `Searching for Temporary Accommodation bookings with crn or name not exists in the database return empty response`(queryParameter: String, queryParameterValue: String) {
+  @CsvSource("S121978", "PersonName")
+  fun `Searching for Temporary Accommodation bookings with crn or name not exists in the database return empty response`(queryParameterValue: String) {
     `Given a User` { userEntity, jwt ->
       `Given an Offender` { offenderDetails, _ ->
         create15TestTemporaryAccommodationBookings(userEntity, offenderDetails)
         val expectedBookingSearchResults = BookingSearchResults(resultsCount = 0, results = emptyList())
 
-        callApiAndAssertResponse("/bookings/search?$queryParameter=$queryParameterValue", jwt, expectedBookingSearchResults, true)
+        callApiAndAssertResponse("/bookings/search?crnOrName=$queryParameterValue", jwt, expectedBookingSearchResults, true)
       }
     }
   }


### PR DESCRIPTION
This [PR CAS-637](https://dsdmoj.atlassian.net/browse/CAS-637) is to remove the `crn` parameter from booking api endpoint as it was replaced by `crnOrName` parameter