### PR TITLE
APS-1492 - Simplify Cas1SpaceBookingRequirements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingRequirementsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingRequirementsTransformer.kt
@@ -3,21 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 
 @Component
 class Cas1SpaceBookingRequirementsTransformer {
-  fun transformJpaToApi(jpa: PlacementRequirementsEntity, criteria: List<CharacteristicEntity>) = Cas1SpaceBookingRequirements(
-    apType = jpa.apType,
-    gender = jpa.gender,
-    essentialCharacteristics = criteria.mapNotNull { it.asCas1SpaceCharacteristic() },
-    desirableCharacteristics = emptyList(),
+  fun transformJpaToApi(cas1SpaceBookingEntity: Cas1SpaceBookingEntity) = Cas1SpaceBookingRequirements(
+    essentialCharacteristics = cas1SpaceBookingEntity.criteria.map { it.asCas1SpaceCharacteristic() },
   )
 
-  private fun CharacteristicEntity.asCas1SpaceCharacteristic() = try {
+  private fun CharacteristicEntity.asCas1SpaceCharacteristic() =
     Cas1SpaceCharacteristic.valueOf(this.propertyName!!)
-  } catch (_: Exception) {
-    null
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -39,8 +39,7 @@ class Cas1SpaceBookingTransformer(
       assessmentId = placementRequest.assessment.id,
       person = personTransformer.transformModelToPersonApi(person),
       requirements = spaceBookingRequirementsTransformer.transformJpaToApi(
-        jpa = placementRequest.placementRequirements,
-        criteria = jpa.criteria,
+        cas1SpaceBookingEntity = jpa,
       ),
       premises = NamedId(
         id = jpa.premises.id,

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -165,23 +165,11 @@ components:
     Cas1SpaceBookingRequirements:
       type: object
       properties:
-        apType:
-          $ref: '_shared.yml#/components/schemas/ApType'
         essentialCharacteristics:
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
-        desirableCharacteristics:
-          type: array
-          deprecated: true
-          description: desirable characteristics are not required and will be removed in the future
-          items:
-            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
-        gender:
-          $ref: '_shared.yml#/components/schemas/Gender'
       required:
-        - apType
-        - gender
         - essentialCharacteristics
     Cas1SpaceSearchRequirements:
       type: object

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6326,23 +6326,11 @@ components:
     Cas1SpaceBookingRequirements:
       type: object
       properties:
-        apType:
-          $ref: '#/components/schemas/ApType'
         essentialCharacteristics:
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
-        desirableCharacteristics:
-          type: array
-          deprecated: true
-          description: desirable characteristics are not required and will be removed in the future
-          items:
-            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
-        gender:
-          $ref: '#/components/schemas/Gender'
       required:
-        - apType
-        - gender
         - essentialCharacteristics
     Cas1SpaceSearchRequirements:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssignKeyWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewDeparture
@@ -16,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooki
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas1SpaceBookingCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
@@ -98,10 +96,7 @@ class Cas1SpaceBookingTest {
               departureDate = LocalDate.now().plusDays(8),
               premisesId = premises.id,
               requirements = Cas1SpaceBookingRequirements(
-                apType = ApType.esap,
-                gender = Gender.male,
                 essentialCharacteristics = listOf(),
-                desirableCharacteristics = listOf(),
               ),
             ),
           )
@@ -131,10 +126,7 @@ class Cas1SpaceBookingTest {
                 departureDate = LocalDate.now().plusDays(8),
                 premisesId = UUID.randomUUID(),
                 requirements = Cas1SpaceBookingRequirements(
-                  apType = ApType.esap,
-                  gender = Gender.male,
                   essentialCharacteristics = listOf(),
-                  desirableCharacteristics = listOf(),
                 ),
               ),
             )
@@ -172,10 +164,7 @@ class Cas1SpaceBookingTest {
                 departureDate = LocalDate.now(),
                 premisesId = premises.id,
                 requirements = Cas1SpaceBookingRequirements(
-                  apType = ApType.esap,
-                  gender = Gender.male,
                   essentialCharacteristics = listOf(),
-                  desirableCharacteristics = listOf(),
                 ),
               ),
             )
@@ -200,13 +189,6 @@ class Cas1SpaceBookingTest {
           val essentialCharacteristics = listOf(
             Cas1SpaceCharacteristic.hasBrailleSignage,
             Cas1SpaceCharacteristic.hasTactileFlooring,
-          )
-
-          val desirableCharacteristics = listOf(
-            Cas1SpaceCharacteristic.hasEnSuite,
-            Cas1SpaceCharacteristic.hasCallForAssistance,
-            Cas1SpaceCharacteristic.isGroundFloor,
-            Cas1SpaceCharacteristic.isCatered,
           )
 
           placementRequest.placementRequirements = placementRequirementsFactory.produceAndPersist {
@@ -237,10 +219,7 @@ class Cas1SpaceBookingTest {
                 departureDate = LocalDate.now().plusDays(8),
                 premisesId = premises.id,
                 requirements = Cas1SpaceBookingRequirements(
-                  apType = placementRequest.placementRequirements.apType,
-                  gender = Gender.male,
                   essentialCharacteristics = essentialCharacteristics,
-                  desirableCharacteristics = desirableCharacteristics,
                 ),
               ),
             )
@@ -252,12 +231,9 @@ class Cas1SpaceBookingTest {
           val result = response.responseBody.blockFirst()!!
 
           assertThat(result.person)
-          assertThat(result.requirements.apType).isEqualTo(placementRequest.placementRequirements.apType)
-          assertThat(result.requirements.gender).isEqualTo(placementRequest.placementRequirements.gender)
           assertThat(result.requirements.essentialCharacteristics).containsExactlyInAnyOrderElementsOf(
             essentialCharacteristics,
           )
-          assertThat(result.requirements.desirableCharacteristics).isEmpty()
           assertThat(result.premises.id).isEqualTo(premises.id)
           assertThat(result.premises.name).isEqualTo(premises.name)
           assertThat(result.apArea.id).isEqualTo(premises.probationRegion.apArea!!.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingRequirementsTransformer
 
@@ -27,11 +29,18 @@ class Cas1SpaceBookingRequirementsTransformerTest {
       .withDesirableCriteria(cas1DesirableSpaceCharacteristics)
       .produce()
 
-    val result = transformer.transformJpaToApi(placementRequirements, cas1EssentialSpaceCharacteristics)
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .withPlacementRequirements(placementRequirements)
+      .produce()
 
-    assertThat(result.apType).isEqualTo(placementRequirements.apType)
-    assertThat(result.gender).isEqualTo(placementRequirements.gender)
-    assertThat(result.desirableCharacteristics).isEmpty()
+    val spaceBooking = Cas1SpaceBookingEntityFactory()
+      .withPlacementRequest(placementRequest)
+      .withCriteria(cas1EssentialSpaceCharacteristics)
+      .produce()
+
+    val result = transformer.transformJpaToApi(spaceBooking)
+
     assertThat(result.essentialCharacteristics).isEqualTo(Cas1SpaceCharacteristic.entries)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -8,10 +8,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummaryDiscriminator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPerson
@@ -118,10 +116,7 @@ class Cas1SpaceBookingTransformerTest {
         .produce()
 
       val expectedRequirements = Cas1SpaceBookingRequirements(
-        apType = ApType.pipe,
-        gender = Gender.female,
         essentialCharacteristics = listOf(),
-        desirableCharacteristics = listOf(),
       )
 
       val expectedCancellationReason = CancellationReason(
@@ -143,10 +138,7 @@ class Cas1SpaceBookingTransformerTest {
 
       every { personTransformer.transformModelToPersonApi(personInfo) } returns expectedPerson
       every {
-        requirementsTransformer.transformJpaToApi(
-          jpa = spaceBooking.placementRequest.placementRequirements,
-          criteria = criteria,
-        )
+        requirementsTransformer.transformJpaToApi(spaceBooking)
       } returns expectedRequirements
       every {
         userTransformer.transformJpaToApi(
@@ -243,10 +235,7 @@ class Cas1SpaceBookingTransformerTest {
         .produce()
 
       val expectedRequirements = Cas1SpaceBookingRequirements(
-        apType = ApType.pipe,
-        gender = Gender.female,
         essentialCharacteristics = listOf(),
-        desirableCharacteristics = listOf(),
       )
 
       val expectedUser = ApprovedPremisesUserFactory().produce()
@@ -261,10 +250,7 @@ class Cas1SpaceBookingTransformerTest {
 
       every { personTransformer.transformModelToPersonApi(personInfo) } returns expectedPerson
       every {
-        requirementsTransformer.transformJpaToApi(
-          jpa = spaceBooking.placementRequest.placementRequirements,
-          criteria = criteria,
-        )
+        requirementsTransformer.transformJpaToApi(spaceBooking)
       } returns expectedRequirements
       every {
         userTransformer.transformJpaToApi(


### PR DESCRIPTION
This commit removes all fields from Cas1SpaceBookingRequirements other than essentialCharacteristics, as none of the other fields were used when creating a space booking, or used by the UI when returning a space booking.

It also updates the transformer logic to derive essential requirements from the space booking itself, instead of the placement request.