### PR TITLE
Added new functions for CAS-573

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/StaffDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/StaffDetail.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+
 data class StaffDetail(
   val email: String?,
   val telephoneNumber: String?,
@@ -16,14 +18,23 @@ data class StaffDetail(
     .sortedByDescending { it.startDate }
 
   fun teamCodes() = teams.map { it.code }
+
+  fun toStaffMember() = StaffMember(
+    staffCode = this.code,
+    staffIdentifier = this.staffIdentifier,
+    forenames = this.name.forenames(),
+    surname = this.name.surname,
+    username = this.username,
+  )
 }
 
 data class PersonName(
   val forename: String,
   val surname: String,
-  val middleName: String?,
+  val middleName: String? = null,
 ) {
   fun deliusName() = "$forename $surname"
+  fun forenames() = "$forename ${middleName?.takeIf { it.isNotEmpty() } ?: ""}".trim()
 }
 
 data class ProbationArea(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -15,8 +15,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Request
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecisionEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
@@ -33,7 +33,7 @@ import java.util.UUID
 class Cas1PlacementApplicationDomainEventService(
   private val domainEventService: DomainEventService,
   private val domainEventTransformer: DomainEventTransformer,
-  private val communityApiClient: CommunityApiClient,
+  private val apDeliusContextApiClient: ApDeliusContextApiClient,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
 ) {
 
@@ -55,7 +55,7 @@ class Cas1PlacementApplicationDomainEventService(
       PlacementType.ADDITIONAL_PLACEMENT -> RequestForPlacementType.additionalPlacement
     }
 
-    val staffDetails = when (val staffDetailsResult = communityApiClient.getStaffUserDetails(username)) {
+    val staffDetails = when (val staffDetailsResult = apDeliusContextApiClient.getStaffDetail(username)) {
       is ClientResult.Success -> staffDetailsResult.body
       is ClientResult.Failure -> staffDetailsResult.throwException()
     }
@@ -70,7 +70,7 @@ class Cas1PlacementApplicationDomainEventService(
       ),
       deliusEventNumber = application.eventNumber,
       createdAt = eventOccurredAt,
-      createdBy = domainEventTransformer.toStaffMember(staffDetails),
+      createdBy = staffDetails.toStaffMember(),
       expectedArrival = dates.expectedArrival,
       duration = dates.duration,
       requestForPlacementType = placementType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DomainEventTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DomainEventTransformer.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffDetail
 
 @Component
 class DomainEventTransformer(private val communityApiClient: CommunityApiClient) {
@@ -23,7 +24,15 @@ class DomainEventTransformer(private val communityApiClient: CommunityApiClient)
     return WithdrawnBy(staffMember, probationArea)
   }
 
+  @Deprecated("This will be removed as part of CAS-573")
   fun toProbationArea(staffDetails: StaffUserDetails): ProbationArea {
+    return ProbationArea(
+      code = staffDetails.probationArea.code,
+      name = staffDetails.probationArea.description,
+    )
+  }
+
+  fun toProbationArea(staffDetails: StaffDetail): ProbationArea {
     return ProbationArea(
       code = staffDetails.probationArea.code,
       name = staffDetails.probationArea.description,
@@ -36,5 +45,6 @@ class DomainEventTransformer(private val communityApiClient: CommunityApiClient)
       is ClientResult.Failure -> result.throwException()
     }
 
+  @Deprecated("This has moved to StaffDetail")
   fun toStaffMember(staffDetails: StaffUserDetails): StaffMember = staffDetails.toStaffMember()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/StaffDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/StaffDetailTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
+
+class StaffDetailTest {
+  private val staffCode = "ABC123"
+  private val staffIdentifier = "123".toLong()
+  private val forename = "Bruce"
+  private val middleName = "Middle"
+  private val surname = "Lee"
+  private val username = "SOME_USERNAME"
+
+  @Test
+  fun `toStaffMember converts to a StaffMember`() {
+    val staffDetail = StaffDetailFactory.staffDetail().copy(
+      code = staffCode,
+      staffIdentifier = staffIdentifier,
+      name = PersonName(forename = forename, surname = surname),
+      username = username,
+    ).toStaffMember()
+
+    val staffMember = StaffMember(
+      staffCode = staffCode,
+      staffIdentifier = staffIdentifier,
+      forenames = forename,
+      surname = surname,
+      username = username,
+    )
+    assertThat(staffDetail.staffCode).isEqualTo(staffMember.staffCode)
+    assertThat(staffDetail.staffIdentifier).isEqualTo(staffMember.staffIdentifier)
+    assertThat(staffDetail.forenames).isEqualTo(staffMember.forenames)
+    assertThat(staffDetail.surname).isEqualTo(staffMember.surname)
+    assertThat(staffDetail.username).isEqualTo(staffMember.username)
+  }
+
+  @Test
+  fun `staff detail produces correct forenames`() {
+    val staffDetail = StaffDetailFactory.staffDetail().copy(
+      name = PersonName(forename = forename, middleName = middleName, surname = surname),
+    )
+    assertThat(staffDetail.name.forenames()).isEqualTo("$forename $middleName")
+  }
+
+  @Test
+  fun `staff detail produces correct Delius name`() {
+    val staffDetail = StaffDetailFactory.staffDetail().copy(
+      name = PersonName(forename = forename, middleName = middleName, surname = surname),
+    )
+    assertThat(staffDetail.name.deliusName()).isEqualTo("$forename $surname")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/StaffUserDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/StaffUserDetailsTest.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.model
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
 
 class StaffUserDetailsTest {
   @Test
@@ -14,6 +16,8 @@ class StaffUserDetailsTest {
     val surname = "Lee"
     val username = "SOME_USERNAME"
 
+    val staffDetail = StaffDetailFactory.staffDetail().copy(code = staffCode, staffIdentifier = staffIdentifier, name = PersonName(forename = forenames, surname = surname), username = username)
+
     val staffUserDetails = StaffUserDetailsFactory()
       .withStaffCode(staffCode)
       .withStaffIdentifier(staffIdentifier)
@@ -21,6 +25,8 @@ class StaffUserDetailsTest {
       .withSurname(surname)
       .withUsername(username)
       .produce()
+
+    assertThat(staffUserDetails.toStaffMember()).isEqualTo(staffDetail.toStaffMember())
 
     assertThat(staffUserDetails.toStaffMember()).isEqualTo(
       StaffMember(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DomainEventTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DomainEventTransformerTest.kt
@@ -11,9 +11,11 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult.Failure
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 
 class DomainEventTransformerTest {
@@ -35,6 +37,7 @@ class DomainEventTransformerTest {
     assertThat(result.name).isEqualTo("theProbationDescription")
   }
 
+  // just for piece of mind - remove in next PR
   @Test
   fun `toStaffMember success`() {
     val staffDetails = StaffUserDetailsFactory()
@@ -45,13 +48,30 @@ class DomainEventTransformerTest {
       .withUsername("theUsername")
       .produce()
 
-    val result = domainEventTransformerService.toStaffMember(staffDetails)
+    val staffDetail = StaffDetailFactory.staffDetail().copy(
+      code = "theStaffCode",
+      staffIdentifier = 22L,
+      name =
+      PersonName(forename = "theForenames", surname = "theSurname"),
+      username = "theUsername",
+    )
+
+    val res = staffDetail.toStaffMember()
+    val result = staffDetails.toStaffMember()
+
+    assertThat(result).isEqualTo(res)
 
     assertThat(result.staffCode).isEqualTo("theStaffCode")
     assertThat(result.staffIdentifier).isEqualTo(22L)
     assertThat(result.forenames).isEqualTo("theForenames")
     assertThat(result.surname).isEqualTo("theSurname")
     assertThat(result.username).isEqualTo("theUsername")
+
+    assertThat(res.staffCode).isEqualTo("theStaffCode")
+    assertThat(res.staffIdentifier).isEqualTo(22L)
+    assertThat(res.forenames).isEqualTo("theForenames")
+    assertThat(res.surname).isEqualTo("theSurname")
+    assertThat(res.username).isEqualTo("theUsername")
   }
 
   @Test


### PR DESCRIPTION
Added new methods preparing for removing StaffUserDetails. toStaffMember() is duplicated, so this adds it into the StaffDetail class, so the others can be removed in the following PR