### PR TITLE
APS-1368: Create a domain event when keyworker is assigned to a booking M&M V2

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -71,6 +71,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-KEYWORKER-ASSIGNED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-keyworker-assigned/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-EXPIRED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-expired/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -62,6 +62,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-KEYWORKER-ASSIGNED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-keyworker-assigned/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-EXPIRED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-expired/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -63,6 +63,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-KEYWORKER-ASSIGNED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-keyworker-assigned/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-EXPIRED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-expired/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -57,6 +57,7 @@ generic-service:
     URL-TEMPLATES_API_CAS1_BOOKING-NOT-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-not-made/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CANCELLED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-cancelled/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-CHANGED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-changed/#eventId
+    URL-TEMPLATES_API_CAS1_BOOKING-KEYWORKER-ASSIGNED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-keyworker-assigned/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-WITHDRAWN-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-withdrawn/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-EXPIRED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-expired/#eventId
     URL-TEMPLATES_API_CAS1_ASSESSMENT-APPEALED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/assessment-appealed/#eventId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/DomainEventUrlConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/DomainEventUrlConfig.kt
@@ -25,6 +25,7 @@ class DomainEventUrlConfig {
       DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> cas1["booking-not-made-event-detail"]
       DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> cas1["booking-cancelled-event-detail"]
       DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> cas1["booking-changed-event-detail"]
+      DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED -> cas1["booking-keyworker-assigned-event-detail"]
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> cas1["application-withdrawn-event-detail"]
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> cas1["assessment-appealed-event-detail"]
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> cas1["assessment-allocated-event-detail"]

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DomainEventsController.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingKeyWorkerAssignedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingNotMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.FurtherInformationRequestedEnvelope
@@ -36,6 +37,8 @@ class DomainEventsController(
   override fun eventsBookingCancelledEventIdGet(eventId: UUID) = getDomainEvent<BookingCancelledEnvelope>(eventId)
 
   override fun eventsBookingChangedEventIdGet(eventId: UUID) = getDomainEvent<BookingChangedEnvelope>(eventId)
+
+  override fun eventsBookingKeyworkerAssignedEventIdGet(eventId: UUID) = getDomainEvent<BookingKeyWorkerAssignedEnvelope>(eventId)
 
   override fun eventsApplicationAssessedEventIdGet(eventId: UUID) = getDomainEvent<ApplicationAssessedEnvelope>(eventId)
 
@@ -83,6 +86,7 @@ class DomainEventsController(
       PlacementApplicationWithdrawnEnvelope::class -> domainEventService::getPlacementApplicationWithdrawnEvent
       BookingCancelledEnvelope::class -> domainEventService::getBookingCancelledEvent
       BookingChangedEnvelope::class -> domainEventService::getBookingChangedEvent
+      BookingKeyWorkerAssignedEnvelope::class -> domainEventService::getBookingKeyWorkerAssignedEvent
       BookingNotMadeEnvelope::class -> domainEventService::getBookingNotMadeEvent
       PersonArrivedEnvelope::class -> domainEventService::getPersonArrivedEvent
       PersonDepartedEnvelope::class -> domainEventService::getPersonDepartedEvent

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -177,7 +177,7 @@ class Cas1SpaceBookingController(
     userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_SPACE_BOOKING_RECORD_KEYWORKER)
 
     ensureEntityFromCasResultIsSuccess(
-      cas1SpaceBookingService.recordKeyWorkerForBooking(
+      cas1SpaceBookingService.recordKeyWorkerAssignedForBooking(
         premisesId,
         bookingId,
         cas1AssignKeyWorker,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -41,6 +41,7 @@ class DomainEventDescriber(
       DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> buildBookingNotMadeDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> buildBookingCancelledDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> buildBookingChangedDescription(domainEventSummary)
+      DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED -> buildBookingKeyWorkerAssignedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> buildApplicationWithdrawnDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED -> buildApplicationExpiredDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> buildAssessmentAppealedDescription(domainEventSummary)
@@ -104,6 +105,16 @@ class DomainEventDescriber(
     return event.describe {
       "A placement at ${it.eventDetails.premises.name} had its arrival and/or departure date changed to " +
         "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()}"
+    }
+  }
+
+  private fun buildBookingKeyWorkerAssignedDescription(domainEventSummary: DomainEventSummary): String? {
+    val event = domainEventService.getBookingKeyWorkerAssignedEvent(domainEventSummary.id())
+    val keyWorkersDetail = event?.data?.eventDetails?.previousKeyWorkerName?.let {
+      "changes from $it to ${event?.data?.eventDetails?.assignedKeyWorkerName}"
+    } ?: "set to ${event?.data?.eventDetails?.assignedKeyWorkerName}"
+    return event.describe {
+      "Keyworker for placement at ${it.eventDetails.premises.name} for ${it.eventDetails.arrivalDate.toUiFormat()} to ${it.eventDetails.departureDate.toUiFormat()} $keyWorkersDetail".trimMargin()
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -232,6 +232,12 @@ enum class DomainEventType(
     "An Approved Premises Booking has been changed",
     TimelineEventType.approvedPremisesBookingChanged,
   ),
+  APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED(
+    DomainEventCas.CAS1,
+    Cas1EventType.bookingKeyWorkerAssigned.value,
+    "A keyworker has been assigned to the booking",
+    TimelineEventType.approvedPremisesBookingKeyworkerAssigned,
+  ),
   APPROVED_PREMISES_APPLICATION_WITHDRAWN(
     DomainEventCas.CAS1,
     Cas1EventType.applicationWithdrawn.value,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingKeyWorkerAssignedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingNotMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.FurtherInformationRequestedEnvelope
@@ -63,6 +64,7 @@ class DomainEventService(
   fun getBookingNotMadeEvent(id: UUID) = get(id, BookingNotMadeEnvelope::class)
   fun getBookingCancelledEvent(id: UUID) = get(id, BookingCancelledEnvelope::class)
   fun getBookingChangedEvent(id: UUID) = get(id, BookingChangedEnvelope::class)
+  fun getBookingKeyWorkerAssignedEvent(id: UUID) = get(id, BookingKeyWorkerAssignedEnvelope::class)
   fun getApplicationWithdrawnEvent(id: UUID) = get(id, ApplicationWithdrawnEnvelope::class)
   fun getApplicationExpiredEvent(id: UUID) = get(id, ApplicationExpiredEnvelope::class)
   fun getPlacementApplicationWithdrawnEvent(id: UUID) = get(id, PlacementApplicationWithdrawnEnvelope::class)
@@ -94,6 +96,7 @@ class DomainEventService(
         (type == PersonDepartedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED) ||
         (type == BookingNotMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE) ||
         (type == BookingChangedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED) ||
+        (type == BookingKeyWorkerAssignedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED) ||
         (type == ApplicationWithdrawnEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN) ||
         (type == ApplicationExpiredEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED) ||
         (type == AssessmentAppealedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED) ||
@@ -263,6 +266,14 @@ class DomainEventService(
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
+      emit = emit,
+    )
+
+  @Transactional
+  fun saveKeyWorkerAssignedEvent(domainEvent: DomainEvent<BookingKeyWorkerAssignedEnvelope>, emit: Boolean) =
+    saveAndEmit(
+      domainEvent = domainEvent,
+      eventType = DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED,
       emit = emit,
     )
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -232,6 +232,7 @@ url-templates:
       booking-not-made-event-detail: http://localhost:3000/events/booking-not-made/#eventId
       booking-cancelled-event-detail: http://localhost:3000/events/booking-cancelled/#eventId
       booking-changed-event-detail: http://localhost:3000/events/booking-changed/#eventId
+      booking-keyworker-assigned-event-detail: http://localhost:3000/events/booking-keyworker-assigned/#eventId
       application-withdrawn-event-detail: http://localhost:3000/events/application-withdrawn/#eventId
       application-expired-event-detail: http://localhost:3000/events/application-expired/#eventId
       assessment-appealed-event-detail: http://localhost:3000/events/assessment-appealed/#eventId

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3740,6 +3740,7 @@ components:
         - approved_premises_booking_not_made
         - approved_premises_booking_cancelled
         - approved_premises_booking_changed
+        - approved_premises_booking_keyworker_assigned
         - approved_premises_application_withdrawn
         - approved_premises_application_expired
         - approved_premises_information_request

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8183,6 +8183,7 @@ components:
         - approved_premises_booking_not_made
         - approved_premises_booking_cancelled
         - approved_premises_booking_changed
+        - approved_premises_booking_keyworker_assigned
         - approved_premises_application_withdrawn
         - approved_premises_application_expired
         - approved_premises_information_request

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4716,6 +4716,7 @@ components:
         - approved_premises_booking_not_made
         - approved_premises_booking_cancelled
         - approved_premises_booking_changed
+        - approved_premises_booking_keyworker_assigned
         - approved_premises_application_withdrawn
         - approved_premises_application_expired
         - approved_premises_information_request

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4331,6 +4331,7 @@ components:
         - approved_premises_booking_not_made
         - approved_premises_booking_cancelled
         - approved_premises_booking_changed
+        - approved_premises_booking_keyworker_assigned
         - approved_premises_application_withdrawn
         - approved_premises_application_expired
         - approved_premises_information_request

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3831,6 +3831,7 @@ components:
         - approved_premises_booking_not_made
         - approved_premises_booking_cancelled
         - approved_premises_booking_changed
+        - approved_premises_booking_keyworker_assigned
         - approved_premises_application_withdrawn
         - approved_premises_application_expired
         - approved_premises_information_request

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -247,6 +247,33 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
+  /events/booking-keyworker-assigned/{eventId}:
+    parameters:
+      - name: eventId
+        description: UUID of the event
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EventId'
+    get:
+      tags:
+        - "'Manage' events"
+      summary: A 'booking-keyworker-assigned' event
+      responses:
+        '200':
+          description: The 'booking-keyworker-assigned' event corresponding to the provided `eventId`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingKeyWorkerAssignedEnvelope'
+        404:
+          description: No 'booking-keyworker-changed' event found for the provided `eventId`
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
   /events/booking-not-made/{eventId}:
     parameters:
       - name: eventId
@@ -1229,6 +1256,61 @@ components:
         - premises
         - arrivalOn
         - departureOn
+    BookingKeyWorkerAssignedEnvelope:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/EventId'
+        timestamp:
+          type: string
+          example: '2022-11-30T14:53:44'
+          format: date-time
+        eventType:
+          $ref: '#/components/schemas/EventType'
+        eventDetails:
+          $ref: '#/components/schemas/BookingKeyWorkerAssigned'
+      required:
+        - id
+        - timestamp
+        - eventType
+        - eventDetails
+    BookingKeyWorkerAssigned:
+      type: object
+      properties:
+        applicationId:
+          $ref: '#/components/schemas/ApplicationId'
+        applicationUrl:
+          $ref: '#/components/schemas/ApplicationUrl'
+        bookingId:
+          $ref: '#/components/schemas/BookingId'
+        personReference:
+          $ref: '#/components/schemas/PersonReference'
+        deliusEventNumber:
+          $ref: '#/components/schemas/DeliusEventNumber'
+        premises:
+          $ref: '#/components/schemas/Premises'
+        arrivalDate:
+          type: string
+          example: '2023-02-12'
+          format: date
+        departureDate:
+          type: string
+          example: '2023-02-12'
+          format: date
+        previousKeyWorkerName:
+          type: string
+        assignedKeyWorkerName:
+          type: string
+      required:
+        - applicationId
+        - applicationUrl
+        - bookingId
+        - personReference
+        - deliusEventNumber
+        - premises
+        - arrivalDate
+        - departureDate
+        - assignedKeyWorkerName
     BookingNotMadeEnvelope:
       type: object
       properties:
@@ -1986,6 +2068,7 @@ components:
           - approved-premises.booking.not-made
           - approved-premises.booking.cancelled
           - approved-premises.booking.changed
+          - approved-premises.booking.keyworker.assigned
           - approved-premises.application.withdrawn
           - approved-premises.application.expired
           - approved-premises.assessment.appealed
@@ -2006,6 +2089,7 @@ components:
         - bookingNotMade
         - bookingCancelled
         - bookingChanged
+        - bookingKeyWorkerAssigned
         - applicationWithdrawn
         - applicationExpired
         - assessmentAppealed

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingKeyWorkerAssignedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingKeyWorkerAssignedFactory.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingKeyWorkerAssigned
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+class BookingKeyWorkerAssignedFactory : Factory<BookingKeyWorkerAssigned> {
+  private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var applicationUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var bookingId: Yielded<UUID> = { UUID.randomUUID() }
+  private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
+  private var deliusEventNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var premises: Yielded<Premises> = { EventPremisesFactory().produce() }
+  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var departureDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var assignedKeyWorkerName: Yielded<String> = { "assigned name" }
+  private var previousKeyWorkerName: Yielded<String>? = null
+
+  fun withApplicationId(applicationId: UUID) = apply {
+    this.applicationId = { applicationId }
+  }
+
+  fun withApplicationUrl(applicationUrl: String) = apply {
+    this.applicationUrl = { applicationUrl }
+  }
+
+  fun withPersonReference(personReference: PersonReference) = apply {
+    this.personReference = { personReference }
+  }
+
+  fun withDeliusEventNumber(deliusEventNumber: String) = apply {
+    this.deliusEventNumber = { deliusEventNumber }
+  }
+
+  fun withBookingId(bookingId: UUID) = apply {
+    this.bookingId = { bookingId }
+  }
+
+  fun withPremises(premises: Premises) = apply {
+    this.premises = { premises }
+  }
+
+  fun withArrivalDate(arrivalDate: LocalDate) = apply {
+    this.arrivalDate = { arrivalDate }
+  }
+
+  fun withDepartureDate(departureDate: LocalDate) = apply {
+    this.departureDate = { departureDate }
+  }
+
+  fun withAssignedKeyWorkerName(assignedKeyWorkerName: String) = apply {
+    this.assignedKeyWorkerName = { assignedKeyWorkerName }
+  }
+
+  fun withPreviousKeyWorkerName(previousKeyWorkerName: String) = apply {
+    this.previousKeyWorkerName = { previousKeyWorkerName }
+  }
+
+  override fun produce() = BookingKeyWorkerAssigned(
+    applicationId = this.applicationId(),
+    applicationUrl = this.applicationUrl(),
+    personReference = this.personReference(),
+    deliusEventNumber = this.deliusEventNumber(),
+    bookingId = this.bookingId(),
+    premises = this.premises(),
+    arrivalDate = this.arrivalDate(),
+    departureDate = this.departureDate(),
+    assignedKeyWorkerName = this.assignedKeyWorkerName(),
+    previousKeyWorkerName = this.previousKeyWorkerName?.invoke(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -25,13 +25,18 @@ fun IntegrationTestBase.APDeliusContext_mockSuccessfulGetReferralDetails(crn: St
     ),
   )
 
-fun IntegrationTestBase.APDeliusContext_mockSuccessfulStaffMembersCall(staffMember: StaffMember, qCode: String) =
+fun IntegrationTestBase.APDeliusContext_mockSuccessfulStaffMembersCall(staffMember: StaffMember, qCode: String) {
   mockSuccessfulGetCallWithJsonResponse(
     url = "/approved-premises/$qCode/staff",
     responseBody = StaffMembersPage(
       content = listOf(staffMember),
     ),
   )
+  mockSuccessfulGetCallWithJsonResponse(
+    url = "/secure/staff/staffCode/${staffMember.code}",
+    responseBody = staffMember,
+  )
+}
 
 fun IntegrationTestBase.APDeliusContext_mockSuccessfulCaseDetailCall(crn: String, response: CaseDetail, responseStatus: Int = 200) =
   mockSuccessfulGetCallWithJsonResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -874,7 +874,7 @@ class Cas1SpaceBookingServiceTest {
     fun `Returns validation error if no premises exist with the given premisesId`() {
       every { cas1PremisesService.findPremiseById(any()) } returns null
 
-      val result = service.recordKeyWorkerForBooking(
+      val result = service.recordKeyWorkerAssignedForBooking(
         premisesId = UUID.randomUUID(),
         bookingId = UUID.randomUUID(),
         keyWorker = Cas1AssignKeyWorker(keyWorker.code),
@@ -892,7 +892,7 @@ class Cas1SpaceBookingServiceTest {
     fun `Returns validation error if no space booking exists with the given bookingId`() {
       every { spaceBookingRepository.findByIdOrNull(any()) } returns null
 
-      val result = service.recordKeyWorkerForBooking(
+      val result = service.recordKeyWorkerAssignedForBooking(
         premisesId = UUID.randomUUID(),
         bookingId = UUID.randomUUID(),
         keyWorker = Cas1AssignKeyWorker(keyWorker.code),
@@ -910,7 +910,7 @@ class Cas1SpaceBookingServiceTest {
     fun `Returns validation error if no staff record exists with the given staff code`() {
       every { staffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.NotFound()
 
-      val result = service.recordKeyWorkerForBooking(
+      val result = service.recordKeyWorkerAssignedForBooking(
         premisesId = UUID.randomUUID(),
         bookingId = UUID.randomUUID(),
         keyWorker = Cas1AssignKeyWorker(keyWorker.code),
@@ -925,12 +925,13 @@ class Cas1SpaceBookingServiceTest {
     }
 
     @Test
-    fun `Updates existing space booking with key worker information `() {
+    fun `Updates existing space booking with key worker information and raises domain event`() {
       val updatedSpaceBookingCaptor = slot<Cas1SpaceBookingEntity>()
 
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
+      every { cas1SpaceBookingManagementDomainEventService.keyWorkerAssigned(any(), any(), any()) } returns Unit
 
-      val result = service.recordKeyWorkerForBooking(
+      val result = service.recordKeyWorkerAssignedForBooking(
         premisesId = UUID.randomUUID(),
         bookingId = UUID.randomUUID(),
         keyWorker = Cas1AssignKeyWorker(keyWorker.code),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingKeyWorkerAssignedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingNotMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.FurtherInformationRequestedEnvelope
@@ -44,6 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Assessmen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAppealedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingChangedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingKeyWorkerAssignedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.FurtherInformationRequestedFactory
@@ -190,6 +192,7 @@ class DomainEventServiceTest {
         DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE to domainEventService::getBookingNotMadeEvent,
         DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED to domainEventService::getBookingCancelledEvent,
         DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED to domainEventService::getBookingChangedEvent,
+        DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED to domainEventService::getBookingKeyWorkerAssignedEvent,
         DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN to domainEventService::getApplicationWithdrawnEvent,
         DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED to domainEventService::getApplicationExpiredEvent,
         DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED to domainEventService::getAssessmentAppealedEvent,
@@ -703,6 +706,34 @@ class DomainEventServiceTest {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
+        )
+      }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `saveBookingKeyWorkerAssignedEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
+      val id = UUID.randomUUID()
+
+      val eventDetails = BookingKeyWorkerAssignedFactory().produce()
+      val domainEventEnvelope = mockk<BookingKeyWorkerAssignedEnvelope>()
+      val domainEvent = mockk<DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
+
+      every { domainEvent.id } returns id
+      every { domainEvent.data } returns domainEventEnvelope
+      every { domainEventEnvelope.eventDetails } returns eventDetails
+
+      val domainEventServiceSpy = spyk(domainEventService)
+
+      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+
+      domainEventServiceSpy.saveKeyWorkerAssignedEvent(domainEvent, emit)
+
+      verify {
+        domainEventServiceSpy.saveAndEmit(
+          domainEvent = domainEvent,
+          eventType = DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED,
+          emit,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.AssessmentAppealedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingCancelledEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingChangedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingKeyWorkerAssignedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingNotMadeEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
@@ -31,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Assessmen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAppealedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingChangedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingKeyWorkerAssignedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.FurtherInformationRequestedFactory
@@ -156,6 +158,12 @@ fun createCas1DomainEventEnvelopeWithLatestJson(
       timestamp = occurredAt,
       eventType = eventType,
       eventDetails = BookingChangedFactory().produce(),
+    )
+    DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED -> BookingKeyWorkerAssignedEnvelope(
+      id = id,
+      timestamp = occurredAt,
+      eventType = eventType,
+      eventDetails = BookingKeyWorkerAssignedFactory().produce(),
     )
     DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> ApplicationWithdrawnEnvelope(
       id = id,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -133,6 +133,7 @@ url-templates:
       booking-not-made-event-detail: http://api/events/booking-not-made/#eventId
       booking-cancelled-event-detail: http://api/events/booking-cancelled/#eventId
       booking-changed-event-detail: http://api/events/booking-changed/#eventId
+      booking-keyworker-assigned-event-detail: http://api/events/booking-keyworker-assigned/#eventId
       application-withdrawn-event-detail: http://api/events/application-withdrawn/#eventId
       application-expired-event-detail: http://api/events/application-expired/#eventId
       assessment-appealed-event-detail: http://api/events/assessment-appealed/#eventId


### PR DESCRIPTION
Adds domain event when assigning a keyworker to a booking
Adds the domain event to the API
Adds a keyworker assigned timeline event
Adds a domain event describer to provide required timeline narrative when a keyworker has been assigned to a booking