### PR TITLE
Update NOMS number used in test scripts

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -47,7 +47,7 @@ generic-service:
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
     SEED_AUTO-SCRIPT_CAS2-ENABLED: true
-    SEED_AUTO-SCRIPT_NOMS: A5276DZ
+    SEED_AUTO-SCRIPT_NOMS: A8723EA
     SEED_AUTO-SCRIPT_PRISON-CODE: MDI
     NOTIFY_MODE: TEST_AND_GUEST_LIST
     HMPPS_SQS_USE_WEB_TOKEN: true

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -36,7 +36,7 @@ generic-service:
     SEED_AUTO_ENABLED: false
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
     SEED_AUTO-SCRIPT_CAS2-ENABLED: true
-    SEED_AUTO-SCRIPT_NOMS: A5276DZ
+    SEED_AUTO-SCRIPT_NOMS: A8723EA
     SEED_AUTO-SCRIPT_PRISON-CODE: MDI
 
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#id


### PR DESCRIPTION
The previous case (X320741 / A5276DZ) was hard-deleted as part of a data cleanup by the Delius test team.

The new case (X823338 / A8723EA) has been set up in the same way, so should work in the same way.