### PR TITLE
remove redis tracking from app insights

### DIFF
--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -8,6 +8,9 @@
   "instrumentation": {
     "logging": {
       "level": "DEBUG"
+    },
+    "redis": {
+      "enabled": false
     }
   },
   "selfDiagnostics": {
@@ -22,9 +25,14 @@
               "key": "http.url",
               "value": "https?://[^/]+/health.*",
               "matchType": "regexp"
+            },
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info.*",
+              "matchType": "regexp"
             }
           ],
-          "percentage": 10
+          "percentage": 5
         }
       ]
     }


### PR DESCRIPTION
This PR forms part of [API-1357](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-1375), reviewing our usage of app insights (which is larrrrrge!)

I have updated the app insight config to not track redis, as there seems little business need for this
I have also reduced the sampling for the health and info endpoint to 5%, as [per this guidance](https://docs.google.com/document/d/1uG7Ne1_B2RwgREI-iMXHVnyQfuIQykDVfMQ1k-h-xHk/edit)