### PR TITLE
APS-153 - Use legacy cas1 management data for seeding space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -197,13 +199,20 @@ data class Cas1SpaceBookingEntity(
   @JoinColumn(name = "non_arrival_reason_id")
   var nonArrivalReason: NonArrivalReasonEntity?,
   var nonArrivalNotes: String?,
+  val deliusEventNumber: String?,
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "migrated_from_booking_id")
   val migratedFromBooking: BookingEntity?,
-  val deliusEventNumber: String?,
+  @Enumerated(EnumType.STRING)
+  val migratedManagementInfoFrom: ManagementInfoSource?,
 ) {
   fun isActive() = !isCancelled()
   fun isCancelled() = cancellationOccurredAt != null
   fun hasArrival() = actualArrivalDateTime != null
   override fun toString() = "Cas1SpaceBookingEntity:$id"
+}
+
+enum class ManagementInfoSource {
+  DELIUS,
+  LEGACY_CAS_1,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -74,7 +74,6 @@ class Cas1BookingToSpaceBookingSeedJob(
     log.info("Have successfully migrated $migratedCount of $bookingsToMigrateSize bookings for premise ${premises.name}")
   }
 
-  @SuppressWarnings("MagicNumber")
   private fun migrateBooking(
     premises: ApprovedPremisesEntity,
     bookingId: UUID,
@@ -123,6 +122,7 @@ class Cas1BookingToSpaceBookingSeedJob(
     log.info("Have migrated booking $bookingId to space booking ${spaceBooking.id}")
   }
 
+  @SuppressWarnings("MagicNumber")
   private fun getManagementInfo(booking: BookingEntity): ManagementInfo? {
     val shouldExistInDelius = !booking.isCancelled
     val referralDetails = if (shouldExistInDelius) {
@@ -144,6 +144,14 @@ class Cas1BookingToSpaceBookingSeedJob(
       )
     }
 
+    if (booking.hasArrivals()) {
+      return ManagementInfo(
+        source = ManagementInfoSource.LegacyCas1,
+        arrivedAt = booking.arrival?.arrivalDateTime,
+        departedAt = booking.departure?.dateTime?.toInstant(),
+      )
+    }
+
     return null
   }
 
@@ -155,6 +163,7 @@ class Cas1BookingToSpaceBookingSeedJob(
 
   enum class ManagementInfoSource {
     Delius,
+    LegacyCas1,
   }
 
   private fun BookingEntity.getEssentialRoomCriteria() =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -130,8 +130,9 @@ class Cas1SpaceBookingService(
         nonArrivalConfirmedAt = null,
         nonArrivalNotes = null,
         nonArrivalReason = null,
-        migratedFromBooking = null,
         deliusEventNumber = application.eventNumber,
+        migratedFromBooking = null,
+        migratedManagementInfoFrom = null,
       ),
     )
 

--- a/src/main/resources/db/migration/all/20241107145256__add_migrated_management_info_from_to_space_bookings.sql
+++ b/src/main/resources/db/migration/all/20241107145256__add_migrated_management_info_from_to_space_bookings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_space_bookings ADD migrated_management_info_from TEXT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ManagementInfoSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
@@ -49,6 +50,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var nonArrivalReason: Yielded<NonArrivalReasonEntity?> = { null }
   private var nonArrivalNotes: Yielded<String?> = { null }
   private var migratedFromBooking: Yielded<BookingEntity?> = { null }
+  private var migratedManagementInfoFrom: Yielded<ManagementInfoSource?> = { null }
   private var deliusEventNumber: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
@@ -233,7 +235,8 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     nonArrivalConfirmedAt = this.nonArrivalConfirmedAt(),
     nonArrivalNotes = this.nonArrivalNotes(),
     nonArrivalReason = this.nonArrivalReason(),
-    migratedFromBooking = this.migratedFromBooking(),
     deliusEventNumber = this.deliusEventNumber(),
+    migratedFromBooking = this.migratedFromBooking(),
+    migratedManagementInfoFrom = this.migratedManagementInfoFrom(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABooking.kt
@@ -2,10 +2,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.`Given a Booking`(
@@ -15,13 +18,36 @@ fun IntegrationTestBase.`Given a Booking`(
   arrivalDate: LocalDate = LocalDate.now().randomDateBefore(14),
   departureDate: LocalDate = LocalDate.now().randomDateBefore(14),
   adhoc: Boolean = false,
-) = bookingEntityFactory.produceAndPersist {
-  withCrn(crn)
-  withPremises(premises ?: approvedPremisesEntityFactory.produceAndPersist())
-  withApplication(application)
-  withArrivalDate(arrivalDate)
-  withDepartureDate(departureDate)
-  withAdhoc(adhoc)
+  actualArrivalDate: LocalDateTime? = null,
+  actualDepartureDate: LocalDateTime? = null,
+): BookingEntity {
+  val booking = bookingEntityFactory.produceAndPersist {
+    withCrn(crn)
+    withPremises(premises ?: approvedPremisesEntityFactory.produceAndPersist())
+    withApplication(application)
+    withArrivalDate(arrivalDate)
+    withDepartureDate(departureDate)
+    withAdhoc(adhoc)
+  }
+
+  actualArrivalDate?.let {
+    arrivalEntityFactory.produceAndPersist {
+      withBooking(booking)
+      withArrivalDate(actualArrivalDate.toLocalDate())
+      withArrivalDateTime(actualArrivalDate.toInstant(ZoneOffset.UTC))
+    }
+  }
+
+  actualDepartureDate?.let {
+    departureEntityFactory.produceAndPersist {
+      withBooking(booking)
+      withDateTime(actualDepartureDate.atOffset(ZoneOffset.UTC))
+      withReason(departureReasonEntityFactory.produceAndPersist())
+      withMoveOnCategory(moveOnCategoryEntityFactory.produceAndPersist())
+    }
+  }
+
+  return booking
 }
 
 @SuppressWarnings("LongParameterList")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Give
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.`Given an Offline Application`
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.APDeliusContext_mockSuccessfulGetReferralDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ManagementInfoSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1SpaceBookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingToSpaceBookingSeedCsvRow
@@ -110,7 +111,7 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     }
 
     val offlineApplication = `Given an Offline Application`(
-      crn = "CRN3-offline",
+      crn = "CRN3",
       eventNumber = "75",
     )
     val booking3OfflineApplication = `Given a Booking for an Offline Application`(
@@ -177,9 +178,10 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking1.cancellationReasonNotes).isNull()
     assertThat(migratedBooking1.departureReason).isNull()
     assertThat(migratedBooking1.departureMoveOnCategory).isNull()
-    assertThat(migratedBooking1.migratedFromBooking!!.id).isEqualTo(booking1DeliusManagementInfo.id)
     assertThat(migratedBooking1.criteria).containsOnly(roomCriteria1, roomCriteria2)
     assertThat(migratedBooking1.deliusEventNumber).isEqualTo("25")
+    assertThat(migratedBooking1.migratedFromBooking!!.id).isEqualTo(booking1DeliusManagementInfo.id)
+    assertThat(migratedBooking1.migratedManagementInfoFrom).isEqualTo(ManagementInfoSource.DELIUS)
 
     val migratedBooking2 = premiseSpaceBookings[1]
     assertThat(migratedBooking2.premises.id).isEqualTo(premises.id)
@@ -203,9 +205,10 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking2.cancellationReasonNotes).isEqualTo("cancellation other reason")
     assertThat(migratedBooking2.departureReason).isNull()
     assertThat(migratedBooking2.departureMoveOnCategory).isNull()
-    assertThat(migratedBooking2.migratedFromBooking!!.id).isEqualTo(booking2LegacyCas1ManagementInfo.id)
     assertThat(migratedBooking2.criteria).isEmpty()
     assertThat(migratedBooking2.deliusEventNumber).isEqualTo("50")
+    assertThat(migratedBooking2.migratedFromBooking!!.id).isEqualTo(booking2LegacyCas1ManagementInfo.id)
+    assertThat(migratedBooking2.migratedManagementInfoFrom).isEqualTo(ManagementInfoSource.LEGACY_CAS_1)
 
     val migratedBooking3 = premiseSpaceBookings[2]
     assertThat(migratedBooking3.premises.id).isEqualTo(premises.id)
@@ -229,9 +232,10 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking3.cancellationReasonNotes).isNull()
     assertThat(migratedBooking3.departureReason).isNull()
     assertThat(migratedBooking3.departureMoveOnCategory).isNull()
-    assertThat(migratedBooking3.migratedFromBooking!!.id).isEqualTo(booking3OfflineApplication.id)
     assertThat(migratedBooking3.criteria).isEmpty()
     assertThat(migratedBooking3.deliusEventNumber).isEqualTo("75")
+    assertThat(migratedBooking3.migratedFromBooking!!.id).isEqualTo(booking3OfflineApplication.id)
+    assertThat(migratedBooking3.migratedManagementInfoFrom).isNull()
 
     val migratedBooking4 = premiseSpaceBookings[3]
     assertThat(migratedBooking4.premises.id).isEqualTo(premises.id)
@@ -255,9 +259,10 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking4.cancellationReasonNotes).isNull()
     assertThat(migratedBooking4.departureReason).isNull()
     assertThat(migratedBooking4.departureMoveOnCategory).isNull()
-    assertThat(migratedBooking4.migratedFromBooking!!.id).isEqualTo(booking4OfflineNoDomainEvent.id)
     assertThat(migratedBooking4.criteria).isEmpty()
     assertThat(migratedBooking4.deliusEventNumber).isNull()
+    assertThat(migratedBooking4.migratedFromBooking!!.id).isEqualTo(booking4OfflineNoDomainEvent.id)
+    assertThat(migratedBooking4.migratedManagementInfoFrom).isNull()
   }
 
   private fun rowsToCsv(rows: List<Cas1BookingToSpaceBookingSeedCsvRow>): String {


### PR DESCRIPTION
This PR falls back to 'legacy' arrival and departure data captured on a `booking` when seeding an equivalent `space booking`. This will only be used if a corresponding record cannot be found in Delius.