### PR TITLE
CAS-573 Removing CommunityApiClient.getStaffUserDetails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
@@ -49,6 +49,7 @@ class ApDeliusContextApiClient(
     path = "/probation-case/$crn/referrals/$bookingId"
   }
 
+  @Cacheable(value = ["staffDetailsCache"], unless = IS_NOT_SUCCESSFUL)
   fun getStaffDetail(username: String) = getRequest<StaffDetail> {
     path = "/staff/$username"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/CommunityApiClient.kt
@@ -2,18 +2,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DataBufferUtils
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.IS_NOT_SUCCESSFUL
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.Conviction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.GroupedDocuments
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffWithoutUsernameUserDetails
 import java.io.OutputStream
 
@@ -23,15 +20,6 @@ class CommunityApiClient(
   objectMapper: ObjectMapper,
   webClientCache: WebClientCache,
 ) : BaseHMPPSClient(webClientConfig, objectMapper, webClientCache) {
-  @Deprecated(
-    message = "Deprecated as part of the move away from the community-api",
-    replaceWith = ReplaceWith("ApDeliusContextApiClient.getStaffDetail(username)"),
-  )
-  @Cacheable(value = ["staffDetailsCache"], unless = IS_NOT_SUCCESSFUL)
-  fun getStaffUserDetails(deliusUsername: String) = getRequest<StaffUserDetails> {
-    path = "/secure/staff/username/$deliusUsername"
-  }
-
   fun getStaffUserDetailsForStaffCode(staffCode: String) = getRequest<StaffWithoutUsernameUserDetails> {
     path = "/secure/staff/staffCode/$staffCode"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -20,10 +20,10 @@ import redis.lock.redlock.RedLock
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.MarshallableHttpMethod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.bankholidaysapi.UKBankHolidays
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.UserOffenderAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import java.time.Duration
 
@@ -47,7 +47,7 @@ class RedisConfiguration {
     return RedisCacheManagerBuilderCustomizer { builder: RedisCacheManagerBuilder ->
       builder.clientCacheFor<StaffMembersPage>("qCodeStaffMembersCache", Duration.ofSeconds(staffMembersExpirySeconds), time, objectMapper)
         .clientCacheFor<UserOffenderAccess>("userAccessCache", Duration.ofSeconds(userAccessExpirySeconds), time, objectMapper)
-        .clientCacheFor<StaffUserDetails>("staffDetailsCache", Duration.ofSeconds(staffDetailsExpirySeconds), time, objectMapper)
+        .clientCacheFor<StaffDetail>("staffDetailsCache", Duration.ofSeconds(staffDetailsExpirySeconds), time, objectMapper)
         .clientCacheFor<ManagingTeamsResponse>("teamsManagingCaseCache", Duration.ofSeconds(teamManagingCasesExpirySeconds), time, objectMapper)
         .clientCacheFor<CaseDetail>("crnGetCaseDetailCache", Duration.ofSeconds(crnGetCaseDetailExpirySeconds), time, objectMapper)
         .clientCacheFor<UKBankHolidays>("ukBankHolidaysCache", Duration.ofSeconds(ukBankHolidaysExpirySeconds), time, objectMapper)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Cru
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
@@ -41,7 +41,7 @@ import java.util.UUID
 class Cas1BookingDomainEventService(
   val domainEventService: DomainEventService,
   val offenderService: OffenderService,
-  val communityApiClient: CommunityApiClient,
+  val apDeliusContextApiClient: ApDeliusContextApiClient,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
 ) {
 
@@ -191,7 +191,7 @@ class Cas1BookingDomainEventService(
   }
 
   private fun getStaffDetails(deliusUsername: String) =
-    when (val staffDetailsResult = communityApiClient.getStaffUserDetails(deliusUsername)) {
+    when (val staffDetailsResult = apDeliusContextApiClient.getStaffDetail(deliusUsername)) {
       is ClientResult.Success -> staffDetailsResult.body
       is ClientResult.Failure -> staffDetailsResult.throwException()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DomainEventTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DomainEventTransformer.kt
@@ -3,32 +3,23 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.ProbationArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.WithdrawnBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffDetail
 
 @Component
-class DomainEventTransformer(private val communityApiClient: CommunityApiClient) {
+class DomainEventTransformer(private val apDeliusContextApiClient: ApDeliusContextApiClient) {
   fun toWithdrawnBy(user: UserEntity) =
-    when (val result = communityApiClient.getStaffUserDetails(user.deliusUsername)) {
+    when (val result = apDeliusContextApiClient.getStaffDetail(user.deliusUsername)) {
       is ClientResult.Success -> toWithdrawnBy(result.body)
       is ClientResult.Failure -> result.throwException()
     }
 
-  fun toWithdrawnBy(staffDetails: StaffUserDetails): WithdrawnBy {
+  fun toWithdrawnBy(staffDetails: StaffDetail): WithdrawnBy {
     val staffMember = staffDetails.toStaffMember()
     val probationArea = toProbationArea(staffDetails)
     return WithdrawnBy(staffMember, probationArea)
-  }
-
-  @Deprecated("This will be removed as part of CAS-573")
-  fun toProbationArea(staffDetails: StaffUserDetails): ProbationArea {
-    return ProbationArea(
-      code = staffDetails.probationArea.code,
-      name = staffDetails.probationArea.description,
-    )
   }
 
   fun toProbationArea(staffDetails: StaffDetail): ProbationArea {
@@ -39,7 +30,7 @@ class DomainEventTransformer(private val communityApiClient: CommunityApiClient)
   }
 
   fun toStaffMember(user: UserEntity) =
-    when (val result = communityApiClient.getStaffUserDetails(user.deliusUsername)) {
+    when (val result = apDeliusContextApiClient.getStaffDetail(user.deliusUsername)) {
       is ClientResult.Success -> result.body.toStaffMember()
       is ClientResult.Failure -> result.throwException()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2009,9 +2009,9 @@ class BookingServiceTest {
 
       every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
 
-      val staffUserDetails = StaffUserDetailsFactory().produce()
+      val staffUserDetails = StaffUserDetailsFactory().produce().toStaffDetail()
 
-      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails.toStaffDetail())
+      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
 
       every { mockDomainEventService.savePersonNotArrivedEvent(any(), any()) } just Runs
 
@@ -2055,13 +2055,7 @@ class BookingServiceTest {
               localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
             ) &&
               data.expectedArrivalOn == bookingEntity.originalArrivalDate &&
-              data.recordedBy == StaffMember(
-              staffCode = staffUserDetails.staffCode,
-              staffIdentifier = staffUserDetails.staffIdentifier,
-              forenames = staffUserDetails.staff.forenames,
-              surname = staffUserDetails.staff.surname,
-              username = staffUserDetails.username,
-            ) &&
+              data.recordedBy == staffUserDetails.toStaffMember() &&
               data.reason == reasonEntity.name &&
               data.legacyReasonCode == reasonEntity.legacyDeliusReasonCode
           },
@@ -2099,9 +2093,9 @@ class BookingServiceTest {
 
       every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
 
-      val staffUserDetails = StaffUserDetailsFactory().produce()
+      val staffUserDetails = StaffUserDetailsFactory().produce().toStaffDetail()
 
-      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails.toStaffDetail())
+      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
 
       every { mockDomainEventService.savePersonNotArrivedEvent(any(), any()) } just Runs
 
@@ -2144,13 +2138,7 @@ class BookingServiceTest {
               localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
             ) &&
               data.expectedArrivalOn == bookingEntity.originalArrivalDate &&
-              data.recordedBy == StaffMember(
-              staffCode = staffUserDetails.staffCode,
-              staffIdentifier = staffUserDetails.staffIdentifier,
-              forenames = staffUserDetails.staff.forenames,
-              surname = staffUserDetails.staff.surname,
-              username = staffUserDetails.username,
-            ) &&
+              data.recordedBy == staffUserDetails.toStaffMember() &&
               data.reason == reasonEntity.name &&
               data.legacyReasonCode == reasonEntity.legacyDeliusReasonCode
           },
@@ -2194,9 +2182,9 @@ class BookingServiceTest {
         )
       } returns AuthorisableActionResult.Success(offenderDetails)
 
-      val staffUserDetails = StaffUserDetailsFactory().produce()
+      val staffUserDetails = StaffUserDetailsFactory().produce().toStaffDetail()
 
-      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails.toStaffDetail())
+      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
 
       every { mockDomainEventService.savePersonNotArrivedEvent(any(), any()) } just Runs
 
@@ -2240,13 +2228,7 @@ class BookingServiceTest {
               localAuthorityAreaName = approvedPremises.localAuthorityArea!!.name,
             ) &&
               data.expectedArrivalOn == bookingEntity.originalArrivalDate &&
-              data.recordedBy == StaffMember(
-              staffCode = staffUserDetails.staffCode,
-              staffIdentifier = staffUserDetails.staffIdentifier,
-              forenames = staffUserDetails.staff.forenames,
-              surname = staffUserDetails.staff.surname,
-              username = staffUserDetails.username,
-            ) &&
+              data.recordedBy == staffUserDetails.toStaffMember() &&
               data.reason == reasonEntity.name &&
               data.legacyReasonCode == reasonEntity.legacyDeliusReasonCode
           },
@@ -2666,9 +2648,9 @@ class BookingServiceTest {
 
       every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
 
-      val staffUserDetails = StaffUserDetailsFactory().produce()
+      val staffUserDetails = StaffUserDetailsFactory().produce().toStaffDetail()
 
-      every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
         staffUserDetails,
       )
@@ -3009,9 +2991,9 @@ class BookingServiceTest {
 
       every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
 
-      val staffUserDetails = StaffUserDetailsFactory().produce()
+      val staffUserDetails = StaffUserDetailsFactory().produce().toStaffDetail()
 
-      every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
         staffUserDetails,
       )
@@ -3827,10 +3809,10 @@ class BookingServiceTest {
         .withUsername(user.deliusUsername)
         .withForenames("John Jacob")
         .withSurname("Johnson")
-        .produce()
+        .produce().toStaffDetail()
 
       every { mockOffenderService.getOffenderByCrn(application.crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)
-      every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
+      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
 
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockExtensionRepository.save(any()) } answers { it.invocation.args[0] as ExtensionEntity }
@@ -7465,10 +7447,10 @@ class BookingServiceTest {
         .withUsername(user.deliusUsername)
         .withForenames("John Jacob")
         .withSurname("Johnson")
-        .produce()
+        .produce().toStaffDetail()
 
       every { mockOffenderService.getOffenderByCrn(application.crn, user.deliusUsername, true) } returns AuthorisableActionResult.Success(offenderDetails)
-      every { mockCommunityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
+      every { mockApDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffUserDetails)
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
       every { mockDateChangeRepository.save(any()) } answers { it.invocation.args[0] as DateChangeEntity }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
@@ -18,8 +18,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.toStaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -48,12 +49,12 @@ class Cas1BookingDomainEventServiceTest {
 
   private val domainEventService = mockk<DomainEventService>()
   private val offenderService = mockk<OffenderService>()
-  private val communityApiClient = mockk<CommunityApiClient>()
+  private val apDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
 
   val service = Cas1BookingDomainEventService(
     domainEventService,
     offenderService,
-    communityApiClient,
+    apDeliusContextApiClient,
     UrlTemplate("http://frontend/applications/#id"),
   )
 
@@ -104,8 +105,8 @@ class Cas1BookingDomainEventServiceTest {
     fun before() {
       every { domainEventService.saveBookingMadeDomainEvent(any()) } just Runs
 
-      val assigneeUserStaffDetails = StaffUserDetailsFactory().produce()
-      every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+      val assigneeUserStaffDetails = StaffUserDetailsFactory().produce().toStaffDetail()
+      every { apDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
         assigneeUserStaffDetails,
       )
@@ -220,8 +221,8 @@ class Cas1BookingDomainEventServiceTest {
     fun before() {
       every { domainEventService.saveBookingMadeDomainEvent(any()) } just Runs
 
-      val assigneeUserStaffDetails = StaffUserDetailsFactory().produce()
-      every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+      val assigneeUserStaffDetails = StaffUserDetailsFactory().produce().toStaffDetail()
+      every { apDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
         assigneeUserStaffDetails,
       )
@@ -444,8 +445,8 @@ class Cas1BookingDomainEventServiceTest {
 
       every { domainEventService.saveBookingNotMadeEvent(any()) } just Runs
 
-      val assigneeUserStaffDetails = StaffUserDetailsFactory().withStaffCode("the staff code").produce()
-      every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+      val assigneeUserStaffDetails = StaffUserDetailsFactory().withStaffCode("the staff code").produce().toStaffDetail()
+      every { apDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
         assigneeUserStaffDetails,
       )
@@ -542,9 +543,9 @@ class Cas1BookingDomainEventServiceTest {
 
       every { offenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
 
-      val staffUserDetails = StaffUserDetailsFactory().produce()
+      val staffUserDetails = StaffUserDetailsFactory().produce().toStaffDetail()
 
-      every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+      every { apDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
         staffUserDetails,
       )
@@ -592,7 +593,7 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(data.premises.legacyApCode).isEqualTo(premises.qCode)
       assertThat(data.premises.localAuthorityAreaName).isEqualTo(premises.localAuthorityArea!!.name)
 
-      assertThat(data.cancelledBy.staffCode).isEqualTo(staffUserDetails.staffCode)
+      assertThat(data.cancelledBy.staffCode).isEqualTo(staffUserDetails.code)
       assertThat(data.cancelledAt).isEqualTo(Instant.parse("2022-08-25T00:00:00.00Z"))
       assertThat(data.cancelledAtDate).isEqualTo(LocalDate.parse("2022-08-25"))
       assertThat(data.cancellationReason).isEqualTo("the reason name")
@@ -632,9 +633,9 @@ class Cas1BookingDomainEventServiceTest {
 
       every { offenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
 
-      val staffUserDetails = StaffUserDetailsFactory().produce()
+      val staffUserDetails = StaffUserDetailsFactory().produce().toStaffDetail()
 
-      every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+      every { apDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
         staffUserDetails,
       )
@@ -682,7 +683,7 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(data.premises.legacyApCode).isEqualTo(premises.qCode)
       assertThat(data.premises.localAuthorityAreaName).isEqualTo(premises.localAuthorityArea!!.name)
 
-      assertThat(data.cancelledBy.staffCode).isEqualTo(staffUserDetails.staffCode)
+      assertThat(data.cancelledBy.staffCode).isEqualTo(staffUserDetails.code)
       assertThat(data.cancelledAt).isEqualTo(Instant.parse("2022-08-25T00:00:00.00Z"))
       assertThat(data.cancelledAtDate).isEqualTo(LocalDate.parse("2022-08-25"))
       assertThat(data.cancellationReason).isEqualTo("the reason name")
@@ -732,8 +733,8 @@ class Cas1BookingDomainEventServiceTest {
         )
       } returns AuthorisableActionResult.Success(offenderDetails)
 
-      val staffUserDetails = StaffUserDetailsFactory().produce()
-      every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(
+      val staffUserDetails = StaffUserDetailsFactory().produce().toStaffDetail()
+      every { apDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(
         HttpStatus.OK,
         staffUserDetails,
       )
@@ -777,7 +778,7 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(data.premises.legacyApCode).isEqualTo(premises.qCode)
       assertThat(data.premises.localAuthorityAreaName).isEqualTo(premises.localAuthorityArea!!.name)
 
-      assertThat(data.cancelledBy.staffCode).isEqualTo(staffUserDetails.staffCode)
+      assertThat(data.cancelledBy.staffCode).isEqualTo(staffUserDetails.code)
       assertThat(data.cancelledAt).isEqualTo(Instant.parse("2025-11-15T00:00:00.00Z"))
       assertThat(data.cancelledAtDate).isEqualTo(LocalDate.parse("2025-11-15"))
       assertThat(data.cancellationReason).isEqualTo("the reason name")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DomainEventTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DomainEventTransformerTest.kt
@@ -8,70 +8,32 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult.Failure
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffUserDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.StaffUserDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.toStaffDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 
 class DomainEventTransformerTest {
 
-  private val communityApiClient = mockk<CommunityApiClient>()
+  private val apDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
 
-  val domainEventTransformerService = DomainEventTransformer(communityApiClient)
+  val domainEventTransformerService = DomainEventTransformer(apDeliusContextApiClient)
 
   @Test
   fun `toProbationArea success`() {
     val staffDetails = StaffUserDetailsFactory()
       .withProbationAreaCode("theProbationCode")
       .withProbationAreaDescription("theProbationDescription")
-      .produce()
+      .produce().toStaffDetail()
 
     val result = domainEventTransformerService.toProbationArea(staffDetails)
 
     assertThat(result.code).isEqualTo("theProbationCode")
     assertThat(result.name).isEqualTo("theProbationDescription")
-  }
-
-  // just for piece of mind - remove in next PR
-  @Test
-  fun `toStaffMember success`() {
-    val staffDetails = StaffUserDetailsFactory()
-      .withStaffCode("theStaffCode")
-      .withStaffIdentifier(22L)
-      .withForenames("theForenames")
-      .withSurname("theSurname")
-      .withUsername("theUsername")
-      .produce()
-
-    val staffDetail = StaffDetailFactory.staffDetail().copy(
-      code = "theStaffCode",
-      staffIdentifier = 22L,
-      name =
-      PersonName(forename = "theForenames", surname = "theSurname"),
-      username = "theUsername",
-    )
-
-    val res = staffDetail.toStaffMember()
-    val result = staffDetails.toStaffMember()
-
-    assertThat(result).isEqualTo(res)
-
-    assertThat(result.staffCode).isEqualTo("theStaffCode")
-    assertThat(result.staffIdentifier).isEqualTo(22L)
-    assertThat(result.forenames).isEqualTo("theForenames")
-    assertThat(result.surname).isEqualTo("theSurname")
-    assertThat(result.username).isEqualTo("theUsername")
-
-    assertThat(res.staffCode).isEqualTo("theStaffCode")
-    assertThat(res.staffIdentifier).isEqualTo(22L)
-    assertThat(res.forenames).isEqualTo("theForenames")
-    assertThat(res.surname).isEqualTo("theSurname")
-    assertThat(res.username).isEqualTo("theUsername")
   }
 
   @Test
@@ -90,9 +52,9 @@ class DomainEventTransformerTest {
       .withForenames("theForenames")
       .withSurname("theSurname")
       .withUsername("theUsername")
-      .produce()
+      .produce().toStaffDetail()
 
-    every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffDetails)
+    every { apDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns ClientResult.Success(HttpStatus.OK, staffDetails)
 
     val result = domainEventTransformerService.toStaffMember(user)
 
@@ -113,7 +75,7 @@ class DomainEventTransformerTest {
       .withDeliusUsername("theUsername")
       .produce()
 
-    val response = ClientResult.Failure.StatusCode<StaffUserDetails>(
+    val response = ClientResult.Failure.StatusCode<StaffDetail>(
       HttpMethod.GET,
       "/",
       HttpStatus.BAD_REQUEST,
@@ -122,7 +84,7 @@ class DomainEventTransformerTest {
 
     val expectedException = response.toException()
 
-    every { communityApiClient.getStaffUserDetails(user.deliusUsername) } returns response
+    every { apDeliusContextApiClient.getStaffDetail(user.deliusUsername) } returns response
 
     val exception = assertThrows<RuntimeException> { domainEventTransformerService.toStaffMember(user) }
 
@@ -139,7 +101,7 @@ class DomainEventTransformerTest {
       .withUsername("theUsername")
       .withProbationAreaCode("theProbationCode")
       .withProbationAreaDescription("theProbationDescription")
-      .produce()
+      .produce().toStaffDetail()
 
     val result = domainEventTransformerService.toWithdrawnBy(staffDetails)
 
@@ -165,12 +127,12 @@ class DomainEventTransformerTest {
       .withUsername("theUsername")
       .withProbationAreaCode("theProbationCode")
       .withProbationAreaDescription("theProbationDescription")
-      .produce()
+      .produce().toStaffDetail()
 
     val user = UserEntityFactory().withDefaultProbationRegion().produce()
 
     every {
-      communityApiClient.getStaffUserDetails(user.deliusUsername)
+      apDeliusContextApiClient.getStaffDetail(user.deliusUsername)
     } returns ClientResult.Success(HttpStatus.OK, staffDetails)
 
     val result = domainEventTransformerService.toWithdrawnBy(user)
@@ -192,7 +154,7 @@ class DomainEventTransformerTest {
     val user = UserEntityFactory().withDefaultProbationRegion().produce()
 
     every {
-      communityApiClient.getStaffUserDetails(user.deliusUsername)
+      apDeliusContextApiClient.getStaffDetail(user.deliusUsername)
     } returns Failure.CachedValueUnavailable(user.deliusUsername)
 
     assertThatThrownBy { domainEventTransformerService.toWithdrawnBy(user) }


### PR DESCRIPTION
The PR removes the final usages of getStaffUserDetails in the community API client