### PR TITLE
CAS-486 Bulk call to delius api to get offender details when get all applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -123,10 +123,11 @@ class ApplicationService(
       ServiceName.temporaryAccommodation -> getAllTemporaryAccommodationApplicationsForUser(userEntity)
     }
 
-    return applicationSummaries
-      .filter {
-        offenderService.canAccessOffender(userDistinguishedName, it.getCrn())
-      }
+    val crns = applicationSummaries.map { it.getCrn() }.distinct()
+    val offendersAccess = offenderService.canAccessOffenders(userDistinguishedName, crns)
+    return applicationSummaries.filter {
+      offendersAccess.containsKey(it.getCrn()) && offendersAccess[it.getCrn()] == true
+    }
   }
 
   fun getAllApprovedPremisesApplications(
@@ -198,10 +199,11 @@ class ApplicationService(
         emptyList()
       }
 
-    return applications
-      .filter {
-        offenderService.canAccessOffender(deliusUsername, it.crn)
-      }
+    val crns = applications.map { it.crn }.distinct()
+    val offendersAccess = offenderService.canAccessOffenders(deliusUsername, crns)
+    return applications.filter {
+      offendersAccess.containsKey(it.crn) && offendersAccess[it.crn] == true
+    }
   }
 
   fun getApplicationForUsername(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -59,12 +59,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.communityAPIMockNotFoundOffenderDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.communityAPIMockOffenderUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.communityAPIMockSuccessfulRegistrationsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -223,11 +222,11 @@ class ApplicationTest : IntegrationTestBase() {
                   withData("{}")
                 }
 
-              communityAPIMockOffenderUserAccessCall(
+              apDeliusContextAddResponseToUserAccessCall(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
                 userEntity.deliusUsername,
-                offenderDetails.otherIds.crn,
-                inclusion = false,
-                exclusion = false,
               )
 
               val responseBody = webTestClient.get()
@@ -296,11 +295,11 @@ class ApplicationTest : IntegrationTestBase() {
                   dateTime,
                 )
 
-              communityAPIMockOffenderUserAccessCall(
+              apDeliusContextAddResponseToUserAccessCall(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
                 assessorUser.deliusUsername,
-                offenderDetails.otherIds.crn,
-                inclusion = false,
-                exclusion = false,
               )
 
               val responseBody = webTestClient.get()
@@ -378,11 +377,11 @@ class ApplicationTest : IntegrationTestBase() {
               val anotherUsersApplication =
                 createTempApplicationEntity(applicationSchema, otherUser, offenderDetails, probationRegion, null)
 
-              communityAPIMockOffenderUserAccessCall(
+              apDeliusContextAddResponseToUserAccessCall(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
                 referrerUser.deliusUsername,
-                offenderDetails.otherIds.crn,
-                inclusion = false,
-                exclusion = false,
               )
 
               val responseBody = webTestClient.get()
@@ -419,9 +418,6 @@ class ApplicationTest : IntegrationTestBase() {
         val crn = "X1234"
 
         val application = produceAndPersistBasicApplication(crn, userEntity, "TEAM1")
-        communityAPIMockNotFoundOffenderDetailsCall(crn)
-
-        communityAPIMockOffenderUserAccessCall(userEntity.deliusUsername, crn, inclusion = false, exclusion = false)
 
         apDeliusContextMockUserAccess(
           CaseAccessFactory()
@@ -482,11 +478,11 @@ class ApplicationTest : IntegrationTestBase() {
         ) { offenderDetails, _ ->
           val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, userEntity, "TEAM1")
 
-          communityAPIMockOffenderUserAccessCall(
+          apDeliusContextAddResponseToUserAccessCall(
+            CaseAccessFactory()
+              .withCrn(offenderDetails.otherIds.crn)
+              .produce(),
             userEntity.deliusUsername,
-            offenderDetails.otherIds.crn,
-            inclusion = false,
-            exclusion = false,
           )
 
           val responseBody = webTestClient.get()
@@ -740,11 +736,11 @@ class ApplicationTest : IntegrationTestBase() {
 
             val application = produceAndPersistBasicApplication(crn, otherUser, "TEAM1")
 
-            communityAPIMockOffenderUserAccessCall(
+            apDeliusContextAddResponseToUserAccessCall(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
               userEntity.deliusUsername,
-              offenderDetails.otherIds.crn,
-              inclusion = false,
-              exclusion = false,
             )
 
             webTestClient.get()
@@ -768,11 +764,11 @@ class ApplicationTest : IntegrationTestBase() {
         ) { offenderDetails, _ ->
           val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, userEntity, "TEAM1")
 
-          communityAPIMockOffenderUserAccessCall(
+          apDeliusContextAddResponseToUserAccessCall(
+            CaseAccessFactory()
+              .withCrn(offenderDetails.otherIds.crn)
+              .produce(),
             userEntity.deliusUsername,
-            offenderDetails.otherIds.crn,
-            inclusion = false,
-            exclusion = false,
           )
 
           val rawResponseBody = webTestClient.get()
@@ -895,11 +891,11 @@ class ApplicationTest : IntegrationTestBase() {
             withData("{}")
           }
 
-          communityAPIMockOffenderUserAccessCall(
+          apDeliusContextAddResponseToUserAccessCall(
+            CaseAccessFactory()
+              .withCrn(offenderDetails.otherIds.crn)
+              .produce(),
             userEntity.deliusUsername,
-            offenderDetails.otherIds.crn,
-            inclusion = false,
-            exclusion = false,
           )
 
           val rawResponseBody = webTestClient.get()
@@ -955,11 +951,11 @@ class ApplicationTest : IntegrationTestBase() {
             )
           }
 
-          communityAPIMockOffenderUserAccessCall(
+          apDeliusContextAddResponseToUserAccessCall(
+            CaseAccessFactory()
+              .withCrn(offenderDetails.otherIds.crn)
+              .produce(),
             userEntity.deliusUsername,
-            offenderDetails.otherIds.crn,
-            inclusion = false,
-            exclusion = false,
           )
 
           val rawResponseBody = webTestClient.get()
@@ -1015,11 +1011,11 @@ class ApplicationTest : IntegrationTestBase() {
               )
             }
 
-            communityAPIMockOffenderUserAccessCall(
+            apDeliusContextAddResponseToUserAccessCall(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
               userEntity.deliusUsername,
-              offenderDetails.otherIds.crn,
-              inclusion = false,
-              exclusion = false,
             )
 
             val rawResponseBody = webTestClient.get()
@@ -1079,11 +1075,11 @@ class ApplicationTest : IntegrationTestBase() {
             )
           }
 
-          communityAPIMockOffenderUserAccessCall(
+          apDeliusContextAddResponseToUserAccessCall(
+            CaseAccessFactory()
+              .withCrn(offenderDetails.otherIds.crn)
+              .produce(),
             createdByUser.deliusUsername,
-            offenderDetails.otherIds.crn,
-            inclusion = false,
-            exclusion = false,
           )
 
           val rawResponseBody = webTestClient.get()
@@ -1220,11 +1216,11 @@ class ApplicationTest : IntegrationTestBase() {
               )
             }
 
-            communityAPIMockOffenderUserAccessCall(
+            apDeliusContextAddResponseToUserAccessCall(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
               userEntity.deliusUsername,
-              offenderDetails.otherIds.crn,
-              inclusion = false,
-              exclusion = false,
             )
 
             webTestClient.get()
@@ -1266,11 +1262,11 @@ class ApplicationTest : IntegrationTestBase() {
               )
             }
 
-            communityAPIMockOffenderUserAccessCall(
+            apDeliusContextAddResponseToUserAccessCall(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
               userEntity.deliusUsername,
-              offenderDetails.otherIds.crn,
-              inclusion = false,
-              exclusion = false,
             )
 
             webTestClient.get()
@@ -1294,11 +1290,11 @@ class ApplicationTest : IntegrationTestBase() {
           withCrn(offenderDetails.otherIds.crn)
         }
 
-        communityAPIMockOffenderUserAccessCall(
+        apDeliusContextAddResponseToUserAccessCall(
+          CaseAccessFactory()
+            .withCrn(offenderDetails.otherIds.crn)
+            .produce(),
           userEntity.deliusUsername,
-          offenderDetails.otherIds.crn,
-          inclusion = false,
-          exclusion = false,
         )
 
         val rawResponseBody = webTestClient.get()
@@ -1338,8 +1334,6 @@ class ApplicationTest : IntegrationTestBase() {
     fun `Create new application returns 404 when a person cannot be found`() {
       givenAUser { _, jwt ->
         val crn = "X1234"
-
-        communityAPIMockNotFoundOffenderDetailsCall(crn)
 
         approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
           withAddedAt(OffsetDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -216,9 +216,8 @@ class ApplicationServiceTest {
     every { mockApplicationRepository.findNonWithdrawnApprovedPremisesSummariesForUser(userId) } returns applicationSummaries
     every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
-    applicationSummaries.forEach {
-      every { mockOffenderService.canAccessOffender(distinguishedName, it.getCrn()) } returns true
-    }
+    val crns = applicationSummaries.map { it.getCrn() }.distinct()
+    every { mockOffenderService.canAccessOffenders(distinguishedName, crns) } returns mapOf(crns.first() to true)
 
     assertThat(
       applicationService.getAllApplicationsForUsername(
@@ -2508,9 +2507,7 @@ class ApplicationServiceTest {
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
     every { mockOfflineApplicationRepository.findAllByService("approved-premises") } returns offlineApplicationEntities
 
-    offlineApplicationEntities.forEach {
-      every { mockOffenderService.canAccessOffender(distinguishedName, it.crn) } returns true
-    }
+    every { mockOffenderService.canAccessOffenders(distinguishedName, emptyList()) } returns emptyMap()
 
     assertThat(
       applicationService.getAllOfflineApplicationsForUsername(
@@ -2557,9 +2554,12 @@ class ApplicationServiceTest {
     every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
     every { mockOfflineApplicationRepository.findAllByService("approved-premises") } returns offlineApplicationEntities
 
-    offlineApplicationEntities.forEach {
-      every { mockOffenderService.canAccessOffender(distinguishedName, it.crn) } returns true
-    }
+    val crns = offlineApplicationEntities.map { it.crn }.distinct()
+    every { mockOffenderService.canAccessOffenders(distinguishedName, crns) } returns mapOf(
+      crns.first() to true,
+      crns.drop(1).first() to true,
+      crns.drop(2).first() to true,
+    )
 
     assertThat(
       applicationService.getAllOfflineApplicationsForUsername(


### PR DESCRIPTION
This [PR CAS-486](https://dsdmoj.atlassian.net/browse/CAS-486) currently when get all application is calling delius api endpoint for each crn. This PR is to change the call to delius api to bulk of crns