### PR TITLE
Improve remote_db_tunnel stability

### DIFF
--- a/script/remote_db_tunnel
+++ b/script/remote_db_tunnel
@@ -177,6 +177,10 @@ else
 
     echo "Port forwarding setup. Now starting CLI"
 
+    # We've found that the port forward is not always available
+    # immediately, leading to connection failures
+    sleep 2
+
     JAQY_CHECKSUM="6d426a6ccf8f7ff07c06346a07a2921561561aa8d9405dace115a6c1947bb4c4"
     JAQY_URL="https://github.com/Teradata/jaqy/releases/download/v1.2.0/jaqy-1.2.0.jar"
     POSTGRES_URL="https://jdbc.postgresql.org/download/postgresql-42.7.3.jar"


### PR DESCRIPTION
I’ve found that intermittently the port forward port isn’t immediately availbale after creation. This commit adds a small sleep before creating the optional CLI connection to avoid connection issues