### PR TITLE
CAS-474 Extend bedspace search api response to include more offender details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.SpaceBookingFilterCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LimitedAccessStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.casLimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromCasResultIsSuccess
@@ -100,7 +100,7 @@ class Cas1SpaceBookingController(
     val user = userService.getUserForRequest()
     val offenderSummaries = offenderService.getPersonSummaryInfoResults(
       crns = searchResults.map { it.crn }.toSet(),
-      limitedAccessStrategy = user.cas1LimitedAccessStrategy(),
+      limitedAccessStrategy = user.casLimitedAccessStrategy(),
     )
 
     val summaries = searchResults.map {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/FutureBookingsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/FutureBookingsReportGenerator.kt
@@ -5,8 +5,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.FutureBo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.FutureBookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.getPersonName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toYesNo
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.tryGetDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.tryGetDetails
 
 class FutureBookingsReportGenerator : ReportGenerator<
   FutureBookingsReportDataAndPersonInfo,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
@@ -7,8 +7,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.Tra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.getPersonGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.getPersonName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toYesNo
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.tryGetDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.tryGetDetails
 
 class TransitionalAccommodationReferralReportGenerator : ReportGenerator<
   TransitionalAccommodationReferralReportDataAndPersonInfo,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/util/ReportingUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/util/ReportingUtils.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.tryGetDetails
 import java.util.UUID
 
 fun UUID.toShortBase58(): String {
@@ -41,11 +41,4 @@ fun PersonSummaryInfoResult.getPersonGender(): String {
     "Prefer to self-describe" -> "Prefer to self-describe"
     else -> this.tryGetDetails { it.profile?.genderIdentity }
   }.toString()
-}
-
-fun <V> PersonSummaryInfoResult.tryGetDetails(value: (CaseSummary) -> V): V? {
-  return when (this) {
-    is PersonSummaryInfoResult.Success.Full -> value(this.summary)
-    else -> null
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -431,9 +431,12 @@ data class CharacteristicNames(
 )
 
 data class TemporaryAccommodationBedSearchResultOverlap(
+  val name: String,
   val crn: String,
+  val sex: String?,
   val days: Int,
   val premisesId: UUID,
   val roomId: UUID,
   val bookingId: UUID,
+  val assessmentId: UUID?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -712,7 +712,7 @@ class OffenderService(
   }
 }
 
-fun UserEntity.cas1LimitedAccessStrategy() = if (this.hasQualification(UserQualification.LAO)) {
+fun UserEntity.casLimitedAccessStrategy() = if (this.hasQualification(UserQualification.LAO)) {
   LimitedAccessStrategy.IgnoreLimitedAccess
 } else {
   LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess(this.deliusUsername)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedSearchResultTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedSearchResultTransformer.kt
@@ -93,10 +93,13 @@ class BedSearchResultTransformer {
       serviceName = ServiceName.temporaryAccommodation,
       overlaps = result.overlaps.map {
         ApiTemporaryAccommodationBedSearchResultOverlap(
+          name = it.name,
           crn = it.crn,
           days = it.days,
           bookingId = it.bookingId,
           roomId = it.roomId,
+          sex = it.sex,
+          assessmentId = it.assessmentId,
         )
       },
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
@@ -32,6 +32,13 @@ fun getNameFromPersonSummaryInfoResult(result: PersonSummaryInfoResult): String 
   }
 }
 
+fun <V> PersonSummaryInfoResult.tryGetDetails(value: (CaseSummary) -> V): V? {
+  return when (this) {
+    is PersonSummaryInfoResult.Success.Full -> value(this.summary)
+    else -> null
+  }
+}
+
 fun OffenderDetailSummary.asCaseSummary() = CaseSummary(
   crn = this.otherIds.crn,
   nomsId = this.otherIds.nomsNumber,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4347,7 +4347,11 @@ components:
     TemporaryAccommodationBedSearchResultOverlap:
       type: object
       properties:
+        name:
+          type: string
         crn:
+          type: string
+        sex:
           type: string
         days:
           type: integer
@@ -4357,7 +4361,11 @@ components:
         roomId:
           type: string
           format: uuid
+        assessmentId:
+          type: string
+          format: uuid
       required:
+        - name
         - crn
         - days
         - bookingId

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8839,7 +8839,11 @@ components:
     TemporaryAccommodationBedSearchResultOverlap:
       type: object
       properties:
+        name:
+          type: string
         crn:
+          type: string
+        sex:
           type: string
         days:
           type: integer
@@ -8849,7 +8853,11 @@ components:
         roomId:
           type: string
           format: uuid
+        assessmentId:
+          type: string
+          format: uuid
       required:
+        - name
         - crn
         - days
         - bookingId

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5549,7 +5549,11 @@ components:
     TemporaryAccommodationBedSearchResultOverlap:
       type: object
       properties:
+        name:
+          type: string
         crn:
+          type: string
+        sex:
           type: string
         days:
           type: integer
@@ -5559,7 +5563,11 @@ components:
         roomId:
           type: string
           format: uuid
+        assessmentId:
+          type: string
+          format: uuid
       required:
+        - name
         - crn
         - days
         - bookingId

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4938,7 +4938,11 @@ components:
     TemporaryAccommodationBedSearchResultOverlap:
       type: object
       properties:
+        name:
+          type: string
         crn:
+          type: string
+        sex:
           type: string
         days:
           type: integer
@@ -4948,7 +4952,11 @@ components:
         roomId:
           type: string
           format: uuid
+        assessmentId:
+          type: string
+          format: uuid
       required:
+        - name
         - crn
         - days
         - bookingId

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4438,7 +4438,11 @@ components:
     TemporaryAccommodationBedSearchResultOverlap:
       type: object
       properties:
+        name:
+          type: string
         crn:
+          type: string
+        sex:
           type: string
         days:
           type: integer
@@ -4448,7 +4452,11 @@ components:
         roomId:
           type: string
           format: uuid
+        assessmentId:
+          type: string
+          format: uuid
       required:
+        - name
         - crn
         - days
         - bookingId


### PR DESCRIPTION
This [PR CAS-474](https://dsdmoj.atlassian.net/browse/CAS-474) is to extend the response of the bedsearch Api endpoint for temporary accommodation to include the following details for the other occupants booked into the property at that time:
- Name
- Sex
- Assessment Id  