### PR TITLE
Fix an issue showing overlap people staying in a bedspace when their bookings was cancelled

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -85,7 +85,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
              INNER JOIN rooms r ON b.room_id = r.id
              LEFT JOIN applications ap ON bk.application_id = ap.id
              LEFT JOIN assessments a ON ap.id = a.application_id
-             LEFT JOIN cancellations c ON b.id = c.booking_id
+             LEFT JOIN cancellations c ON bk.id = c.booking_id
     WHERE bk.premises_id IN (:premisesIds) AND bk.arrival_date <= :endDate AND bk.departure_date >= :startDate AND c.id IS NULL
     """,
     nativeQuery = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -588,6 +588,22 @@ class BedSearchTest : IntegrationTestBase() {
             withId(UUID.randomUUID())
           }
 
+          val cancelledOverlappingBookingForBedInPremisesTwo = bookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withApplication(application)
+            withPremises(premisesTwo)
+            withBed(overlappingBedInPremisesTwo)
+            withArrivalDate(LocalDate.parse("2023-07-25"))
+            withDepartureDate(LocalDate.parse("2023-08-05"))
+            withCrn(offenderDetails.otherIds.crn)
+            withId(UUID.randomUUID())
+          }
+
+          cancellationEntityFactory.produceAndPersist {
+            withBooking(cancelledOverlappingBookingForBedInPremisesTwo)
+            withReason(cancellationReasonEntityFactory.produceAndPersist())
+          }
+
           ApDeliusContext_addResponseToUserAccessCall(
             CaseAccessFactory()
               .withCrn(offenderDetails.otherIds.crn)


### PR DESCRIPTION
This PR CAS-1207 is to fix an issue showing overlap people staying in a bedspace when their bookings was cancelled