### PR TITLE
APS-1349 Add filter by CRU management area id.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -73,6 +73,7 @@ class TasksController(
     sortDirection: SortDirection?,
     allocatedFilter: AllocatedFilter?,
     apAreaId: UUID?,
+    cruManagementAreaId: UUID?,
     allocatedToUserId: UUID?,
     requiredQualification: ApiUserQualification?,
     crnOrName: String?,
@@ -96,6 +97,7 @@ class TasksController(
       TaskService.TaskFilterCriteria(
         allocatedFilter = allocatedFilter,
         apAreaId = apAreaId,
+        cruManagementAreaId = cruManagementAreaId,
         types = taskEntityTypes,
         allocatedToUserId = allocatedToUserId,
         requiredQualification = requiredQualification,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -73,6 +73,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
           (cast(:apAreaId as uuid) IS NULL) OR
           (area.id = :apAreaId)
         ) AND (
+          (cast(:cruManagementAreaId as uuid) IS NULL) OR
+          (apa.cas1_cru_management_area_id = :cruManagementAreaId)          
+        ) AND (
           (cast(:allocatedToUserId as uuid) IS NULL) OR
           assessment.allocated_to_user_id = :allocatedToUserId
         ) AND (
@@ -115,6 +118,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         ) AND (
           (cast(:apAreaId as uuid) IS NULL) OR
           (area.id = :apAreaId)
+        ) AND (
+          (cast(:cruManagementAreaId as uuid) IS NULL) OR
+          (apa.cas1_cru_management_area_id = :cruManagementAreaId)          
         ) AND (
           (cast(:allocatedToUserId as uuid) IS NULL) OR
           placement_application.allocated_to_user_id = :allocatedToUserId
@@ -169,6 +175,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
           (cast(:apAreaId as uuid) IS NULL) OR
           (area.id = :apAreaId)
         ) AND (
+          (cast(:cruManagementAreaId as uuid) IS NULL) OR
+          (apa.cas1_cru_management_area_id = :cruManagementAreaId)           
+        ) AND (
           (cast(:allocatedToUserId as uuid) IS NULL) OR
           placement_request.allocated_to_user_id = :allocatedToUserId
         ) AND (
@@ -195,6 +204,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
   fun getAll(
     isAllocated: Boolean?,
     apAreaId: UUID?,
+    cruManagementAreaId: UUID?,
     taskTypes: List<String>,
     allocatedToUserId: UUID?,
     requiredQualification: String?,
@@ -211,6 +221,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
   fun getAllPlacementRequests(
     isAllocated: Boolean?,
     apAreaId: UUID?,
+    cruManagementAreaId: UUID?,
     taskTypes: List<String>,
     allocatedToUserId: UUID?,
     requiredQualification: String?,
@@ -227,6 +238,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
   fun getAllPlacementApplications(
     isAllocated: Boolean?,
     apAreaId: UUID?,
+    cruManagementAreaId: UUID?,
     taskTypes: List<String>,
     allocatedToUserId: UUID?,
     requiredQualification: String?,
@@ -243,6 +255,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
   fun getAllAssessments(
     isAllocated: Boolean?,
     apAreaId: UUID?,
+    cruManagementAreaId: UUID?,
     taskTypes: List<String>,
     allocatedToUserId: UUID?,
     requiredQualification: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -49,6 +49,7 @@ class TaskService(
   data class TaskFilterCriteria(
     val allocatedFilter: AllocatedFilter?,
     val apAreaId: UUID?,
+    val cruManagementAreaId: UUID?,
     val types: List<TaskEntityType>,
     val allocatedToUserId: UUID?,
     val requiredQualification: UserQualification?,
@@ -135,6 +136,7 @@ class TaskService(
     return repoFunction(
       isAllocated,
       filterCriteria.apAreaId,
+      filterCriteria.cruManagementAreaId,
       taskTypes.map { it.name },
       filterCriteria.allocatedToUserId,
       filterCriteria.requiredQualification?.value,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2957,7 +2957,15 @@ paths:
         - name: apAreaId
           in: query
           required: false
-          description: Approved Premises Area ID to filter results by
+          description: Approved Premises Area ID to filter results by.  Deprecated, Use cruManagementAreaId instead.
+          deprecated: true
+          schema:
+            type: string
+            format: uuid
+        - name: cruManagementAreaId
+          in: query
+          required: false
+          description: filter by CRU management area ID
           schema:
             type: string
             format: uuid

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2959,7 +2959,15 @@ paths:
         - name: apAreaId
           in: query
           required: false
-          description: Approved Premises Area ID to filter results by
+          description: Approved Premises Area ID to filter results by.  Deprecated, Use cruManagementAreaId instead.
+          deprecated: true
+          schema:
+            type: string
+            format: uuid
+        - name: cruManagementAreaId
+          in: query
+          required: false
+          description: filter by CRU management area ID
           schema:
             type: string
             format: uuid

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
@@ -27,6 +28,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
   reallocated: Boolean = false,
   placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
   apArea: ApAreaEntity? = null,
+  cruManagementArea: Cas1CruManagementAreaEntity? = null,
   dueAt: OffsetDateTime? = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
   name: String? = null,
   requiredQualification: UserQualification? = null,
@@ -60,6 +62,7 @@ fun IntegrationTestBase.`Given a Placement Application`(
     allocatedToUser = assessmentAllocatedToUser,
     createdByUser = assessmentCreatedByUser,
     apArea = apArea,
+    cruManagementArea = cruManagementArea,
     name = name,
     requiredQualification = requiredQualification,
     noticeType = noticeType,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
@@ -43,6 +44,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
   applicationSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
   booking: BookingEntity? = null,
   apArea: ApAreaEntity? = null,
+  cruManagementArea: Cas1CruManagementAreaEntity? = null,
   dueAt: OffsetDateTime? = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
   duration: Int? = null,
   assessmentSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
@@ -87,6 +89,7 @@ fun IntegrationTestBase.`Given a Placement Request`(
       risksFactory.produce(),
     )
     withApArea(apArea)
+    withCruManagementArea(cruManagementArea)
     applyQualification(requiredQualification)
     withNoticeType(noticeType)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -30,6 +31,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
   createdAt: OffsetDateTime? = null,
   isWithdrawn: Boolean = false,
   apArea: ApAreaEntity? = null,
+  cruManagementArea: Cas1CruManagementAreaEntity? = null,
   dueAt: OffsetDateTime? = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
   name: String? = null,
   requiredQualification: UserQualification? = null,
@@ -53,6 +55,7 @@ fun IntegrationTestBase.`Given an Assessment for Approved Premises`(
     withReleaseType("licence")
     withIsWithdrawn(isWithdrawn)
     withApArea(apArea)
+    withCruManagementArea(cruManagementArea)
     if (name !== null) {
       withName(name)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -308,6 +308,7 @@ class TaskServiceTest {
 
     val isAllocated = true
     val apAreaId = UUID.randomUUID()
+    val cruManagementAreaId = UUID.randomUUID()
 
     val assessments = List(3) { generateAssessment() }
     val placementApplications = List(4) { generatePlacementApplication() }
@@ -367,6 +368,7 @@ class TaskServiceTest {
       taskRepositoryMock.getAll(
         isAllocated,
         apAreaId,
+        cruManagementAreaId,
         taskEntityTypes.map { it.name },
         allocatedToUserId,
         requiredQualification.value,
@@ -387,6 +389,7 @@ class TaskServiceTest {
       TaskService.TaskFilterCriteria(
         AllocatedFilter.allocated,
         apAreaId,
+        cruManagementAreaId,
         taskEntityTypes,
         allocatedToUserId,
         requiredQualification,


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1349

Change tasks GET to filter by CRU management area id as well as AP area id, (until the front end is switched over to use the CRU management area id at which point the AP area join can be removed).

We have several endpoints that allow filtering of results on AP Area ID. These will need updating to support filtering on CRU Management Area ID instead. The option to filter on AP Area ID should be deprecated in favour of CRU Management Area.

This PR updates TasksController.tasksGet (tested by TasksTest). We only need to support this when filtering on assessments and placement applications (don’t add this for placement requests filtering - this is deprecated and will most likely be removed at some point). In the SQL this will work by filtering on the CRU Management Area linked to the application i.e. (approved_premises_applications.cas1_cru_management_area_id).