### PR TITLE
Pre-fetch space booking criteria for planning

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -99,13 +99,14 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
     value =
     """
     SELECT b FROM Cas1SpaceBookingEntity b
+    LEFT JOIN FETCH b.criteria
     WHERE b.premises.id = :premisesId
     AND b.cancellationOccurredAt IS NULL 
     AND b.canonicalArrivalDate <= :day 
     AND b.canonicalDepartureDate > :day
   """,
   )
-  fun findAllBookingsOnGivenDayForPremises(premisesId: UUID, day: LocalDate): List<Cas1SpaceBookingEntity>
+  fun findAllBookingsOnGivenDayWithCriteria(premisesId: UUID, day: LocalDate): List<Cas1SpaceBookingEntity>
 }
 
 interface Cas1SpaceBookingSearchResult {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
@@ -36,7 +36,7 @@ class SpacePlanningModelsFactory(
     }
 
   fun spaceBookingsForDay(day: LocalDate, premises: ApprovedPremisesEntity): List<SpaceBooking> =
-    spaceBookingRepository.findAllBookingsOnGivenDayForPremises(premises.id, day)
+    spaceBookingRepository.findAllBookingsOnGivenDayWithCriteria(premises.id, day)
       .map { booking ->
         SpaceBooking(
           id = booking.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
@@ -309,7 +309,7 @@ class SpacePlanningModelsFactoryTest {
       val premises = ApprovedPremisesEntityFactory().withDefaults().produce()
 
       every {
-        spaceBookingRepository.findAllBookingsOnGivenDayForPremises(
+        spaceBookingRepository.findAllBookingsOnGivenDayWithCriteria(
           premisesId = premises.id,
           day = LocalDate.of(2020, 4, 4),
         )
@@ -344,7 +344,7 @@ class SpacePlanningModelsFactoryTest {
       val premises = ApprovedPremisesEntityFactory().withDefaults().produce()
 
       every {
-        spaceBookingRepository.findAllBookingsOnGivenDayForPremises(
+        spaceBookingRepository.findAllBookingsOnGivenDayWithCriteria(
           premisesId = premises.id,
           day = LocalDate.of(2020, 4, 4),
         )


### PR DESCRIPTION
This avoids lazy loading criteria for each relevant space booking