### PR TITLE
CAS-600 Ignore case when HPTs search by CRN

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -134,10 +134,10 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
              join applications ap on a.application_id = ap.id
              left outer join temporary_accommodation_applications taa on ap.id = taa.id
              left outer join probation_delivery_units pdu on taa.probation_delivery_unit_id = pdu.id
-       where taa.probation_region_id = ?1
-             and (?2 is null OR ap.crn = ?2 OR lower(taa.name) LIKE CONCAT('%', lower(?2),'%'))
+       where taa.probation_region_id = :probationRegionId
+             and (:crnOrName is null OR lower(ap.crn) = lower(:crnOrName) OR lower(taa.name) LIKE CONCAT('%', lower(:crnOrName),'%'))
              and a.reallocated_at is null
-             and ((?3) is null OR
+             and ((:statuses) is null OR
                                 (
                                   CASE
                                     WHEN a.decision='REJECTED' THEN 'REJECTED'
@@ -146,7 +146,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
                                     WHEN a.decision is null AND a.allocated_to_user_id is not null THEN 'IN_REVIEW'
                                     WHEN a.decision is null AND a.allocated_to_user_id is null THEN 'UNALLOCATED'
                                   END  
-                                ) IN (?3)                       
+                                ) IN (:statuses)                       
                 )
     """,
     countQuery = """
@@ -155,10 +155,10 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
                join assessments a on aa.assessment_id = a.id
                join applications ap on a.application_id = ap.id
                left outer join temporary_accommodation_applications taa on ap.id = taa.id
-         where taa.probation_region_id = ?1
-               and (?2 is null OR ap.crn = ?2)
+         where taa.probation_region_id = :probationRegionId
+               and (:crnOrName is null OR lower(ap.crn) = lower(:crnOrName))
                and a.reallocated_at is null
-               and ((?3) is null OR
+               and ((:statuses) is null OR
                                 (
                                   CASE
                                     WHEN a.decision='REJECTED' THEN 'REJECTED'
@@ -167,7 +167,7 @@ interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
                                     WHEN a.decision is null AND a.allocated_to_user_id is not null THEN 'IN_REVIEW'
                                     WHEN a.decision is null AND a.allocated_to_user_id is null THEN 'UNALLOCATED'
                                   END  
-                                ) IN (?3)                       
+                                ) IN (:statuses)                       
                 )
     """,
     nativeQuery = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -266,7 +266,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
       WHERE b.service = 'temporary-accommodation'
       AND (:status is null or b.status = :status)
       AND (Cast(:probationRegionId as varchar) is null or p.probation_region_id = :probationRegionId)
-      AND (:crnOrName is null OR b.crn = :crnOrName OR lower(offenders.name) LIKE CONCAT('%', lower(:crnOrName),'%'))
+      AND (:crnOrName is null OR lower(b.crn) = lower(:crnOrName) OR lower(offenders.name) LIKE CONCAT('%', lower(:crnOrName),'%'))
     """,
     countQuery = """
       $OFFENDERS_QUERY
@@ -280,7 +280,7 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
       WHERE b.service = 'temporary-accommodation'
       AND (:status is null or b.status = :status)
       AND (Cast(:probationRegionId as varchar) is null or p.probation_region_id = :probationRegionId)
-      AND (:crnOrName is null OR b.crn = :crnOrName OR lower(offenders.name) LIKE CONCAT('%', lower(:crnOrName),'%'))
+      AND (:crnOrName is null OR lower(b.crn) = lower(:crnOrName) OR lower(offenders.name) LIKE CONCAT('%', lower(:crnOrName),'%'))
     """,
     nativeQuery = true,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -1453,10 +1453,21 @@ class AssessmentTest : IntegrationTestBase() {
 
           otherAssessment.schemaUpToDate = true
 
+          // when CRN is upper case
           assertResponseForUrl(
             jwt,
             ServiceName.temporaryAccommodation,
             "/assessments?crnOrName=${offender.first.otherIds.crn}",
+            ExpectedResponse.OK(
+              assessmentSummaryMapper(offender.first, offender.second).toSummaries(assessment),
+            ),
+          )
+
+          // when CRN is lower case
+          assertResponseForUrl(
+            jwt,
+            ServiceName.temporaryAccommodation,
+            "/assessments?crnOrName=${offender.first.otherIds.crn.lowercase()}",
             ExpectedResponse.OK(
               assessmentSummaryMapper(offender.first, offender.second).toSummaries(assessment),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -68,7 +68,11 @@ class BookingSearchTest : IntegrationTestBase() {
           createTestTemporaryAccommodationBookings(userEntity.probationRegion, 1, 1, crn)
         val expectedResponse = getExpectedResponseWithoutPersonName(expectedBookingSearchResult, crn)
 
+        // when CRN is upper case
         callApiAndAssertResponse("/bookings/search?crnOrName=$crn", jwt, expectedResponse, true)
+
+        // when CRN is lower case
+        callApiAndAssertResponse("/bookings/search?crnOrName=${crn.lowercase()}", jwt, expectedResponse, true)
       }
     }
   }
@@ -83,7 +87,11 @@ class BookingSearchTest : IntegrationTestBase() {
         createTestTemporaryAccommodationBookings(userEntity.probationRegion, 1, 1, crn)
         val expectedResponse = getExpectedResponse(expectedBookingInSearchResult, offenderDetails)
 
+        // when CRN is upper case
         callApiAndAssertResponse("/bookings/search?crnOrName=${offenderDetails.otherIds.crn}", jwt, expectedResponse, true)
+
+        // when CRN is lower case
+        callApiAndAssertResponse("/bookings/search?crnOrName=${offenderDetails.otherIds.crn.lowercase()}", jwt, expectedResponse, true)
       }
     }
   }


### PR DESCRIPTION
This [PR CAS-600](https://dsdmoj.atlassian.net/browse/CAS-600) is to ignore case sensitivity when HPTs search by CRN in referrals and bookings  