### PR TITLE
APS-1486 - Use space booking event no. for domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
@@ -51,6 +51,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val premises = updatedCas1SpaceBooking.premises
     val offenderDetails = getOffenderForCrn(updatedCas1SpaceBooking.crn)
     val keyWorker = getStaffMemberDetails(updatedCas1SpaceBooking.keyWorkerStaffCode)
+    val eventNumber = updatedCas1SpaceBooking.deliusEventNumber!!
 
     val actualArrivalDate = updatedCas1SpaceBooking.actualArrivalDateTime!!
 
@@ -76,7 +77,7 @@ class Cas1SpaceBookingManagementDomainEventService(
               crn = updatedCas1SpaceBooking.crn,
               noms = offenderDetails?.nomsId ?: "Unknown NOMS Id",
             ),
-            deliusEventNumber = application.eventNumber,
+            deliusEventNumber = eventNumber,
             premises = Premises(
               id = premises.id,
               name = premises.name,
@@ -107,6 +108,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val premises = departedCas1SpaceBooking.premises
     val offenderDetails = getOffenderForCrn(departedCas1SpaceBooking.crn)
     val keyWorker = getStaffMemberDetails(departedCas1SpaceBooking.keyWorkerStaffCode)
+    val eventNumber = departedCas1SpaceBooking.deliusEventNumber!!
 
     val actualDepartureDate = departedCas1SpaceBooking.actualDepartureDateTime!!
 
@@ -132,7 +134,7 @@ class Cas1SpaceBookingManagementDomainEventService(
               crn = departedCas1SpaceBooking.crn,
               noms = offenderDetails?.nomsId ?: "Unknown NOMS Id",
             ),
-            deliusEventNumber = application.eventNumber,
+            deliusEventNumber = eventNumber,
             premises = Premises(
               id = premises.id,
               name = premises.name,
@@ -175,6 +177,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val application = updatedCas1SpaceBooking.application
     val premises = updatedCas1SpaceBooking.premises
     val offenderDetails = getOffenderForCrn(updatedCas1SpaceBooking.crn)
+    val eventNumber = updatedCas1SpaceBooking.deliusEventNumber!!
 
     domainEventService.saveKeyWorkerAssignedEvent(
       emit = false,
@@ -198,7 +201,7 @@ class Cas1SpaceBookingManagementDomainEventService(
               crn = updatedCas1SpaceBooking.crn,
               noms = offenderDetails?.nomsId ?: "Unknown NOMS Id",
             ),
-            deliusEventNumber = application.eventNumber,
+            deliusEventNumber = eventNumber,
             premises = Premises(
               id = premises.id,
               name = premises.name,
@@ -219,12 +222,12 @@ class Cas1SpaceBookingManagementDomainEventService(
   private fun getStaffMemberDetails(staffCode: String?): StaffMember? {
     val staffMember = staffCode?.let {
       val staffMemberDetailsResult =
-        communityApiClient.getStaffUserDetailsForStaffCode(staffCode!!)
+        communityApiClient.getStaffUserDetailsForStaffCode(staffCode)
       when (staffMemberDetailsResult) {
         is ClientResult.Success -> {
           val keyWorker = staffMemberDetailsResult.body
           StaffMember(
-            staffCode = keyWorker.staffCode!!,
+            staffCode = keyWorker.staffCode,
             staffIdentifier = keyWorker.staffIdentifier,
             forenames = keyWorker.staff.forenames,
             surname = keyWorker.staff.surname,
@@ -233,7 +236,7 @@ class Cas1SpaceBookingManagementDomainEventService(
         }
         is ClientResult.Failure -> staffMemberDetailsResult.throwException()
       }
-    } ?: null
+    }
     return staffMember
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -947,6 +947,7 @@ class Cas1SpaceBookingTest {
         withKeyworkerName(user.name)
         withKeyworkerStaffCode(user.deliusStaffCode)
         withKeyworkerAssignedAt(Instant.now())
+        withDeliusEventNumber("25")
       }
 
       webTestClient.post()
@@ -1000,6 +1001,7 @@ class Cas1SpaceBookingTest {
         withCanonicalArrivalDate(LocalDate.parse("2029-05-29"))
         withCanonicalDepartureDate(LocalDate.parse("2029-06-29"))
         withKeyworkerAssignedAt(Instant.now())
+        withDeliusEventNumber("75")
       }
     }
 
@@ -1178,6 +1180,7 @@ class Cas1SpaceBookingTest {
         withKeyworkerName(user.name)
         withKeyworkerStaffCode(user.deliusStaffCode)
         withKeyworkerAssignedAt(Instant.now())
+        withDeliusEventNumber("50")
       }
 
       webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -57,6 +57,10 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
     applicationTimelineTransformer,
   )
 
+  companion object Constants {
+    const val DELIUS_EVENT_NUMBER = "52"
+  }
+
   @Nested
   inner class ArrivalRecorded {
 
@@ -90,6 +94,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       .withExpectedDepartureDate(departureDate)
       .withCanonicalDepartureDate(departureDate)
       .withKeyworkerStaffCode(keyWorker.staffCode)
+      .withDeliusEventNumber(DELIUS_EVENT_NUMBER)
       .produce()
 
     @BeforeEach
@@ -134,7 +139,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       assertThat(data.applicationSubmittedOn).isEqualTo(application.submittedAt!!.toLocalDate())
       assertThat(data.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")
       assertThat(data.arrivedAt).isEqualTo(arrivalDate)
-      assertThat(data.deliusEventNumber).isEqualTo(application.eventNumber)
+      assertThat(data.deliusEventNumber).isEqualTo(DELIUS_EVENT_NUMBER)
       assertThat(data.premises.id).isEqualTo(premises.id)
       assertThat(data.premises.name).isEqualTo(premises.name)
       assertThat(data.premises.apCode).isEqualTo(premises.apCode)
@@ -150,6 +155,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
     fun `record arrival and emits domain event with no keyWorker information if keyWorker is not present in original booking`() {
       val existingSpaceBooking = Cas1SpaceBookingEntityFactory()
         .withApplication(application)
+        .withDeliusEventNumber(DELIUS_EVENT_NUMBER)
         .withPremises(premises)
         .withActualArrivalDateTime(arrivalDate)
         .withCanonicalArrivalDate(arrivalDate.toLocalDate())
@@ -224,6 +230,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
     private val departedSpaceBooking = Cas1SpaceBookingEntityFactory()
       .withApplication(application)
+      .withDeliusEventNumber(DELIUS_EVENT_NUMBER)
       .withPremises(premises)
       .withActualArrivalDateTime(arrivedDate)
       .withCanonicalArrivalDate(arrivedDate.toLocalDate())
@@ -290,7 +297,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       assertThat(domainEventEventDetails.bookingId).isEqualTo(departedSpaceBooking.id)
       assertThat(domainEventEventDetails.personReference.crn).isEqualTo(departedSpaceBooking.crn)
       assertThat(domainEventEventDetails.personReference.noms).isEqualTo(caseSummary.nomsId)
-      assertThat(domainEventEventDetails.deliusEventNumber).isEqualTo(application.eventNumber)
+      assertThat(domainEventEventDetails.deliusEventNumber).isEqualTo(DELIUS_EVENT_NUMBER)
       assertThat(domainEventEventDetails.departedAt).isEqualTo(departedDate.toLocalDateTime(ZoneOffset.UTC).toInstant())
       assertThat(domainEventEventDetails.reason).isEqualTo(departureReason.name)
       assertThat(domainEventEventDetails.legacyReasonCode).isEqualTo(departureReason.legacyDeliusReasonCode)
@@ -337,11 +344,12 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
     val keyWorker = StaffWithoutUsernameUserDetailsFactory()
       .produce()
 
-    val keyWorkerName = "${keyWorker.staff.forenames} ${keyWorker.staff.surname}"
-    val previousKeyWorkerName = "Previous $keyWorkerName"
+    private val keyWorkerName = "${keyWorker.staff.forenames} ${keyWorker.staff.surname}"
+    private val previousKeyWorkerName = "Previous $keyWorkerName"
 
     private val spaceBookingWithoutKeyWorker = Cas1SpaceBookingEntityFactory()
       .withApplication(application)
+      .withDeliusEventNumber(DELIUS_EVENT_NUMBER)
       .withPremises(premises)
       .withActualArrivalDateTime(arrivalDate)
       .withCanonicalArrivalDate(arrivalDate.toLocalDate())
@@ -351,6 +359,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
     private val spaceBookingWithKeyWorker = Cas1SpaceBookingEntityFactory()
       .withApplication(application)
+      .withDeliusEventNumber(DELIUS_EVENT_NUMBER)
       .withPremises(premises)
       .withActualArrivalDateTime(arrivalDate)
       .withCanonicalArrivalDate(arrivalDate.toLocalDate())
@@ -438,7 +447,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       assertThat(domainEventEventDetails.bookingId).isEqualTo(spaceBooking.id)
       assertThat(domainEventEventDetails.personReference.crn).isEqualTo(spaceBooking.crn)
       assertThat(domainEventEventDetails.personReference.noms).isEqualTo(caseSummary.nomsId)
-      assertThat(domainEventEventDetails.deliusEventNumber).isEqualTo(application.eventNumber)
+      assertThat(domainEventEventDetails.deliusEventNumber).isEqualTo(DELIUS_EVENT_NUMBER)
       assertThat(domainEventEventDetails.arrivalDate).isEqualTo(spaceBooking.canonicalArrivalDate)
       assertThat(domainEventEventDetails.departureDate).isEqualTo(spaceBooking.canonicalDepartureDate)
       val domainEventPremises = domainEventEventDetails.premises


### PR DESCRIPTION
Whilst cas1_space_bookings.delius_event_number is nullable and domain events require a non-null value, we will guarantee that this is always set to a value for any space bookings that has not already occurred.

APS-1488 will be used to manage backfilling this value when migrating from bookings to space bookings