### PR TITLE
Tighten up ENV VAR reading logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,7 +149,7 @@ tasks.bootRun {
     println("Reading env vars from file $envFilePath")
     file(envFilePath).readLines().forEach {
       if (it.isNotBlank() && !it.startsWith("#")) {
-        val (key, value) = it.split('=')
+        val (key, value) = it.split("=", limit = 2)
         println("Setting env var $key")
         environment(key, value)
       }


### PR DESCRIPTION
previously if the env var value had an ‘=‘ symbol we weren’t correctly reading the full value