### PR TITLE
APS-1444 Add ‘read only’ option to /profile/v2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -24,7 +24,10 @@ class ProfileController(
     return ResponseEntity(userTransformer.transformJpaToApi(userEntity, xServiceName), HttpStatus.OK)
   }
 
-  override fun profileV2Get(xServiceName: ServiceName): ResponseEntity<ProfileResponse> {
+  override fun profileV2Get(
+    xServiceName: ServiceName,
+    readOnly: Boolean?,
+  ): ResponseEntity<ProfileResponse> {
     val username = userService.getDeliusUserNameForRequest()
     val getUserResponse = userService.getUserForProfile(username)
 
@@ -42,7 +45,10 @@ class ProfileController(
     }
 
     val responseToReturn =
-      if (getUserResponse is UserService.GetUserResponse.Success && !getUserResponse.createdOnGet) {
+      if (getUserResponse is UserService.GetUserResponse.Success &&
+        !getUserResponse.createdOnGet &&
+        readOnly != true
+      ) {
         log.info("Updating user record for $username")
         userService.updateUserFromDelius(getUserResponse.user, xServiceName)
       } else {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3948,6 +3948,12 @@ paths:
           description: Filters the user details to those relevant to the specified service.
           schema:
             $ref: '_shared.yml#/components/schemas/ServiceName'
+        - name: readOnly
+          in: query
+          required: false
+          description: If set to true, will not attempt to update the user from delius
+          schema:
+            type: boolean
       responses:
         200:
           description: successfully retrieved information on user

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3950,6 +3950,12 @@ paths:
           description: Filters the user details to those relevant to the specified service.
           schema:
             $ref: '#/components/schemas/ServiceName'
+        - name: readOnly
+          in: query
+          required: false
+          description: If set to true, will not attempt to update the user from delius
+          schema:
+            type: boolean
       responses:
         200:
           description: successfully retrieved information on user


### PR DESCRIPTION
The CAS1 UI will update its view of the user by calling /profile/v2 whenever a change in the user’s hash is detected (via the X-CAS-User-Version header). When this update is required, there is no need to invoke delius to check for any other updates, because the change in the version header indicates that our persisted user is already up to date.

This commit adds a ‘readOnly’ option to /profile/v2 that will supress any attempts to update the user from delius. This will help us avoid getting into ‘infinite update loops’ if we consider a field updated from delius in the X-CAS-User-Version header, and that field’s value is constantly changing.