### PR TITLE
CAS-451 Add turnaround days to the script

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingGapReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingGapReportRepository.kt
@@ -5,40 +5,59 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
 
 val GAP_RANGES_QUERY = """
-with bed_bookings as (select
-    probation_regions.name as probation_region,
-    probation_delivery_units.name as pdu_name,
-    premises.name as premises_name,
-    rooms.name as room_name,
-    range_agg(daterange(arrival_date, departure_date,'[]')) as booked_days,
-    lower(range_agg(daterange(arrival_date, departure_date))) as date_min
+with bed_bookings as(select
+probation_regions.name as probation_region,
+probation_delivery_units.name as pdu_name,
+premises.name as premises_name,
+rooms.name as room_name,
+arrival_date,
+departure_date,
+(select working_day_count
+from turnarounds
+where turnarounds.id = (
+    select id
+    from turnarounds
+    where  turnarounds.booking_id = bookings.id
+    order by turnarounds.created_at desc
+    limit 1)) turnaround_days
 from bookings
-   left join premises on premises.id = bookings.premises_id
-   left join probation_regions on probation_regions.id = premises.probation_region_id
-   left join temporary_accommodation_premises on temporary_accommodation_premises.premises_id = bookings.premises_id
-   left join probation_delivery_units on probation_delivery_units.id = temporary_accommodation_premises.probation_delivery_unit_id
-   left join beds on beds.id = bookings.bed_id
-   left join rooms on rooms.id = beds.room_id
-   left join confirmations on confirmations.booking_id = bookings.id
-   left join cancellations on  cancellations.booking_id = bookings.id
-where bookings.service = 'temporary-accommodation' and cancellations.id is null
+  left join premises on premises.id = bookings.premises_id
+  left join probation_regions on probation_regions.id = premises.probation_region_id
+  left join temporary_accommodation_premises on temporary_accommodation_premises.premises_id = bookings.premises_id
+  left join probation_delivery_units on probation_delivery_units.id = temporary_accommodation_premises.probation_delivery_unit_id
+  left join beds on beds.id = bookings.bed_id
+  left join rooms on rooms.id = beds.room_id
+  left join confirmations on confirmations.booking_id = bookings.id
+  left join cancellations on  cancellations.booking_id = bookings.id
+where bookings.service = 'temporary-accommodation' and cancellations.id is null),
+bed_booked_days as (select
+   probation_region,
+   pdu_name,
+   premises_name,
+   room_name,
+   range_agg(daterange(arrival_date, departure_date,'[]')) as booked_days,
+   lower(range_agg(daterange(arrival_date, departure_date))) as date_min,
+   upper(range_agg(daterange(arrival_date, departure_date))) as date_max
+from bed_bookings
 group by probation_region, pdu_name, premises_name, room_name
 order by probation_region, pdu_name, premises_name, room_name),
 booking_gaps as (select
-    probation_region,
-    pdu_name,
-    premises_name,
-    room_name,
-    unnest(multirange(daterange(date_min, current_date)) - booked_days) as gap
-from bed_bookings) 
+probation_region,
+pdu_name,
+premises_name,
+room_name,
+unnest(multirange(daterange(date_min, date_max)) - booked_days) as gap
+from bed_booked_days)
 select
-    probation_region,
-    pdu_name,
-    premises_name,
-    room_name,
-    gap::text,
-    upper(gap) - lower(gap) as gap_days
+    booking_gaps.probation_region,
+    booking_gaps.pdu_name,
+    booking_gaps.premises_name,
+    booking_gaps.room_name as bed_name,
+    booking_gaps.gap::text,
+    upper(gap) - lower(gap) as gap_days,
+    turnaround_days
 from booking_gaps
+left join bed_bookings on departure_date = lower(gap) - 1 and  booking_gaps.premises_name =  bed_bookings.premises_name and booking_gaps.room_name = bed_bookings.room_name
 """.trimIndent()
 
 @Repository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -3450,6 +3450,13 @@ class Cas3ReportsTest : IntegrationTestBase() {
 
         val booking1 = createBooking(premises, bedOne, offenderDetails.otherIds.crn, LocalDate.of(2023, 4, 5), booking1DepartureDate)
 
+        val turnaroundBooking1 = turnaroundFactory.produceAndPersist {
+          withBooking(booking1)
+          withWorkingDayCount(5)
+        }
+
+        booking1.turnarounds = mutableListOf(turnaroundBooking1)
+
         confirmationEntityFactory.produceAndPersist {
           withBooking(booking1)
         }
@@ -3467,6 +3474,13 @@ class Cas3ReportsTest : IntegrationTestBase() {
 
         val booking2 = createBooking(premises, bedTwo, offenderDetails.otherIds.crn, LocalDate.of(2023, 4, 19), booking2DepartureDate)
 
+        val turnaroundBooking2 = turnaroundFactory.produceAndPersist {
+          withBooking(booking2)
+          withWorkingDayCount(2)
+        }
+
+        booking2.turnarounds = mutableListOf(turnaroundBooking2)
+
         confirmationEntityFactory.produceAndPersist {
           withBooking(booking2)
         }
@@ -3482,7 +3496,16 @@ class Cas3ReportsTest : IntegrationTestBase() {
 
         val booking4ArrivalDate = LocalDate.of(2024, 5, 12)
         val booking4DepartureDate = LocalDate.of(2024, 7, 17)
-        createBooking(premises, bedTwo, offenderDetails.otherIds.crn, booking4ArrivalDate, booking4DepartureDate)
+        val booking4 = createBooking(premises, bedTwo, offenderDetails.otherIds.crn, booking4ArrivalDate, booking4DepartureDate)
+
+        val turnaroundBooking4 = turnaroundFactory.produceAndPersist {
+          withBooking(booking4)
+          withWorkingDayCount(0)
+        }
+
+        booking4.turnarounds = mutableListOf(turnaroundBooking4)
+
+        GovUKBankHolidaysAPI_mockSuccessfullCallWithEmptyResponse()
 
         val gapRangesReport = cas3ReportService.createBookingGapRangesReport()
 
@@ -3493,25 +3516,10 @@ class Cas3ReportsTest : IntegrationTestBase() {
             "probation_region" to premises.probationRegion.name,
             "pdu_name" to probationDeliveryUnit.name,
             "premises_name" to premises.name,
-            "room_name" to "room1",
-            "gap" to "[${booking1DepartureDate.plusDays(1)},$today)",
-            "gap_days" to ChronoUnit.DAYS.between(booking1DepartureDate.plusDays(1), LocalDate.now()).toInt(),
-          ),
-          mutableMapOf<String, Any?>(
-            "probation_region" to premises.probationRegion.name,
-            "pdu_name" to probationDeliveryUnit.name,
-            "premises_name" to premises.name,
-            "room_name" to "room2",
+            "bed_name" to "room2",
             "gap" to "[${booking2DepartureDate.plusDays(1)},$booking4ArrivalDate)",
             "gap_days" to ChronoUnit.DAYS.between(booking2DepartureDate.plusDays(1), booking4ArrivalDate).toInt(),
-          ),
-          mutableMapOf<String, Any?>(
-            "probation_region" to premises.probationRegion.name,
-            "pdu_name" to probationDeliveryUnit.name,
-            "premises_name" to premises.name,
-            "room_name" to "room2",
-            "gap" to "[${booking4DepartureDate.plusDays(1)},$today)",
-            "gap_days" to ChronoUnit.DAYS.between(booking4DepartureDate.plusDays(1), LocalDate.now()).toInt(),
+            "turnaround_days" to 2,
           ),
         )
 


### PR DESCRIPTION
This [PR CAS-451](https://dsdmoj.atlassian.net/browse/CAS-541) is to:
- Include provisional bookings
- Exclude cancelled bookings 
- Add a new column the turnaround days for bedspace booking to the report. The query is a proof of concept so we are not looking to the performance in the current stage
- Remove the gap between the departure date of the last booking and the current date 