### PR TITLE
Generate status for space booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -18,6 +18,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -34,6 +35,11 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
       b.crn as crn,
       b.canonical_arrival_date as canonicalArrivalDate,
       b.canonical_departure_date as canonicalDepartureDate,
+      b.expected_arrival_date as expectedArrivalDate,
+      b.expected_departure_date as expectedDepartureDate,
+      b.actual_arrival_date_time as actualArrivalDateTime,
+      b.actual_departure_date_time as actualDepartureDateTime,
+      b.non_arrival_confirmed_at as nonArrivalConfirmedAtDateTime,
       apa.risk_ratings -> 'tier' -> 'value' ->> 'level' as tier,
       b.key_worker_staff_code as keyWorkerStaffCode,
       b.key_worker_assigned_at as keyWorkerAssignedAt,
@@ -116,6 +122,11 @@ interface Cas1SpaceBookingSearchResult {
   val crn: String
   val canonicalArrivalDate: LocalDate
   val canonicalDepartureDate: LocalDate
+  val expectedArrivalDate: LocalDate
+  val expectedDepartureDate: LocalDate
+  val actualArrivalDateTime: LocalDateTime?
+  val actualDepartureDateTime: LocalDateTime?
+  val nonArrivalConfirmedAtDateTime: LocalDateTime?
   val tier: String?
   val keyWorkerStaffCode: String?
   val keyWorkerAssignedAt: Instant?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/SpaceBookingDates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/SpaceBookingDates.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+const val TWO_WEEKS = 2L
+const val SIX_WEEKS = 6L
+
+data class SpaceBookingDates(
+  val expectedArrivalDate: LocalDate,
+  val expectedDepartureDate: LocalDate,
+  val actualArrivalDateTime: LocalDateTime?,
+  val actualDepartureDateTime: LocalDateTime?,
+  val nonArrivalConfirmedAtDateTime: LocalDateTime?,
+) {
+  fun isNotArrived(): Boolean = this.nonArrivalConfirmedAtDateTime != null
+
+  fun isDepartingWithin2Weeks(nowDate: LocalDate): Boolean {
+    val twoWeeksFromNow = LocalDate.now().plusWeeks(2)
+    return hasArrivedAndNotDeparted() &&
+      expectedDepartureDate.isAfter(nowDate) &&
+      expectedDepartureDate.isBefore(twoWeeksFromNow.plusDays(1))
+  }
+
+  fun isDepartingToday(nowDate: LocalDate) =
+    nowDate == expectedDepartureDate && hasArrivedAndNotDeparted()
+
+  fun hasArrivedAndNotDeparted() = hasArrived() && !hasDeparted()
+
+  private fun hasArrived() = actualArrivalDateTime != null
+
+  fun hasDeparted() = actualDepartureDateTime != null
+
+  fun isArrivalToday(nowDate: LocalDate): Boolean =
+    !hasArrived() && expectedArrivalDate == nowDate
+
+  fun isArrivalWithin2Weeks(nowDate: LocalDate): Boolean {
+    val twoWeeksFromNow = LocalDate.now().plusWeeks(TWO_WEEKS)
+    return !hasArrived() &&
+      expectedArrivalDate.isAfter(nowDate) &&
+      expectedArrivalDate.isBefore(twoWeeksFromNow.plusDays(1))
+  }
+
+  fun isArrivalWithin6Weeks(nowDate: LocalDate): Boolean {
+    val sixWeeksFromNow = nowDate.plusWeeks(SIX_WEEKS)
+    return !hasArrived() &&
+      expectedArrivalDate.isAfter(nowDate) &&
+      expectedArrivalDate.isBefore(sixWeeksFromNow.plusDays(1))
+  }
+
+  fun isOverdueArrival(nowDate: LocalDate) =
+    !hasArrived() && nowDate.isAfter(expectedArrivalDate)
+
+  fun isOverdueDeparture(nowDate: LocalDate) =
+    hasArrivedAndNotDeparted() && nowDate.isAfter(expectedDepartureDate)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingStatusTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingStatusTransformer.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummaryStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.SpaceBookingDates
+import java.time.LocalDate
+
+@Component
+class Cas1SpaceBookingStatusTransformer {
+
+  fun transformToSpaceBookingSummaryStatus(
+    spaceBookingDates: SpaceBookingDates,
+  ): Cas1SpaceBookingSummaryStatus? {
+    val nowDate = LocalDate.now()
+    return when {
+      spaceBookingDates.isNotArrived() -> Cas1SpaceBookingSummaryStatus.notArrived
+      spaceBookingDates.hasDeparted() -> Cas1SpaceBookingSummaryStatus.departed
+      spaceBookingDates.isOverdueDeparture(nowDate) -> Cas1SpaceBookingSummaryStatus.overdueDeparture
+      spaceBookingDates.isDepartingToday(nowDate) -> Cas1SpaceBookingSummaryStatus.departingToday
+      spaceBookingDates.isDepartingWithin2Weeks(nowDate) -> Cas1SpaceBookingSummaryStatus.departingWithin2Weeks
+      spaceBookingDates.hasArrivedAndNotDeparted() -> Cas1SpaceBookingSummaryStatus.arrived
+      spaceBookingDates.isArrivalToday(nowDate) -> Cas1SpaceBookingSummaryStatus.arrivingToday
+      spaceBookingDates.isArrivalWithin2Weeks(nowDate) -> Cas1SpaceBookingSummaryStatus.arrivingWithin2Weeks
+      spaceBookingDates.isArrivalWithin6Weeks(nowDate) -> Cas1SpaceBookingSummaryStatus.arrivingWithin6Weeks
+      spaceBookingDates.isOverdueArrival(nowDate) -> Cas1SpaceBookingSummaryStatus.overdueArrival
+      else -> null
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.SpaceBookingDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
@@ -25,6 +26,7 @@ class Cas1SpaceBookingTransformer(
   private val spaceBookingRequirementsTransformer: Cas1SpaceBookingRequirementsTransformer,
   private val cancellationReasonTransformer: CancellationReasonTransformer,
   private val userTransformer: UserTransformer,
+  private val spaceBookingStatusTransformer: Cas1SpaceBookingStatusTransformer,
 ) {
   fun transformJpaToApi(
     person: PersonInfoResult,
@@ -129,5 +131,14 @@ class Cas1SpaceBookingTransformer(
         ),
       )
     },
+    status = spaceBookingStatusTransformer.transformToSpaceBookingSummaryStatus(
+      SpaceBookingDates(
+        searchResult.expectedArrivalDate,
+        searchResult.expectedDepartureDate,
+        searchResult.actualArrivalDateTime,
+        searchResult.actualDepartureDateTime,
+        searchResult.nonArrivalConfirmedAtDateTime,
+      ),
+    ),
   )
 }

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -375,6 +375,8 @@ components:
           type: string
         keyWorkerAllocation:
           $ref: '#/components/schemas/Cas1KeyWorkerAllocation'
+        status:
+          $ref: '#/components/schemas/Cas1SpaceBookingSummaryStatus'
       required:
         - id
         - person
@@ -388,6 +390,19 @@ components:
         - canonicalDepartureDate
         - keyWorkerName
         - tier
+    Cas1SpaceBookingSummaryStatus:
+      type: string
+      enum:
+        - arrivingWithin6Weeks
+        - arrivingWithin2Weeks
+        - arrivingToday
+        - overdueArrival
+        - arrived
+        - notArrived
+        - departingWithin2Weeks
+        - departingToday
+        - overdueDeparture
+        - departed
     Cas1SpaceBookingResidency:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6575,6 +6575,8 @@ components:
           type: string
         keyWorkerAllocation:
           $ref: '#/components/schemas/Cas1KeyWorkerAllocation'
+        status:
+          $ref: '#/components/schemas/Cas1SpaceBookingSummaryStatus'
       required:
         - id
         - person
@@ -6588,6 +6590,19 @@ components:
         - canonicalDepartureDate
         - keyWorkerName
         - tier
+    Cas1SpaceBookingSummaryStatus:
+      type: string
+      enum:
+        - arrivingWithin6Weeks
+        - arrivingWithin2Weeks
+        - arrivingToday
+        - overdueArrival
+        - arrived
+        - notArrived
+        - departingWithin2Weeks
+        - departingToday
+        - overdueDeparture
+        - departed
     Cas1SpaceBookingResidency:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingStatusTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingStatusTransformerTest.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummaryStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.SpaceBookingDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingStatusTransformer
+import java.util.stream.Stream
+
+class Cas1SpaceBookingStatusTransformerTest {
+
+  private val transformer = Cas1SpaceBookingStatusTransformer()
+
+  @ParameterizedTest
+  @MethodSource("spaceBookingSummaryStatusCases")
+  fun `Space booking status is transformed correctly`(
+    testCaseForSpaceBookingSummaryStatus: TestCaseForSpaceBookingSummaryStatus,
+    expectedStatus: Cas1SpaceBookingSummaryStatus,
+  ) {
+    val result = transformer.transformToSpaceBookingSummaryStatus(
+      SpaceBookingDates(
+        testCaseForSpaceBookingSummaryStatus.expectedArrivalDate,
+        testCaseForSpaceBookingSummaryStatus.expectedDepartureDate,
+        testCaseForSpaceBookingSummaryStatus.actualArrivalDateTime,
+        testCaseForSpaceBookingSummaryStatus.actualDepartureDateTime,
+        testCaseForSpaceBookingSummaryStatus.nonArrivalConfirmedAtDateTime,
+      ),
+    )
+    assertThat(result).isEqualTo(expectedStatus)
+  }
+
+  companion object {
+    @JvmStatic
+    fun spaceBookingSummaryStatusCases(): Stream<Arguments> {
+      return Cas1SpaceBookingSummaryStatusTestHelper().spaceBookingSummaryStatusCases()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingSummaryStatusTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingSummaryStatusTestHelper.kt
@@ -1,0 +1,176 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import org.junit.jupiter.params.provider.Arguments
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummaryStatus
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.stream.Stream
+
+data class TestCaseForSpaceBookingSummaryStatus(
+  val expectedArrivalDate: LocalDate,
+  val actualArrivalDateTime: LocalDateTime?,
+  val expectedDepartureDate: LocalDate,
+  val actualDepartureDateTime: LocalDateTime?,
+  val nonArrivalConfirmedAtDateTime: LocalDateTime?,
+)
+
+class Cas1SpaceBookingSummaryStatusTestHelper {
+  private val nowDateTime: LocalDateTime = LocalDateTime.now()
+  private val dateWayInTheFuture: LocalDateTime = nowDateTime.plusDays(800)
+
+  fun spaceBookingSummaryStatusCases(): Stream<Arguments> {
+    return (
+      getArrivedCase() +
+        getArrivalTodayCase() +
+        getOverdueArrivalCases() +
+        getArrivalWithin2WeeksCases() +
+        getArrivalWithin6WeeksCases() +
+        getDepartingTodayCase() +
+        getDepartedCase() +
+        getOverdueDepartureCases() +
+        getDepartingWithin2WeeksCases() +
+        getNotArrivedCase()
+      ).stream()
+  }
+
+  private fun getArrivedCase() = listOf(
+    Arguments.of(
+      TestCaseForSpaceBookingSummaryStatus(
+        expectedArrivalDate = nowDateTime.toLocalDate(),
+        actualArrivalDateTime = nowDateTime,
+        expectedDepartureDate = dateWayInTheFuture.toLocalDate(),
+        actualDepartureDateTime = null,
+        nonArrivalConfirmedAtDateTime = null,
+      ),
+      Cas1SpaceBookingSummaryStatus.arrived,
+    ),
+  )
+
+  private fun getNotArrivedCase() = listOf(
+    Arguments.of(
+      TestCaseForSpaceBookingSummaryStatus(
+        expectedArrivalDate = nowDateTime.toLocalDate(),
+        actualArrivalDateTime = null,
+        expectedDepartureDate = dateWayInTheFuture.toLocalDate(),
+        actualDepartureDateTime = null,
+        nonArrivalConfirmedAtDateTime = nowDateTime,
+      ),
+      Cas1SpaceBookingSummaryStatus.notArrived,
+    ),
+  )
+
+  private fun getArrivalTodayCase() = listOf(
+    Arguments.of(
+      TestCaseForSpaceBookingSummaryStatus(
+        expectedArrivalDate = nowDateTime.toLocalDate(),
+        actualArrivalDateTime = null,
+        expectedDepartureDate = dateWayInTheFuture.toLocalDate(),
+        actualDepartureDateTime = null,
+        nonArrivalConfirmedAtDateTime = null,
+      ),
+      Cas1SpaceBookingSummaryStatus.arrivingToday,
+    ),
+  )
+
+  private fun getOverdueArrivalCases() = (1L..14L).toList()
+    .map {
+      Arguments.of(
+        TestCaseForSpaceBookingSummaryStatus(
+          expectedArrivalDate = nowDateTime.toLocalDate().minusDays(it),
+          actualArrivalDateTime = null,
+          expectedDepartureDate = dateWayInTheFuture.toLocalDate(),
+          actualDepartureDateTime = null,
+          nonArrivalConfirmedAtDateTime = null,
+        ),
+        Cas1SpaceBookingSummaryStatus.overdueArrival,
+      )
+    }
+
+  private fun getArrivalWithin2WeeksCases() = (1L..14L).toList()
+    .map {
+      Arguments.of(
+        TestCaseForSpaceBookingSummaryStatus(
+          expectedArrivalDate = nowDateTime.toLocalDate().plusDays(it),
+          actualArrivalDateTime = null,
+          expectedDepartureDate = dateWayInTheFuture.toLocalDate(),
+          actualDepartureDateTime = null,
+          nonArrivalConfirmedAtDateTime = null,
+        ),
+        Cas1SpaceBookingSummaryStatus.arrivingWithin2Weeks,
+      )
+    }
+
+  private fun getArrivalWithin6WeeksCases() = (15L..42L).toList()
+    .map {
+      Arguments.of(
+        TestCaseForSpaceBookingSummaryStatus(
+          expectedArrivalDate = nowDateTime.toLocalDate().plusDays(it),
+          actualArrivalDateTime = null,
+          expectedDepartureDate = dateWayInTheFuture.toLocalDate(),
+          actualDepartureDateTime = null,
+          nonArrivalConfirmedAtDateTime = null,
+        ),
+        Cas1SpaceBookingSummaryStatus.arrivingWithin6Weeks,
+      )
+    }
+
+  private fun getDepartingTodayCase(): List<Arguments> {
+    val date1dayAgo = nowDateTime.minusDays(1)
+    return listOf(
+      Arguments.of(
+        TestCaseForSpaceBookingSummaryStatus(
+          expectedArrivalDate = date1dayAgo.toLocalDate(),
+          actualArrivalDateTime = date1dayAgo,
+          expectedDepartureDate = nowDateTime.toLocalDate(),
+          actualDepartureDateTime = null,
+          nonArrivalConfirmedAtDateTime = null,
+        ),
+        Cas1SpaceBookingSummaryStatus.departingToday,
+      ),
+    )
+  }
+
+  private fun getDepartedCase(): List<Arguments> {
+    val date1dayAgo = nowDateTime.minusDays(1)
+    return listOf(
+      Arguments.of(
+        TestCaseForSpaceBookingSummaryStatus(
+          expectedArrivalDate = date1dayAgo.toLocalDate(),
+          actualArrivalDateTime = date1dayAgo,
+          expectedDepartureDate = nowDateTime.toLocalDate(),
+          actualDepartureDateTime = nowDateTime,
+          nonArrivalConfirmedAtDateTime = null,
+        ),
+        Cas1SpaceBookingSummaryStatus.departed,
+      ),
+    )
+  }
+
+  private fun getOverdueDepartureCases() = (1L..14L).toList()
+    .map {
+      Arguments.of(
+        TestCaseForSpaceBookingSummaryStatus(
+          expectedArrivalDate = nowDateTime.minusDays(100).toLocalDate(),
+          actualArrivalDateTime = nowDateTime.minusDays(100),
+          expectedDepartureDate = nowDateTime.minusDays(it).toLocalDate(),
+          actualDepartureDateTime = null,
+          nonArrivalConfirmedAtDateTime = null,
+        ),
+        Cas1SpaceBookingSummaryStatus.overdueDeparture,
+      )
+    }
+
+  private fun getDepartingWithin2WeeksCases() = (1L..14L).toList()
+    .map {
+      Arguments.of(
+        TestCaseForSpaceBookingSummaryStatus(
+          expectedArrivalDate = nowDateTime.minusDays(100).toLocalDate(),
+          actualArrivalDateTime = nowDateTime.minusDays(100),
+          expectedDepartureDate = nowDateTime.plusDays(it).toLocalDate(),
+          actualDepartureDateTime = null,
+          nonArrivalConfirmedAtDateTime = null,
+        ),
+        Cas1SpaceBookingSummaryStatus.departingWithin2Weeks,
+      )
+    }
+}


### PR DESCRIPTION
**PR includes:**
- Generate all space booking statuses based on `expectedArrivalDate` / `expectedDepartureDate` / `actualArrivalDate` / `actualDepartureDate`
- The exception is the `notArrived` status which is driven by the `nonArrivalConfirmedAtDateTime`(i.e. if this is set then `notArrived`) - Spoke with @RobBoothMOJ on this
- For reference business-logic see the related ticket: https://dsdmoj.atlassian.net/browse/APS-1370