### PR TITLE
APS-1362 - Add bootRunDebug task, removing hardcoded profile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,12 +132,25 @@ tasks {
   compileTestScala { enabled = false }
 }
 
+// this is deprecated in favour of bootRunDebug, which does not set an active profile
+// it will be removed once ap-tools has been updated to use bootRunDebug
 tasks.register("bootRunLocal") {
   group = "application"
   description = "Runs this project as a Spring Boot application with the local profile"
   doFirst {
     tasks.bootRun.configure {
       systemProperty("spring.profiles.active", "local")
+      jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=32323")
+    }
+  }
+  finalizedBy("bootRun")
+}
+
+tasks.register("bootRunDebug") {
+  group = "application"
+  description = "Runs this project as a Spring Boot application with debug configuration"
+  doFirst {
+    tasks.bootRun.configure {
       jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=32323")
     }
   }


### PR DESCRIPTION
We currently use bootRunLocal to start the API from ap-tools. This task hardcodes the spring profile being used to ‘local’. To support running tests against upstream services, we want to be able to run against the ‘dev’ profile. Therefore, this commit introduces a new ‘bootRunDebug’ task that is identical to ‘bootRunLocal’ but removes the hardcoded profile.

The calling ap-tools code already sets the active profile in the env var, so this will not breaking existing behaviour