### PR TITLE
APS-1492 - Support migrating bookings to space bookings for offline applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -216,7 +216,7 @@ class Cas1SpaceBookingController(
     val user = userService.getUserForRequest()
 
     val person = offenderService.getPersonInfoResult(
-      booking.placementRequest.application.crn,
+      booking.crn,
       user.deliusUsername,
       user.hasQualification(UserQualification.LAO),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -141,9 +141,12 @@ data class Cas1SpaceBookingEntity(
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "offline_application_id")
   var offlineApplication: OfflineApplicationEntity?,
+  /**
+   * Placement request will only be null for migrated [BookingEntity]s, where adhoc = true
+   */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "placement_request_id")
-  val placementRequest: PlacementRequestEntity,
+  val placementRequest: PlacementRequestEntity?,
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "created_by_user_id")
   val createdBy: UserEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -147,9 +147,13 @@ data class Cas1SpaceBookingEntity(
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "placement_request_id")
   val placementRequest: PlacementRequestEntity?,
+  /**
+   * createdAt will only be null for migrated [BookingEntity]s where no 'Booking Made' domain event
+   * existed for the booking (i.e. those migrated into the system when it went live)
+   */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "created_by_user_id")
-  val createdBy: UserEntity,
+  val createdBy: UserEntity?,
   val createdAt: OffsetDateTime,
   val expectedArrivalDate: LocalDate,
   var expectedDepartureDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -77,7 +77,6 @@ class Cas1BookingToSpaceBookingSeedJob(
     val offlineApplication = booking.offlineApplication
 
     val bookingMadeDomainEvent = getBookingMadeDomainEvent(bookingId)
-      ?: error("Can't find booking made domain event for booking $bookingId")
 
     val spaceBooking = spaceBookingRepository.save(
       Cas1SpaceBookingEntity(
@@ -86,7 +85,7 @@ class Cas1BookingToSpaceBookingSeedJob(
         application = application,
         offlineApplication = offlineApplication,
         placementRequest = booking.placementRequest,
-        createdBy = getCreatedByUser(bookingMadeDomainEvent),
+        createdBy = bookingMadeDomainEvent?.let { getCreatedByUser(it) },
         createdAt = booking.createdAt,
         expectedArrivalDate = booking.arrivalDate,
         expectedDepartureDate = booking.departureDate,
@@ -109,7 +108,7 @@ class Cas1BookingToSpaceBookingSeedJob(
         nonArrivalConfirmedAt = null,
         nonArrivalNotes = null,
         migratedFromBooking = booking,
-        deliusEventNumber = getDomainEventNumber(bookingMadeDomainEvent),
+        deliusEventNumber = bookingMadeDomainEvent?.let { getDomainEventNumber(bookingMadeDomainEvent) },
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -128,7 +128,7 @@ class Cas1BookingEmailService(
       departureDate = canonicalDepartureDate,
       premises = premises,
       application = application,
-      placementApplication = placementRequest.placementApplication,
+      placementApplication = placementRequest?.placementApplication,
     )
 
   private fun BookingEntity.toBookingInfo(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -32,11 +32,12 @@ class Cas1SpaceBookingTransformer(
     otherBookingsAtPremiseForCrn: List<Cas1SpaceBookingAtPremises>,
   ): Cas1SpaceBooking {
     val placementRequest = jpa.placementRequest
-    val application = placementRequest.application
+    val application = jpa.application
+    val applicationId = application?.id ?: jpa.offlineApplication!!.id
     return Cas1SpaceBooking(
       id = jpa.id,
-      applicationId = application.id,
-      assessmentId = placementRequest.assessment.id,
+      applicationId = applicationId,
+      assessmentId = placementRequest?.assessment?.id,
       person = personTransformer.transformModelToPersonApi(person),
       requirements = spaceBookingRequirementsTransformer.transformJpaToApi(
         cas1SpaceBookingEntity = jpa,
@@ -55,7 +56,7 @@ class Cas1SpaceBookingTransformer(
       expectedArrivalDate = jpa.expectedArrivalDate,
       expectedDepartureDate = jpa.expectedDepartureDate,
       createdAt = jpa.createdAt.toInstant(),
-      tier = application.riskRatings?.tier?.value?.level,
+      tier = application?.riskRatings?.tier?.value?.level,
       keyWorkerAllocation = jpa.extractKeyWorkerAllocation(),
       actualArrivalDate = jpa.actualArrivalDateTime,
       actualDepartureDate = jpa.actualDepartureDateTime,
@@ -63,7 +64,7 @@ class Cas1SpaceBookingTransformer(
       canonicalDepartureDate = jpa.canonicalDepartureDate,
       otherBookingsInPremisesForCrn = otherBookingsAtPremiseForCrn.map { it.toSpaceBookingDate() },
       cancellation = jpa.extractCancellation(),
-      requestForPlacementId = jpa.placementRequest.placementApplication?.id ?: jpa.placementRequest.id,
+      requestForPlacementId = jpa.placementRequest?.placementApplication?.id ?: jpa.placementRequest?.id,
       deliusEventNumber = jpa.deliusEventNumber,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -52,7 +52,7 @@ class Cas1SpaceBookingTransformer(
           name = it.name,
         )
       },
-      bookedBy = userTransformer.transformJpaToApi(jpa.createdBy, ServiceName.approvedPremises),
+      bookedBy = jpa.createdBy?.let { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) },
       expectedArrivalDate = jpa.expectedArrivalDate,
       expectedDepartureDate = jpa.expectedDepartureDate,
       createdAt = jpa.createdAt.toInstant(),

--- a/src/main/resources/db/migration/all/20241105112719__make_space_booking_placement_request_nullable.sql
+++ b/src/main/resources/db/migration/all/20241105112719__make_space_booking_placement_request_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_space_bookings ALTER COLUMN placement_request_id DROP NOT NULL;

--- a/src/main/resources/db/migration/all/20241105153718__make_space_booking_created_by_nullable.sql
+++ b/src/main/resources/db/migration/all/20241105153718__make_space_booking_created_by_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_space_bookings ALTER COLUMN created_by_user_id DROP NOT NULL;

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -326,7 +326,6 @@ components:
       required:
         - id
         - applicationId
-        - assessmentId
         - person
         - requirements
         - premises

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -330,7 +330,6 @@ components:
         - requirements
         - premises
         - apArea
-        - bookedBy
         - expectedArrivalDate
         - expectedDepartureDate
         - canonicalArrivalDate

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6487,7 +6487,6 @@ components:
       required:
         - id
         - applicationId
-        - assessmentId
         - person
         - requirements
         - premises

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6491,7 +6491,6 @@ components:
         - requirements
         - premises
         - apArea
-        - bookedBy
         - expectedArrivalDate
         - expectedDepartureDate
         - canonicalArrivalDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -26,7 +26,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var placementRequest: Yielded<PlacementRequestEntity?> = { PlacementRequestEntityFactory().withDefaults().produce() }
   private var application: Yielded<ApprovedPremisesApplicationEntity?> = { ApprovedPremisesApplicationEntityFactory().withDefaults().produce() }
   private var offlineApplication: Yielded<OfflineApplicationEntity?> = { null }
-  private var createdBy: Yielded<UserEntity> = { UserEntityFactory().withDefaults().produce() }
+  private var createdBy: Yielded<UserEntity?> = { UserEntityFactory().withDefaults().produce() }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
   private var expectedArrivalDate: Yielded<LocalDate> = { LocalDate.now() }
   private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now() }
@@ -79,7 +79,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.placementRequest = placementRequest
   }
 
-  fun withCreatedBy(createdBy: UserEntity) = apply {
+  fun withCreatedBy(createdBy: UserEntity?) = apply {
     this.createdBy = { createdBy }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var premises: Yielded<ApprovedPremisesEntity> = { ApprovedPremisesEntityFactory().withDefaults().produce() }
-  private var placementRequest: Yielded<PlacementRequestEntity> = { PlacementRequestEntityFactory().withDefaults().produce() }
+  private var placementRequest: Yielded<PlacementRequestEntity?> = { PlacementRequestEntityFactory().withDefaults().produce() }
   private var application: Yielded<ApprovedPremisesApplicationEntity?> = { ApprovedPremisesApplicationEntityFactory().withDefaults().produce() }
   private var offlineApplication: Yielded<OfflineApplicationEntity?> = { null }
   private var createdBy: Yielded<UserEntity> = { UserEntityFactory().withDefaults().produce() }
@@ -67,7 +67,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.premises = premises
   }
 
-  fun withPlacementRequest(placementRequest: PlacementRequestEntity) = apply {
+  fun withPlacementRequest(placementRequest: PlacementRequestEntity?) = apply {
     this.placementRequest = { placementRequest }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -795,7 +795,7 @@ class Cas1SpaceBookingTest {
       assertThat(response.id).isEqualTo(spaceBooking.id)
       assertThat(response.otherBookingsInPremisesForCrn).hasSize(1)
       assertThat(response.otherBookingsInPremisesForCrn[0].id).isEqualTo(otherSpaceBookingAtPremises.id)
-      assertThat(response.requestForPlacementId).isEqualTo(spaceBooking.placementRequest.id)
+      assertThat(response.requestForPlacementId).isEqualTo(spaceBooking.placementRequest!!.id)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -238,9 +238,9 @@ class Cas1SpaceBookingTest {
           assertThat(result.premises.name).isEqualTo(premises.name)
           assertThat(result.apArea.id).isEqualTo(premises.probationRegion.apArea!!.id)
           assertThat(result.apArea.name).isEqualTo(premises.probationRegion.apArea!!.name)
-          assertThat(result.bookedBy.id).isEqualTo(applicant.id)
-          assertThat(result.bookedBy.name).isEqualTo(applicant.name)
-          assertThat(result.bookedBy.deliusUsername).isEqualTo(applicant.deliusUsername)
+          assertThat(result.bookedBy!!.id).isEqualTo(applicant.id)
+          assertThat(result.bookedBy!!.name).isEqualTo(applicant.name)
+          assertThat(result.bookedBy!!.deliusUsername).isEqualTo(applicant.deliusUsername)
           assertThat(result.expectedArrivalDate).isEqualTo(LocalDate.now().plusDays(1))
           assertThat(result.expectedDepartureDate).isEqualTo(LocalDate.now().plusDays(8))
           assertThat(result.createdAt).satisfies(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABooking.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import java.time.LocalDate
@@ -21,4 +22,21 @@ fun IntegrationTestBase.`Given a Booking`(
   withArrivalDate(arrivalDate)
   withDepartureDate(departureDate)
   withAdhoc(adhoc)
+}
+
+@SuppressWarnings("LongParameterList")
+fun IntegrationTestBase.`Given a Booking for an Offline Application`(
+  crn: String,
+  offlineApplication: OfflineApplicationEntity,
+  premises: PremisesEntity? = null,
+  arrivalDate: LocalDate = LocalDate.now().randomDateBefore(14),
+  departureDate: LocalDate = LocalDate.now().randomDateBefore(14),
+) = bookingEntityFactory.produceAndPersist {
+  withCrn(crn)
+  withPremises(premises ?: approvedPremisesEntityFactory.produceAndPersist())
+  withApplication(null)
+  withOfflineApplication(offlineApplication)
+  withArrivalDate(arrivalDate)
+  withDepartureDate(departureDate)
+  withAdhoc(true)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOfflineApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOfflineApplication.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+@SuppressWarnings("LongParameterList")
+fun IntegrationTestBase.`Given an Offline Application`(
+  crn: String,
+  eventNumber: String? = randomStringMultiCaseWithNumbers(6),
+) = offlineApplicationEntityFactory.produceAndPersist {
+  withCrn(crn)
+  withEventNumber(eventNumber)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -123,7 +123,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
 
     val migratedBooking1 = premiseSpaceBookings[0]
     assertThat(migratedBooking1.premises.id).isEqualTo(premises.id)
-    assertThat(migratedBooking1.placementRequest.id).isEqualTo(placementRequest1.id)
+    assertThat(migratedBooking1.placementRequest!!.id).isEqualTo(placementRequest1.id)
     assertThat(migratedBooking1.createdBy.id).isEqualTo(booking1CreatedByUser.id)
     assertThat(migratedBooking1.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 5, 1))
     assertThat(migratedBooking1.expectedDepartureDate).isEqualTo(LocalDate.of(2024, 5, 5))
@@ -148,7 +148,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
 
     val migratedBooking2 = premiseSpaceBookings[1]
     assertThat(migratedBooking2.premises.id).isEqualTo(premises.id)
-    assertThat(migratedBooking2.placementRequest.id).isEqualTo(placementRequest2.id)
+    assertThat(migratedBooking2.placementRequest!!.id).isEqualTo(placementRequest2.id)
     assertThat(migratedBooking2.createdBy.id).isEqualTo(booking2CreatedByUser.id)
     assertThat(migratedBooking2.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 6, 1))
     assertThat(migratedBooking2.expectedDepartureDate).isEqualTo(LocalDate.of(2024, 6, 5))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -116,6 +116,14 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
       user = booking3CreatedByUser,
     )
 
+    val booking4OfflineNoDomainEvent = `Given a Booking for an Offline Application`(
+      crn = "CRN4",
+      premises = premises,
+      offlineApplication = offlineApplication,
+      arrivalDate = LocalDate.of(2024, 8, 1),
+      departureDate = LocalDate.of(2024, 8, 5),
+    )
+
     val existingMigratedSpaceBooking1ToRemove = `Given a CAS1 Space Booking`(
       crn = "CRN1",
       premises = premises,
@@ -132,12 +140,12 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(cas1SpaceBookingRepository.findByIdOrNull(existingMigratedSpaceBooking1ToRemove.id)).isNull()
 
     val premiseSpaceBookings = cas1SpaceBookingTestRepository.findByPremisesId(premises.id)
-    assertThat(premiseSpaceBookings).hasSize(3)
+    assertThat(premiseSpaceBookings).hasSize(4)
 
     val migratedBooking1 = premiseSpaceBookings[0]
     assertThat(migratedBooking1.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking1.placementRequest!!.id).isEqualTo(placementRequest1.id)
-    assertThat(migratedBooking1.createdBy.id).isEqualTo(booking1CreatedByUser.id)
+    assertThat(migratedBooking1.createdBy!!.id).isEqualTo(booking1CreatedByUser.id)
     assertThat(migratedBooking1.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 5, 1))
     assertThat(migratedBooking1.expectedDepartureDate).isEqualTo(LocalDate.of(2024, 5, 5))
     assertThat(migratedBooking1.actualArrivalDateTime).isNull()
@@ -163,7 +171,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     val migratedBooking2 = premiseSpaceBookings[1]
     assertThat(migratedBooking2.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking2.placementRequest!!.id).isEqualTo(placementRequest2.id)
-    assertThat(migratedBooking2.createdBy.id).isEqualTo(booking2CreatedByUser.id)
+    assertThat(migratedBooking2.createdBy!!.id).isEqualTo(booking2CreatedByUser.id)
     assertThat(migratedBooking2.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 6, 1))
     assertThat(migratedBooking2.expectedDepartureDate).isEqualTo(LocalDate.of(2024, 6, 5))
     assertThat(migratedBooking2.actualArrivalDateTime).isNull()
@@ -189,7 +197,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     val migratedBooking3 = premiseSpaceBookings[2]
     assertThat(migratedBooking3.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking3.placementRequest).isNull()
-    assertThat(migratedBooking3.createdBy.id).isEqualTo(booking3CreatedByUser.id)
+    assertThat(migratedBooking3.createdBy!!.id).isEqualTo(booking3CreatedByUser.id)
     assertThat(migratedBooking3.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 7, 1))
     assertThat(migratedBooking3.expectedDepartureDate).isEqualTo(LocalDate.of(2024, 7, 5))
     assertThat(migratedBooking3.actualArrivalDateTime).isNull()
@@ -211,6 +219,32 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking3.migratedFromBooking!!.id).isEqualTo(booking3OfflineApplication.id)
     assertThat(migratedBooking3.criteria).isEmpty()
     assertThat(migratedBooking3.deliusEventNumber).isEqualTo("75")
+
+    val migratedBooking4 = premiseSpaceBookings[3]
+    assertThat(migratedBooking4.premises.id).isEqualTo(premises.id)
+    assertThat(migratedBooking4.placementRequest).isNull()
+    assertThat(migratedBooking4.createdBy).isNull()
+    assertThat(migratedBooking4.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 8, 1))
+    assertThat(migratedBooking4.expectedDepartureDate).isEqualTo(LocalDate.of(2024, 8, 5))
+    assertThat(migratedBooking4.actualArrivalDateTime).isNull()
+    assertThat(migratedBooking4.actualDepartureDateTime).isNull()
+    assertThat(migratedBooking4.canonicalArrivalDate).isEqualTo(LocalDate.of(2024, 8, 1))
+    assertThat(migratedBooking4.canonicalDepartureDate).isEqualTo(LocalDate.of(2024, 8, 5))
+    assertThat(migratedBooking4.crn).isEqualTo("CRN4")
+    assertThat(migratedBooking4.keyWorkerName).isNull()
+    assertThat(migratedBooking4.keyWorkerStaffCode).isNull()
+    assertThat(migratedBooking4.keyWorkerAssignedAt).isNull()
+    assertThat(migratedBooking4.application).isNull()
+    assertThat(migratedBooking4.offlineApplication!!.id).isEqualTo(offlineApplication.id)
+    assertThat(migratedBooking4.cancellationReason).isNull()
+    assertThat(migratedBooking4.cancellationOccurredAt).isNull()
+    assertThat(migratedBooking4.cancellationRecordedAt).isNull()
+    assertThat(migratedBooking4.cancellationReasonNotes).isNull()
+    assertThat(migratedBooking4.departureReason).isNull()
+    assertThat(migratedBooking4.departureMoveOnCategory).isNull()
+    assertThat(migratedBooking4.migratedFromBooking!!.id).isEqualTo(booking4OfflineNoDomainEvent.id)
+    assertThat(migratedBooking4.criteria).isEmpty()
+    assertThat(migratedBooking4.deliusEventNumber).isNull()
   }
 
   private fun rowsToCsv(rows: List<Cas1BookingToSpaceBookingSeedCsvRow>): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -7,11 +7,13 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Booking`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Booking for an Offline Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS1 Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a CAS1 Space Booking`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a Placement Request`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given a User`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Approved Premises`
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offline Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1SpaceBookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
@@ -85,7 +87,6 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
       booking2CreatedByUser,
       placementRequest2,
     )
-
     val cancellationReason = cancellationReasonEntityFactory.produceAndPersist()
     cancellationEntityFactory.produceAndPersist {
       withBooking(booking2)
@@ -95,12 +96,24 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
       withOtherReason("cancellation other reason")
     }
 
-    // ignored adhoc booking
-    `Given a Booking`(
+    val offlineApplication = `Given an Offline Application`(
+      crn = "CRN3-offline",
+      eventNumber = "75",
+    )
+    val booking3OfflineApplication = `Given a Booking for an Offline Application`(
       crn = "CRN3",
       premises = premises,
-      application = application1,
-      adhoc = true,
+      offlineApplication = offlineApplication,
+      arrivalDate = LocalDate.of(2024, 7, 1),
+      departureDate = LocalDate.of(2024, 7, 5),
+    )
+    val (booking3CreatedByUser) = `Given a User`()
+    cas1BookingDomainEventSet.adhocBookingMade(
+      onlineApplication = null,
+      offlineApplication = offlineApplication,
+      eventNumber = "75",
+      booking = booking3OfflineApplication,
+      user = booking3CreatedByUser,
     )
 
     val existingMigratedSpaceBooking1ToRemove = `Given a CAS1 Space Booking`(
@@ -119,7 +132,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(cas1SpaceBookingRepository.findByIdOrNull(existingMigratedSpaceBooking1ToRemove.id)).isNull()
 
     val premiseSpaceBookings = cas1SpaceBookingTestRepository.findByPremisesId(premises.id)
-    assertThat(premiseSpaceBookings).hasSize(2)
+    assertThat(premiseSpaceBookings).hasSize(3)
 
     val migratedBooking1 = premiseSpaceBookings[0]
     assertThat(migratedBooking1.premises.id).isEqualTo(premises.id)
@@ -136,6 +149,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking1.keyWorkerStaffCode).isNull()
     assertThat(migratedBooking1.keyWorkerAssignedAt).isNull()
     assertThat(migratedBooking1.application!!.id).isEqualTo(application1.id)
+    assertThat(migratedBooking1.offlineApplication).isNull()
     assertThat(migratedBooking1.cancellationReason).isNull()
     assertThat(migratedBooking1.cancellationOccurredAt).isNull()
     assertThat(migratedBooking1.cancellationRecordedAt).isNull()
@@ -161,6 +175,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking2.keyWorkerStaffCode).isNull()
     assertThat(migratedBooking2.keyWorkerAssignedAt).isNull()
     assertThat(migratedBooking2.application!!.id).isEqualTo(application2.id)
+    assertThat(migratedBooking2.offlineApplication).isNull()
     assertThat(migratedBooking2.cancellationReason).isEqualTo(cancellationReason)
     assertThat(migratedBooking2.cancellationOccurredAt).isEqualTo(LocalDate.of(2024, 1, 1))
     assertThat(migratedBooking2.cancellationRecordedAt).isEqualTo(LocalDateTime.of(2025, 1, 2, 3, 4, 5).toInstant(ZoneOffset.UTC))
@@ -170,6 +185,32 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking2.migratedFromBooking!!.id).isEqualTo(booking2.id)
     assertThat(migratedBooking2.criteria).isEmpty()
     assertThat(migratedBooking2.deliusEventNumber).isEqualTo("50")
+
+    val migratedBooking3 = premiseSpaceBookings[2]
+    assertThat(migratedBooking3.premises.id).isEqualTo(premises.id)
+    assertThat(migratedBooking3.placementRequest).isNull()
+    assertThat(migratedBooking3.createdBy.id).isEqualTo(booking3CreatedByUser.id)
+    assertThat(migratedBooking3.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 7, 1))
+    assertThat(migratedBooking3.expectedDepartureDate).isEqualTo(LocalDate.of(2024, 7, 5))
+    assertThat(migratedBooking3.actualArrivalDateTime).isNull()
+    assertThat(migratedBooking3.actualDepartureDateTime).isNull()
+    assertThat(migratedBooking3.canonicalArrivalDate).isEqualTo(LocalDate.of(2024, 7, 1))
+    assertThat(migratedBooking3.canonicalDepartureDate).isEqualTo(LocalDate.of(2024, 7, 5))
+    assertThat(migratedBooking3.crn).isEqualTo("CRN3")
+    assertThat(migratedBooking3.keyWorkerName).isNull()
+    assertThat(migratedBooking3.keyWorkerStaffCode).isNull()
+    assertThat(migratedBooking3.keyWorkerAssignedAt).isNull()
+    assertThat(migratedBooking3.application).isNull()
+    assertThat(migratedBooking3.offlineApplication!!.id).isEqualTo(offlineApplication.id)
+    assertThat(migratedBooking3.cancellationReason).isNull()
+    assertThat(migratedBooking3.cancellationOccurredAt).isNull()
+    assertThat(migratedBooking3.cancellationRecordedAt).isNull()
+    assertThat(migratedBooking3.cancellationReasonNotes).isNull()
+    assertThat(migratedBooking3.departureReason).isNull()
+    assertThat(migratedBooking3.departureMoveOnCategory).isNull()
+    assertThat(migratedBooking3.migratedFromBooking!!.id).isEqualTo(booking3OfflineApplication.id)
+    assertThat(migratedBooking3.criteria).isEmpty()
+    assertThat(migratedBooking3.deliusEventNumber).isEqualTo("75")
   }
 
   private fun rowsToCsv(rows: List<Cas1BookingToSpaceBookingSeedCsvRow>): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -142,7 +142,7 @@ class Cas1SpaceBookingTransformerTest {
       } returns expectedRequirements
       every {
         userTransformer.transformJpaToApi(
-          spaceBooking.createdBy,
+          spaceBooking.createdBy!!,
           ServiceName.approvedPremises,
         )
       } returns expectedUser
@@ -254,7 +254,7 @@ class Cas1SpaceBookingTransformerTest {
       } returns expectedRequirements
       every {
         userTransformer.transformJpaToApi(
-          spaceBooking.createdBy,
+          spaceBooking.createdBy!!,
           ServiceName.approvedPremises,
         )
       } returns expectedUser

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -89,7 +89,6 @@ class Cas1SpaceBookingTransformerTest {
 
       val placementRequest = PlacementRequestEntityFactory()
         .withDefaults()
-        .withApplication(application)
         .produce()
 
       val cancellationReason = CancellationReasonEntityFactory().produce()
@@ -100,6 +99,7 @@ class Cas1SpaceBookingTransformerTest {
       )
 
       val spaceBooking = Cas1SpaceBookingEntityFactory()
+        .withApplication(application)
         .withPlacementRequest(placementRequest)
         .withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
         .withKeyworkerName("Mr Key Worker")


### PR DESCRIPTION
This PR includes changes that allows us to migrate a subset of legacy `bookings` where:

1. There is no corresponding linked placement request (the case for all offline applications and adhoc bookings)
2. There is no corresponding APPROVED_PREMISES_BOOKING_MADE domain event

This is a small subset of bookings, but some have arrival/departure dates in the future so they must be migrated

As a side effect of this change, the following fields are no longer mandatory on the SpaceBooking API type:

* assessmentId
* bookedBy