### PR TITLE
APS-1460: Removed expected departure date from Cas1 Arrival endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
@@ -33,7 +33,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -48,7 +47,6 @@ class Cas1SpaceBookingManagementDomainEventService(
 
   fun arrivalRecorded(
     updatedCas1SpaceBooking: Cas1SpaceBookingEntity,
-    previousExpectedDepartureOn: LocalDate? = null,
   ) {
     val domainEventId = UUID.randomUUID()
 
@@ -89,7 +87,6 @@ class Cas1SpaceBookingManagementDomainEventService(
             keyWorker = keyWorker,
             arrivedAt = actualArrivalDate,
             expectedDepartureOn = updatedCas1SpaceBooking.expectedDepartureDate,
-            previousExpectedDepartureOn = previousExpectedDepartureOn,
             notes = null,
           ),
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -174,23 +174,13 @@ class Cas1SpaceBookingService(
       return existingCas1SpaceBooking.id hasConflictError "An arrival is already recorded for this Space Booking"
     }
 
-    val previousExpectedDepartureOn =
-      if (existingCas1SpaceBooking.expectedDepartureDate != cas1NewArrival.expectedDepartureDate) {
-        existingCas1SpaceBooking.expectedDepartureDate
-      } else {
-        null
-      }
-
     existingCas1SpaceBooking.actualArrivalDateTime = cas1NewArrival.arrivalDateTime
     existingCas1SpaceBooking.canonicalArrivalDate = LocalDate.ofInstant(cas1NewArrival.arrivalDateTime, ZoneId.systemDefault())
-    existingCas1SpaceBooking.expectedDepartureDate = cas1NewArrival.expectedDepartureDate
-    existingCas1SpaceBooking.canonicalDepartureDate = cas1NewArrival.expectedDepartureDate
 
     val result = cas1SpaceBookingRepository.save(existingCas1SpaceBooking)
 
     cas1SpaceBookingManagementDomainEventService.arrivalRecorded(
       existingCas1SpaceBooking,
-      previousExpectedDepartureOn,
     )
 
     success(result)

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -425,14 +425,10 @@ components:
     Cas1NewArrival:
       type: object
       properties:
-        expectedDepartureDate:
-          type: string
-          format: date
         arrivalDateTime:
           type: string
           format: date-time
       required:
-        - expectedDepartureDate
         - arrivalDateTime
     Cas1NonArrival:
       type: object

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6625,14 +6625,10 @@ components:
     Cas1NewArrival:
       type: object
       properties:
-        expectedDepartureDate:
-          type: string
-          format: date
         arrivalDateTime:
           type: string
           format: date-time
       required:
-        - expectedDepartureDate
         - arrivalDateTime
     Cas1NonArrival:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -876,7 +876,6 @@ class Cas1SpaceBookingTest {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           Cas1NewArrival(
-            expectedDepartureDate = LocalDate.now().plusMonths(1),
             arrivalDateTime = LocalDateTime.now().toInstant(ZoneOffset.UTC),
           ),
         )
@@ -919,7 +918,6 @@ class Cas1SpaceBookingTest {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           Cas1NewArrival(
-            expectedDepartureDate = LocalDate.now().plusMonths(1),
             arrivalDateTime = LocalDateTime.now().toInstant(ZoneOffset.UTC),
           ),
         )
@@ -963,7 +961,6 @@ class Cas1SpaceBookingTest {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           Cas1NewArrival(
-            expectedDepartureDate = LocalDate.now().plusMonths(1),
             arrivalDateTime = LocalDateTime.now().toInstant(ZoneOffset.UTC),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -210,29 +210,6 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       val data = domainEvent.data.eventDetails
       assertThat(data.keyWorker).isNull()
     }
-
-    @Test
-    fun `record arrival and emits domain event recognising change in expected departure date`() {
-      val spaceBooking = spaceBookingFactory.withApplication(application).produce()
-
-      val previousExpectedDepartureDate = departureDate.plusMonths(1)
-      service.arrivalRecorded(spaceBooking, previousExpectedDepartureDate)
-
-      val domainEventArgument = slot<DomainEvent<PersonArrivedEnvelope>>()
-
-      verify(exactly = 1) {
-        domainEventService.savePersonArrivedEvent(
-          capture(domainEventArgument),
-          emit = false,
-        )
-      }
-
-      val domainEvent = domainEventArgument.captured
-
-      val data = domainEvent.data.eventDetails
-      assertThat(data.previousExpectedDepartureOn).isEqualTo(previousExpectedDepartureDate)
-      assertThat(data.expectedDepartureOn).isEqualTo(departureDate)
-    }
   }
 
   @Nested


### PR DESCRIPTION
Removed expected departure date from CAS1 Arrival endpoint

Removed setting of previousExpectedDepartureOn but left the field in place, on the `PersonArrived` domain event.  
Discussion with David 7/5 we thought there would likely be value in this being captured and while API definitions are in a state of flux, worth keeping for the time being.