### PR TITLE
CAS-1171 - Make close assessment idempotent

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -90,6 +91,7 @@ class AssessmentService(
   private val clock: Clock,
   private val lockableAssessmentRepository: LockableAssessmentRepository,
 ) {
+  private val log = LoggerFactory.getLogger(this::class.java)
 
   fun getVisibleAssessmentSummariesForUserCAS1(
     user: UserEntity,
@@ -609,9 +611,8 @@ class AssessmentService(
     }
 
     if (assessment.completedAt != null) {
-      return AuthorisableActionResult.Success(
-        ValidatableActionResult.GeneralValidationError("This assessment has already been closed"),
-      )
+      log.info("User: ${user.id} attempted to close assessment: $assessmentId. This assessment has already been closed.")
+      return AuthorisableActionResult.Success(ValidatableActionResult.Success(assessment))
     }
 
     assessment.completedAt = OffsetDateTime.now()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1693,7 +1693,7 @@ class AssessmentServiceTest {
   }
 
   @Test
-  fun `closeAssessment returns general validation error for Assessment where it has already been closed`() {
+  fun `closeAssessment returns OK for Assessment where it has already been closed`() {
     val probationRegion = ProbationRegionEntityFactory()
       .withYieldedApArea { ApAreaEntityFactory().produce() }
       .produce()
@@ -1740,9 +1740,7 @@ class AssessmentServiceTest {
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity
-    assertThat(validationResult is ValidatableActionResult.GeneralValidationError)
-    val generalValidationError = validationResult as ValidatableActionResult.GeneralValidationError
-    assertThat(generalValidationError.message).isEqualTo("This assessment has already been closed")
+    assertThat((validationResult as ValidatableActionResult.Success).entity.id).isEqualTo(assessment.id)
   }
 
   @Test


### PR DESCRIPTION
This change makes closing an already closed asseessment return OK and log out a message, instead of throwing an error.

This will prevent unnecessary alerts in the cas-events channel.