### PR TITLE
APS-1234 - Seed Women’s Estate Test User in local environment

### DIFF
--- a/src/main/resources/db/migration/local/R__4_cas1_cru_management_areas.sql
+++ b/src/main/resources/db/migration/local/R__4_cas1_cru_management_areas.sql
@@ -3,3 +3,4 @@
 -- differs in local and dev/test
 
 UPDATE cas1_cru_management_areas SET assessment_auto_allocation_username = 'JIMSNOWLDAP';
+UPDATE cas1_cru_management_areas SET assessment_auto_allocation_username = 'CRUWOMENSESTATE' WHERE id = 'bfb04c2a-1954-4512-803d-164f7fcf252c';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AutoScriptTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AutoScriptTest.kt
@@ -42,6 +42,7 @@ class Cas1AutoScriptTest : IntegrationTestBase() {
         applicationService,
         userService,
         offenderService,
+        cas1CruManagementAreaRepository,
       ).script()
     }
   }


### PR DESCRIPTION
This commit adds default roles to the CRUWOMENSESTATE user for local deployments. It also overrides their CRU Management Area to be the women’s estate management area, and sets them as the auto allocation user for assessments