### PR TITLE
Remove /profile endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ProfileController.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.ProfileApiDelegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProfileResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 
@@ -17,12 +16,6 @@ class ProfileController(
   private val userTransformer: UserTransformer,
 ) : ProfileApiDelegate {
   private val log = LoggerFactory.getLogger(this::class.java)
-
-  override fun profileGet(xServiceName: ServiceName): ResponseEntity<User> {
-    val userEntity = userService.getUserForRequest()
-
-    return ResponseEntity(userTransformer.transformJpaToApi(userEntity, xServiceName), HttpStatus.OK)
-  }
 
   override fun profileV2Get(
     xServiceName: ServiceName,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -3862,31 +3862,6 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
-  /profile:
-    get:
-      tags:
-        - Auth
-      summary: Returns information on the logged in user
-      parameters:
-        - name: X-Service-Name
-          in: header
-          required: true
-          description: Filters the user details to those relevant to the specified service.
-          schema:
-            $ref: '_shared.yml#/components/schemas/ServiceName'
-      responses:
-        200:
-          description: successfully retrieved information on user
-          content:
-            'application/json':
-              schema:
-                $ref: '_shared.yml#/components/schemas/User'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /profile/v2:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -3864,31 +3864,6 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
-  /profile:
-    get:
-      tags:
-        - Auth
-      summary: Returns information on the logged in user
-      parameters:
-        - name: X-Service-Name
-          in: header
-          required: true
-          description: Filters the user details to those relevant to the specified service.
-          schema:
-            $ref: '#/components/schemas/ServiceName'
-      responses:
-        200:
-          description: successfully retrieved information on user
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/User'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
   /profile/v2:
     get:
       tags:


### PR DESCRIPTION
This has been superceded by /profile/v2, which is now used by both CAS1 and CAS3