### PR TITLE
APS-1314 Add CAS1 Users Endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.util.UUID
 
 @Service
@@ -29,13 +30,7 @@ class UsersController(
 ) : UsersApiDelegate {
 
   override fun usersIdGet(id: UUID, xServiceName: ServiceName): ResponseEntity<User> {
-    val getUserResponse = when (val result = userService.updateUser(id, xServiceName)) {
-      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, "User")
-      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
-      is AuthorisableActionResult.Success -> result.entity
-    }
-
-    return when (getUserResponse) {
+    return when (val getUserResponse = extractEntityFromCasResult(userService.updateUser(id, xServiceName))) {
       UserService.GetUserResponse.StaffRecordNotFound -> throw NotFoundProblem(id, "Staff")
       is UserService.GetUserResponse.Success -> ResponseEntity(userTransformer.transformJpaToApi(getUserResponse.user, xServiceName), HttpStatus.OK)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
@@ -123,11 +122,9 @@ class UsersController(
       throw ForbiddenProblem()
     }
 
-    val userEntity = when (val result = userService.updateUserRolesAndQualifications(id, userRolesAndQualifications)) {
-      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(id, "User")
-      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
-      is AuthorisableActionResult.Success -> result.entity
-    }
+    val userEntity = extractEntityFromCasResult(
+      userService.updateUserRolesAndQualifications(id, userRolesAndQualifications),
+    )
 
     return ResponseEntity(userTransformer.transformJpaToApi(userEntity, ServiceName.approvedPremises), HttpStatus.OK)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1UsersController.kt
@@ -1,23 +1,60 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.UsersCas1Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1UpdateUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRolesAndQualifications
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.util.UUID
 
-class Cas1UsersController : UsersCas1Delegate {
-
-  override fun deleteUser(id: UUID): ResponseEntity<Unit> {
-    return super.deleteUser(id)
-  }
+@Service
+class Cas1UsersController(
+  private val userService: UserService,
+  private val userTransformer: UserTransformer,
+  private val userAccessService: UserAccessService,
+) : UsersCas1Delegate {
 
   override fun getUser(id: UUID): ResponseEntity<ApprovedPremisesUser> {
-    return super.getUser(id)
+    return when (val getUserResponse = extractEntityFromCasResult(userService.updateUser(id, ServiceName.approvedPremises))) {
+      UserService.GetUserResponse.StaffRecordNotFound -> throw NotFoundProblem(id, "Staff")
+      is UserService.GetUserResponse.Success -> ResponseEntity(userTransformer.transformCas1JpaToApi(getUserResponse.user), HttpStatus.OK)
+    }
   }
 
-  override fun updateUser(id: UUID, updateUser: Cas1UpdateUser): ResponseEntity<User> {
-    return super.updateUser(id, updateUser)
+  override fun deleteUser(id: UUID): ResponseEntity<Unit> {
+    if (!userAccessService.currentUserCanManageUsers(ServiceName.approvedPremises)) {
+      throw ForbiddenProblem()
+    }
+    return ResponseEntity.ok(
+      userService.deleteUser(id),
+    )
+  }
+
+  override fun updateUser(id: UUID, cas1UpdateUser: Cas1UpdateUser): ResponseEntity<User> {
+    if (!userAccessService.currentUserCanManageUsers(ServiceName.approvedPremises)) {
+      throw ForbiddenProblem()
+    }
+
+    val userEntity = extractEntityFromCasResult(
+      userService.updateUserRolesAndQualifications(
+        id,
+        UserRolesAndQualifications(
+          cas1UpdateUser.roles,
+          cas1UpdateUser.qualifications,
+        ),
+      ),
+    )
+
+    return ResponseEntity(userTransformer.transformJpaToApi(userEntity, ServiceName.approvedPremises), HttpStatus.OK)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1UsersController.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.UsersCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1UpdateUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
+import java.util.UUID
+
+class Cas1UsersController : UsersCas1Delegate {
+
+  override fun deleteUser(id: UUID): ResponseEntity<Unit> {
+    return super.deleteUser(id)
+  }
+
+  override fun getUser(id: UUID): ResponseEntity<ApprovedPremisesUser> {
+    return super.getUser(id)
+  }
+
+  override fun updateUser(id: UUID, updateUser: Cas1UpdateUser): ResponseEntity<User> {
+    return super.updateUser(id, updateUser)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.TypedTask
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotAllowedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
@@ -155,10 +156,10 @@ class TaskService(
     val assigneeUserResult = userService.updateUser(userToAllocateToId, ServiceName.approvedPremises)
 
     val assigneeUser =
-      if (assigneeUserResult is AuthorisableActionResult.Success &&
-        assigneeUserResult.entity is UserService.GetUserResponse.Success
+      if (assigneeUserResult is CasResult.Success &&
+        assigneeUserResult.value is UserService.GetUserResponse.Success
       ) {
-        assigneeUserResult.entity.user
+        assigneeUserResult.value.user
       } else {
         return AuthorisableActionResult.NotFound()
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -207,8 +207,8 @@ class UserService(
   fun updateUserRolesAndQualifications(
     id: UUID,
     userRolesAndQualifications: UserRolesAndQualifications,
-  ): AuthorisableActionResult<UserEntity> {
-    val user = userRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()
+  ): CasResult<UserEntity> {
+    val user = userRepository.findByIdOrNull(id) ?: return CasResult.NotFound("User")
     val roles = userRolesAndQualifications.roles
     val qualifications = userRolesAndQualifications.qualifications
     user.isActive = true
@@ -221,7 +221,7 @@ class UserService(
     user: UserEntity,
     roles: List<ApprovedPremisesUserRole>,
     qualifications: List<APIUserQualification>,
-  ): AuthorisableActionResult<UserEntity> {
+  ): CasResult<UserEntity> {
     clearQualifications(user)
     clearRolesForService(user, ServiceName.approvedPremises)
 
@@ -233,7 +233,7 @@ class UserService(
       this.addQualificationToUser(user, transformQualifications(it))
     }
 
-    return AuthorisableActionResult.Success(user)
+    return CasResult.Success(user)
   }
 
   fun updateUser(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasSimpleResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApAreaMappingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
@@ -238,9 +239,9 @@ class UserService(
   fun updateUser(
     id: UUID,
     forService: ServiceName,
-  ): AuthorisableActionResult<GetUserResponse> {
-    val user = userRepository.findByIdOrNull(id) ?: return AuthorisableActionResult.NotFound()
-    return AuthorisableActionResult.Success(updateUser(user, forService))
+  ): CasResult<GetUserResponse> {
+    val user = userRepository.findByIdOrNull(id) ?: return CasResult.NotFound("User")
+    return CasResult.Success(updateUser(user, forService))
   }
 
   fun updateUser(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -54,35 +54,39 @@ class UserTransformer(
     )
 
   fun transformJpaToApi(jpa: UserEntity, serviceName: ServiceName) = when (serviceName) {
-    ServiceName.approvedPremises -> ApprovedPremisesUser(
-      id = jpa.id,
-      deliusUsername = jpa.deliusUsername,
-      roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformApprovedPremisesRoleToApi),
-      email = jpa.email,
-      name = jpa.name,
-      telephoneNumber = jpa.telephoneNumber,
-      isActive = jpa.isActive,
-      qualifications = jpa.qualifications.map(::transformQualificationToApi),
-      permissions = jpa.roles.distinctBy { it.role }.mapNotNull(::transformApprovedPremisesRoleToPermissionApi).flatten().distinct(),
-      region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
-      service = "CAS1",
-      apArea = jpa.apArea?.let { apAreaTransformer.transformJpaToApi(it) } ?: throw InternalServerErrorProblem("CAS1 user ${jpa.id} should have AP Area Set"),
-      version = UserEntity.getVersionHashCode((jpa.roles.map { it.role })),
-    )
-    ServiceName.temporaryAccommodation -> TemporaryAccommodationUser(
-      id = jpa.id,
-      deliusUsername = jpa.deliusUsername,
-      email = jpa.email,
-      name = jpa.name,
-      telephoneNumber = jpa.telephoneNumber,
-      isActive = jpa.isActive,
-      roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformTemporaryAccommodationRoleToApi),
-      region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
-      probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) },
-      service = "CAS3",
-    )
+    ServiceName.approvedPremises -> transformCas1JpaToApi(jpa)
+    ServiceName.temporaryAccommodation -> transformCas3JpatoApi(jpa)
     ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
   }
+
+  fun transformCas1JpaToApi(jpa: UserEntity) = ApprovedPremisesUser(
+    id = jpa.id,
+    deliusUsername = jpa.deliusUsername,
+    roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformApprovedPremisesRoleToApi),
+    email = jpa.email,
+    name = jpa.name,
+    telephoneNumber = jpa.telephoneNumber,
+    isActive = jpa.isActive,
+    qualifications = jpa.qualifications.map(::transformQualificationToApi),
+    permissions = jpa.roles.distinctBy { it.role }.mapNotNull(::transformApprovedPremisesRoleToPermissionApi).flatten().distinct(),
+    region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
+    service = "CAS1",
+    apArea = jpa.apArea?.let { apAreaTransformer.transformJpaToApi(it) } ?: throw InternalServerErrorProblem("CAS1 user ${jpa.id} should have AP Area Set"),
+    version = UserEntity.getVersionHashCode((jpa.roles.map { it.role })),
+  )
+
+  fun transformCas3JpatoApi(jpa: UserEntity) = TemporaryAccommodationUser(
+    id = jpa.id,
+    deliusUsername = jpa.deliusUsername,
+    email = jpa.email,
+    name = jpa.name,
+    telephoneNumber = jpa.telephoneNumber,
+    isActive = jpa.isActive,
+    roles = jpa.roles.distinctBy { it.role }.mapNotNull(::transformTemporaryAccommodationRoleToApi),
+    region = probationRegionTransformer.transformJpaToApi(jpa.probationRegion),
+    probationDeliveryUnit = jpa.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) },
+    service = "CAS3",
+  )
 
   fun transformProfileResponseToApi(userName: String, userResponse: UserService.GetUserResponse, xServiceName: ServiceName): ProfileResponse {
     return when (userResponse) {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -4071,7 +4071,8 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
     put:
-      summary: Update information about a specific user's roles and qualifications
+      summary: Update information about a specific user's roles and qualifications. Deprecated. Instead use PUT /cas1/user/{userid}
+      deprecated: true
       parameters:
         - name: X-Service-Name
           in: header
@@ -4106,7 +4107,8 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
     delete:
-      summary: Deletes the user
+      summary: Deletes the user. Deprecated. Instead use DELETE /cas1/user/{userid}
+      deprecated: true
       parameters:
         - name: id
           in: path

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -1042,3 +1042,90 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /users/{id}:
+    get:
+      summary: Get information about a specific user
+      operationId: getUser
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Id of the user
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successfully retrieved information on user
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ApprovedPremisesUser'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+    put:
+      summary: Update a user
+      operationId: updateUser
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Id of the user
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: 'cas1-schemas.yml#/components/schemas/Cas1UpdateUser'
+        required: true
+      responses:
+        200:
+          description: Successfully added information about user roles and qualifications
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/User'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+    delete:
+      summary: Deletes the user
+      operationId: deleteUser
+      tags:
+        - users
+      parameters:
+        - name: id
+          in: path
+          description: ID of the user
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -462,3 +462,17 @@ components:
       enum:
         - man
         - woman
+    Cas1UpdateUser:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: '_shared.yml#/components/schemas/ApprovedPremisesUserRole'
+        qualifications:
+          type: array
+          items:
+            $ref: '_shared.yml#/components/schemas/UserQualification'
+      required:
+        - roles
+        - qualifications

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4073,7 +4073,8 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
     put:
-      summary: Update information about a specific user's roles and qualifications
+      summary: Update information about a specific user's roles and qualifications. Deprecated. Instead use PUT /cas1/user/{userid}
+      deprecated: true
       parameters:
         - name: X-Service-Name
           in: header
@@ -4108,7 +4109,8 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
     delete:
-      summary: Deletes the user
+      summary: Deletes the user. Deprecated. Instead use DELETE /cas1/user/{userid}
+      deprecated: true
       parameters:
         - name: id
           in: path

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1044,6 +1044,93 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /users/{id}:
+    get:
+      summary: Get information about a specific user
+      operationId: getUser
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Id of the user
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successfully retrieved information on user
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ApprovedPremisesUser'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+    put:
+      summary: Update a user
+      operationId: updateUser
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Id of the user
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Cas1UpdateUser'
+        required: true
+      responses:
+        200:
+          description: Successfully added information about user roles and qualifications
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/User'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+    delete:
+      summary: Deletes the user
+      operationId: deleteUser
+      tags:
+        - users
+      parameters:
+        - name: id
+          in: path
+          description: ID of the user
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
 components:
   responses:
     401Response:
@@ -6655,3 +6742,17 @@ components:
       enum:
         - man
         - woman
+    Cas1UpdateUser:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovedPremisesUserRole'
+        qualifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserQualification'
+      required:
+        - roles
+        - qualifications

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/StaffUserDetailsFactory.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 
-@Deprecated(message = "StaffUserDetails are being removed with the community api", replaceWith = ReplaceWith("StaffDetailsFactory"))
+@Deprecated(message = "StaffUserDetails are being removed with the community api", replaceWith = ReplaceWith("StaffDetailFactory"))
 class StaffUserDetailsFactory : Factory<StaffUserDetails> {
   private var username: Yielded<String> = { randomStringUpperCase(10) }
   private var email: Yielded<String?> = { randomStringUpperCase(8) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1UsersTest.kt
@@ -1,0 +1,329 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserRolesAndQualifications
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory.probationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory.team
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addStaffDetailResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffDetail
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as APIUserQualification
+
+class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
+  val id: UUID = UUID.fromString("aff9a4dc-e208-4e4b-abe6-99aff7f6af8a")
+
+  @Nested
+  inner class GetUser {
+
+    @Test
+    fun `Getting a user without a JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas1/users/$id")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Getting a user with a non-Delius JWT returns 403`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "other-auth-source",
+      )
+
+      webTestClient.get()
+        .uri("/cas1/users/$id")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `Getting a user with a Nomis JWT returns 403`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+      )
+
+      webTestClient.get()
+        .uri("/cas1/users/$id")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `Getting a user with the POM role returns 403`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_POM"),
+      )
+
+      webTestClient.get()
+        .uri("/cas1/users/$id")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `Getting an Approved Premises user returns OK with correct body`() {
+      val deliusUsername = "JimJimmerson"
+      val forename = "Jim"
+      val surname = "Jimmerson"
+      val name = "$forename $surname"
+      val email = "foo@bar.com"
+      val telephoneNumber = "123445677"
+
+      val jwt = jwtAuthHelper.createAuthorizationCodeJwt(
+        subject = deliusUsername,
+        authSource = "delius",
+        roles = listOf("ROLE_PROBATION"),
+      )
+
+      val region = `Given a Probation Region`()
+
+      userEntityFactory.produceAndPersist {
+        withId(id)
+        withDeliusUsername(deliusUsername)
+        withName(name)
+        withEmail(email)
+        withTelephoneNumber(telephoneNumber)
+        withYieldedProbationRegion { region }
+      }
+
+      ApDeliusContext_addStaffDetailResponse(
+        StaffDetail(
+          email = email,
+          telephoneNumber = telephoneNumber,
+          staffIdentifier = 5678L,
+          teams = listOf(team()),
+          probationArea = probationArea(),
+          username = deliusUsername,
+          name = PersonName(forename, surname, "C"),
+          code = "STAFF1",
+          active = true,
+        ),
+      )
+
+      mockClientCredentialsJwtRequest("username", listOf("ROLE_COMMUNITY"), authSource = "delius")
+
+      val result = webTestClient.get()
+        .uri("/cas1/users/$id")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(ApprovedPremisesUser::class.java)
+        .responseBody
+        .blockFirst()!!
+
+      assertThat(result.id).isEqualTo(id)
+      assertThat(result.region).isEqualTo(ProbationRegion(region.id, region.name))
+      assertThat(result.deliusUsername).isEqualTo(deliusUsername)
+      assertThat(result.name).isEqualTo(name)
+      assertThat(result.email).isEqualTo(email)
+      assertThat(result.telephoneNumber).isEqualTo(telephoneNumber)
+      assertThat(result.roles).isEqualTo(emptyList<ApprovedPremisesUserRole>())
+      assertThat(result.qualifications).isEqualTo(emptyList<UserQualification>())
+      assertThat(result.service).isEqualTo("CAS1")
+      assertThat(result.isActive).isEqualTo(true)
+      assertThat(result.apArea).isEqualTo(ApArea(region.apArea!!.id, region.apArea!!.identifier, region.apArea!!.name))
+      assertThat(result.permissions).isEqualTo(emptyList<UserPermission>())
+      assertThat(result.version).isNotZero()
+    }
+  }
+
+  @Nested
+  inner class UpdateUser {
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"], mode = EnumSource.Mode.EXCLUDE)
+    fun `Updating a user without an approved role is forbidden`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val id = UUID.randomUUID()
+        webTestClient.put()
+          .uri("/cas1/users/$id")
+          .header("Authorization", "Bearer $jwt")
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            UserRolesAndQualifications(
+              listOf(),
+              listOf(),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @Test
+    fun `Updating a users with no internal role (aka the Applicant pseudo-role) is forbidden`() {
+      `Given a User` { _, jwt ->
+        val id = UUID.randomUUID()
+        webTestClient.put()
+          .uri("/cas1/users/$id")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            UserRolesAndQualifications(
+              listOf(),
+              listOf(),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
+    fun `Updating a user returns OK with correct body when user has an approved role`(role: UserRole) {
+      val id = UUID.randomUUID()
+      val qualifications = listOf(APIUserQualification.emergency, APIUserQualification.pipe)
+      val roles = listOf(
+        ApprovedPremisesUserRole.assessor,
+        ApprovedPremisesUserRole.reportViewer,
+        ApprovedPremisesUserRole.excludedFromAssessAllocation,
+        ApprovedPremisesUserRole.excludedFromMatchAllocation,
+        ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation,
+      )
+      val region = `Given a Probation Region`()
+
+      userEntityFactory.produceAndPersist {
+        withId(id)
+        withIsActive(false)
+        withYieldedProbationRegion { region }
+        withYieldedApArea { `Given an AP Area`() }
+      }
+
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        webTestClient.put()
+          .uri("/cas1/users/$id")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            UserRolesAndQualifications(
+              roles = roles,
+              qualifications = qualifications,
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath(".qualifications").isArray
+          .jsonPath(".qualifications[0]").isEqualTo("emergency")
+          .jsonPath(".roles").isArray
+          .jsonPath(".roles[0]").isEqualTo(ApprovedPremisesUserRole.assessor.value)
+          .jsonPath(".roles[1]").isEqualTo(ApprovedPremisesUserRole.reportViewer.value)
+          .jsonPath(".roles[2]").isEqualTo(ApprovedPremisesUserRole.excludedFromAssessAllocation.value)
+          .jsonPath(".roles[3]").isEqualTo(ApprovedPremisesUserRole.excludedFromMatchAllocation.value)
+          .jsonPath(".roles[4]").isEqualTo(ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation.value)
+          .jsonPath(".isActive").isEqualTo(true)
+      }
+    }
+  }
+
+  @Nested
+  inner class DeleteUser {
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"], mode = EnumSource.Mode.EXCLUDE)
+    fun `Deleting a user with an unapproved role is forbidden`(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        val id = UUID.randomUUID()
+        webTestClient.delete()
+          .uri("/cas1/users/$id")
+          .header("Authorization", "Bearer $jwt")
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @Test
+    fun `Deleting a user with no internal role (aka the Applicant pseudo-role) is forbidden`() {
+      `Given a User`() { _, jwt ->
+        val id = UUID.randomUUID()
+        webTestClient.delete()
+          .uri("/cas1/users/$id")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @Test
+    fun `Deleting a user with a non-Delius JWT returns 403`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+      )
+
+      webTestClient.delete()
+        .uri("/cas1/users/$id")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
+    fun `Deleting a user with an approved role deletes successfully`(role: UserRole) {
+      userEntityFactory.produceAndPersist {
+        withId(id)
+        withYieldedProbationRegion { `Given a Probation Region`() }
+      }
+
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        webTestClient.delete()
+          .uri("/cas1/users/$id")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+
+        val userFromDatabase = userRepository.findByIdOrNull(id)
+        assertThat(userFromDatabase?.isActive).isEqualTo(false)
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"], mode = EnumSource.Mode.EXCLUDE)
+    fun `Deleting a user without an approved role is forbidden `(role: UserRole) {
+      `Given a User`(roles = listOf(role)) { _, jwt ->
+        webTestClient.delete()
+          .uri("/cas1/users/$id")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.TypedTask
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplicationService
@@ -115,7 +116,7 @@ class TaskServiceTest {
     every { userAccessServiceMock.userCanReallocateTask(any()) } returns true
 
     val assigneeUserId = UUID.fromString("55aa66be-0819-494e-955b-90b9aaa4f0c6")
-    every { userServiceMock.updateUser(assigneeUserId, ServiceName.approvedPremises) } returns AuthorisableActionResult.NotFound()
+    every { userServiceMock.updateUser(assigneeUserId, ServiceName.approvedPremises) } returns CasResult.NotFound()
 
     val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUserId, UUID.randomUUID())
 
@@ -420,7 +421,7 @@ class TaskServiceTest {
         ServiceName.approvedPremises,
       )
     } returns
-      AuthorisableActionResult.Success(
+      CasResult.Success(
         UserService.GetUserResponse.Success(user),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -47,7 +47,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.KeyValue
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
@@ -1189,10 +1188,10 @@ class UserServiceTest {
 
       val result = userService.updateUserRolesAndQualificationsForUser(user, roles, qualifications)
 
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      result as AuthorisableActionResult.Success
+      assertThat(result).isInstanceOf(CasResult.Success::class.java)
+      result as CasResult.Success
 
-      val entity = result.entity
+      val entity = result.value
 
       assertThat(entity.id).isEqualTo(user.id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.KeyValue
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -881,8 +882,8 @@ class UserServiceTest {
       verify(exactly = 0) { mockCommunityApiClient.getStaffUserDetails(any()) }
       verify(exactly = 1) { mockUserRepository.save(any()) }
 
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      val getUserResponse = (result as AuthorisableActionResult.Success).entity
+      assertThat(result).isInstanceOf(CasResult.Success::class.java)
+      val getUserResponse = (result as CasResult.Success).value
 
       assertThat(getUserResponse).isInstanceOf(GetUserResponse::class.java)
       val entity = (getUserResponse as GetUserResponse.Success).user
@@ -918,11 +919,11 @@ class UserServiceTest {
 
       val result = userService.updateUser(id, ServiceName.temporaryAccommodation)
 
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      result as AuthorisableActionResult.Success
+      assertThat(result).isInstanceOf(CasResult.Success::class.java)
+      result as CasResult.Success
 
-      assertThat(result.entity).isInstanceOf(GetUserResponse.Success::class.java)
-      val entity = (result.entity as GetUserResponse.Success).user
+      assertThat(result.value).isInstanceOf(GetUserResponse.Success::class.java)
+      val entity = (result.value as GetUserResponse.Success).user
 
       assertThat(entity.email).isNull()
 
@@ -935,7 +936,7 @@ class UserServiceTest {
     fun `it returns not found when there is no user for that ID`() {
       every { mockUserRepository.findByIdOrNull(id) } returns null
       val result = userService.updateUser(id, ServiceName.approvedPremises)
-      assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+      assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
     }
 
     @Test
@@ -958,8 +959,8 @@ class UserServiceTest {
 
       val result = userService.updateUser(id, ServiceName.approvedPremises)
 
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      val getUserResponse = (result as AuthorisableActionResult.Success).entity
+      assertThat(result).isInstanceOf(CasResult.Success::class.java)
+      val getUserResponse = (result as CasResult.Success).value
 
       assertThat(getUserResponse).isEqualTo(GetUserResponse.StaffRecordNotFound)
     }
@@ -1064,8 +1065,8 @@ class UserServiceTest {
 
       val result = userService.updateUser(id, forService)
 
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      val getUserResponse = (result as AuthorisableActionResult.Success).entity
+      assertThat(result).isInstanceOf(CasResult.Success::class.java)
+      val getUserResponse = (result as CasResult.Success).value
 
       assertThat(getUserResponse).isInstanceOf(GetUserResponse.Success::class.java)
       val entity = (getUserResponse as GetUserResponse.Success).user
@@ -1116,11 +1117,11 @@ class UserServiceTest {
 
       val result = userService.updateUser(id, ServiceName.temporaryAccommodation)
 
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      result as AuthorisableActionResult.Success
+      assertThat(result).isInstanceOf(CasResult.Success::class.java)
+      result as CasResult.Success
 
-      assertThat(result.entity).isInstanceOf(GetUserResponse.Success::class.java)
-      val entity = (result.entity as GetUserResponse.Success).user
+      assertThat(result.value).isInstanceOf(GetUserResponse.Success::class.java)
+      val entity = (result.value as GetUserResponse.Success).user
 
       assertThat(entity.email).isEqualTo("null")
 
@@ -1134,7 +1135,7 @@ class UserServiceTest {
 
       val result = userService.updateUser(id, ServiceName.approvedPremises)
 
-      assertThat(result).isInstanceOf(AuthorisableActionResult.NotFound::class.java)
+      assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
     }
 
     @Test
@@ -1155,8 +1156,8 @@ class UserServiceTest {
 
       val result = userService.updateUser(id, ServiceName.approvedPremises)
 
-      assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-      val getUserResponse = (result as AuthorisableActionResult.Success).entity
+      assertThat(result).isInstanceOf(CasResult.Success::class.java)
+      val getUserResponse = (result as CasResult.Success).value
 
       assertThat(getUserResponse).isEqualTo(GetUserResponse.StaffRecordNotFound)
     }


### PR DESCRIPTION
This PR copies existing functionality from the shared /users endpoint to /cas1/users. Specifically:

* get user by id
* delete user - only used by CAS1
* update user - only used by CAS1

This is in preparation for changes to the update user endpoint. It allows us to simplify the implementation logic, and also explicitly state the ApprovedPremiseUser type in the response

A ticket has been created to remove delete user/update user from the shared endpoint once the ui is using the new endpoints - APS-1363