### PR TITLE
Add simple scheduled task with distributed lock

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,9 @@ dependencies {
 
   implementation("com.opencsv:opencsv:5.9")
 
+  implementation("net.javacrumbs.shedlock:shedlock-spring:5.16.0")
+  implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.13.9")
   testImplementation("net.bytebuddy:byte-buddy:1.14.18")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/SchedulingConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/SchedulingConfig.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+@ConditionalOnProperty(value = ["scheduling.enabled"], havingValue = "true", matchIfMissing = false)
+class SchedulingConfig {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @Bean
+  fun lockProvider(
+    connectionFactory: RedisConnectionFactory,
+    @Value("\${spring.profiles.active:default}") environment: String,
+  ): LockProvider {
+    log.info("Creating RedisLockProvider with environment '$environment'")
+    return RedisLockProvider(connectionFactory, environment)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.scheduled
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class Cas1ExpiredApplicationsScheduledJob {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @Scheduled(cron = "0 0/30 * * * ?")
+  @SchedulerLock(name = "cas1_expire_applications", lockAtMostFor = "5m", lockAtLeastFor = "1m")
+  fun expireApplications() {
+    log.info("Checking for expired applications (Dry Run)")
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -297,6 +297,9 @@ pagination:
 reports:
   jdbc-fetch-size: 200
 
+scheduling:
+  enabled: true
+
 feature-flags:
   cas1-appeal-manager-can-assess-applications: false
   cas1-only-list-adjudications-up-to-12-months: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1UsersTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an AP Area`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ApDeliusContext_addStaffDetailResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
@@ -209,7 +208,7 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         ApprovedPremisesUserRole.excludedFromMatchAllocation,
         ApprovedPremisesUserRole.excludedFromPlacementApplicationAllocation,
       )
-      
+
       val id = `Given a User`().first.id
 
       `Given a User`(roles = listOf(role)) { _, jwt ->

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -204,6 +204,9 @@ notify:
   emailaddresses:
     cas2assessors: "assessors@example.com"
 
+scheduling:
+  enable: false
+
 logging.level.org.springframework.jdbc.core.JdbcTemplate: debug
 
 feature-flags:


### PR DESCRIPTION
This commits adds a spring-based scheduled task that makes use of a redis-based distributed lock to ensure that task only runs on one instance of the application.

This is being added as a basic check that the distributed lock acts as expected in our deployment environments.