### PR TITLE
APS-1486 - Add DeliusEventNumber to SpaceBooking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -169,6 +169,7 @@ data class Cas1SpaceBookingEntity(
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "migrated_from_booking_id")
   val migratedFromBooking: BookingEntity?,
+  val deliusEventNumber: String?,
 ) {
   fun isActive() = !isCancelled()
   fun isCancelled() = cancellationOccurredAt != null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -127,6 +127,7 @@ class Cas1SpaceBookingService(
         nonArrivalNotes = null,
         nonArrivalReason = null,
         migratedFromBooking = null,
+        deliusEventNumber = application.eventNumber,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -65,6 +65,7 @@ class Cas1SpaceBookingTransformer(
       otherBookingsInPremisesForCrn = otherBookingsAtPremiseForCrn.map { it.toSpaceBookingDate() },
       cancellation = jpa.extractCancellation(),
       requestForPlacementId = jpa.placementRequest.placementApplication?.id ?: jpa.placementRequest.id,
+      deliusEventNumber = jpa.deliusEventNumber,
     )
   }
 

--- a/src/main/resources/db/migration/all/20241104104349__add_delius_event_number_to_space_booking.sql
+++ b/src/main/resources/db/migration/all/20241104104349__add_delius_event_number_to_space_booking.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_space_bookings ADD delius_event_number text NULL;

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -333,6 +333,8 @@ components:
             $ref: '#/components/schemas/Cas1SpaceBookingDates'
         cancellation:
           $ref: '#/components/schemas/Cas1SpaceBookingCancellation'
+        deliusEventNumber:
+          type: string
       required:
         - id
         - applicationId

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6492,6 +6492,8 @@ components:
             $ref: '#/components/schemas/Cas1SpaceBookingDates'
         cancellation:
           $ref: '#/components/schemas/Cas1SpaceBookingCancellation'
+        deliusEventNumber:
+          type: string
       required:
         - id
         - applicationId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -47,6 +47,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var nonArrivalReason: Yielded<NonArrivalReasonEntity?> = { null }
   private var nonArrivalNotes: Yielded<String?> = { null }
   private var migratedFromBooking: Yielded<BookingEntity?> = { null }
+  private var deliusEventNumber: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -190,6 +191,10 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.migratedFromBooking = { booking }
   }
 
+  fun withDeliusEventNumber(deliusEventNumber: String?) = apply {
+    this.deliusEventNumber = { deliusEventNumber }
+  }
+
   override fun produce() = Cas1SpaceBookingEntity(
     id = this.id(),
     premises = this.premises(),
@@ -218,5 +223,6 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     nonArrivalNotes = this.nonArrivalNotes(),
     nonArrivalReason = this.nonArrivalReason(),
     migratedFromBooking = this.migratedFromBooking(),
+    deliusEventNumber = this.deliusEventNumber(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 
@@ -11,13 +12,15 @@ fun IntegrationTestBase.`Given a CAS1 Application`(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   submittedAt: OffsetDateTime? = null,
+  eventNumber: String = randomInt(1, 9).toString(),
   block: (application: ApplicationEntity) -> Unit = {},
-) = `Given an Application`(createdByUser, crn, submittedAt, block)
+) = `Given an Application`(createdByUser, crn, submittedAt, eventNumber, block)
 
 fun IntegrationTestBase.`Given an Application`(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   submittedAt: OffsetDateTime? = null,
+  eventNumber: String = randomInt(1, 9).toString(),
   block: (application: ApplicationEntity) -> Unit = {},
 ): ApprovedPremisesApplicationEntity {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -29,6 +32,7 @@ fun IntegrationTestBase.`Given an Application`(
     withCreatedByUser(createdByUser)
     withApplicationSchema(applicationSchema)
     withSubmittedAt(submittedAt)
+    withEventNumber(eventNumber)
   }
 
   block(application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -38,7 +38,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     val criteria1 = characteristicEntityFactory.produceAndPersist()
     val criteria2 = characteristicEntityFactory.produceAndPersist()
 
-    val application1 = `Given a CAS1 Application`(createdByUser = otherUser)
+    val application1 = `Given a CAS1 Application`(createdByUser = otherUser, eventNumber = "25")
     val booking1 = `Given a Booking`(
       crn = "CRN1",
       premises = premises,
@@ -62,7 +62,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
       placementRequest1,
     )
 
-    val application2 = `Given a CAS1 Application`(createdByUser = otherUser)
+    val application2 = `Given a CAS1 Application`(createdByUser = otherUser, eventNumber = "50")
     val booking2 = `Given a Booking`(
       crn = "CRN2",
       premises = premises,
@@ -144,6 +144,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking1.departureMoveOnCategory).isNull()
     assertThat(migratedBooking1.migratedFromBooking!!.id).isEqualTo(booking1.id)
     assertThat(migratedBooking1.criteria).containsOnly(criteria1, criteria2)
+    assertThat(migratedBooking1.deliusEventNumber).isEqualTo("25")
 
     val migratedBooking2 = premiseSpaceBookings[1]
     assertThat(migratedBooking2.premises.id).isEqualTo(premises.id)
@@ -168,6 +169,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking2.departureMoveOnCategory).isNull()
     assertThat(migratedBooking2.migratedFromBooking!!.id).isEqualTo(booking2.id)
     assertThat(migratedBooking2.criteria).isEmpty()
+    assertThat(migratedBooking2.deliusEventNumber).isEqualTo("50")
   }
 
   private fun rowsToCsv(rows: List<Cas1BookingToSpaceBookingSeedCsvRow>): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -252,7 +252,11 @@ class Cas1SpaceBookingServiceTest {
     @Test
     fun `Creates new booking if all data is valid, updates application status, raises domain event and sends email`() {
       val premises = ApprovedPremisesEntityFactory().withDefaults().produce()
-      val application = ApprovedPremisesApplicationEntityFactory().withDefaults().produce()
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withDefaults()
+        .withEventNumber("42")
+        .produce()
+
       val placementApplication = PlacementApplicationEntityFactory().withDefaults().produce()
 
       val placementRequest = PlacementRequestEntityFactory()
@@ -331,6 +335,7 @@ class Cas1SpaceBookingServiceTest {
       assertThat(persistedBooking.nonArrivalReason).isNull()
       assertThat(persistedBooking.nonArrivalNotes).isNull()
       assertThat(persistedBooking.nonArrivalReason).isNull()
+      assertThat(persistedBooking.deliusEventNumber).isEqualTo("42")
 
       verify { cas1ApplicationStatusService.spaceBookingMade(persistedBooking) }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -114,6 +114,7 @@ class Cas1SpaceBookingTransformerTest {
         .withCancellationReason(cancellationReason)
         .withCancellationReasonNotes("some extra info on cancellation")
         .withCriteria(criteria)
+        .withDeliusEventNumber("97")
         .produce()
 
       val expectedRequirements = Cas1SpaceBookingRequirements(
@@ -182,6 +183,7 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.cancellation!!.recordedAt).isEqualTo(Instant.parse("2023-12-29T11:25:10.00Z"))
       assertThat(result.cancellation!!.reason).isEqualTo(expectedCancellationReason)
       assertThat(result.cancellation!!.reasonNotes).isEqualTo("some extra info on cancellation")
+      assertThat(result.deliusEventNumber).isEqualTo("97")
 
       assertThat(result.otherBookingsInPremisesForCrn).hasSize(1)
       assertThat(result.otherBookingsInPremisesForCrn[0].canonicalArrivalDate).isEqualTo(LocalDate.parse("2025-04-06"))


### PR DESCRIPTION
This commit persists a delius_event_number to the cas1_space_bookings table.

Whilst each booking logically must have a delius_event_number, there are a non-trivial number of bookings created via offline_applications where the event number is not known, and without a corresponding APPROVED_PREMISES_BOOKING_MADE domain event to derive this from. For this reason, the new column is optional.