### PR TITLE
CAS-1213 Remove Referral end point from CAS3 reports end points

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/ReportsController.kt
@@ -39,31 +39,6 @@ class ReportsController(
   private val cas3ReportService: Cas3ReportService,
 ) : ReportsCas3Delegate {
 
-  override fun reportsReferralsGet(
-    xServiceName: ServiceName,
-    year: Int,
-    month: Int,
-    probationRegionId: UUID?,
-  ): ResponseEntity<StreamingResponseBody> {
-    if (!userAccessService.currentUserCanViewReport()) {
-      throw ForbiddenProblem()
-    }
-    validateParameters(probationRegionId, month)
-
-    val startDate = LocalDate.of(year, month, 1)
-    val endDate = LocalDate.of(year, month, startDate.month.length(startDate.isLeapYear))
-    val properties = TransitionalAccommodationReferralReportProperties(probationRegionId, startDate, endDate)
-
-    return when (xServiceName) {
-      ServiceName.temporaryAccommodation -> {
-        generateXlsxStreamingResponse { outputStream ->
-          cas3ReportService.createCas3ApplicationReferralsReport(properties, outputStream)
-        }
-      }
-      else -> throw UnsupportedOperationException("Only supported for CAS3")
-    }
-  }
-
   override fun reportsReportNameGet(
     reportName: Cas3ReportType,
     startDate: LocalDate,
@@ -162,14 +137,6 @@ class ReportsController(
           outputStream,
         )
       }
-    }
-  }
-
-  private fun validateParameters(probationRegionId: UUID?, month: Int) {
-    validateUserAccessibility(probationRegionId)
-
-    if (month < 1 || month > 12) {
-      throw BadRequestProblem(errorDetail = "month must be between 1 and 12")
     }
   }
 

--- a/src/main/resources/static/cas3-api.yml
+++ b/src/main/resources/static/cas3-api.yml
@@ -5,45 +5,6 @@ info:
 servers:
   - url: /cas3
 paths:
-  /reports/referrals:
-    get:
-      tags:
-        - CAS3 Reports
-      summary: Returns a spreadsheet of all cas3 referrals for specified duration and (optional) region
-      parameters:
-        - name: X-Service-Name
-          in: header
-          required: true
-          description: Only bookings for this service will be returned
-          schema:
-            $ref: '_shared.yml#/components/schemas/ServiceName'
-        - name: probationRegionId
-          in: query
-          required: false
-          description: If provided, only bookings for this region will be returned
-          schema:
-            type: string
-            format: uuid
-        - name: year
-          in: query
-          required: true
-          description: If provided, only bookings for this year will be returned
-          schema:
-            type: integer
-        - name: month
-          in: query
-          required: true
-          description: If provided, only bookings for this month will be returned - must be provided with year
-          schema:
-            type: integer
-      responses:
-        200:
-          description: Successfully retrieved the report
-          content:
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-              schema:
-                type: string
-                format: binary
   /reports/{reportName}:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -7,45 +7,6 @@ info:
 servers:
   - url: /cas3
 paths:
-  /reports/referrals:
-    get:
-      tags:
-        - CAS3 Reports
-      summary: Returns a spreadsheet of all cas3 referrals for specified duration and (optional) region
-      parameters:
-        - name: X-Service-Name
-          in: header
-          required: true
-          description: Only bookings for this service will be returned
-          schema:
-            $ref: '#/components/schemas/ServiceName'
-        - name: probationRegionId
-          in: query
-          required: false
-          description: If provided, only bookings for this region will be returned
-          schema:
-            type: string
-            format: uuid
-        - name: year
-          in: query
-          required: true
-          description: If provided, only bookings for this year will be returned
-          schema:
-            type: integer
-        - name: month
-          in: query
-          required: true
-          description: If provided, only bookings for this month will be returned - must be provided with year
-          schema:
-            type: integer
-      responses:
-        200:
-          description: Successfully retrieved the report
-          content:
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-              schema:
-                type: string
-                format: binary
   /reports/{reportName}:
     get:
       tags:


### PR DESCRIPTION
This[ PR CAS-1213](https://dsdmoj.atlassian.net/browse/CAS-1213) is to remove `/reports/referrals` Api as is no longer in use and is replaced with `/reports/{reportName}`