### PR TITLE
APS-1453 - Use transaction per premise when migrating space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
@@ -6,6 +6,7 @@ abstract class SeedJob<RowType> (
   val id: UUID = UUID.randomUUID(),
   val fileName: String,
   val requiredHeaders: Set<String>? = null,
+  val runInTransaction: Boolean = true,
 ) {
   init {
     if (fileName.contains("/") || fileName.contains("\\")) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -243,6 +243,7 @@ class SeedService(
           getBean(DomainEventService::class),
           getBean(UserRepository::class),
           getBean(DeliusService::class),
+          getBean(TransactionTemplate::class),
         )
 
         SeedFileType.approvedPremisesSpacePlanningDryRun -> Cas1PlanSpacePlanningDryRunSeedJob(
@@ -254,7 +255,11 @@ class SeedService(
 
       val seedStarted = LocalDateTime.now()
 
-      transactionTemplate.executeWithoutResult { processJob(job, resolveCsvPath) }
+      if (job.runInTransaction) {
+        transactionTemplate.executeWithoutResult { processJob(job, resolveCsvPath) }
+      } else {
+        processJob(job, resolveCsvPath)
+      }
 
       val timeTaken = ChronoUnit.MILLIS.between(seedStarted, LocalDateTime.now())
       seedLogger.info("Seed request complete. Took $timeTaken millis")


### PR DESCRIPTION
This commit allows seed jobs to manage their own transactions, and subsequently changes the ‘booking to space booking’ logic to migrate each premise in its own transaction. There’s concern that if trying to migrate a large number of premises in one execution this wll result in a very large transaction which may lead to resource issues during processing