### PR TITLE
Change future bookings report to use getPersonSummaryInfoResults

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.SpaceBookingFilterCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.casLimitedAccessStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromCasResultIsSuccess
@@ -100,7 +100,7 @@ class Cas1SpaceBookingController(
     val user = userService.getUserForRequest()
     val offenderSummaries = offenderService.getPersonSummaryInfoResults(
       crns = searchResults.map { it.crn }.toSet(),
-      limitedAccessStrategy = user.casLimitedAccessStrategy(),
+      limitedAccessStrategy = user.cas1LimitedAccessStrategy(),
     )
 
     val summaries = searchResults.map {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -188,7 +188,7 @@ class BedSearchService(
         val crns = overlappedBookings.map { it.crn }.distinct().toSet()
         val offenderSummaries = offenderService.getPersonSummaryInfoResults(
           crns = crns.toSet(),
-          limitedAccessStrategy = user.casLimitedAccessStrategy(),
+          limitedAccessStrategy = user.cas3LimitedAccessStrategy(),
         )
 
         val groupedOverlappedBookings = overlappedBookings

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -712,8 +712,10 @@ class OffenderService(
   }
 }
 
-fun UserEntity.casLimitedAccessStrategy() = if (this.hasQualification(UserQualification.LAO)) {
+fun UserEntity.cas1LimitedAccessStrategy() = if (this.hasQualification(UserQualification.LAO)) {
   LimitedAccessStrategy.IgnoreLimitedAccess
 } else {
   LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess(this.deliusUsername)
 }
+
+fun UserEntity.cas3LimitedAccessStrategy() = LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess(this.deliusUsername)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ReportServiceTest.kt
@@ -72,7 +72,7 @@ class Cas3ReportServiceTest {
 
     every { mockTransitionalAccommodationReferralReportRowRepository.findAllReferrals(any(), any(), any()) } returns listOf(testTransitionalAccommodationReferralReportData)
     every { mockUserService.getUserForRequest() } returns UserEntityFactory().withUnitTestControlProbationRegion().produce()
-    every { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) } returns listOf(
+    every { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) } returns listOf(
       PersonSummaryInfoResult.Success.Full("", CaseSummaryFactory().produce()),
     )
 
@@ -86,7 +86,7 @@ class Cas3ReportServiceTest {
       )
     }
     verify { mockUserService.getUserForRequest() }
-    verify(exactly = 1) { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) }
+    verify(exactly = 1) { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) }
   }
 
   @Test
@@ -99,7 +99,7 @@ class Cas3ReportServiceTest {
 
     every { mockTransitionalAccommodationReferralReportRowRepository.findAllReferrals(any(), any(), any()) } returns listOf(testTransitionalAccommodationReferralReportData)
     every { mockUserService.getUserForRequest() } returns UserEntityFactory().withUnitTestControlProbationRegion().produce()
-    every { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) } returns listOf(
+    every { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) } returns listOf(
       PersonSummaryInfoResult.Success.Full("", CaseSummaryFactory().produce()),
     )
 
@@ -129,7 +129,7 @@ class Cas3ReportServiceTest {
       )
     }
     verify { mockUserService.getUserForRequest() }
-    verify(exactly = 1) { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) }
+    verify(exactly = 1) { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) }
   }
 
   @Test
@@ -141,7 +141,7 @@ class Cas3ReportServiceTest {
 
     every { mockTransitionalAccommodationReferralReportRowRepository.findAllReferrals(any(), any(), any()) } returns emptyList()
     every { mockUserService.getUserForRequest() } returns UserEntityFactory().withUnitTestControlProbationRegion().produce()
-    every { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) } returns emptyList()
+    every { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) } returns emptyList()
 
     cas3ReportService.createCas3ApplicationReferralsReport(properties, ByteArrayOutputStream())
 
@@ -153,7 +153,7 @@ class Cas3ReportServiceTest {
       )
     }
     verify(exactly = 1) { mockUserService.getUserForRequest() }
-    verify(exactly = 0) { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) }
+    verify(exactly = 0) { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) }
   }
 
   @Test
@@ -175,7 +175,7 @@ class Cas3ReportServiceTest {
       createDBReferralReportData("crn3"),
     )
     every { mockUserService.getUserForRequest() } returns UserEntityFactory().withUnitTestControlProbationRegion().produce()
-    every { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) } returns listOf(
+    every { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) } returns listOf(
       PersonSummaryInfoResult.Success.Full("", CaseSummaryFactory().produce()),
     )
 
@@ -189,7 +189,7 @@ class Cas3ReportServiceTest {
       )
     }
     verify { mockUserService.getUserForRequest() }
-    verify(exactly = 2) { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) }
+    verify(exactly = 2) { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) }
   }
 
   @Test
@@ -211,10 +211,10 @@ class Cas3ReportServiceTest {
       createDBReferralReportData("crn3"),
     )
     every { mockUserService.getUserForRequest() } returns UserEntityFactory().withUnitTestControlProbationRegion().produce()
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2"), any()) } returns listOf(
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2"), any()) } returns listOf(
       PersonSummaryInfoResult.Success.Full("", CaseSummaryFactory().produce()),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn3"), any()) } throws RuntimeException("some exception")
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn3"), any()) } throws RuntimeException("some exception")
 
     Assertions.assertThatExceptionOfType(RuntimeException::class.java)
       .isThrownBy {
@@ -229,7 +229,7 @@ class Cas3ReportServiceTest {
       )
     }
     verify { mockUserService.getUserForRequest() }
-    verify(exactly = 2) { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) }
+    verify(exactly = 2) { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) }
   }
 
   @Test
@@ -243,7 +243,7 @@ class Cas3ReportServiceTest {
 
     every { mockBookingsReportRepository.findAllByOverlappingDate(startDate, endDate, ServiceName.temporaryAccommodation.value, probationRegionId) } returns listOf(bookingsReportData)
     every { mockUserService.getUserForRequest() } returns UserEntityFactory().withUnitTestControlProbationRegion().produce()
-    every { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) } returns listOf(
+    every { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) } returns listOf(
       PersonSummaryInfoResult.Success.Full(crn, CaseSummaryFactory().produce()),
     )
 
@@ -258,7 +258,7 @@ class Cas3ReportServiceTest {
       )
     }
     verify { mockUserService.getUserForRequest() }
-    verify(exactly = 1) { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) }
+    verify(exactly = 1) { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) }
   }
 
   @Test
@@ -282,7 +282,7 @@ class Cas3ReportServiceTest {
       createBookingReportData(crns[2]),
     )
     every { mockUserService.getUserForRequest() } returns UserEntityFactory().withUnitTestControlProbationRegion().produce()
-    every { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) } returns listOf(
+    every { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) } returns listOf(
       PersonSummaryInfoResult.Success.Full(crns[0], CaseSummaryFactory().produce()),
       PersonSummaryInfoResult.Success.Full(crns[1], CaseSummaryFactory().produce()),
       PersonSummaryInfoResult.Success.Full(crns[2], CaseSummaryFactory().produce()),
@@ -299,7 +299,7 @@ class Cas3ReportServiceTest {
       )
     }
     verify { mockUserService.getUserForRequest() }
-    verify(exactly = 2) { mockOffenderService.getOffenderSummariesByCrns(any<Set<String>>(), any()) }
+    verify(exactly = 2) { mockOffenderService.getPersonSummaryInfoResults(any<Set<String>>(), any()) }
   }
 
   private fun createDBReferralReportData(): TestTransitionalAccommodationReferralReportData {


### PR DESCRIPTION
This [PR CAS-643](https://dsdmoj.atlassian.net/browse/CAS-643) is to use  getPersonSummaryInfoResults instead of getOffenderSummariesByCrns to get offender details