### PR TITLE
APS-1344 Set CRU Management area to Womens Estate if isWomensApplication is true.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -55,6 +55,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
@@ -87,6 +88,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
@@ -129,6 +131,8 @@ class ApplicationServiceTest {
   private val mockApplicationListener = mockk<ApplicationListener>()
   private val mockLockableApplicationRepository = mockk<LockableApplicationRepository>()
   private val mockProbationDeliveryUnitRepository = mockk<ProbationDeliveryUnitRepository>()
+  private val mockCas1CruManagementAreaRepository = mockk<Cas1CruManagementAreaRepository>()
+  private val mockFeatureFlagService = mockk<FeatureFlagService>()
 
   private val applicationService = ApplicationService(
     mockUserRepository,
@@ -156,6 +160,8 @@ class ApplicationServiceTest {
     Clock.systemDefaultZone(),
     mockLockableApplicationRepository,
     mockProbationDeliveryUnitRepository,
+    mockCas1CruManagementAreaRepository,
+    mockFeatureFlagService,
   )
 
   @Test
@@ -1736,6 +1742,8 @@ class ApplicationServiceTest {
         )
       } returns theCaseManagerUserDetailsEntity
 
+      every { mockFeatureFlagService.getBooleanFlag("cas1-womens-estate-enabled") } returns true
+
       val result =
         applicationService.submitApprovedPremisesApplication(
           applicationId,
@@ -1833,6 +1841,8 @@ class ApplicationServiceTest {
         )
       } returns theCaseManagerUserDetailsEntity
 
+      every { mockFeatureFlagService.getBooleanFlag("cas1-womens-estate-enabled") } returns true
+
       val result =
         applicationService.submitApprovedPremisesApplication(
           applicationId,
@@ -1919,6 +1929,8 @@ class ApplicationServiceTest {
           match { it.name == "caseManagerName" && it.email == "caseManagerEmail" && it.telephoneNumber == "caseManagerPhone" },
         )
       } returns theCaseManagerUserDetailsEntity
+
+      every { mockFeatureFlagService.getBooleanFlag("cas1-womens-estate-enabled") } returns true
 
       val result =
         applicationService.submitApprovedPremisesApplication(
@@ -2030,6 +2042,8 @@ class ApplicationServiceTest {
       application.applicantUserDetails = existingApplicantUserDetails
       application.caseManagerUserDetails = existingCaseManagerUserDetails
 
+      every { mockFeatureFlagService.getBooleanFlag("cas1-womens-estate-enabled") } returns true
+
       val result =
         applicationService.submitApprovedPremisesApplication(
           applicationId,
@@ -2081,6 +2095,8 @@ class ApplicationServiceTest {
 
       val existingApplicantUserDetails = application.applicantUserDetails!!
       val existingCaseManagerUserDetails = application.caseManagerUserDetails!!
+
+      every { mockFeatureFlagService.getBooleanFlag("cas1-womens-estate-enabled") } returns true
 
       every {
         mockCas1ApplicationUserDetailsRepository.save(match { it.id == existingApplicantUserDetails.id })


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1344

If the feature flag `cas1-womens-estate-enabled` is true and `isWomensApplication` is set to true on submission of the application, set `application.cas1_cru_management_area_id `to the ‘Women’s Estate' entry. 

To do this we can use the hardcoded UUID already in the `Cas1CruManagementAreaEntity`:

```
  companion object {
    val WOMENS_ESTATE_ID = UUID.fromString("bfb04c2a-1954-4512-803d-164f7fcf252c")
  }
```
This change will be done in ApplicationService.submitApprovedPremisesApplication

This new test is as per the existing test `Submit standard application does not auto allocate the assessment, sends emails and raises domain events` but with:

- `isWomensApplication = true` in the submission post
- mocking the feature flag `cas1-womens-estate-enabled` to be true
- asserting that the CRU management area has been set to the Women's Estate value