### PR TITLE
APS-1448 - Add Space Booking Day Planner Logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -10,6 +10,10 @@ import java.util.UUID
 
 interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
 
+  companion object Constants {
+    val SINGLE_ROOM_CHARACTERISTIC: UUID = UUID.fromString("7d59280e-aca0-4842-994e-b22cbc076fe8")
+  }
+
   @Query("SELECT c FROM CharacteristicEntity c WHERE c.serviceScope = :serviceName")
   fun findAllByServiceScope(serviceName: String): List<CharacteristicEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpaceBookingDayPlanner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpaceBookingDayPlanner.kt
@@ -1,0 +1,153 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning
+
+import org.springframework.stereotype.Service
+
+@Service
+class SpaceBookingDayPlanner {
+  /**
+   * Given a list of available beds and required bookings for a given day, will attempt to optimally
+   * assign bookings to beds to determine a premise's capacity on a given day.
+   *
+   * We do not currently intend to present the 'booking to room', instead we are only using this planning
+   * to determine the number of free spaces after bookings are planned.
+   *
+   * If we were to present 'booking to room' planning, we may wish to discuss further optimisation
+   * with premises e.g. would they want to plan bookings into the fullest multiple occupancy room possible,
+   * Or is the goal to minimise shared rooms? What's more important, minimising characteristic surplus, or
+   * minimising single bookings into room with the least other beds?
+   *
+   * Planning goals:
+   *
+   * <ol>
+   *   <li>Priority is given to bookings with constraints, those with the most constraints being planned first</li>
+   *   <li>Bookings are placed into rooms with the least surplus characteristics</li>
+   *   <li>Single occupancy bookings are never placed in rooms with other bookings</li>
+   *   <li>If there are multiple competing rooms (after above goals are satisfied), single occupancy bookings will
+   *   be placed into rooms with the least beds (ensuring minimum 'wastage' in these scenarios)</li>
+   * </ol>
+   *
+   * @param beds All beds available on the day being planned (i.e. won't include out of service beds or beds inactive according to start/end date)
+   * @param bookings All required bookings. The code assumes that the premise level characteristics have already been met
+   */
+  fun plan(
+    beds: Set<Bed>,
+    bookings: Set<SpaceBooking>,
+  ): DayPlannerResult {
+    val bedLedger = BedLedger(beds)
+    val planned = mutableListOf<DayPlannerPlannedBooking>()
+    val unplanned = mutableListOf<DayPlannerUnplannedBooking>()
+
+    val sortedBookings = bookings.toList()
+      .sortedByDescending { b -> b.requiredCharacteristics.sumOf { c -> c.weighting } }
+      .toMutableList()
+
+    sortedBookings.forEach { booking ->
+      val requiresSingleRoom = booking.requiredCharacteristics.any { it.singleRoom }
+      val characteristicsExcludingSingleRoom = booking.requiredCharacteristics.filter { !it.singleRoom }.toSet()
+
+      when (
+        val findResult = bedLedger.findBed(
+          characteristics = characteristicsExcludingSingleRoom,
+          requiresSingleRoom = requiresSingleRoom,
+        )
+      ) {
+        is FindBedResult.BedsFound -> {
+          findResult.beds.forEach { bed ->
+            planned.add(
+              DayPlannerPlannedBooking(
+                bed = bed,
+                booking = booking,
+              ),
+            )
+            bedLedger.reserve(bed)
+          }
+        }
+
+        is FindBedResult.BedNotFound -> {
+          unplanned.add(
+            DayPlannerUnplannedBooking(
+              booking = booking,
+            ),
+          )
+        }
+      }
+    }
+
+    return DayPlannerResult(
+      planned = planned.toList(),
+      unplanned = unplanned.toSet(),
+    )
+  }
+}
+
+private class BedLedger(initialState: Set<Bed>) {
+  private val allBeds = initialState.sortedBy { it.label }.toMutableList()
+  private val availableBeds = initialState.sortedBy { it.label }.toMutableList()
+  private val reservedBeds = mutableListOf<Bed>()
+  private val bedsByRoom = allBeds.groupBy { it.room }
+
+  fun findBed(
+    characteristics: Set<Characteristic>,
+    requiresSingleRoom: Boolean,
+  ): FindBedResult {
+    val bedsWithRequiredCharacteristics = findBedsWithRequiredCharacteristics(characteristics, requiresSingleRoom)
+    val bedWithLeastSurplusCharacteristics = findBedWithLeastSurplusCharacteristics(bedsWithRequiredCharacteristics, characteristics)
+
+    if (bedWithLeastSurplusCharacteristics == null) {
+      return FindBedResult.BedNotFound
+    }
+
+    return if (requiresSingleRoom) {
+      FindBedResult.BedsFound(bedsByRoom[bedWithLeastSurplusCharacteristics.room]!!.toSet())
+    } else {
+      FindBedResult.BedsFound(setOf(bedWithLeastSurplusCharacteristics))
+    }
+  }
+
+  private fun findBedsWithRequiredCharacteristics(
+    characteristics: Set<Characteristic>,
+    requiresSingleRoom: Boolean,
+  ): List<Bed> {
+    val bedsWithMatchingCharacteristics = availableBeds
+      .filter { availableBed -> availableBed.room.characteristics.containsAll(characteristics) }
+
+    return if (requiresSingleRoom) {
+      bedsWithMatchingCharacteristics
+        .filter { availableBed -> !isRoomOccupied(availableBed) }
+        .sortedBy { availableBed -> bedsByRoom.getOrDefault(availableBed.room, emptyList()).size }
+    } else {
+      bedsWithMatchingCharacteristics
+    }
+  }
+
+  private fun findBedWithLeastSurplusCharacteristics(beds: List<Bed>, characteristics: Set<Characteristic>) =
+    beds
+      .map { bed -> Pair(bed, bed.room.characteristics.minus(characteristics).size) }
+      .minByOrNull { it.second }?.first
+
+  fun reserve(bed: Bed) {
+    availableBeds.remove(bed)
+    reservedBeds.add(bed)
+  }
+
+  private fun isRoomOccupied(bed: Bed) = reservedBeds.any { reservedBed -> reservedBed.room == bed.room }
+}
+
+sealed interface FindBedResult {
+  class BedsFound(val beds: Set<Bed>) : FindBedResult
+  data object BedNotFound : FindBedResult
+}
+
+data class DayPlannerResult(
+  val planned: List<DayPlannerPlannedBooking>,
+  val unplanned: Set<DayPlannerUnplannedBooking>,
+)
+
+data class DayPlannerPlannedBooking(
+  val bed: Bed,
+  val booking: SpaceBooking,
+)
+
+data class DayPlannerUnplannedBooking(
+  val booking: SpaceBooking,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpaceBookingDayPlannerResultRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpaceBookingDayPlannerResultRenderer.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning
+
+object SpaceBookingDayPlannerResultRenderer {
+
+  @SuppressWarnings("MagicNumber")
+  fun render(
+    beds: Set<Bed>,
+    result: DayPlannerResult,
+  ): String {
+    val output = StringBuilder()
+
+    output.appendLine("Planned: ${result.planned.size}")
+
+    if (result.planned.isNotEmpty()) {
+      output.appendLine("")
+      output.appendLine("| Bed             | Booking         | Bed Characteristics            |")
+      output.appendLine("| --------------- | --------------- | ------------------------------ |")
+      beds.sortedBy { it.label }.forEach { bed ->
+
+        output.append("| ${bed.label.padEnd(15)} ")
+
+        val booking = result.planned.firstOrNull { it.bed == bed }?.booking
+        output.append("| ${(booking?.label ?: "").padEnd(15)} ")
+
+        val bedCharacteristics = bed.room.characteristics.joinToString(",") { bedCharacteristic ->
+          val matched = booking?.let {
+            if (booking.requiredCharacteristics.contains(bedCharacteristic)) {
+              "(+)"
+            } else {
+              "(-)"
+            }
+          }
+
+          bedCharacteristic.name + (matched ?: "")
+        }
+        output.appendLine("| ${bedCharacteristics.padEnd(30)} |")
+      }
+
+      output.appendLine("")
+    }
+
+    output.appendLine("Unplanned: ${result.unplanned.size}")
+    if (result.unplanned.isNotEmpty()) {
+      output.appendLine("")
+      output.appendLine("| Booking         | Characteristics                |")
+      output.appendLine("| --------------- | ------------------------------ |")
+      result.unplanned.sortedBy { it.booking.label }.forEach { unplanned ->
+        val booking = unplanned.booking
+        output.append("| ${booking.label.padEnd(15)} |")
+        output.appendLine(" ${booking.requiredCharacteristics.joinToString(",") { it.name }.padEnd(30)} |")
+      }
+    }
+    return output.toString().trimIndent()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpaceBookingPlanningModels.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpaceBookingPlanningModels.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning
+
+import java.util.UUID
+
+data class Characteristic(
+  val id: UUID,
+  val name: String,
+  val weighting: Int,
+  val singleRoom: Boolean = false,
+)
+
+data class Bed(
+  val id: UUID,
+  val label: String,
+  val room: Room,
+)
+
+data class Room(
+  val id: UUID,
+  val label: String,
+  val characteristics: Set<Characteristic>,
+)
+
+data class SpaceBooking(
+  val spaceBookingId: UUID,
+  val label: String,
+  val requiredCharacteristics: Set<Characteristic>,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpaceBookingDayPlannerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpaceBookingDayPlannerTest.kt
@@ -1,0 +1,439 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.planning
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.Bed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.Characteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.Room
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpaceBookingDayPlanner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpaceBookingDayPlannerResultRenderer.render
+import java.util.UUID
+
+class SpaceBookingDayPlannerTest {
+
+  companion object Constants {
+    val CHARACTERISTIC_1 = Characteristic(UUID.randomUUID(), "c1", weighting = 100)
+    val CHARACTERISTIC_2 = Characteristic(UUID.randomUUID(), "c2", weighting = 100)
+    val CHARACTERISTIC_3 = Characteristic(UUID.randomUUID(), "c3", weighting = 100)
+    val CHARACTERISTIC_4 = Characteristic(UUID.randomUUID(), "c4", weighting = 100)
+    val CHARACTERISTIC_5_WEIGHTING_1000 = Characteristic(UUID.randomUUID(), "c5", weighting = 1000)
+    val CHARACTERISTIC_SINGLE_ROOM = Characteristic(UUID.randomUUID(), "single", weighting = 100, singleRoom = true)
+  }
+
+  val service = SpaceBookingDayPlanner()
+
+  @Test
+  fun `No rooms or bookings do nothing`() {
+    assertPlanningOutcome(
+      beds = emptySet(),
+      bookings = emptySet(),
+      expected = """
+        Planned: 0
+        Unplanned: 0
+      """,
+    )
+  }
+
+  @Test
+  fun `If no rooms all bookings are unplanned`() {
+    val booking1 = booking("booking1")
+    val booking2 = booking("booking2")
+
+    assertPlanningOutcome(
+      beds = emptySet(),
+      bookings = setOf(booking1, booking2),
+      expected = """
+        Planned: 0
+        Unplanned: 2
+        
+        | Booking         | Characteristics                |
+        | --------------- | ------------------------------ |
+        | booking1        |                                |
+        | booking2        |                                |
+      """,
+    )
+  }
+
+  @Test
+  fun `Sufficient rooms for each booking, no characteristics`() {
+    val booking1 = booking("booking1")
+    val booking2 = booking("booking2")
+
+    val bed1 = bed("bed1")
+    val bed2 = bed("bed2")
+
+    assertPlanningOutcome(
+      beds = setOf(bed1, bed2),
+      bookings = setOf(booking1, booking2),
+      expected = """
+        Planned: 2
+        
+        | Bed             | Booking         | Bed Characteristics            |
+        | --------------- | --------------- | ------------------------------ |
+        | bed1            | booking1        |                                |
+        | bed2            | booking2        |                                |
+        
+        Unplanned: 0
+      """,
+    )
+  }
+
+  @Test
+  fun `Sufficient rooms for each booking, single characteristics`() {
+    val booking1 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_2))
+    val booking2 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_1))
+
+    val bed1 = bed("bed1", roomCharacteristics = setOf(CHARACTERISTIC_1))
+    val bed2 = bed("bed2", roomCharacteristics = setOf(CHARACTERISTIC_2))
+
+    assertPlanningOutcome(
+      beds = setOf(bed1, bed2),
+      bookings = setOf(booking1, booking2),
+      expected = """
+        Planned: 2
+        
+        | Bed             | Booking         | Bed Characteristics            |
+        | --------------- | --------------- | ------------------------------ |
+        | bed1            | booking2        | c1(+)                          |
+        | bed2            | booking1        | c2(+)                          |
+        
+        Unplanned: 0
+      """,
+    )
+  }
+
+  @Test
+  fun `If bed doesn't exist with required characteristic cannot plan booking`() {
+    val bookingWithCharacteristic = booking(
+      label = "booking1",
+      requiredCharacteristics = setOf(CHARACTERISTIC_1),
+    )
+
+    val bed1 = bed("bed1")
+    val bed2 = bed("bed2")
+
+    assertPlanningOutcome(
+      beds = setOf(bed1, bed2),
+      bookings = setOf(bookingWithCharacteristic),
+      expected = """
+        Planned: 0
+        Unplanned: 1
+        
+        | Booking         | Characteristics                |
+        | --------------- | ------------------------------ |
+        | booking1        | c1                             |
+      """,
+    )
+  }
+
+  @Test
+  fun `If bed with required characteristic is already taken cannot plan booking`() {
+    val booking1 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_1))
+    val booking2 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_1))
+
+    val bed1 = bed("bed1", roomCharacteristics = setOf(CHARACTERISTIC_1))
+    val bed2 = bed("bed2")
+
+    assertPlanningOutcome(
+      beds = setOf(bed1, bed2),
+      bookings = setOf(booking1, booking2),
+      expected = """
+      Planned: 1
+  
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | bed1            | booking1        | c1(+)                          |
+      | bed2            |                 |                                |
+      
+      Unplanned: 1
+      
+      | Booking         | Characteristics                |
+      | --------------- | ------------------------------ |
+      | booking2        | c1                             |
+      """,
+    )
+  }
+
+  @Test
+  fun `Bookings with multiple characteristics take precedence over bookings with less`() {
+    val booking1 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_1))
+    val booking2 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_3))
+    val booking3 = booking("booking3", requiredCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2, CHARACTERISTIC_4))
+
+    val bed1 = bed("bed1", roomCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2, CHARACTERISTIC_3, CHARACTERISTIC_4))
+    val bed2 = bed("bed2", roomCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2, CHARACTERISTIC_3, CHARACTERISTIC_4))
+
+    assertPlanningOutcome(
+      beds = setOf(bed1, bed2),
+      bookings = setOf(booking1, booking2, booking3),
+      expected = """
+      Planned: 2
+      
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | bed1            | booking3        | c1(+),c2(+),c3(-),c4(+)        |
+      | bed2            | booking2        | c1(+),c2(-),c3(+),c4(-)        |
+      
+      Unplanned: 1
+      
+      | Booking         | Characteristics                |
+      | --------------- | ------------------------------ |
+      | booking1        | c1                             |
+      """,
+    )
+  }
+
+  @Test
+  fun `Use rooms with the least surplus characteristics`() {
+    val booking1 = booking("booking1", requiredCharacteristics = setOf())
+    val booking2 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_3))
+    val booking3 = booking("booking3", requiredCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2))
+    val booking4 = booking("booking4", requiredCharacteristics = setOf(CHARACTERISTIC_4))
+
+    val bed1 = bed("bed1", roomCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2, CHARACTERISTIC_3, CHARACTERISTIC_4))
+    val bed2 = bed("bed2", roomCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_3))
+    val bed3 = bed("bed3", roomCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2))
+    val bed4 = bed("bed4", roomCharacteristics = setOf(CHARACTERISTIC_4))
+    val bed5 = bed("bed5", roomCharacteristics = setOf())
+
+    assertPlanningOutcome(
+      beds = setOf(bed1, bed2, bed3, bed4, bed5),
+      bookings = setOf(booking1, booking2, booking3, booking4),
+      expected = """
+      Planned: 4
+  
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | bed1            |                 | c1,c2,c3,c4                    |
+      | bed2            | booking2        | c1(+),c3(+)                    |
+      | bed3            | booking3        | c1(+),c2(+)                    |
+      | bed4            | booking4        | c4(+)                          |
+      | bed5            | booking1        |                                |
+      
+      Unplanned: 0
+      """,
+    )
+  }
+
+  @Test
+  fun `Use booking with greatest total characteristic weighting when determining planning order`() {
+    val booking1 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2, CHARACTERISTIC_3, CHARACTERISTIC_4))
+    val booking2 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_5_WEIGHTING_1000))
+
+    val bed1 = bed("bed1", roomCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2, CHARACTERISTIC_3, CHARACTERISTIC_4, CHARACTERISTIC_5_WEIGHTING_1000))
+    val bed2 = bed("bed2", roomCharacteristics = setOf())
+    val bed3 = bed("bed3", roomCharacteristics = setOf())
+
+    assertPlanningOutcome(
+      beds = setOf(bed1, bed2, bed3),
+      bookings = setOf(booking1, booking2),
+      expected = """
+      Planned: 1
+      
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | bed1            | booking2        | c1(-),c2(-),c3(-),c4(-),c5(+)  |
+      | bed2            |                 |                                |
+      | bed3            |                 |                                |
+      
+      Unplanned: 1
+      
+      | Booking         | Characteristics                |
+      | --------------- | ------------------------------ |
+      | booking1        | c1,c2,c3,c4                    |
+      """,
+    )
+  }
+
+  @Test
+  fun `Booking requiring a single room is not planned if an unoccupied room is not available`() {
+    val booking2 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2))
+    val booking1 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_SINGLE_ROOM))
+
+    val room1 = Room(UUID.randomUUID(), "room1", characteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2))
+    val room1Bed1 = bed("room1 bed1", room = room1)
+    val room1Bed2 = bed("room1 bed2", room = room1)
+    val room1Bed3 = bed("room1 bed3", room = room1)
+
+    assertPlanningOutcome(
+      beds = setOf(room1Bed1, room1Bed2, room1Bed3),
+      bookings = setOf(booking1, booking2),
+      expected = """
+      Planned: 1
+  
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | room1 bed1      | booking1        | c1(+),c2(+)                    |
+      | room1 bed2      |                 | c1,c2                          |
+      | room1 bed3      |                 | c1,c2                          |
+      
+      Unplanned: 1
+      
+      | Booking         | Characteristics                |
+      | --------------- | ------------------------------ |
+      | booking2        | single                         |
+      """,
+    )
+  }
+
+  @Test
+  fun `Booking requiring a single room is treated with weighting like other bookings with characteristics`() {
+    val booking1 = booking("booking1", requiredCharacteristics = setOf())
+    val booking2 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_SINGLE_ROOM))
+    val booking3 = booking("booking3", requiredCharacteristics = setOf(CHARACTERISTIC_SINGLE_ROOM, CHARACTERISTIC_1))
+
+    val bed1 = bed("bed1", roomCharacteristics = setOf(CHARACTERISTIC_1))
+    val bed2 = bed("bed2", roomCharacteristics = setOf(CHARACTERISTIC_1))
+
+    assertPlanningOutcome(
+      beds = setOf(bed1, bed2),
+      bookings = setOf(booking1, booking2, booking3),
+      expected = """
+      Planned: 2
+      
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | bed1            | booking3        | c1(+)                          |
+      | bed2            | booking2        | c1(-)                          |
+      
+      Unplanned: 1
+      
+      | Booking         | Characteristics                |
+      | --------------- | ------------------------------ |
+      | booking1        |                                |
+      """,
+    )
+  }
+
+  @Test
+  fun `Booking requiring a single room is never put into a room with other bookings, even if other rooms have less surplus characteristics`() {
+    val booking2 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2))
+    val booking1 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_SINGLE_ROOM))
+
+    val room1 = Room(UUID.randomUUID(), "room1", characteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2))
+    val room1Bed1 = bed("room1 bed1", room = room1)
+    val room1Bed2 = bed("room1 bed2", room = room1)
+
+    val room2 = Room(UUID.randomUUID(), "room2", characteristics = setOf(CHARACTERISTIC_1, CHARACTERISTIC_2, CHARACTERISTIC_4))
+    val room2Bed1 = bed("room2 bed1", room = room2)
+    val room2Bed2 = bed("room2 bed2", room = room2)
+
+    assertPlanningOutcome(
+      beds = setOf(room1Bed1, room1Bed2, room2Bed1, room2Bed2),
+      bookings = setOf(booking1, booking2),
+      expected = """
+      Planned: 3
+    
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | room1 bed1      | booking1        | c1(+),c2(+)                    |
+      | room1 bed2      |                 | c1,c2                          |
+      | room2 bed1      | booking2        | c1(-),c2(-),c4(-)              |
+      | room2 bed2      | booking2        | c1(-),c2(-),c4(-)              |
+      
+      Unplanned: 0
+      """,
+    )
+  }
+
+  @Test
+  fun `Single room booking will block use of other beds in the room`() {
+    val booking1 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_SINGLE_ROOM))
+    val booking2 = booking("booking2", requiredCharacteristics = setOf(CHARACTERISTIC_SINGLE_ROOM))
+    val booking3 = booking("booking3", requiredCharacteristics = setOf())
+
+    val room1 = Room(UUID.randomUUID(), "room1", characteristics = setOf())
+    val room1Bed1 = bed("room1 bed1", room = room1)
+    val room1Bed2 = bed("room1 bed2", room = room1)
+
+    val room2 = Room(UUID.randomUUID(), "room2", characteristics = setOf())
+    val room2Bed1 = bed("room2 bed1", room = room2)
+    val room2Bed2 = bed("room2 bed2", room = room2)
+    val room2Bed3 = bed("room2 bed3", room = room2)
+
+    assertPlanningOutcome(
+      beds = setOf(room1Bed1, room1Bed2, room2Bed1, room2Bed2, room2Bed3),
+      bookings = setOf(booking1, booking2, booking3),
+      expected = """
+      Planned: 5
+      
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | room1 bed1      | booking1        |                                |
+      | room1 bed2      | booking1        |                                |
+      | room2 bed1      | booking2        |                                |
+      | room2 bed2      | booking2        |                                |
+      | room2 bed3      | booking2        |                                |
+      
+      Unplanned: 1
+      
+      | Booking         | Characteristics                |
+      | --------------- | ------------------------------ |
+      | booking3        |                                |
+      """,
+    )
+  }
+
+  @Test
+  fun `Booking requiring a single room is put into a room with the least beds`() {
+    val booking2 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_SINGLE_ROOM))
+
+    val room1 = Room(UUID.randomUUID(), "room1", characteristics = setOf())
+    val room1Bed1 = bed("room1 bed1", room = room1)
+    val room1Bed2 = bed("room1 bed2", room = room1)
+    val room1Bed3 = bed("room1 bed3", room = room1)
+
+    val room2 = Room(UUID.randomUUID(), "room2", characteristics = setOf())
+    val room2Bed1 = bed("room2 bed1", room = room2)
+    val room2Bed2 = bed("room2 bed2", room = room2)
+
+    assertPlanningOutcome(
+      beds = setOf(room1Bed1, room1Bed2, room1Bed3, room2Bed1, room2Bed2),
+      bookings = setOf(booking2),
+      expected = """
+      Planned: 2
+    
+      | Bed             | Booking         | Bed Characteristics            |
+      | --------------- | --------------- | ------------------------------ |
+      | room1 bed1      |                 |                                |
+      | room1 bed2      |                 |                                |
+      | room1 bed3      |                 |                                |
+      | room2 bed1      | booking1        |                                |
+      | room2 bed2      | booking1        |                                |
+      
+      Unplanned: 0
+      """,
+    )
+  }
+
+  private fun assertPlanningOutcome(
+    beds: Set<Bed>,
+    bookings: Set<SpaceBooking>,
+    expected: String,
+  ) {
+    val result = service.plan(beds, bookings)
+    assertThat(render(beds, result)).isEqualTo(expected.trimIndent())
+  }
+
+  fun bed(
+    label: String,
+    roomCharacteristics: Set<Characteristic> = emptySet(),
+    room: Room = Room(
+      id = UUID.randomUUID(),
+      label = label,
+      characteristics = roomCharacteristics,
+    ),
+  ) = Bed(
+    id = UUID.randomUUID(),
+    label = label,
+    room = room,
+  )
+
+  fun booking(label: String, requiredCharacteristics: Set<Characteristic> = emptySet()) =
+    SpaceBooking(
+      UUID.randomUUID(),
+      label,
+      requiredCharacteristics,
+    )
+}


### PR DESCRIPTION
This PR adds a SpaceBookingDayPlanner service. Given a list of rooms and space bookings, this will attempt to optimally assign a a space booking to each room, where possible.

Subsequent commits will make use of this planner to plan occupancy over a period of time for a given premise, which will then be used for occupancy calculation