### PR TITLE
APS-1447 - Fix username resolution seeding space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -121,8 +121,10 @@ class Cas1BookingToSpaceBookingSeedJob(
   }
 
   private fun getCreatedByUser(bookingMadeDomainEvent: DomainEvent<BookingMadeEnvelope>): UserEntity {
-    val createdByUsername = bookingMadeDomainEvent.data.eventDetails.bookedBy.staffMember!!.username ?: error("Can't find created by username for booking ${bookingMadeDomainEvent.bookingId}")
-    return userRepository.findByDeliusUsername(createdByUsername) ?: error("Can't find user with username $createdByUsername")
+    val createdByUsernameUpper =
+      bookingMadeDomainEvent.data.eventDetails.bookedBy.staffMember!!.username?.uppercase()
+        ?: error("Can't find created by username for booking ${bookingMadeDomainEvent.bookingId}")
+    return userRepository.findByDeliusUsername(createdByUsernameUpper) ?: error("Can't find user with username $createdByUsernameUpper")
   }
 
   private fun getDomainEventNumber(bookingMadeDomainEvent: DomainEvent<BookingMadeEnvelope>): String {


### PR DESCRIPTION
All usernames are stored in upper case in the database, so when retrieving users we should user an uppercase username.

This is no automated regression test for this as it’s alot of work to create the scenario, and any regression would be highlighted when attempting to seed bookings