### PR TITLE
APS-1453 - Limit space planning to specific characteristics

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -11,7 +11,14 @@ import java.util.UUID
 interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
 
   companion object Constants {
+    const val CAS1_PROPERTY_NAME_ARSON_DESIGNATED = "isArsonDesignated"
+    const val CAS1_PROPERTY_NAME_ARSON_SUITABLE = "isArsonSuitable"
+    const val CAS1_PROPERTY_NAME_ENSUITE = "hasEnSuite"
+    const val CAS1_PROPERTY_NAME_GROUND_FLOOR = "isGroundFloor"
     const val CAS1_PROPERTY_NAME_SINGLE_ROOM = "isSingle"
+    const val CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED = "isStepFreeDesignated"
+    const val CAS1_PROPERTY_NAME_SUITED_FOR_SEX_OFFENDERS = "isSuitedForSexOffenders"
+    const val CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED = "isWheelchairDesignated"
   }
 
   @Query("SELECT c FROM CharacteristicEntity c WHERE c.serviceScope = :serviceName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
 
   companion object Constants {
-    val CAS1_SINGLE_ROOM_CHARACTERISTIC_ID: UUID = UUID.fromString("7d59280e-aca0-4842-994e-b22cbc076fe8")
+    const val CAS1_PROPERTY_NAME_SINGLE_ROOM = "isSingle"
   }
 
   @Query("SELECT c FROM CharacteristicEntity c WHERE c.serviceScope = :serviceName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_SINGLE_ROOM_CHARACTERISTIC_ID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningModelsFactory.Constants.DEFAULT_CHARACTERISTIC_WEIGHT
 import java.time.LocalDate
 
@@ -81,6 +81,6 @@ class SpacePlanningModelsFactory(
     id = characteristicEntity.id,
     label = characteristicEntity.propertyName ?: "",
     weighting = DEFAULT_CHARACTERISTIC_WEIGHT,
-    singleRoom = characteristicEntity.id == CAS1_SINGLE_ROOM_CHARACTERISTIC_ID,
+    singleRoom = characteristicEntity.propertyName == CAS1_PROPERTY_NAME_SINGLE_ROOM,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
@@ -6,7 +6,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_DESIGNATED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_GROUND_FLOOR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SUITED_FOR_SEX_OFFENDERS
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningModelsFactory.Constants.CHARACTERISTIC_ALLOW_LIST
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningModelsFactory.Constants.DEFAULT_CHARACTERISTIC_WEIGHT
 import java.time.LocalDate
 
@@ -16,6 +24,16 @@ class SpacePlanningModelsFactory(
 ) {
   object Constants {
     const val DEFAULT_CHARACTERISTIC_WEIGHT = 100
+    val CHARACTERISTIC_ALLOW_LIST = listOf(
+      CAS1_PROPERTY_NAME_ARSON_DESIGNATED,
+      CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+      CAS1_PROPERTY_NAME_ENSUITE,
+      CAS1_PROPERTY_NAME_GROUND_FLOOR,
+      CAS1_PROPERTY_NAME_SINGLE_ROOM,
+      CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+      CAS1_PROPERTY_NAME_SUITED_FOR_SEX_OFFENDERS,
+      CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED,
+    )
   }
 
   fun allBeds(
@@ -72,8 +90,10 @@ class SpacePlanningModelsFactory(
   )
 
   private fun toRoomCharacteristics(characteristicEntities: List<CharacteristicEntity>) = characteristicEntities
+    .asSequence()
     .filter { it.isActive }
     .filter { it.isModelScopeRoom() }
+    .filter { CHARACTERISTIC_ALLOW_LIST.contains(it.propertyName) }
     .map { toCharacteristic(it) }
     .toSet()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
@@ -14,9 +14,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_DESIGNATED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_GROUND_FLOOR
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.BedEnded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.BedOutOfService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.Characteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningModelsFactory
@@ -32,16 +36,17 @@ class SpacePlanningModelsFactoryTest {
 
     @Test
     fun `all room and bed properties including active characteristics are correctly mapped`() {
-      val characteristic1 = CharacteristicEntityFactory().withPropertyName("c1").withIsActive(true).withModelScope("room").produce()
-      val characteristic2 = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("room").produce()
+      val characteristic1 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_DESIGNATED).withIsActive(true).withModelScope("room").produce()
+      val characteristic2 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_SUITABLE).withIsActive(true).withModelScope("room").produce()
       val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withIsActive(true).withModelScope("room").produce()
-      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName("disabled").withIsActive(false).withModelScope("room").produce()
-      val characteristicPremise = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("premises").produce()
+      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ENSUITE).withIsActive(false).withModelScope("room").produce()
+      val characteristicNotAllowed = CharacteristicEntityFactory().withPropertyName("not in allow list").withIsActive(true).withModelScope("room").produce()
+      val characteristicPremise = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_GROUND_FLOOR).withIsActive(true).withModelScope("premises").produce()
 
       val roomEntity = RoomEntityFactory()
         .withDefaults()
         .withName("the room name")
-        .withCharacteristics(characteristic1, characteristicDisabled, characteristic2, characteristicSingleRoom, characteristicPremise)
+        .withCharacteristics(characteristic1, characteristicDisabled, characteristic2, characteristicSingleRoom, characteristicPremise, characteristicNotAllowed)
         .produce()
 
       val bedEntity = BedEntityFactory()
@@ -126,16 +131,17 @@ class SpacePlanningModelsFactoryTest {
 
     @Test
     fun `all room and bed properties including active characteristics are correctly mapped`() {
-      val characteristic1 = CharacteristicEntityFactory().withPropertyName("c1").withIsActive(true).withModelScope("room").produce()
-      val characteristic2 = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("room").produce()
+      val characteristic1 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_DESIGNATED).withIsActive(true).withModelScope("room").produce()
+      val characteristic2 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_SUITABLE).withIsActive(true).withModelScope("room").produce()
       val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withIsActive(true).withModelScope("room").produce()
-      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName("disabled").withIsActive(false).withModelScope("room").produce()
-      val characteristicPremise = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("premises").produce()
+      val characteristicNotAllowed = CharacteristicEntityFactory().withPropertyName("not in allow list").withIsActive(true).withModelScope("room").produce()
+      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ENSUITE).withIsActive(false).withModelScope("room").produce()
+      val characteristicPremise = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_GROUND_FLOOR).withIsActive(true).withModelScope("premises").produce()
 
       val roomEntity = RoomEntityFactory()
         .withDefaults()
         .withName("the room name")
-        .withCharacteristics(characteristic1, characteristicDisabled, characteristic2, characteristicSingleRoom, characteristicPremise)
+        .withCharacteristics(characteristic1, characteristicDisabled, characteristic2, characteristicSingleRoom, characteristicPremise, characteristicNotAllowed)
         .produce()
 
       val bedEntity = BedEntityFactory()
@@ -326,11 +332,12 @@ class SpacePlanningModelsFactoryTest {
 
     @Test
     fun `all booking properties including active room characteristics are correctly mapped`() {
-      val characteristic1 = CharacteristicEntityFactory().withPropertyName("c1").withIsActive(true).withModelScope("room").produce()
-      val characteristic2 = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("room").produce()
+      val characteristic1 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_DESIGNATED).withIsActive(true).withModelScope("room").produce()
+      val characteristic2 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_SUITABLE).withIsActive(true).withModelScope("room").produce()
       val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withModelScope("room").withIsActive(true).produce()
-      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName("disabled").withIsActive(false).withModelScope("room").produce()
-      val characteristicPremise = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("premises").produce()
+      val characteristicNotAllowed = CharacteristicEntityFactory().withPropertyName("not in allow list").withIsActive(true).withModelScope("room").produce()
+      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ENSUITE).withIsActive(false).withModelScope("room").produce()
+      val characteristicPremise = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_GROUND_FLOOR).withIsActive(true).withModelScope("premises").produce()
 
       val booking1 = Cas1SpaceBookingEntityFactory()
         .withCrn("booking1")
@@ -339,7 +346,7 @@ class SpacePlanningModelsFactoryTest {
 
       val booking2 = Cas1SpaceBookingEntityFactory()
         .withCrn("booking2")
-        .withCriteria(listOf(characteristicSingleRoom, characteristicDisabled, characteristicPremise))
+        .withCriteria(listOf(characteristicSingleRoom, characteristicDisabled, characteristicPremise, characteristicNotAllowed))
         .produce()
 
       val premises = ApprovedPremisesEntityFactory().withDefaults().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
@@ -14,9 +14,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_SINGLE_ROOM_CHARACTERISTIC_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.BedEnded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.BedOutOfService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.Characteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningModelsFactory
@@ -34,7 +34,7 @@ class SpacePlanningModelsFactoryTest {
     fun `all room and bed properties including active characteristics are correctly mapped`() {
       val characteristic1 = CharacteristicEntityFactory().withPropertyName("c1").withIsActive(true).withModelScope("room").produce()
       val characteristic2 = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("room").produce()
-      val characteristicSingleRoom = CharacteristicEntityFactory().withId(CAS1_SINGLE_ROOM_CHARACTERISTIC_ID).withPropertyName("single").withIsActive(true).withModelScope("room").produce()
+      val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withIsActive(true).withModelScope("room").produce()
       val characteristicDisabled = CharacteristicEntityFactory().withPropertyName("disabled").withIsActive(false).withModelScope("room").produce()
       val characteristicPremise = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("premises").produce()
 
@@ -128,7 +128,7 @@ class SpacePlanningModelsFactoryTest {
     fun `all room and bed properties including active characteristics are correctly mapped`() {
       val characteristic1 = CharacteristicEntityFactory().withPropertyName("c1").withIsActive(true).withModelScope("room").produce()
       val characteristic2 = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("room").produce()
-      val characteristicSingleRoom = CharacteristicEntityFactory().withId(CAS1_SINGLE_ROOM_CHARACTERISTIC_ID).withPropertyName("single").withIsActive(true).withModelScope("room").produce()
+      val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withIsActive(true).withModelScope("room").produce()
       val characteristicDisabled = CharacteristicEntityFactory().withPropertyName("disabled").withIsActive(false).withModelScope("room").produce()
       val characteristicPremise = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("premises").produce()
 
@@ -328,7 +328,7 @@ class SpacePlanningModelsFactoryTest {
     fun `all booking properties including active room characteristics are correctly mapped`() {
       val characteristic1 = CharacteristicEntityFactory().withPropertyName("c1").withIsActive(true).withModelScope("room").produce()
       val characteristic2 = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("room").produce()
-      val characteristicSingleRoom = CharacteristicEntityFactory().withId(CAS1_SINGLE_ROOM_CHARACTERISTIC_ID).withPropertyName("single").withModelScope("room").withIsActive(true).produce()
+      val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withModelScope("room").withIsActive(true).produce()
       val characteristicDisabled = CharacteristicEntityFactory().withPropertyName("disabled").withIsActive(false).withModelScope("room").produce()
       val characteristicPremise = CharacteristicEntityFactory().withPropertyName("c2").withIsActive(true).withModelScope("premises").produce()
 


### PR DESCRIPTION
Whilst rooms have many characteristics, only a handful can be considered mandatory on a `placement_request`. Given this, this commit limits the characteristics considered for planning to those that will have an impact on planning. This considerably simplifies the planning output as irrelevant characteristics on the room are no longer shown