### PR TITLE
Configure IT SQS Listener to optomise shutdown

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SnsDomainEventListener.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SnsDomainEventListener.kt
@@ -26,7 +26,7 @@ class SnsDomainEventListener(private val objectMapper: ObjectMapper) {
    * We utilise the [hmpss spring boot sqs starter](https://github.com/ministryofjustice/hmpps-spring-boot-sqs)
    * to configure the queue container factory, using localstack to emulate SNS.
    */
-  @SqsListener(queueNames = ["domaineventsqueue"], factory = "hmppsQueueContainerFactoryProxy")
+  @SqsListener(queueNames = ["domaineventsqueue"], factory = "hmppsQueueContainerFactoryProxy", pollTimeoutSeconds = "1")
   fun processMessage(rawMessage: String?) {
     val (message) = objectMapper.readValue(rawMessage, Message::class.java)
     val event = objectMapper.readValue(message, SnsEvent::class.java)


### PR DESCRIPTION
This commits sets the lowest possible poll timeout on the SQS listener used during integration tests to minimise waiting when the spring context shutdowns at the end of tests.