### PR TITLE
APS-1446 - Capture criteria on space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermissio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission.CAS1_SPACE_BOOKING_VIEW
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.forCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -43,6 +44,7 @@ class Cas1SpaceBookingController(
   private val spaceBookingTransformer: Cas1SpaceBookingTransformer,
   private val cas1SpaceBookingService: Cas1SpaceBookingService,
   private val cas1WithdrawableService: Cas1WithdrawableService,
+  private val characteristicService: CharacteristicService,
 ) : SpaceBookingsCas1Delegate {
 
   override fun getSpaceBookingTimeline(premisesId: UUID, bookingId: UUID): ResponseEntity<TimelineEvent> {
@@ -55,6 +57,10 @@ class Cas1SpaceBookingController(
   ): ResponseEntity<Cas1SpaceBooking> {
     val user = userService.getUserForRequest()
 
+    val characteristics = characteristicService.getCharacteristicsByPropertyNames(
+      body.requirements.essentialCharacteristics.map { it.value },
+    )
+
     val booking = extractEntityFromCasResult(
       spaceBookingService.createNewBooking(
         body.premisesId,
@@ -62,6 +68,7 @@ class Cas1SpaceBookingController(
         body.arrivalDate,
         body.departureDate,
         user,
+        characteristics,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -4,6 +4,8 @@ import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.ManyToMany
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.springframework.data.domain.Page
@@ -149,6 +151,13 @@ data class Cas1SpaceBookingEntity(
   @JoinColumn(name = "cancellation_reason_id")
   var cancellationReason: CancellationReasonEntity?,
   var cancellationReasonNotes: String?,
+  @ManyToMany
+  @JoinTable(
+    name = "cas1_space_bookings_criteria",
+    joinColumns = [JoinColumn(name = "space_booking_id")],
+    inverseJoinColumns = [JoinColumn(name = "characteristic_id")],
+  )
+  val criteria: List<CharacteristicEntity>,
 ) {
   fun isActive() = !isCancelled()
   fun isCancelled() = cancellationOccurredAt != null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -61,6 +62,7 @@ class Cas1SpaceBookingService(
     arrivalDate: LocalDate,
     departureDate: LocalDate,
     createdBy: UserEntity,
+    characteristics: List<CharacteristicEntity>,
   ): CasResult<Cas1SpaceBookingEntity> = validatedCasResult {
     val premises = cas1PremisesService.findPremiseById(premisesId)
     if (premises == null) {
@@ -120,6 +122,7 @@ class Cas1SpaceBookingService(
         cancellationReasonNotes = null,
         departureMoveOnCategory = null,
         departureReason = null,
+        criteria = characteristics,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingRequirementsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingRequirementsTransformer.kt
@@ -8,11 +8,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 
 @Component
 class Cas1SpaceBookingRequirementsTransformer {
-  fun transformJpaToApi(jpa: PlacementRequirementsEntity) = Cas1SpaceBookingRequirements(
+  fun transformJpaToApi(jpa: PlacementRequirementsEntity, criteria: List<CharacteristicEntity>) = Cas1SpaceBookingRequirements(
     apType = jpa.apType,
     gender = jpa.gender,
-    essentialCharacteristics = jpa.essentialCriteria.mapNotNull { it.asCas1SpaceCharacteristic() },
-    desirableCharacteristics = jpa.desirableCriteria.mapNotNull { it.asCas1SpaceCharacteristic() },
+    essentialCharacteristics = criteria.mapNotNull { it.asCas1SpaceCharacteristic() },
+    desirableCharacteristics = emptyList(),
   )
 
   private fun CharacteristicEntity.asCas1SpaceCharacteristic() = try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -38,7 +38,10 @@ class Cas1SpaceBookingTransformer(
       applicationId = application.id,
       assessmentId = placementRequest.assessment.id,
       person = personTransformer.transformModelToPersonApi(person),
-      requirements = spaceBookingRequirementsTransformer.transformJpaToApi(placementRequest.placementRequirements),
+      requirements = spaceBookingRequirementsTransformer.transformJpaToApi(
+        jpa = placementRequest.placementRequirements,
+        criteria = jpa.criteria,
+      ),
       premises = NamedId(
         id = jpa.premises.id,
         name = jpa.premises.name,

--- a/src/main/resources/db/migration/all/20241028103820__add_criteria_to_space_booking.sql
+++ b/src/main/resources/db/migration/all/20241028103820__add_criteria_to_space_booking.sql
@@ -1,0 +1,7 @@
+CREATE TABLE cas1_space_bookings_criteria (
+  space_booking_id UUID NOT NULL,
+  characteristic_id UUID NOT NULL,
+  PRIMARY KEY (space_booking_id, characteristic_id),
+  FOREIGN KEY (space_booking_id) REFERENCES cas1_space_bookings (id),
+  FOREIGN KEY (characteristic_id) REFERENCES characteristics (id)
+);

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -173,6 +173,8 @@ components:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         desirableCharacteristics:
           type: array
+          deprecated: true
+          description: desirable characteristics are not required and will be removed in the future
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         gender:
@@ -180,6 +182,7 @@ components:
       required:
         - apType
         - gender
+        - essentialCharacteristics
     Cas1SpaceSearchRequirements:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6560,6 +6560,8 @@ components:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         desirableCharacteristics:
           type: array
+          deprecated: true
+          description: desirable characteristics are not required and will be removed in the future
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         gender:
@@ -6567,6 +6569,7 @@ components:
       required:
         - apType
         - gender
+        - essentialCharacteristics
     Cas1SpaceSearchRequirements:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
@@ -39,6 +40,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var cancellationReasonNotes: Yielded<String?> = { null }
   private var departureReason: Yielded<DepartureReasonEntity?> = { null }
   private var departureMoveOnCategory: Yielded<MoveOnCategoryEntity?> = { null }
+  private var criteria: Yielded<List<CharacteristicEntity>> = { emptyList() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -162,6 +164,10 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.departureMoveOnCategory = { moveOnCategory }
   }
 
+  fun withCriteria(criteria: List<CharacteristicEntity>) = apply {
+    this.criteria = { criteria }
+  }
+
   override fun produce() = Cas1SpaceBookingEntity(
     id = this.id(),
     premises = this.premises(),
@@ -185,5 +191,6 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     cancellationReasonNotes = cancellationReasonNotes(),
     departureReason = this.departureReason(),
     departureMoveOnCategory = this.departureMoveOnCategory(),
+    criteria = this.criteria(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceChara
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1SpaceBookingCancellation
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
@@ -209,22 +208,14 @@ class Cas1SpaceBookingTest {
             Cas1SpaceCharacteristic.isCatered,
           )
 
-          val essentialCriteria = essentialCharacteristics.map {
-            it.asCharacteristicEntity()
-          }
-
-          val desirableCriteria = desirableCharacteristics.map {
-            it.asCharacteristicEntity()
-          }
-
           placementRequest.placementRequirements = placementRequirementsFactory.produceAndPersist {
             withYieldedPostcodeDistrict {
               postCodeDistrictFactory.produceAndPersist()
             }
             withApplication(application as ApprovedPremisesApplicationEntity)
             withAssessment(placementRequest.assessment)
-            withEssentialCriteria(essentialCriteria)
-            withDesirableCriteria(desirableCriteria)
+            withEssentialCriteria(emptyList())
+            withDesirableCriteria(emptyList())
           }
 
           placementRequestRepository.saveAndFlush(placementRequest)
@@ -265,9 +256,7 @@ class Cas1SpaceBookingTest {
           assertThat(result.requirements.essentialCharacteristics).containsExactlyInAnyOrderElementsOf(
             essentialCharacteristics,
           )
-          assertThat(result.requirements.desirableCharacteristics).containsExactlyInAnyOrderElementsOf(
-            desirableCharacteristics,
-          )
+          assertThat(result.requirements.desirableCharacteristics).isEmpty()
           assertThat(result.premises.id).isEqualTo(premises.id)
           assertThat(result.premises.name).isEqualTo(premises.name)
           assertThat(result.apArea.id).isEqualTo(premises.probationRegion.apArea!!.id)
@@ -291,13 +280,6 @@ class Cas1SpaceBookingTest {
             .isEqualTo(ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED)
         }
       }
-    }
-
-    private fun Cas1SpaceCharacteristic.asCharacteristicEntity() = characteristicEntityFactory.produceAndPersist {
-      withName(this@asCharacteristicEntity.value)
-      withPropertyName(this@asCharacteristicEntity.value)
-      withServiceScope(ServiceName.approvedPremises.value)
-      withModelScope("*")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PageCriteriaFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
@@ -134,6 +135,7 @@ class Cas1SpaceBookingServiceTest {
         arrivalDate = LocalDate.now(),
         departureDate = LocalDate.now().plusDays(1),
         createdBy = user,
+        characteristics = emptyList(),
       )
 
       assertThat(result).isInstanceOf(CasResult.FieldValidationError::class.java)
@@ -163,6 +165,7 @@ class Cas1SpaceBookingServiceTest {
         arrivalDate = LocalDate.now(),
         departureDate = LocalDate.now().plusDays(1),
         createdBy = user,
+        characteristics = emptyList(),
       )
 
       assertThat(result).isInstanceOf(CasResult.FieldValidationError::class.java)
@@ -196,6 +199,7 @@ class Cas1SpaceBookingServiceTest {
         arrivalDate = LocalDate.now().plusDays(1),
         departureDate = LocalDate.now(),
         createdBy = user,
+        characteristics = emptyList(),
       )
 
       assertThat(result).isInstanceOf(CasResult.FieldValidationError::class.java)
@@ -235,6 +239,7 @@ class Cas1SpaceBookingServiceTest {
         arrivalDate = LocalDate.now(),
         departureDate = LocalDate.now().plusDays(1),
         createdBy = user,
+        characteristics = emptyList(),
       )
 
       assertThat(result).isInstanceOf(CasResult.ConflictError::class.java)
@@ -298,6 +303,10 @@ class Cas1SpaceBookingServiceTest {
         arrivalDate = arrivalDate,
         departureDate = departureDate,
         createdBy = user,
+        characteristics = listOf(
+          CharacteristicEntityFactory().withName("c1").produce(),
+          CharacteristicEntityFactory().withName("c2").produce(),
+        ),
       )
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
@@ -318,6 +327,7 @@ class Cas1SpaceBookingServiceTest {
       assertThat(persistedBooking.crn).isEqualTo(application.crn)
       assertThat(persistedBooking.keyWorkerStaffCode).isNull()
       assertThat(persistedBooking.keyWorkerAssignedAt).isNull()
+      assertThat(persistedBooking.criteria).hasSize(2)
 
       verify { cas1ApplicationStatusService.spaceBookingMade(persistedBooking) }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
@@ -18,19 +18,20 @@ class Cas1SpaceBookingRequirementsTransformerTest {
 
   @Test
   fun `Placement requirements are transformed correctly`() {
-    val cas1SpaceCharacteristics = Cas1SpaceCharacteristic.entries.map { it.toCharacteristicEntity() }
+    val cas1EssentialSpaceCharacteristics = Cas1SpaceCharacteristic.entries.map { it.toCharacteristicEntity() }
+    val cas1DesirableSpaceCharacteristics = Cas1SpaceCharacteristic.entries.map { it.toCharacteristicEntity() }
 
     val placementRequirements = PlacementRequirementsEntityFactory()
       .withDefaults()
-      .withEssentialCriteria(cas1SpaceCharacteristics)
-      .withDesirableCriteria(cas1SpaceCharacteristics)
+      .withEssentialCriteria(emptyList())
+      .withDesirableCriteria(cas1DesirableSpaceCharacteristics)
       .produce()
 
-    val result = transformer.transformJpaToApi(placementRequirements)
+    val result = transformer.transformJpaToApi(placementRequirements, cas1EssentialSpaceCharacteristics)
 
     assertThat(result.apType).isEqualTo(placementRequirements.apType)
     assertThat(result.gender).isEqualTo(placementRequirements.gender)
-    assertThat(result.desirableCharacteristics).isEqualTo(Cas1SpaceCharacteristic.entries)
+    assertThat(result.desirableCharacteristics).isEmpty()
     assertThat(result.essentialCharacteristics).isEqualTo(Cas1SpaceCharacteristic.entries)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
@@ -95,6 +96,11 @@ class Cas1SpaceBookingTransformerTest {
 
       val cancellationReason = CancellationReasonEntityFactory().produce()
 
+      val criteria = listOf(
+        CharacteristicEntityFactory().produce(),
+        CharacteristicEntityFactory().produce(),
+      )
+
       val spaceBooking = Cas1SpaceBookingEntityFactory()
         .withPlacementRequest(placementRequest)
         .withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
@@ -107,6 +113,7 @@ class Cas1SpaceBookingTransformerTest {
         .withCancellationRecordedAt(Instant.parse("2023-12-29T11:25:10.00Z"))
         .withCancellationReason(cancellationReason)
         .withCancellationReasonNotes("some extra info on cancellation")
+        .withCriteria(criteria)
         .produce()
 
       val expectedRequirements = Cas1SpaceBookingRequirements(
@@ -134,7 +141,12 @@ class Cas1SpaceBookingTransformerTest {
       )
 
       every { personTransformer.transformModelToPersonApi(personInfo) } returns expectedPerson
-      every { requirementsTransformer.transformJpaToApi(spaceBooking.placementRequest.placementRequirements) } returns expectedRequirements
+      every {
+        requirementsTransformer.transformJpaToApi(
+          jpa = spaceBooking.placementRequest.placementRequirements,
+          criteria = criteria,
+        )
+      } returns expectedRequirements
       every {
         userTransformer.transformJpaToApi(
           spaceBooking.createdBy,
@@ -209,6 +221,11 @@ class Cas1SpaceBookingTransformerTest {
         .withPlacementApplication(placementApplication)
         .produce()
 
+      val criteria = listOf(
+        CharacteristicEntityFactory().produce(),
+        CharacteristicEntityFactory().produce(),
+      )
+
       val spaceBooking = Cas1SpaceBookingEntityFactory()
         .withPlacementRequest(placementRequest)
         .withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
@@ -220,6 +237,7 @@ class Cas1SpaceBookingTransformerTest {
         .withCancellationOccurredAt(LocalDate.parse("2039-12-28"))
         .withCancellationRecordedAt(Instant.parse("2023-12-29T11:25:10.00Z"))
         .withCancellationReasonNotes("some extra info on cancellation")
+        .withCriteria(criteria)
         .produce()
 
       val expectedRequirements = Cas1SpaceBookingRequirements(
@@ -240,7 +258,12 @@ class Cas1SpaceBookingTransformerTest {
       )
 
       every { personTransformer.transformModelToPersonApi(personInfo) } returns expectedPerson
-      every { requirementsTransformer.transformJpaToApi(spaceBooking.placementRequest.placementRequirements) } returns expectedRequirements
+      every {
+        requirementsTransformer.transformJpaToApi(
+          jpa = spaceBooking.placementRequest.placementRequirements,
+          criteria = criteria,
+        )
+      } returns expectedRequirements
       every {
         userTransformer.transformJpaToApi(
           spaceBooking.createdBy,


### PR DESCRIPTION
Before this commit a space bookings ‘essential’ and ‘desirable’ criteria were derived from its associated placement request requirements.

This commit

1. Add persistence of ‘essential’ criteria on the space booking entity (just named ‘criteria’), populating this from the space booking creation POST
2. Populating the space booking ‘essential’ criteria from the space booking entity when returning a space booking (instead of the placement request)
3. Deprecates the ‘desirable’ criteria when creating a space booking, and no longer populating it when returning a space booking. This will be removed by a subsequent commit.