### PR TITLE
APS-1386 ensure that if a placement request is submitted with expired application, it returns an error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -268,6 +268,10 @@ class PlacementApplicationService(
 
     val placementApplicationEntity = (placementApplicationAuthorisationResult as Either.Right).value
 
+    if (placementApplicationEntity.application.status == ApprovedPremisesApplicationStatus.EXPIRED) {
+      return CasResult.GeneralValidationError("Placement requests cannot be made for an expired application")
+    }
+
     placementApplicationEntity.data = data
 
     val savedApplication = placementApplicationRepository.save(placementApplicationEntity)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -290,6 +290,10 @@ class PlacementApplicationService(
 
     val submittedPlacementApplication = (placementApplicationAuthorisationResult as Either.Right).value
 
+    if (submittedPlacementApplication.application.status == ApprovedPremisesApplicationStatus.EXPIRED) {
+      return CasResult.GeneralValidationError("Placement requests cannot be made for an expired application")
+    }
+
     val allocatedUser = userAllocator.getUserForPlacementApplicationAllocation(submittedPlacementApplication)
 
     val now = OffsetDateTime.now(clock)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -77,6 +77,10 @@ class PlacementApplicationService(
       return generalError("You cannot request a placement request for an application that has been withdrawn")
     }
 
+    if (application.status == ApprovedPremisesApplicationStatus.EXPIRED) {
+      return generalError("Placement requests cannot be made for an expired application")
+    }
+
     val placementApplication = placementApplicationRepository.save(
       PlacementApplicationEntity(
         id = UUID.randomUUID(),


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1386

**Problem Description**
Whilst we will hide any way to create a placement request on the front end, we should ensure that placement requests cannot be made, and will return and error if they are made.

**Desired Outcome**

- Add logic that will return an error where a placement request is made with an application that has the status ‘Expired Application’
- Return the error: ‘Placement requests cannot be made with an expired application’
- Capture the event in sentry, 