### PR TITLE
APS-1418: Update Cas1 Premises Summary endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -33,7 +33,10 @@ class Cas1PremisesController(
       )
   }
 
-  override fun getPremisesSummaries(gender: Cas1ApprovedPremisesGender?): ResponseEntity<List<Cas1PremisesBasicSummary>> {
+  override fun getPremisesSummaries(
+    gender: Cas1ApprovedPremisesGender?,
+    apAreaId: UUID?,
+  ): ResponseEntity<List<Cas1PremisesBasicSummary>> {
     return ResponseEntity
       .ok()
       .body(
@@ -43,6 +46,7 @@ class Cas1PremisesController(
             Cas1ApprovedPremisesGender.woman -> ApprovedPremisesGender.WOMAN
             null -> null
           },
+          apAreaId,
         ).map {
           cas1PremisesTransformer.toPremiseBasicSummary(it)
         },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -32,7 +32,7 @@ class Cas1PremisesService(
     )
   }
 
-  fun getPremises(gender: ApprovedPremisesGender?) = premisesRepository.findForSummaries(gender)
+  fun getPremises(gender: ApprovedPremisesGender?, apAreaId: UUID?) = premisesRepository.findForSummaries(gender, apAreaId)
 
   fun findPremiseById(id: UUID) = premisesRepository.findByIdOrNull(id)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesTransformer.kt
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesBasicSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesBasicSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
 
@@ -26,12 +26,12 @@ class Cas1PremisesTransformer(
     )
   }
 
-  fun toPremiseBasicSummary(entity: PremisesEntity): Cas1PremisesBasicSummary {
-    val apArea = entity.probationRegion.apArea!!
+  fun toPremiseBasicSummary(entity: ApprovedPremisesBasicSummary): Cas1PremisesBasicSummary {
     return Cas1PremisesBasicSummary(
       id = entity.id,
       name = entity.name,
-      apArea = NamedId(apArea.id, apArea.name),
+      apArea = NamedId(entity.apAreaId, entity.apAreaName),
+      bedCount = entity.bedCount,
     )
   }
 }

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -95,6 +95,12 @@ paths:
           description: If specified, only return premises for the corresponding gender
           schema:
             $ref: 'cas1-schemas.yml#/components/schemas/Cas1ApprovedPremisesGender'
+        - name: apAreaId
+          in: query
+          description: ID of the AP area to filter by
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -11,10 +11,14 @@ components:
           example: Hope House
         apArea:
           $ref: '_shared.yml#/components/schemas/NamedId'
+        bedCount:
+          type: integer
+          example: 22
       required:
         - id
         - name
         - apArea
+        - bedCount
     Cas1PremisesSearchResultSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -97,6 +97,12 @@ paths:
           description: If specified, only return premises for the corresponding gender
           schema:
             $ref: '#/components/schemas/Cas1ApprovedPremisesGender'
+        - name: apAreaId
+          in: query
+          description: ID of the AP area to filter by
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation
@@ -6383,10 +6389,14 @@ components:
           example: Hope House
         apArea:
           $ref: '#/components/schemas/NamedId'
+        bedCount:
+          type: integer
+          example: 22
       required:
         - id
         - name
         - apArea
+        - bedCount
     Cas1PremisesSearchResultSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesTransformerTest.kt
@@ -12,10 +12,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesBasicSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremisesTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PremisesServiceTest.CONSTANTS.PREMISES_ID
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -81,29 +81,21 @@ class Cas1PremisesTransformerTest {
 
     @Test
     fun success() {
-      val apArea = ApAreaEntityFactory()
-        .withId(AP_AREA_ID)
-        .withName("the ap area name")
-        .produce()
+      val premisesSummary = ApprovedPremisesBasicSummary(
+        PREMISES_ID,
+        "the name",
+        AP_AREA_ID,
+        "the ap area name",
+        12,
+      )
 
-      val probationRegion = ProbationRegionEntityFactory()
-        .withDefaults()
-        .withApArea(apArea)
-        .produce()
+      val result = transformer.toPremiseBasicSummary(premisesSummary)
 
-      val premises = ApprovedPremisesEntityFactory()
-        .withDefaults()
-        .withId(PREMISES_ID)
-        .withName("the name")
-        .withProbationRegion(probationRegion)
-        .produce()
-
-      val result = transformer.toPremiseBasicSummary(premises)
-
-      assertThat(result.id).isEqualTo(premises.id)
+      assertThat(result.id).isEqualTo(PREMISES_ID)
       assertThat(result.name).isEqualTo("the name")
       assertThat(result.apArea.id).isEqualTo(AP_AREA_ID)
       assertThat(result.apArea.name).isEqualTo("the ap area name")
+      assertThat(result.bedCount).isEqualTo(12)
     }
   }
 }


### PR DESCRIPTION
To ensure consistency with the existing, non-namespaced endpoint the following have been added to the new, namespaced endpoint: 

- filtering by area. Added optional `apAreaId`  query parameter
- bed count is returned in the summary data.  This is a 'live' bed count for the given premises, how many beds the premises has live at the time,  and not an 'available' bed count which would incorporate booking data ( i.e. live beds - booked beds).

There is only one consumer of the new summary query.   The data returned by the query has been changed to retrieve only that needed rather than complete premises records.  This was primarily due to the need for bed count, which is calculated when the query is executed, rather than being data persisted in the records themselves.