### PR TITLE
APS-1289: Updated seed job to recognise gender change in AP

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -266,7 +266,7 @@ class ApprovedPremisesEntity(
   status: PropertyStatus,
   var point: Point?, // TODO: Make not-null once Premises have had point added in all environments
   @Enumerated(value = EnumType.STRING)
-  val gender: ApprovedPremisesGender,
+  var gender: ApprovedPremisesGender,
 ) : PremisesEntity(
   id,
   name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/ApprovedPremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/ApprovedPremisesSeedJob.kt
@@ -223,6 +223,7 @@ class ApprovedPremisesSeedJob(
       this.localAuthorityArea = localAuthorityArea
       this.status = row.status
       this.point = if (row.longitude != null && row.latitude != null) geometryFactory.createPoint(Coordinate(row.latitude, row.longitude)) else null
+      this.gender = row.gender
     }
 
     characteristics.forEach {


### PR DESCRIPTION
Amended the seed service job which makes changes to existing Approved Premises records, to update the Gender field. 