### PR TITLE
APS-1286 Add simple timeline description for space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -133,6 +133,11 @@ class DomainEventDescriber(
   @SuppressWarnings("TooGenericExceptionThrown")
   private fun buildBookingCancelledDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getBookingCancelledEvent(domainEventSummary.id())
+
+    if (domainEventSummary.cas1SpaceBookingId != null) {
+      return "Space booking cancelled"
+    }
+
     return event.describe { data ->
       val booking = bookingRepository.findByIdOrNull(data.eventDetails.bookingId)
         ?: throw RuntimeException("Booking ID ${data.eventDetails.bookingId} with cancellation not found")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -398,6 +398,30 @@ class DomainEventDescriberTest {
   }
 
   @Test
+  fun `Returns expected description for space booking cancelled event`() {
+    val spaceBookingId = UUID.randomUUID()
+
+    val domainEventSummary = DomainEventSummaryImpl
+      .ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
+      .copy(cas1SpaceBookingId = UUID.randomUUID())
+
+    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
+      BookingCancelledEnvelope(
+        id = it,
+        timestamp = Instant.now(),
+        eventType = EventType.bookingCancelled,
+        eventDetails = BookingCancelledFactory()
+          .withBookingId(spaceBookingId)
+          .produce(),
+      )
+    }
+
+    val result = domainEventDescriber.getDescription(domainEventSummary)
+
+    assertThat(result).isEqualTo("Space booking cancelled")
+  }
+
+  @Test
   fun `Returns expected description for booking changed event`() {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED)
 


### PR DESCRIPTION
Whilst space bookings cannot currently be directly withdrawn on the UI, they can be withdrawn indirectly by withdrawing the associated application.

This leads to a domain event entry for space booking withdrawal but the timeline describer trys to render this using a regular booking entity, which fails because a regular booking with that ID doesn’t exist.

This PR adds a simple timeline description for space booking withdrawal to resolve the error. This will be replaced with a complete message in a subsequent commit.

![Screenshot 2024-10-04 at 12 47 14](https://github.com/user-attachments/assets/d76d2d3e-a13f-4f93-b3db-0c644b441081)
