### PR TITLE
APS-1350 add cru filter to users list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -41,6 +41,7 @@ class UsersController(
     qualifications: List<UserQualification>?,
     probationRegionId: UUID?,
     apAreaId: UUID?,
+    cruManagementAreaId: UUID?,
     page: Int?,
     sortBy: UserSortField?,
     sortDirection: SortDirection?,
@@ -54,6 +55,7 @@ class UsersController(
       page,
       sortBy,
       sortDirection,
+      cruManagementAreaId,
     ) { user ->
       userTransformer.transformJpaToApi(user, ServiceName.approvedPremises)
     }
@@ -90,13 +92,14 @@ class UsersController(
     page: Int?,
     sortBy: UserSortField?,
     sortDirection: SortDirection?,
+    cruManagementAreaId: UUID? = null,
     resultTransformer: (UserEntity) -> T,
   ): ResponseEntity<List<T>> {
     if (!userAccessService.currentUserCanManageUsers(xServiceName)) {
       throw ForbiddenProblem()
     }
 
-    val (users, metadata) = userService.getUsersWithQualificationsAndRoles(
+    val (users, metadata) = userService.getUsers(
       qualifications?.map(::transformApiQualification),
       roles?.map(UserRole::valueOf),
       sortBy,
@@ -104,6 +107,7 @@ class UsersController(
       page,
       probationRegionId,
       apAreaId,
+      cruManagementAreaId,
     )
 
     return ResponseEntity.ok().headers(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa.specification/UserSpecifications.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.criteria.Predicate
 import jakarta.persistence.criteria.Root
 import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1CruManagementArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
@@ -14,11 +15,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
 import java.util.UUID
 
+@SuppressWarnings("LongParameterList")
 fun hasQualificationsAndRoles(
   qualifications: List<UserQualification>?,
   roles: List<UserRole>?,
   region: UUID?,
   apArea: UUID?,
+  cruManagementArea: UUID?,
   showOnlyActive: Boolean = false,
 ): Specification<UserEntity> {
   return Specification { root: Root<UserEntity>, query: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
@@ -72,6 +75,16 @@ fun hasQualificationsAndRoles(
       predicates.add(
         criteriaBuilder.and(
           criteriaBuilder.equal(apAreaID, apArea),
+        ),
+      )
+    }
+
+    if (cruManagementArea != null) {
+      val cruManagementAreaId = root.get<Cas1CruManagementArea>("cruManagementArea").get<UUID>("id")
+
+      predicates.add(
+        criteriaBuilder.and(
+          criteriaBuilder.equal(cruManagementAreaId, cruManagementArea),
         ),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -123,7 +123,7 @@ class UserService(
     val version: Int,
   )
 
-  fun getUsersWithQualificationsAndRoles(
+  fun getUsers(
     qualifications: List<UserQualification>?,
     roles: List<UserRole>?,
     sortBy: UserSortField?,
@@ -131,6 +131,7 @@ class UserService(
     page: Int?,
     region: UUID?,
     apArea: UUID?,
+    cruManagementAreaId: UUID?,
   ): Pair<List<UserEntity>, PaginationMetadata?> {
     var metadata: PaginationMetadata? = null
     val users: List<UserEntity>
@@ -139,12 +140,12 @@ class UserService(
 
     if (pageable == null) {
       users = userRepository.findAll(
-        hasQualificationsAndRoles(qualifications, roles, region, apArea, true),
+        hasQualificationsAndRoles(qualifications, roles, region, apArea, cruManagementAreaId, true),
         Sort.by(Sort.Direction.ASC, "name"),
       )
     } else {
       val response = userRepository.findAll(
-        hasQualificationsAndRoles(qualifications, roles, region, apArea, true),
+        hasQualificationsAndRoles(qualifications, roles, region, apArea, cruManagementAreaId, true),
         pageable,
       )
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3991,7 +3991,15 @@ paths:
             format: uuid
         - name: apAreaId
           in: query
-          description: Approved premises area ID to filter results by
+          description: Approved premises area ID to filter results by.  Deprecated, Use cruManagementAreaId instead.
+          deprecated: true
+          schema:
+            type: string
+            format: uuid
+        - name: cruManagementAreaId
+          in: query
+          required: false
+          description: filter by CRU management area ID
           schema:
             type: string
             format: uuid

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3993,7 +3993,15 @@ paths:
             format: uuid
         - name: apAreaId
           in: query
-          description: Approved premises area ID to filter results by
+          description: Approved premises area ID to filter results by.  Deprecated, Use cruManagementAreaId instead.
+          deprecated: true
+          schema:
+            type: string
+            format: uuid
+        - name: cruManagementAreaId
+          in: query
+          required: false
+          description: filter by CRU management area ID
           schema:
             type: string
             format: uuid

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -445,6 +445,7 @@ class TasksTest {
       }
     }
 
+    @Deprecated("Superseded by FilterByCruManagementArea")
     @Nested
     inner class FilterByApArea : InitialiseDatabasePerClassTestBase() {
       private lateinit var tasks: Map<TaskType, List<Task>>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -517,6 +517,65 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
 
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
+    fun `GET to users with an approved role returns list filtered by user's CRU management area`(role: UserRole) {
+      `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
+        `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+          `Given a User` { userWithNoRole, _ ->
+            `Given a User`(roles = listOf(role)) { requestUser, jwt ->
+              val apArea = `Given an AP Area`()
+
+              val probationRegionApArea = `Given an AP Area`()
+              val probationRegion = probationRegionEntityFactory.produceAndPersist {
+                withApArea(probationRegionApArea)
+              }
+
+              val cruManagementArea = `Given a CAS1 CRU Management Area`()
+
+              val userOne = userEntityFactory.produceAndPersist {
+                withProbationRegion(probationRegion)
+                withApArea(apArea)
+                withCruManagementArea(cruManagementArea)
+              }
+
+              val userTwo = userEntityFactory.produceAndPersist {
+                withProbationRegion(probationRegion)
+                withApArea(apArea)
+                withCruManagementArea(cruManagementArea)
+              }
+
+              userEntityFactory.produceAndPersist {
+                withProbationRegion(probationRegion)
+                withApArea(apArea)
+                withCruManagementArea(`Given a CAS1 CRU Management Area`())
+              }
+
+              webTestClient.get()
+                .uri("/users?cruManagementAreaId=${cruManagementArea.id}")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectHeader().doesNotExist("X-Pagination-CurrentPage")
+                .expectHeader().doesNotExist("X-Pagination-TotalPages")
+                .expectHeader().doesNotExist("X-Pagination-TotalResults")
+                .expectHeader().doesNotExist("X-Pagination-PageSize")
+                .expectBody()
+                .json(
+                  objectMapper.writeValueAsString(
+                    listOf(userOne, userTwo).map {
+                      userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
+                    },
+                  ),
+                )
+            }
+          }
+        }
+      }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = ["CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role returns paginated list ordered by name`(role: UserRole) {
       `Given a User`(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
         `Given a User`(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->


### PR DESCRIPTION
We need to enhance GET `/users` as follows:

- add an optional filter on `users.cas1_cru_management_area_id`. This will be similar to the existing `ap_area_id` which should be deprecate in favour of this filter
- ~~add an additional field in the response providing the id and name of the user’s `Cas1CruManagementAreaEntity`. This should already be available ‘for free’ as it has already been added to the ApprovedPremisesUser API type.~~ This has already been done.