### PR TITLE
Make record departure endpoint idempotent

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -331,7 +331,11 @@ class Cas1SpaceBookingService(
     }
 
     if (existingCas1SpaceBooking.actualDepartureDateTime != null) {
-      return existingCas1SpaceBooking.id hasConflictError "A departure is already recorded for this Space Booking."
+      return if (hasExactDepartureDataAlreadyBeenRecorded(existingCas1SpaceBooking, cas1NewDeparture)) {
+        success(existingCas1SpaceBooking)
+      } else {
+        existingCas1SpaceBooking.id hasConflictError "A departure is already recorded for this Space Booking."
+      }
     }
 
     existingCas1SpaceBooking.actualDepartureDateTime = cas1NewDeparture.departureDateTime
@@ -348,6 +352,15 @@ class Cas1SpaceBookingService(
     )
 
     success(result)
+  }
+
+  private fun hasExactDepartureDataAlreadyBeenRecorded(
+    existingCas1SpaceBooking: Cas1SpaceBookingEntity,
+    newDeparture: Cas1NewDeparture,
+  ): Boolean {
+    return newDeparture.departureDateTime == existingCas1SpaceBooking.actualDepartureDateTime &&
+      newDeparture.reasonId == existingCas1SpaceBooking.departureReason?.id &&
+      newDeparture.moveOnCategoryId == existingCas1SpaceBooking.departureMoveOnCategory?.id
   }
 
   fun search(


### PR DESCRIPTION
Update `cas1SpaceBookingService.recordDepartureForBooking` to return a success outcome if the same required values in `Cas1NewDeparture` the are already set on `existingCas1SpaceBooking`. If different values are already set, return a conflict error as per the current behaviour when `existingCas1SpaceBooking.actualDepartureDateTime` != null