### PR TITLE
APS-1496 - Populate arrival and departure dates when migrating booking to space booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
@@ -89,4 +89,5 @@ data class CaseSummaries(
 
 data class ReferralDetail(
   val arrivedAt: ZonedDateTime?,
+  val departedAt: ZonedDateTime?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -54,6 +54,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeliusService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
@@ -236,6 +237,7 @@ class SeedService(
           getBean(DomainEventRepository::class),
           getBean(DomainEventService::class),
           getBean(UserRepository::class),
+          getBean(DeliusService::class),
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeliusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DeliusService.kt
@@ -10,16 +10,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 class DeliusService(
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
 ) {
-
-  fun referralHasArrival(booking: BookingEntity): Boolean {
-    val referralDetails = when (val clientResult = apDeliusContextApiClient.getReferralDetails(booking.crn, booking.id.toString())) {
+  fun getReferralDetails(booking: BookingEntity) =
+    when (val clientResult = apDeliusContextApiClient.getReferralDetails(booking.crn, booking.id.toString())) {
       is ClientResult.Success -> clientResult.body
       is ClientResult.Failure.StatusCode -> when (clientResult.status) {
-        HttpStatus.NOT_FOUND -> return false
+        HttpStatus.NOT_FOUND -> null
         else -> clientResult.throwException()
       }
       is ClientResult.Failure -> clientResult.throwException()
     }
-    return referralDetails.arrivedAt != null
-  }
+
+  fun referralHasArrival(booking: BookingEntity) = (getReferralDetails(booking)?.arrivedAt != null)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -2716,6 +2716,7 @@ class BookingTest : IntegrationTestBase() {
                 crn = booking.crn,
                 bookingId = booking.id.toString(),
                 arrivedAt = null,
+                departedAt = null,
               )
 
               webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -1825,6 +1825,7 @@ class WithdrawalTest : IntegrationTestBase() {
       crn = booking.crn,
       bookingId = booking.id.toString(),
       arrivedAt = if (hasArrivalInDelius) { ZonedDateTime.now() } else { null },
+      departedAt = null,
     )
 
     return booking

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -17,11 +17,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.User
 import java.time.ZonedDateTime
 import java.util.UUID
 
-fun IntegrationTestBase.APDeliusContext_mockSuccessfulGetReferralDetails(crn: String, bookingId: String, arrivedAt: ZonedDateTime?) =
+fun IntegrationTestBase.APDeliusContext_mockSuccessfulGetReferralDetails(
+  crn: String,
+  bookingId: String,
+  arrivedAt: ZonedDateTime?,
+  departedAt: ZonedDateTime?,
+) =
   mockSuccessfulGetCallWithJsonResponse(
     url = "/probation-case/$crn/referrals/$bookingId",
     responseBody = ReferralDetail(
       arrivedAt = arrivedAt,
+      departedAt = departedAt,
     ),
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DeliusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DeliusServiceTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeliusService
 import java.time.ZonedDateTime
 
 class DeliusServiceTest {
-
   private val apDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
 
   private val service = DeliusService(apDeliusContextApiClient)
@@ -35,6 +34,7 @@ class DeliusServiceTest {
           HttpStatus.OK,
           ReferralDetail(
             arrivedAt = ZonedDateTime.now(),
+            departedAt = ZonedDateTime.now().plusDays(1),
           ),
         )
 
@@ -50,6 +50,7 @@ class DeliusServiceTest {
           HttpStatus.OK,
           ReferralDetail(
             arrivedAt = null,
+            departedAt = null,
           ),
         )
 


### PR DESCRIPTION
This PR retrieves the arrival and departure date from delius when migrating bookings to space bookings, and saves them on the space booking, if defined.