### PR TITLE
CAS-440 Change to return data domain as json instead of string

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentReferralHistoryNoteTransformer.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryDomainEventNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
@@ -15,7 +16,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 
 @Component
-class AssessmentReferralHistoryNoteTransformer {
+class AssessmentReferralHistoryNoteTransformer(
+  private val objectMapper: ObjectMapper,
+) {
 
   fun transformJpaToApi(jpa: AssessmentReferralHistoryNoteEntity): ReferralHistoryNote = when (jpa) {
     is AssessmentReferralHistoryUserNoteEntity -> { transformJpaToReferralHistoryUserNote(jpa) }
@@ -48,7 +51,7 @@ class AssessmentReferralHistoryNoteTransformer {
     ReferralHistoryDomainEventNote(
       id = domainEventEntity.id,
       createdAt = domainEventEntity.createdAt.toInstant(),
-      messageDetails = ReferralHistoryNoteMessageDetails(domainEvent = domainEventEntity.data),
+      messageDetails = ReferralHistoryNoteMessageDetails(domainEvent = objectMapper.readTree(domainEventEntity.data)),
       createdByUserName = user.name,
       type = "domainEvent",
     )

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2904,7 +2904,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          type: object
+          $ref: '#/components/schemas/AnyValue'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7347,7 +7347,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          type: object
+          $ref: '#/components/schemas/AnyValue'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3880,7 +3880,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          type: object
+          $ref: '#/components/schemas/AnyValue'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3495,7 +3495,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          type: object
+          $ref: '#/components/schemas/AnyValue'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2995,7 +2995,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          type: object
+          $ref: '#/components/schemas/AnyValue'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -2916,12 +2916,12 @@ class AssessmentTest : IntegrationTestBase() {
           .referralHistoryNotes!!
 
         assertThat(response.size).isEqualTo(2)
-        val releaseDateUpdatedEvent = objectMapper.readValue(
-          response[0].messageDetails!!.domainEvent as String,
+        val releaseDateUpdatedEvent = objectMapper.convertValue(
+          response[0].messageDetails!!.domainEvent,
           CAS3AssessmentUpdatedEvent::class.java,
         )
-        val accommodationReqFromUpdatedEvent = objectMapper.readValue(
-          response[1].messageDetails!!.domainEvent as String,
+        val accommodationReqFromUpdatedEvent = objectMapper.convertValue(
+          response[1].messageDetails!!.domainEvent,
           CAS3AssessmentUpdatedEvent::class.java,
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentReferralHistoryNoteTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentReferralHistoryNoteTransformerTest.kt
@@ -1,5 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -20,6 +24,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomNumberChars
 
 class AssessmentReferralHistoryNoteTransformerTest {
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(Jdk8Module())
+    registerModule(JavaTimeModule())
+    registerKotlinModule()
+  }
+
   @Test
   fun `transformJpaToApi transforms correctly for a user note`() {
     val probationRegion = ProbationRegionEntityFactory()
@@ -44,7 +54,7 @@ class AssessmentReferralHistoryNoteTransformerTest {
       .withCreatedBy(user)
       .produce()
 
-    val result = AssessmentReferralHistoryNoteTransformer().transformJpaToApi(note)
+    val result = AssessmentReferralHistoryNoteTransformer(objectMapper).transformJpaToApi(note)
 
     assertThat(result is ReferralHistoryUserNote).isTrue
     result as ReferralHistoryUserNote
@@ -81,7 +91,7 @@ class AssessmentReferralHistoryNoteTransformerTest {
       .withType(noteType)
       .produce()
 
-    val result = AssessmentReferralHistoryNoteTransformer().transformJpaToApi(note)
+    val result = AssessmentReferralHistoryNoteTransformer(objectMapper).transformJpaToApi(note)
 
     assertThat(result is ReferralHistorySystemNote).isTrue
     result as ReferralHistorySystemNote
@@ -134,7 +144,7 @@ class AssessmentReferralHistoryNoteTransformerTest {
       .withType(ReferralHistorySystemNoteType.REJECTED)
       .produce()
 
-    val result = AssessmentReferralHistoryNoteTransformer().transformJpaToApi(note, assessment)
+    val result = AssessmentReferralHistoryNoteTransformer(objectMapper).transformJpaToApi(note, assessment)
 
     assertThat(result is ReferralHistorySystemNote).isTrue
     result as ReferralHistorySystemNote
@@ -184,7 +194,7 @@ class AssessmentReferralHistoryNoteTransformerTest {
       .withType(noteType)
       .produce()
 
-    val result = AssessmentReferralHistoryNoteTransformer().transformJpaToApi(note, assessment)
+    val result = AssessmentReferralHistoryNoteTransformer(objectMapper).transformJpaToApi(note, assessment)
 
     assertThat(result is ReferralHistorySystemNote).isTrue
     result as ReferralHistorySystemNote


### PR DESCRIPTION
This [PR CAS-440](https://dsdmoj.atlassian.net/browse/CAS-440) is to change to return data domain as json instead of string