### PR TITLE
Fix auto seeded CAS1 application for access needs

### DIFF
--- a/src/main/resources/db/seed/local+dev+test/cas1_application_data/application_data.json
+++ b/src/main/resources/db/seed/local+dev+test/cas1_application_data/application_data.json
@@ -403,18 +403,19 @@
       "interpreterLanguage": ""
     },
     "access-needs-further-questions": {
-      "_csrf": "54GQ0iU3-nWE3ZvVDp46lWUpjhHq1xwH0gSc",
       "needsWheelchair": "no",
-      "healthConditionsDetail": "",
       "healthConditions": "no",
-      "prescribedMedicationDetail": "",
+      "healthConditionsDetail": "",
       "prescribedMedication": "no",
-      "additionalAdjustments": ""
+      "prescribedMedicationDetail": ""
     },
     "covid": {
       "boosterEligibility": "no",
       "boosterEligibilityDetail": "",
       "immunosuppressed": "no"
+    },
+    "access-needs-additional-details": {
+      "additionalAdjustments": ""
     }
   },
   "further-considerations": {


### PR DESCRIPTION
A change was recently made in the UI that split the access needs questions across two screens. This commit updates the application data for the automatically created CAS1 application to reflect this change, ensuring it’s in a submittable state after being created