### PR TITLE
APS-1362 Auto Seed Test Users for test/dev environments

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -46,6 +46,7 @@ generic-service:
     PREEMPTIVE-CACHE-DELAY-MS: 60000
     SEED_AUTO_ENABLED: true
     SEED_AUTO_FILE-PREFIXES: classpath:db/seed/local+dev+test,classpath:db/seed/dev+test
+    SEED_AUTO-SCRIPT_CAS1-ENABLED: true
     SEED_AUTO-SCRIPT_CAS2-ENABLED: true
     SEED_AUTO-SCRIPT_NOMS: A5276DZ
     SEED_AUTO-SCRIPT_PRISON-CODE: MDI

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedOnStartupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedOnStartupService.kt
@@ -9,6 +9,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2AutoScript
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import java.io.File
 import java.io.IOException
 
@@ -19,11 +21,18 @@ class SeedOnStartupService(
   private val cas2AutoScript: Cas2AutoScript,
   private val seedService: SeedService,
   private val seedLogger: SeedLogger,
+  private val environmentService: EnvironmentService,
+  private val sentryService: SentryService,
 ) {
   @SuppressWarnings("NestedBlockDepth")
   @PostConstruct
   fun seedOnStartup() {
     if (!seedConfig.auto.enabled) {
+      return
+    }
+
+    if (environmentService.isNotATestEnvironment()) {
+      sentryService.captureErrorMessage("Auto seeding should not be enabled outside of local and dev environments")
       return
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Service
+
+@Service
+class EnvironmentService(
+  val environment: Environment,
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @PostConstruct
+  fun logProfiles() {
+    log.info("Active profiles are ${environment.activeProfiles}")
+  }
+
+  fun isLocal() = environment.activeProfiles.any { it.equals("local", ignoreCase = true) }
+  fun isDev() = environment.activeProfiles.any { it.equals("dev", ignoreCase = true) }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
@@ -16,6 +16,12 @@ class EnvironmentService(
     log.info("Active profiles are ${environment.activeProfiles}")
   }
 
-  fun isLocal() = environment.activeProfiles.any { it.equals("local", ignoreCase = true) }
-  fun isDev() = environment.activeProfiles.any { it.equals("dev", ignoreCase = true) }
+  fun isLocal() = profileActive("local")
+  fun isDev() = profileActive("dev")
+  fun isProd() = profileActive("prod")
+  fun isPreProd() = profileActive("preprod")
+
+  fun isNotATestEnvironment() = isProd() || isPreProd() || (!isLocal() && !isDev())
+
+  fun profileActive(name: String) = environment.activeProfiles.any { it.equals(name, ignoreCase = true) }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AutoScriptTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AutoScriptTest.kt
@@ -6,28 +6,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ManagingTeamsResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1AutoScript
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
 class Cas1AutoScriptTest : IntegrationTestBase() {
 
   @Autowired
-  lateinit var seedLogger: SeedLogger
-
-  @Autowired
-  lateinit var applicationService: ApplicationService
-
-  @Autowired
-  lateinit var userService: UserService
-
-  @Autowired
-  lateinit var offenderService: OffenderService
+  lateinit var cas1AutoScript: Cas1AutoScript
 
   @Test
-  fun `ensure auto script runs`() {
+  fun `ensure local auto script runs`() {
     `Given an Offender` { offenderDetails, _ ->
 
       APDeliusContext_mockSuccessfulTeamsManagingCaseCall(
@@ -37,13 +24,12 @@ class Cas1AutoScriptTest : IntegrationTestBase() {
         ),
       )
 
-      Cas1AutoScript(
-        seedLogger,
-        applicationService,
-        userService,
-        offenderService,
-        cas1CruManagementAreaRepository,
-      ).script()
+      cas1AutoScript.scriptLocal()
     }
+  }
+
+  @Test
+  fun `ensure dev auto script runs`() {
+    cas1AutoScript.scriptDev()
   }
 }


### PR DESCRIPTION
This commits adds logic to CAS1 auto seeding to ensure that the required users for e2e tests in the test/dev environments exist on startup, when running in test/dev environments. This works by using the spring profile name.

It also ensures all test users are assigned all available qualifications, reflecting the current configuration.

Whilst this change helps ensure the dev/test environments are correctly configured, it also simplifies running tests locally against upstream services in dev