### PR TITLE
Don’t revert CRU Management Area on user update

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -335,7 +335,9 @@ class UserService(
     if (forService == ServiceName.approvedPremises) {
       val apArea = cas1ApAreaMappingService.determineApArea(user.probationRegion, staffDetail.teamCodes(), staffDetail.username)
       user.apArea = apArea
-      user.cruManagementArea = apArea.defaultCruManagementArea
+      if (user.cruManagementAreaOverride == null) {
+        user.cruManagementArea = apArea.defaultCruManagementArea
+      }
     }
 
     return userRepository.save(user)


### PR DESCRIPTION
Before this commit if a user had cruManagementAreaOverride set, the value of user.cruManagementArea was reverted to the default value whenever a user was updated from delius, essentially removing the override.