### PR TITLE
APS-1362 - Fixes to support running E2E tests against upstream dev

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,10 +134,9 @@ tasks {
 
 tasks.register("bootRunLocal") {
   group = "application"
-  description = "Runs this project as a Spring Boot application with the local profile"
+  description = "Runs this project as a Spring Boot application"
   doFirst {
     tasks.bootRun.configure {
-      systemProperty("spring.profiles.active", "local")
       jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=32323")
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,7 +149,7 @@ tasks.bootRun {
     println("Reading env vars from file $envFilePath")
     file(envFilePath).readLines().forEach {
       if (it.isNotBlank() && !it.startsWith("#")) {
-        val (key, value) = it.split('=')
+        val (key, value) = it.split("=", limit = 2)
         println("Setting env var $key")
         environment(key, value)
       }

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -46,6 +46,7 @@ generic-service:
     PREEMPTIVE-CACHE-DELAY-MS: 60000
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
+    SEED_AUTO-SCRIPT_CAS1-ENABLED: true
     SEED_AUTO-SCRIPT_CAS2-ENABLED: true
     SEED_AUTO-SCRIPT_NOMS: A5276DZ
     SEED_AUTO-SCRIPT_PRISON-CODE: MDI

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -35,6 +35,7 @@ generic-service:
     DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false
     SEED_AUTO_ENABLED: false
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
+    SEED_AUTO-SCRIPT_CAS1-ENABLED: true
     SEED_AUTO-SCRIPT_CAS2-ENABLED: true
     SEED_AUTO-SCRIPT_NOMS: A5276DZ
     SEED_AUTO-SCRIPT_PRISON-CODE: MDI

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedController.kt
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.SeedApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedRequest
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedService
 
 @Service
 class SeedController(private val seedService: SeedService) : SeedApiDelegate {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedOnStartupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedOnStartupService.kt
@@ -1,0 +1,88 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import jakarta.annotation.PostConstruct
+import org.apache.commons.io.FileUtils
+import org.slf4j.LoggerFactory
+import org.springframework.core.io.ClassPathResource
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
+import java.io.File
+import java.io.IOException
+
+@Service
+class SeedOnStartupService(
+  private val seedConfig: SeedConfig,
+  private val cas1AutoScript: Cas1AutoScript,
+  private val cas2AutoScript: Cas2AutoScript,
+  private val seedService: SeedService,
+) {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @SuppressWarnings("NestedBlockDepth")
+  @PostConstruct
+  fun autoSeed() {
+    if (!seedConfig.auto.enabled) {
+      return
+    }
+
+    log.info("Auto-seeding from locations: ${seedConfig.auto.filePrefixes}")
+    for (filePrefix in seedConfig.auto.filePrefixes) {
+      val csvFiles = try {
+        PathMatchingResourcePatternResolver().getResources("$filePrefix/*.csv")
+      } catch (e: IOException) {
+        log.warn(e.message!!)
+        continue
+      }
+
+      csvFiles.sortBy { it.filename }
+
+      for (csv in csvFiles) {
+        val csvName = csv.filename!!
+          .replace("\\.csv$".toRegex(), "")
+          .replace("^[0-9]+__".toRegex(), "")
+        val seedFileType = SeedFileType.values().firstOrNull { it.value == csvName }
+        if (seedFileType == null) {
+          log.warn("Seed file ${csv.file.path} does not have a known job type; skipping.")
+        } else {
+          log.info("Found seed job of type $seedFileType in $filePrefix")
+          val filePath = if (csv is ClassPathResource) {
+            csv.inputStream
+
+            val targetFile = File("${seedConfig.filePrefix}/${csv.filename}")
+            log.info("Copying class path resource ${csv.filename} to ${targetFile.absolutePath}")
+            FileUtils.copyInputStreamToFile(csv.inputStream, targetFile)
+
+            targetFile.absolutePath
+          } else {
+            csv.file.path
+          }
+
+          seedService.seedData(seedFileType, seedFileType.value) { filePath }
+        }
+      }
+    }
+
+    if (seedConfig.autoScript.cas1Enabled) {
+      autoScriptCas1()
+    }
+
+    if (seedConfig.autoScript.cas2Enabled) {
+      autoScriptCas2()
+    }
+  }
+
+  fun autoScriptCas1() {
+    log.info("**Auto-scripting CAS1**")
+    cas1AutoScript.script()
+  }
+
+  fun autoScriptCas2() {
+    log.info("**Auto-scripting CAS2**")
+    cas2AutoScript.script()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -1,12 +1,8 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
-import jakarta.annotation.PostConstruct
-import org.apache.commons.io.FileUtils
 import org.springframework.context.ApplicationContext
-import org.springframework.core.io.ClassPathResource
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
@@ -32,18 +28,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.Cas1UpdateNomsNumberSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CharacteristicsSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationBedspaceSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.TemporaryAccommodationPremisesSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UpdateUsersFromApiSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApStaffUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesBookingCancelSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingAdhocPropertySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1CruManagementAreaSeedJob
@@ -56,14 +45,21 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAsse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateEventNumberSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1WithdrawPlacementRequestSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2ApplicationsSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.ExternalUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.NomisUsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RoomService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.findRootCause
-import java.io.File
-import java.io.IOException
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 import kotlin.reflect.KClass
@@ -74,78 +70,15 @@ class SeedService(
   private val applicationContext: ApplicationContext,
   private val transactionTemplate: TransactionTemplate,
   private val seedLogger: SeedLogger,
-  private val cas1AutoScript: Cas1AutoScript,
-  private val cas2AutoScript: Cas2AutoScript,
 ) {
-
-  @PostConstruct
-  fun autoSeed() {
-    if (!seedConfig.auto.enabled) {
-      return
-    }
-
-    seedLogger.info("Auto-seeding from locations: ${seedConfig.auto.filePrefixes}")
-    for (filePrefix in seedConfig.auto.filePrefixes) {
-      val csvFiles = try {
-        PathMatchingResourcePatternResolver().getResources("$filePrefix/*.csv")
-      } catch (e: IOException) {
-        seedLogger.warn(e.message!!)
-        continue
-      }
-
-      csvFiles.sortBy { it.filename }
-
-      for (csv in csvFiles) {
-        val csvName = csv.filename!!
-          .replace("\\.csv$".toRegex(), "")
-          .replace("^[0-9]+__".toRegex(), "")
-        val seedFileType = SeedFileType.values().firstOrNull { it.value == csvName }
-        if (seedFileType == null) {
-          seedLogger.warn("Seed file ${csv.file.path} does not have a known job type; skipping.")
-        } else {
-          seedLogger.info("Found seed job of type $seedFileType in $filePrefix")
-          val filePath = if (csv is ClassPathResource) {
-            csv.inputStream
-
-            val targetFile = File("${seedConfig.filePrefix}/${csv.filename}")
-            seedLogger.info("Copying class path resource ${csv.filename} to ${targetFile.absolutePath}")
-            FileUtils.copyInputStreamToFile(csv.inputStream, targetFile)
-
-            targetFile.absolutePath
-          } else {
-            csv.file.path
-          }
-
-          seedData(seedFileType, seedFileType.value) { filePath }
-        }
-      }
-    }
-
-    if (seedConfig.autoScript.cas1Enabled) {
-      autoScriptCas1()
-    }
-
-    if (seedConfig.autoScript.cas2Enabled) {
-      autoScriptCas2()
-    }
-  }
-
-  fun autoScriptCas1() {
-    seedLogger.info("**Auto-scripting CAS1**")
-    cas1AutoScript.script()
-  }
-
-  fun autoScriptCas2() {
-    seedLogger.info("**Auto-scripting CAS2**")
-    cas2AutoScript.script()
-  }
 
   @Async
   fun seedDataAsync(seedFileType: SeedFileType, filename: String) = seedData(seedFileType, filename)
 
   fun seedData(seedFileType: SeedFileType, filename: String) = seedData(seedFileType, filename) { "${seedConfig.filePrefix}/${this.fileName}" }
 
-  private fun seedData(seedFileType: SeedFileType, filename: String, resolveCsvPath: SeedJob<*>.() -> String) {
+  @SuppressWarnings("CyclomaticComplexMethod")
+  fun seedData(seedFileType: SeedFileType, filename: String, resolveCsvPath: SeedJob<*>.() -> String) {
     seedLogger.info("Starting seed request: $seedFileType - $filename")
 
     try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -32,8 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApStaffUsersSe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesBookingCancelSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ApAreaEmailAddressSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingAdhocPropertySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1CruManagementAreaSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DomainEventReplaySeedJob

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
@@ -1,12 +1,22 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 
 @Service
 class EnvironmentService(
-  val environment: Environment
+  val environment: Environment,
 ) {
-  fun isLocal() = environment.activeProfiles.contains("local")
-  fun isDev() = environment.activeProfiles.contains("dev")
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @PostConstruct
+  fun logProfiles() {
+    log.info("Active profiles are ${environment.activeProfiles}")
+  }
+
+  fun isLocal() = environment.activeProfiles.any { it.equals("local", ignoreCase = true) }
+  fun isDev() = environment.activeProfiles.any { it.equals("dev", ignoreCase = true) }
+  fun isControlledEnvironment() = !isLocal() && !isDev()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Service
+
+@Service
+class EnvironmentService(
+  val environment: Environment
+) {
+  fun isLocal() = environment.activeProfiles.contains("local")
+  fun isDev() = environment.activeProfiles.contains("dev")
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AutoScriptTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AutoScriptTest.kt
@@ -6,30 +6,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
 class Cas1AutoScriptTest : IntegrationTestBase() {
-
   @Autowired
-  lateinit var seedLogger: SeedLogger
-
-  @Autowired
-  lateinit var applicationService: ApplicationService
-
-  @Autowired
-  lateinit var userService: UserService
-
-  @Autowired
-  lateinit var offenderService: OffenderService
+  lateinit var cas1AutoScript: Cas1AutoScript
 
   @Test
-  fun `ensure auto script runs`() {
+  fun `ensure local auto script runs`() {
     `Given an Offender` { offenderDetails, _ ->
-
       APDeliusContext_mockSuccessfulTeamsManagingCaseCall(
         offenderDetails.otherIds.crn,
         ManagingTeamsResponse(
@@ -37,13 +22,12 @@ class Cas1AutoScriptTest : IntegrationTestBase() {
         ),
       )
 
-      Cas1AutoScript(
-        seedLogger,
-        applicationService,
-        userService,
-        offenderService,
-        cas1CruManagementAreaRepository,
-      ).script()
+      cas1AutoScript.scriptLocal()
     }
+  }
+
+  @Test
+  fun `ensure dev auto script runs`() {
+    cas1AutoScript.scriptDev()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.LogEntry
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/SeedOnStartupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/SeedOnStartupServiceTest.kt
@@ -29,6 +29,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.LogEntry
 
 class SeedOnStartupServiceTest {
@@ -38,8 +40,11 @@ class SeedOnStartupServiceTest {
   private val mockSeedLogger = mockk<SeedLogger>()
   private val mockCas1AutoScript = mockk<Cas1AutoScript>()
   private val mockCas2AutoScript = mockk<Cas2AutoScript>()
-  private val logEntries = mutableListOf<LogEntry>()
   private val mockSeedService = mockk<SeedService>()
+  private val mockEnvironmentService = mockk<EnvironmentService>()
+  private val mockSentryService = mockk<SentryService>()
+
+  private val logEntries = mutableListOf<LogEntry>()
 
   private val service = SeedOnStartupService(
     seedConfig,
@@ -47,6 +52,8 @@ class SeedOnStartupServiceTest {
     mockCas2AutoScript,
     mockSeedService,
     mockSeedLogger,
+    mockEnvironmentService,
+    mockSentryService,
   )
 
   @BeforeEach
@@ -65,6 +72,7 @@ class SeedOnStartupServiceTest {
     }
     every { mockCas1AutoScript.script() } answers { }
     every { mockCas2AutoScript.script() } answers { }
+    every { mockEnvironmentService.isControlledEnvironment() } returns false
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/SeedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/SeedServiceTest.kt
@@ -24,11 +24,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SeedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.LogEntry
 
 class SeedServiceTest {


### PR DESCRIPTION
Note - i'm currently breaking this out into separate PRs to make it more manageable:

* https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/2386
* https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/2388

This PR:

* fixes an issue in the env var processing on startup related to '=' character appearing in values
* tidy up the 'auto scripting' code, renaming to 'seed on startup'
* adds configuration for dev+test environments to seed on startup, allowing us to configure users that only exist in dev+test environments with the correct roles
* added some safety checks for auto seeding to ensure it never runs in prod or prod like environments, and raises an alert if an attempt is made