### PR TITLE
APS-1474 upgrade DPS gradle spring boot plugin to 6.0.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: 'gradle'
 
       - name: Initialize CodeQL

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.apache.commons.io.FileUtils
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.6"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.6"
   kotlin("plugin.spring") version "1.9.22"
   id("org.openapi.generator") version "7.7.0"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.9.22"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-cache")
 
   runtimeOnly("org.ehcache:ehcache")
+  runtimeOnly("org.flywaydb:flyway-database-postgresql")
 
   implementation(kotlin("reflect"))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.apache.commons.io.FileUtils
 
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.6"
-  kotlin("plugin.spring") version "1.9.22"
+  kotlin("plugin.spring") version "2.0.20"
   id("org.openapi.generator") version "7.7.0"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.9.22"
   id("io.gatling.gradle") version "3.12.0"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -927,7 +927,7 @@ class ApplicationTest : IntegrationTestBase() {
   inner class Cas3GetApplication {
 
     @Test
-    fun `Get single application returns 200 with correct body for Temporary Accommodation when requesting user created application`() {
+    fun `Get single application returns 200 with correct body when requesting user created application`() {
       givenAUser { userEntity, jwt ->
         givenAnOffender { offenderDetails, _ ->
           temporaryAccommodationApplicationJsonSchemaRepository.deleteAll()
@@ -985,7 +985,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get single application returns 200 with correct body for Temporary Accommodation when a user with the CAS3_ASSESSOR role requests a submitted application in their region`() {
+    fun `Get single application returns 200 with correct body when a user with the CAS3_ASSESSOR role requests a submitted application in their region`() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         givenAUser(probationRegion = userEntity.probationRegion) { createdByUser, _ ->
           givenAnOffender { offenderDetails, _ ->
@@ -1190,7 +1190,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get single application returns 403 Forbidden for Temporary Accommodation when a user with the CAS3_ASSESSOR role requests an application not in their region`() {
+    fun `Get single application returns 403 Forbidden when a user with the CAS3_ASSESSOR role requests an application not in their region`() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         givenAUser { createdByUser, _ ->
           givenAnOffender { offenderDetails, _ ->
@@ -1236,7 +1236,7 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get single application returns 403 Forbidden for Temporary Accommodation when a user without the CAS3_ASSESSOR role requests an application not created by them`() {
+    fun `Get single application returns 403 Forbidden when a user without the CAS3_ASSESSOR role requests an application not created by them`() {
       givenAUser { userEntity, jwt ->
         givenAUser(probationRegion = userEntity.probationRegion) { createdByUser, _ ->
           givenAnOffender { offenderDetails, _ ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -587,7 +587,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class SubmitPlacementApplicationTest {
+  inner class SubmitPlacementApp {
     @Test
     fun `submitting a placement request application without a JWT returns 401`() {
       webTestClient.post()
@@ -1257,7 +1257,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
    * Note - Withdrawal cascading is tested in [WithdrawalTest]
    */
   @Nested
-  inner class WithdrawPlacementApplicationTest {
+  inner class WithdrawPlacementApplication {
 
     @Test
     fun `withdrawing a placement application JWT returns 401`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -1043,7 +1043,7 @@ class ReportsTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class GetBedUtilizationReport {
+  inner class GetBedUtilReport {
     @Test
     fun `Get bed utilisation report for all regions returns 403 Forbidden if user does not have all regions access`() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -1891,7 +1891,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class GetBedUtilizationReport {
+  inner class GetBedUtilReport {
     @Test
     fun `Get bed utilisation report returns OK with correct body`() {
       givenAUser(roles = listOf(CAS3_ASSESSOR)) { userEntity, jwt ->


### PR DESCRIPTION
HMPPS dps gradle spring boot plugin has been updated from version 5.15.6 to version 6.0.6 in the Kotlin template project so we should be using this version in the CAS API too.

HMPPS DPS gradle spring boot plugin version 5.15.6:
Spring version: 3.2.5
Kotlin version: 1.9.22

HMPPS DPS gradle spring boot plugin version 6.0.6:
Spring version: 3.3.4
Kotlin version: 2.0.20

Upgrading HMPPS dps gradle spring boot plugin from 5.15.6 to 6.0.6 resulted in following error when running ./gradlew compileTestKotlin:

`Caused by: java.io.FileNotFoundException: .../hmpps-approved-premises-api/build/classes/kotlin/test/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest$Cas3GetApplication$Get_single_application_returns_200_with_correct_body_for_Temporary_Accommodation_when_a_user_with_the_CAS3_ASSESSOR_role_requests_a_submitted_application_in_their_region$lambda$12$lambda$11$lambda$10$$inlined$returnResult$1.class (File name too long)`

Integration tests that resulted in class filenames being too long have been fixed.

Increasing the gradle spring boot plugin version also required the linting plugin to be upgraded which has been done in an earlier PR https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/2450.