### PR TITLE
APS-1475 Upgrade gov notify Java client to 5.2.1.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ dependencies {
 
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:3.1.3")
 
-  implementation("uk.gov.service.notify:notifications-java-client:5.0.0-RELEASE")
+  implementation("uk.gov.service.notify:notifications-java-client:5.2.1-RELEASE")
 
   gatlingImplementation("org.springframework.boot:spring-boot-starter-webflux")
 }


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1475

The gov notify email client is currently at version 5.2.1.