### PR TITLE
APS-1241: Implement Space Booking Timeline M&M V2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicSe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.SpaceBookingFilterCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
@@ -44,11 +45,13 @@ class Cas1SpaceBookingController(
   private val spaceBookingTransformer: Cas1SpaceBookingTransformer,
   private val cas1SpaceBookingService: Cas1SpaceBookingService,
   private val cas1WithdrawableService: Cas1WithdrawableService,
+  private val cas1SpaceBookingManagementDomainEventService: Cas1SpaceBookingManagementDomainEventService,
   private val characteristicService: CharacteristicService,
 ) : SpaceBookingsCas1Delegate {
 
-  override fun getSpaceBookingTimeline(premisesId: UUID, bookingId: UUID): ResponseEntity<TimelineEvent> {
-    return super.getSpaceBookingTimeline(premisesId, bookingId)
+  override fun getSpaceBookingTimeline(premisesId: UUID, bookingId: UUID): ResponseEntity<List<TimelineEvent>> {
+    val events = cas1SpaceBookingManagementDomainEventService.getTimeline(bookingId)
+    return ResponseEntity(events, HttpStatus.OK)
   }
 
   override fun createSpaceBooking(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -51,10 +51,19 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
       LEFT OUTER JOIN Cas1SpaceBookingEntity sb ON sb.id = d.cas1SpaceBookingId
       LEFT OUTER JOIN AppealEntity a ON a.application.id = d.applicationId 
       LEFT OUTER JOIN UserEntity u ON u.id = d.triggeredByUserId
-      WHERE d.applicationId = :applicationId
+      WHERE
+        (
+            (:applicationId IS NULL) OR (
+                d.applicationId = :applicationId
+            )
+        ) AND (
+            (:spaceBookingId IS NULL) OR (
+                d.cas1SpaceBookingId = :spaceBookingId
+            )
+        )
     """,
   )
-  fun findAllTimelineEventsByApplicationId(applicationId: UUID): List<DomainEventSummary>
+  fun findAllTimelineEventsByIds(applicationId: UUID?, spaceBookingId: UUID?): List<DomainEventSummary>
 
   @Query(
     "SELECT * FROM domain_events domain_event " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -267,7 +267,13 @@ class DomainEventService(
     )
 
   fun getAllDomainEventsForApplication(applicationId: UUID) =
-    domainEventRepository.findAllTimelineEventsByApplicationId(applicationId).distinctBy { it.id }
+    getAllDomainEventsById(applicationId = applicationId)
+
+  fun getAllDomainEventsForSpaceBooking(spaceBookingId: UUID) =
+    getAllDomainEventsById(spaceBookingId = spaceBookingId)
+
+  private fun getAllDomainEventsById(applicationId: UUID? = null, spaceBookingId: UUID? = null) =
+    domainEventRepository.findAllTimelineEventsByIds(applicationId, spaceBookingId).distinctBy { it.id }
 
   @Transactional
   fun saveAndEmit(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonD
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
@@ -22,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -33,6 +35,7 @@ class Cas1SpaceBookingManagementDomainEventService(
   val offenderService: OffenderService,
   val communityApiClient: CommunityApiClient,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+  private val applicationTimelineTransformer: ApplicationTimelineTransformer,
 ) {
 
   fun arrivalRecorded(
@@ -149,6 +152,13 @@ class Cas1SpaceBookingManagementDomainEventService(
         ),
       ),
     )
+  }
+
+  fun getTimeline(bookingId: UUID): List<TimelineEvent> {
+    val domainEvents = domainEventService.getAllDomainEventsForSpaceBooking(bookingId)
+    return domainEvents.map {
+      applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(it)
+    }
   }
 
   private fun getStaffMemberDetails(staffCode: String?): StaffMember? {

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -746,7 +746,9 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '_shared.yml#/components/schemas/TimelineEvent'
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/TimelineEvent'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -748,7 +748,9 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/TimelineEvent'
+                type: array
+                items:
+                  $ref: '#/components/schemas/TimelineEvent'
         401:
           $ref: '#/components/responses/401Response'
         403:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -48,6 +48,10 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     this.bookingId = { bookingId }
   }
 
+  fun withCas1SpaceBookingId(cas1SpaceBookingId: UUID?) = apply {
+    this.cas1SpaceBookingId = { cas1SpaceBookingId }
+  }
+
   fun withCrn(crn: String) = apply {
     this.crn = { crn }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/DomainEventAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/DomainEventAsserter.kt
@@ -17,13 +17,21 @@ class DomainEventAsserter(
   fun blockForEmittedDomainEvent(eventType: DomainEventType) = snsDomainEventListener.blockForMessage(eventType)
 
   fun assertDomainEventStoreCount(applicationId: UUID, expectedCount: Int) {
-    assertThat(domainEventRepository.findAllTimelineEventsByApplicationId(applicationId)).hasSize(expectedCount)
+    assertThat(
+      domainEventRepository.findAllTimelineEventsByIds(
+        applicationId = applicationId,
+        spaceBookingId = null,
+      ),
+    ).hasSize(expectedCount)
   }
 
   fun assertDomainEventOfTypeStored(applicationId: UUID, eventType: DomainEventType): DomainEventEntity {
     assertThat(
       domainEventRepository
-        .findAllTimelineEventsByApplicationId(applicationId)
+        .findAllTimelineEventsByIds(
+          applicationId = applicationId,
+          spaceBookingId = null,
+        )
         .map { it.type },
     ).contains(eventType)
 
@@ -33,7 +41,10 @@ class DomainEventAsserter(
   fun assertDomainEventsOfTypeStored(applicationId: UUID, eventType: DomainEventType, expectedCount: Int) {
     assertThat(
       domainEventRepository
-        .findAllTimelineEventsByApplicationId(applicationId)
+        .findAllTimelineEventsByIds(
+          applicationId = applicationId,
+          spaceBookingId = null,
+        )
         .count { it.type == eventType },
     ).isEqualTo(expectedCount)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTimelineTest.kt
@@ -1,0 +1,207 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import com.fasterxml.jackson.core.type.TypeReference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Probation Region`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offender`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventCas
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.domainevents.DomainEventSummaryImpl
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeWithLatestJson
+import java.time.LocalDate
+
+class Cas1SpaceBookingTimelineTest : InitialiseDatabasePerClassTestBase() {
+  @Autowired
+  lateinit var applicationTimelineTransformer: ApplicationTimelineTransformer
+
+  lateinit var user: UserEntity
+  lateinit var domainEvents: List<DomainEventEntity>
+
+  lateinit var premises: ApprovedPremisesEntity
+  lateinit var spaceBooking: Cas1SpaceBookingEntity
+
+  @BeforeAll
+  fun setup() {
+    val userArgs = `Given a User`()
+
+    user = userArgs.first
+
+    val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    val assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist {
+      withPermissiveSchema()
+    }
+
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(applicationSchema)
+      withCreatedByUser(user)
+    }
+
+    val otherApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(applicationSchema)
+      withCreatedByUser(user)
+    }
+
+    val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
+      withApplication(application)
+      withAllocatedToUser(user)
+      withAssessmentSchema(assessmentSchema)
+    }
+
+    val otherAssessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
+      withApplication(otherApplication)
+      withAllocatedToUser(user)
+      withAssessmentSchema(assessmentSchema)
+    }
+
+    premises = approvedPremisesEntityFactory.produceAndPersist {
+      withYieldedProbationRegion { `Given a Probation Region`() }
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+    }
+
+    val (offender) = `Given an Offender`()
+    val (placementRequest) = `Given a Placement Request`(
+      placementRequestAllocatedTo = user,
+      assessmentAllocatedTo = user,
+      createdByUser = user,
+    )
+
+    spaceBooking = cas1SpaceBookingEntityFactory.produceAndPersist {
+      withCrn(offender.otherIds.crn)
+      withPremises(premises)
+      withPlacementRequest(placementRequest)
+      withApplication(application)
+      withCreatedBy(user)
+      withCanonicalArrivalDate(LocalDate.parse("2029-05-29"))
+      withCanonicalDepartureDate(LocalDate.parse("2029-06-29"))
+    }
+
+    val otherSpaceBooking = cas1SpaceBookingEntityFactory.produceAndPersist {
+      withCrn(offender.otherIds.crn)
+      withPremises(premises)
+      withPlacementRequest(placementRequest)
+      withApplication(otherApplication)
+      withCreatedBy(user)
+      withCanonicalArrivalDate(LocalDate.parse("2029-06-29"))
+      withCanonicalDepartureDate(LocalDate.parse("2029-07-29"))
+    }
+
+    domainEvents = DomainEventType.entries.filter { it.cas == DomainEventCas.CAS1 }.map {
+      createDomainEvent(it, otherSpaceBooking, otherApplication, otherAssessment, user)
+      return@map createDomainEvent(it, spaceBooking, application, assessment, user)
+    }
+  }
+
+  @Test
+  fun `Get space booking timeline without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/premises/0/space-bookings/1/timeline")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Get space booking timeline with non existent id parameters returns 404`() {
+    `Given a User` { _, jwt ->
+      webTestClient.get()
+        .uri("/premises/1/space-bookings/2/timeline")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Get space booking timeline returns all expected items`() {
+    `Given a User` { _, jwt ->
+
+      val rawResponseBody = webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/space-bookings/${spaceBooking.id}/timeline")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.approvedPremises.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult<String>()
+        .responseBody
+        .blockFirst()
+
+      val responseBody =
+        objectMapper.readValue(
+          rawResponseBody,
+          object : TypeReference<List<TimelineEvent>>() {},
+        )
+
+      val expectedItems = mutableListOf<TimelineEvent>()
+
+      expectedItems.addAll(
+        domainEvents.map {
+          applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(
+            DomainEventSummaryImpl(
+              it.id.toString(),
+              it.type,
+              it.occurredAt,
+              it.applicationId,
+              it.assessmentId,
+              null,
+              premises.id,
+              null,
+              it.cas1SpaceBookingId,
+              it.triggerSource,
+              user,
+            ),
+          )
+        },
+      )
+      assertThat(responseBody.count()).isEqualTo(expectedItems.count())
+      assertThat(responseBody).hasSameElementsAs(expectedItems)
+    }
+  }
+
+  private fun createDomainEvent(
+    type: DomainEventType,
+    spaceBookingEntity: Cas1SpaceBookingEntity,
+    applicationEntity: ApprovedPremisesApplicationEntity,
+    assessmentEntity: ApprovedPremisesAssessmentEntity,
+    userEntity: UserEntity,
+  ): DomainEventEntity {
+    val data = if (type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED) {
+      val clarificationNote = assessmentClarificationNoteEntityFactory.produceAndPersist {
+        withAssessment(assessmentEntity)
+        withCreatedBy(userEntity)
+      }
+      createCas1DomainEventEnvelopeWithLatestJson(type, clarificationNote.id)
+    } else {
+      createCas1DomainEventEnvelopeWithLatestJson(type)
+    }
+
+    return domainEventFactory.produceAndPersist {
+      withApplicationId(applicationEntity.id)
+      withCas1SpaceBookingId(spaceBookingEntity.id)
+      withData(data)
+      withTriggeredByUserId(userEntity.id)
+      withTriggerSourceSystem()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
@@ -44,12 +45,14 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
   private val domainEventService = mockk<DomainEventService>()
   private val offenderService = mockk<OffenderService>()
   private val communityApiClient = mockk<CommunityApiClient>()
+  private val applicationTimelineTransformer = mockk<ApplicationTimelineTransformer>()
 
   val service = Cas1SpaceBookingManagementDomainEventService(
     domainEventService,
     offenderService,
     communityApiClient,
     UrlTemplate("http://frontend/applications/#id"),
+    applicationTimelineTransformer,
   )
 
   @Nested


### PR DESCRIPTION
This PR implements Space Booking Timeline for Match and Manage V2
Changes included in this PR :

- Updated CAS1 API to return list of timeline events
- Added getTimeline function to cas1 domain event service 
- Updated timeline query to incorporate spaceBookingId parameter