### PR TITLE
CAS-1210 - Fix PDU name spelling error

### DIFF
--- a/src/main/resources/db/migration/all/2024110609000000__correct_pdu_spelling.sql
+++ b/src/main/resources/db/migration/all/2024110609000000__correct_pdu_spelling.sql
@@ -1,0 +1,1 @@
+update probation_delivery_units set name = 'Redcar, Cleveland and Middlesbrough' where name = 'Redcar, Cleveland and Middlesborough'


### PR DESCRIPTION
changes 'Redcar, Cleveland and Middlesborough' to name = 'Redcar, Cleveland and Middlesbrough'