### PR TITLE
Fix bed count for cas1 premise summary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -70,7 +70,7 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
     """,
     nativeQuery = true,
   )
-  fun findOutOfServiceBeds(
+  fun findOutOfServiceBedIds(
     premisesId: UUID?,
     apAreaId: UUID?,
     excludePast: Boolean,
@@ -81,9 +81,6 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
 
   @Query("SELECT oosb FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE c is NULL")
   fun findAllActive(): List<Cas1OutOfServiceBedEntity>
-
-  @Query("SELECT count(*) FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE oosb.premises.id = :premisesId AND c is NULL")
-  fun countAllActiveForPremisesId(premisesId: UUID): Int
 
   @Query("SELECT oosb FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE oosb.premises.id = :premisesId AND c is NULL")
   fun findAllActiveForPremisesId(premisesId: UUID): List<Cas1OutOfServiceBedEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import jakarta.transaction.Transactional
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedSortField
@@ -276,7 +277,7 @@ class Cas1OutOfServiceBedService(
     val excludeCurrent = !temporality.contains(Temporality.current)
     val excludeFuture = !temporality.contains(Temporality.future)
 
-    val page = outOfServiceBedRepository.findOutOfServiceBeds(
+    val page = outOfServiceBedRepository.findOutOfServiceBedIds(
       premisesId,
       apAreaId,
       excludePast,
@@ -292,7 +293,16 @@ class Cas1OutOfServiceBedService(
 
   fun getActiveOutOfServiceBedsForPremisesId(premisesId: UUID) = outOfServiceBedRepository.findAllActiveForPremisesId(premisesId)
 
-  fun getActiveOutOfServiceBedsCountForPremisesId(premisesId: UUID) = outOfServiceBedRepository.countAllActiveForPremisesId(premisesId)
+  fun getCurrentOutOfServiceBedsCountForPremisesId(premisesId: UUID): Int {
+    return outOfServiceBedRepository.findOutOfServiceBedIds(
+      premisesId = premisesId,
+      apAreaId = null,
+      excludePast = true,
+      excludeCurrent = false,
+      excludeFuture = true,
+      pageable = Pageable.unpaged(),
+    ).size
+  }
 
   fun getOutOfServiceBedWithConflictingDates(
     startDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -20,7 +20,7 @@ class Cas1PremisesService(
       ?: return CasResult.NotFound("premises", premisesId.toString())
 
     val bedCount = premisesService.getBedCount(premise)
-    val outOfServiceBedsCount = cas1OutOfServiceBedService.getActiveOutOfServiceBedsCountForPremisesId(premisesId)
+    val outOfServiceBedsCount = cas1OutOfServiceBedService.getCurrentOutOfServiceBedsCountForPremisesId(premisesId)
 
     return CasResult.Success(
       Cas1PremisesSummaryInfo(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOutOfServiceBed.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOutOfServiceBed.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+fun IntegrationTestBase.`Given an Out of Service Bed`(
+  bed: BedEntity,
+  startDate: LocalDate = LocalDate.now(),
+  endDate: LocalDate = LocalDate.now(),
+  cancelled: Boolean = false,
+): Cas1OutOfServiceBedEntity {
+  val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+    withCreatedAt(OffsetDateTime.now())
+    withBed(bed)
+  }
+
+  outOfServiceBed.apply {
+    this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+      withCreatedBy(`Given a User`().first)
+      withOutOfServiceBed(this@apply)
+      withStartDate(startDate)
+      withEndDate(endDate)
+      withReason(cas1OutOfServiceBedReasonEntityFactory.produceAndPersist())
+    }
+  }
+
+  if (cancelled) {
+    val cancellation = cas1OutOfServiceBedCancellationEntityFactory.produceAndPersist {
+      withOutOfServiceBed(outOfServiceBed)
+    }
+    outOfServiceBed.cancellation = cancellation
+    cas1OutOfServiceBedTestRepository.save(outOfServiceBed)
+  }
+
+  return outOfServiceBed
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
@@ -575,7 +575,7 @@ class Cas1OutOfServiceBedServiceTest {
       val expectedPageable = getPageableOrAllPages(expectedSortFieldString, sortDirection, page = null, pageSize = null, unsafe = true)
 
       every {
-        outOfServiceBedRepository.findOutOfServiceBeds(
+        outOfServiceBedRepository.findOutOfServiceBedIds(
           premisesId = any(),
           apAreaId = any(),
           excludePast = any(),
@@ -595,7 +595,7 @@ class Cas1OutOfServiceBedServiceTest {
       )
 
       verify(exactly = 1) {
-        outOfServiceBedRepository.findOutOfServiceBeds(
+        outOfServiceBedRepository.findOutOfServiceBedIds(
           premisesId = null,
           apAreaId = null,
           excludePast = false,
@@ -610,7 +610,7 @@ class Cas1OutOfServiceBedServiceTest {
     @ParameterizedTest
     fun `Filters correctly according to the temporality`(temporality: List<Temporality>) {
       every {
-        outOfServiceBedRepository.findOutOfServiceBeds(
+        outOfServiceBedRepository.findOutOfServiceBedIds(
           premisesId = any(),
           apAreaId = any(),
           excludePast = any(),
@@ -630,7 +630,7 @@ class Cas1OutOfServiceBedServiceTest {
       )
 
       verify(exactly = 1) {
-        outOfServiceBedRepository.findOutOfServiceBeds(
+        outOfServiceBedRepository.findOutOfServiceBedIds(
           premisesId = null,
           apAreaId = null,
           excludePast = !temporality.contains(Temporality.past),
@@ -644,7 +644,7 @@ class Cas1OutOfServiceBedServiceTest {
     @Test
     fun `Filters correctly according to the premises ID`() {
       every {
-        outOfServiceBedRepository.findOutOfServiceBeds(
+        outOfServiceBedRepository.findOutOfServiceBedIds(
           premisesId = any(),
           apAreaId = any(),
           excludePast = any(),
@@ -666,7 +666,7 @@ class Cas1OutOfServiceBedServiceTest {
       )
 
       verify(exactly = 1) {
-        outOfServiceBedRepository.findOutOfServiceBeds(
+        outOfServiceBedRepository.findOutOfServiceBedIds(
           premisesId = expectedId,
           apAreaId = null,
           excludePast = false,
@@ -680,7 +680,7 @@ class Cas1OutOfServiceBedServiceTest {
     @Test
     fun `Filters correctly according to the AP area ID`() {
       every {
-        outOfServiceBedRepository.findOutOfServiceBeds(
+        outOfServiceBedRepository.findOutOfServiceBedIds(
           premisesId = any(),
           apAreaId = any(),
           excludePast = any(),
@@ -702,7 +702,7 @@ class Cas1OutOfServiceBedServiceTest {
       )
 
       verify(exactly = 1) {
-        outOfServiceBedRepository.findOutOfServiceBeds(
+        outOfServiceBedRepository.findOutOfServiceBedIds(
           premisesId = null,
           apAreaId = expectedId,
           excludePast = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
@@ -61,7 +61,7 @@ class Cas1PremisesServiceTest {
       every { approvedPremisesRepository.findByIdOrNull(PREMISES_ID) } returns premises
 
       every { premisesService.getBedCount(premises) } returns 56
-      every { cas1OutOfServiceBedService.getActiveOutOfServiceBedsCountForPremisesId(PREMISES_ID) } returns 4
+      every { cas1OutOfServiceBedService.getCurrentOutOfServiceBedsCountForPremisesId(PREMISES_ID) } returns 4
 
       val result = service.getPremisesSummary(PREMISES_ID)
 


### PR DESCRIPTION
Before this commit the code populating the ‘outOfServiceBedsCount’ when viewing a premise considered any out of service bed record linked to the premise regardless of the start and end date as ‘current’.