### PR TITLE
APS-1345 - Add auto allocation config to CRU Management Area (2)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1CruManagementAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1CruManagementAreaEntity.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -19,13 +18,13 @@ interface Cas1CruManagementAreaRepository : JpaRepository<Cas1CruManagementAreaE
  */
 @Entity
 @Table(name = "cas1_cru_management_areas")
-@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class Cas1CruManagementAreaEntity(
   @Id
   val id: UUID,
-  val name: String,
-  val emailAddress: String?,
+  var name: String,
+  var emailAddress: String?,
   val notifyReplyToEmailId: String?,
+  var assessmentAutoAllocationUsername: String?,
 ) {
   companion object {
     val WOMENS_ESTATE_ID = UUID.fromString("bfb04c2a-1954-4512-803d-164f7fcf252c")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1CruManagementAreaSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1CruManagementAreaSeedJob.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import java.util.UUID
+
+class Cas1CruManagementAreaSeedJob(
+  fileName: String,
+  private val cas1CruManagementAreaRepository: Cas1CruManagementAreaRepository,
+) : SeedJob<CruManagementAreaSeedCsvRow>(
+  id = UUID.randomUUID(),
+  fileName = fileName,
+  requiredHeaders = setOf(
+    "id",
+    "current_name",
+    "email_address",
+    "assessment_auto_allocation_username",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = CruManagementAreaSeedCsvRow(
+    id = UUID.fromString(columns["id"]!!.trim()),
+    currentName = columns["current_name"]!!.trim(),
+    emailAddress = columns["email_address"]!!.trim(),
+    assessmentAutoAllocationUsername = columns["assessment_auto_allocation_username"]!!.trim(),
+  )
+
+  override fun processRow(row: CruManagementAreaSeedCsvRow) {
+    val id = row.id
+    val managementArea = cas1CruManagementAreaRepository.findByIdOrNull(id)
+      ?: error("CRU Management Area with id '$id' does not exist")
+
+    val currentName = row.currentName
+    if (managementArea.name != currentName) {
+      error("Not updating entry for '$id' as current name '$currentName' in seed file doesn't match actual name '${managementArea.name}'")
+    }
+
+    val emailAddress = row.emailAddress.ifBlank { null }
+    val autoAlloc = row.assessmentAutoAllocationUsername.ifBlank { null }
+
+    val before = managementArea.copy()
+
+    managementArea.emailAddress = emailAddress
+    managementArea.assessmentAutoAllocationUsername = autoAlloc
+    cas1CruManagementAreaRepository.save(managementArea)
+
+    log.info("Management are was $before, is now $managementArea")
+  }
+}
+
+data class CruManagementAreaSeedCsvRow(
+  val id: UUID,
+  val currentName: String,
+  val emailAddress: String,
+  val assessmentAutoAllocationUsername: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SeedService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
@@ -47,6 +48,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingAdhocPropertySeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1CruManagementAreaSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DomainEventReplaySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DuplicateApplicationSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedJob
@@ -296,6 +298,11 @@ class SeedService(
         SeedFileType.updateUsersFromApi -> UpdateUsersFromApiSeedJob(
           filename,
           getBean(UserService::class),
+        )
+
+        SeedFileType.approvedPremisesCruManagementAreas -> Cas1CruManagementAreaSeedJob(
+          filename,
+          getBean(Cas1CruManagementAreaRepository::class),
         )
       }
 

--- a/src/main/resources/db/migration/all/20240927144633__add_auto_allocation_field_to_cru_management_area.sql
+++ b/src/main/resources/db/migration/all/20240927144633__add_auto_allocation_field_to_cru_management_area.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_cru_management_areas ADD assessment_auto_allocation_username TEXT NULL;

--- a/src/main/resources/db/migration/dev+test/R__9_cas1_cru_management_areas.sql
+++ b/src/main/resources/db/migration/dev+test/R__9_cas1_cru_management_areas.sql
@@ -1,0 +1,5 @@
+-- Ideally we'd manage this with the a seed job CSV in 'seed.local+dev+test', but
+-- the required configuration for assessment_auto_allocation_username currently
+-- differs in local and dev/test
+
+UPDATE cas1_cru_management_areas SET assessment_auto_allocation_username = 'AP_USER_TEST_1';

--- a/src/main/resources/db/migration/local/R__4_cas1_cru_management_areas.sql
+++ b/src/main/resources/db/migration/local/R__4_cas1_cru_management_areas.sql
@@ -1,0 +1,5 @@
+-- Ideally we'd manage this with the a seed job CSV in 'seed.local+dev+test', but
+-- the required configuration for assessment_auto_allocation_username currently
+-- differs in local and dev/test
+
+UPDATE cas1_cru_management_areas SET assessment_auto_allocation_username = 'JIMSNOWLDAP';

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3828,6 +3828,7 @@ components:
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
         - approved_premises_out_of_service_beds
+        - approved_premises_cru_management_areas
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8306,6 +8306,7 @@ components:
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
         - approved_premises_out_of_service_beds
+        - approved_premises_cru_management_areas
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4967,6 +4967,7 @@ components:
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
         - approved_premises_out_of_service_beds
+        - approved_premises_cru_management_areas
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4419,6 +4419,7 @@ components:
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
         - approved_premises_out_of_service_beds
+        - approved_premises_cru_management_areas
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3919,6 +3919,7 @@ components:
         - approved_premises_update_event_number
         - approved_premises_link_booking_to_placement_request
         - approved_premises_out_of_service_beds
+        - approved_premises_cru_management_areas
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1CruManagementAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1CruManagementAreaEntityFactory.kt
@@ -12,6 +12,7 @@ class Cas1CruManagementAreaEntityFactory : Factory<Cas1CruManagementAreaEntity> 
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var emailAddress: Yielded<String?> = { randomStringUpperCase(10) }
   private var notifyReplyToEmailId: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var assessmentAutoAllocationUsername: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -29,10 +30,15 @@ class Cas1CruManagementAreaEntityFactory : Factory<Cas1CruManagementAreaEntity> 
     this.notifyReplyToEmailId = { notifyReplyToEmailId }
   }
 
+  fun withAssessmentAutoAllocationUsername(assessmentAutoAllocationUsername: String?) = apply {
+    this.assessmentAutoAllocationUsername = { assessmentAutoAllocationUsername }
+  }
+
   override fun produce() = Cas1CruManagementAreaEntity(
     id = this.id(),
     name = this.name(),
     emailAddress = this.emailAddress(),
     notifyReplyToEmailId = this.notifyReplyToEmailId(),
+    assessmentAutoAllocationUsername = this.assessmentAutoAllocationUsername(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CruManagementAreaTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CruManagementAreaTest.kt
@@ -1,0 +1,150 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.CruManagementAreaSeedCsvRow
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedCas1CruManagementAreaTest : SeedTestBase() {
+
+  lateinit var areaId: UUID
+
+  @BeforeEach
+  fun setupArea() {
+    areaId = cas1CruManagementAreaRepository.save(
+      Cas1CruManagementAreaEntityFactory()
+        .withId(UUID.randomUUID())
+        .withName("Existing Name")
+        .withEmailAddress("exisdtingEmail@here.com")
+        .withAssessmentAutoAllocationUsername("existingUserName")
+        .produce(),
+    ).id
+  }
+
+  @Test
+  fun `Attempting to seed using an invalid id logs an error`() {
+    val invalidId = UUID.randomUUID()
+    withCsv(
+      csvName = "invalid-id",
+      contents = listOf(
+        CruManagementAreaSeedCsvRow(
+          id = invalidId,
+          currentName = "doesnt matter",
+          emailAddress = "doesnt matter",
+          assessmentAutoAllocationUsername = "doesnt matter",
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesCruManagementAreas, "invalid-id.csv")
+
+    assertThat(logEntries)
+      .withFailMessage("-> logEntries actually contains: $logEntries")
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Error on row 1:" &&
+          it.throwable != null &&
+          it.throwable.message == "CRU Management Area with id '$invalidId' does not exist"
+      }
+  }
+
+  @Test
+  fun `Attempting to seed using an invalid name logs an error`() {
+    withCsv(
+      csvName = "invalid-name",
+      contents = listOf(
+        CruManagementAreaSeedCsvRow(
+          id = areaId,
+          currentName = "Wrong Name",
+          emailAddress = "doesnt matter",
+          assessmentAutoAllocationUsername = "doesnt matter",
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesCruManagementAreas, "invalid-name.csv")
+
+    assertThat(logEntries)
+      .withFailMessage("-> logEntries actually contains: $logEntries")
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Error on row 1:" &&
+          it.throwable != null &&
+          it.throwable.message == "Not updating entry for '$areaId' as current name 'Wrong Name' in seed file doesn't match actual name 'Existing Name'"
+      }
+  }
+
+  @Test
+  fun `Updating cru management area persists correctly`() {
+    withCsv(
+      csvName = "valid-csv",
+      contents = listOf(
+        CruManagementAreaSeedCsvRow(
+          id = areaId,
+          currentName = "Existing Name",
+          emailAddress = "updated@test.com",
+          assessmentAutoAllocationUsername = "updated delius username",
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesCruManagementAreas, "valid-csv.csv")
+
+    val updatedArea = cas1CruManagementAreaRepository.findByIdOrNull(areaId)!!
+
+    assertThat(updatedArea.emailAddress).isEqualTo("updated@test.com")
+    assertThat(updatedArea.assessmentAutoAllocationUsername).isEqualTo("updated delius username")
+  }
+
+  @Test
+  fun `Updating cru management area with null values correctly`() {
+    withCsv(
+      csvName = "valid-csv",
+      contents = listOf(
+        CruManagementAreaSeedCsvRow(
+          id = areaId,
+          currentName = "Existing Name",
+          emailAddress = "   ",
+          assessmentAutoAllocationUsername = "  ",
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesCruManagementAreas, "valid-csv.csv")
+
+    val updatedArea = cas1CruManagementAreaRepository.findByIdOrNull(areaId)!!
+
+    assertThat(updatedArea.emailAddress).isNull()
+    assertThat(updatedArea.assessmentAutoAllocationUsername).isNull()
+  }
+
+  private fun List<CruManagementAreaSeedCsvRow>.toCsv(): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "id",
+        "current_name",
+        "email_address",
+        "assessment_auto_allocation_username",
+      )
+      .newRow()
+
+    this.forEach {
+      builder
+        .withQuotedField(it.id)
+        .withQuotedField(it.currentName)
+        .withQuotedField(it.emailAddress)
+        .withQuotedField(it.assessmentAutoAllocationUsername)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}


### PR DESCRIPTION
This commit adds an ‘assessmentAutoAllocationUsername’ property the Cas1CruManagementAreaEntity, to be used for auto allocation. This field isn’t currently in use, this will follow in a subsequent commit.

This commit also adds a seed job that can be used to update a CRU Managment Areas email and auto allocation configuration.

The default values for assessmentAutoAllocationUsername in local/dev/test are set to match their helm equivalents