### PR TITLE
Add request for placement Id to Cas1SpaceBooking type.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -61,6 +61,7 @@ class Cas1SpaceBookingTransformer(
       canonicalDepartureDate = jpa.canonicalDepartureDate,
       otherBookingsInPremisesForCrn = otherBookingsAtPremiseForCrn.map { it.toSpaceBookingDate() },
       cancellation = jpa.extractCancellation(),
+      requestForPlacementId = jpa.placementRequest.placementApplication?.id ?: jpa.placementRequest.id,
     )
   }
 

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -292,6 +292,9 @@ components:
           $ref: '_shared.yml#/components/schemas/NamedId'
         bookedBy:
           $ref: '_shared.yml#/components/schemas/User'
+        requestForPlacementId:
+          type: string
+          format: uuid
         expectedArrivalDate:
           type: string
           format: date

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6679,6 +6679,9 @@ components:
           $ref: '#/components/schemas/NamedId'
         bookedBy:
           $ref: '#/components/schemas/User'
+        requestForPlacementId:
+          type: string
+          format: uuid
         expectedArrivalDate:
           type: string
           format: date

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -836,6 +836,7 @@ class Cas1SpaceBookingTest {
       assertThat(response.id).isEqualTo(spaceBooking.id)
       assertThat(response.otherBookingsInPremisesForCrn).hasSize(1)
       assertThat(response.otherBookingsInPremisesForCrn[0].id).isEqualTo(otherSpaceBookingAtPremises.id)
+      assertThat(response.requestForPlacementId).isEqualTo(spaceBooking.placementRequest.id)
     }
   }
 


### PR DESCRIPTION
Ref: [https://dsdmoj.atlassian.net/browse/APS-1400](https://dsdmoj.atlassian.net/browse/APS-1400)

`Cas1SpaceBookingType` is returned from `/premises/{premisesId}/space-bookings/{bookingId}`; request for placement id is required by the UI.