### PR TITLE
APS-1300: Update Application Status when withdrawing Space Booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -115,6 +115,8 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
   """,
   )
   fun findAllBookingsOnGivenDayWithCriteria(premisesId: UUID, day: LocalDate): List<Cas1SpaceBookingEntity>
+
+  fun findAllByApplication(application: ApplicationEntity): List<Cas1SpaceBookingEntity>
 }
 
 interface Cas1SpaceBookingSearchResult {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationStatusService.kt
@@ -4,12 +4,16 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 
 @Service
 class Cas1ApplicationStatusService(
   val applicationRepository: ApplicationRepository,
+  val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
+  val bookingRepository: BookingRepository,
 ) {
 
   fun bookingMade(booking: BookingEntity) {
@@ -21,6 +25,38 @@ class Cas1ApplicationStatusService(
 
   fun spaceBookingMade(spaceBooking: Cas1SpaceBookingEntity) {
     bookingMade(spaceBooking.application!!)
+  }
+
+  fun lastBookingCancelled(
+    booking: BookingEntity,
+    isUserRequestedWithdrawal: Boolean,
+  ) {
+    if (!isUserRequestedWithdrawal || booking.application == null) {
+      return
+    }
+    val application = booking.application!!
+    val bookings = bookingRepository.findAllByApplication(application)
+    val anyActiveBookings = bookings.any { it.isActive() }
+    if (!anyActiveBookings) {
+      lastBookingCancelled(booking.application!! as ApprovedPremisesApplicationEntity)
+    }
+  }
+
+  fun spaceBookingCancelled(spaceBooking: Cas1SpaceBookingEntity, isUserRequestedWithdrawal: Boolean = true) {
+    if (!isUserRequestedWithdrawal || spaceBooking.application == null) {
+      return
+    }
+    val application = spaceBooking.application!!
+    val spaceBookingsForApplication = cas1SpaceBookingRepository.findAllByApplication(application)
+    val anyActiveBookings = spaceBookingsForApplication.any { it.isActive() }
+    if (!anyActiveBookings) {
+      lastBookingCancelled(spaceBooking.application!!)
+    }
+  }
+
+  private fun lastBookingCancelled(application: ApprovedPremisesApplicationEntity) {
+    application.status = ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT
+    applicationRepository.save(application)
   }
 
   private fun bookingMade(application: ApprovedPremisesApplicationEntity) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -451,6 +451,10 @@ class Cas1SpaceBookingService(
       else -> throw InternalServerErrorProblem("Withdrawal triggered automatically is not supported")
     }
     cas1BookingDomainEventService.spaceBookingCancelled(spaceBooking, user, reason)
+    cas1ApplicationStatusService.spaceBookingCancelled(
+      spaceBooking,
+      isUserRequestedWithdrawal = withdrawalContext.triggeringEntityType == WithdrawableEntityType.SpaceBooking,
+    )
 
     spaceBooking.application?.let {
       cas1BookingEmailService.spaceBookingWithdrawn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -1505,7 +1505,7 @@ class Cas1SpaceBookingTest {
     }
 
     @Test
-    fun `Create Cancellation on CAS1 Booking returns OK with correct body and sends emails when user has role CRU_MEMBER`() {
+    fun `Create Cancellation on CAS1 Booking returns OK with correct body, updates status and sends emails when user has role CRU_MEMBER`() {
       givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER)) { _, jwt ->
         webTestClient.post()
           .uri("/cas1/premises/${premises.id}/space-bookings/${spaceBooking.id}/cancellations")
@@ -1527,6 +1527,9 @@ class Cas1SpaceBookingTest {
       emailAsserter.assertEmailRequested(placementApplicationCreator.email!!, notifyConfig.templates.bookingWithdrawnV2)
       emailAsserter.assertEmailRequested(spaceBooking.premises.emailAddress!!, notifyConfig.templates.bookingWithdrawnV2)
       emailAsserter.assertEmailRequested(application.cruManagementArea!!.emailAddress!!, notifyConfig.templates.bookingWithdrawnV2)
+
+      assertThat(approvedPremisesApplicationRepository.findByIdOrNull(spaceBooking.application!!.id)!!.status)
+        .isEqualTo(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
@@ -9,12 +10,14 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
   crn: String,
   premises: ApprovedPremisesEntity? = null,
   migratedFromBooking: BookingEntity? = null,
+  application: ApprovedPremisesApplicationEntity? = null,
 ): Cas1SpaceBookingEntity {
   val (user) = givenAUser()
   val (placementRequest) = givenAPlacementRequest(
     placementRequestAllocatedTo = user,
     assessmentAllocatedTo = user,
     createdByUser = user,
+    application = application,
   )
 
   return cas1SpaceBookingEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -1443,6 +1443,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { cas1BookingEmailService.spaceBookingWithdrawn(spaceBooking, application, WithdrawalTriggeredByUser(user)) } returns Unit
       every { cas1BookingDomainEventService.spaceBookingCancelled(spaceBooking, user, reason) } returns Unit
+      every { cas1ApplicationStatusService.spaceBookingCancelled(spaceBooking) } returns Unit
 
       val result = service.withdraw(
         spaceBooking = spaceBooking,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationStatusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationStatusServiceTest.kt
@@ -10,17 +10,28 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationStatusService
+import java.time.LocalDate
 
 @ExtendWith(MockKExtension::class)
 class Cas1ApplicationStatusServiceTest {
   @MockK
   private lateinit var applicationRepository: ApplicationRepository
+
+  @MockK
+  private lateinit var cas1SpaceBookingRepository: Cas1SpaceBookingRepository
+
+  @MockK
+  private lateinit var bookingRepository: BookingRepository
 
   @InjectMockKs
   private lateinit var service: Cas1ApplicationStatusService
@@ -81,6 +92,145 @@ class Cas1ApplicationStatusServiceTest {
       verify { applicationRepository.save(application) }
 
       assertThat(application.status).isEqualTo(ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED)
+    }
+  }
+
+  @Nested
+  inner class BookingCancelled {
+
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withDefaults()
+      .withStatus(ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED)
+      .produce()
+
+    @Test
+    fun `if not linked to application (manual booking), do nothing`() {
+      val booking = BookingEntityFactory()
+        .withDefaults()
+        .withApplication(null)
+        .produce()
+
+      service.lastBookingCancelled(booking, true)
+
+      verify { applicationRepository wasNot Called }
+    }
+
+    @Test
+    fun `if cancellation not user requested, do nothing`() {
+      val booking = BookingEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .produce()
+
+      service.lastBookingCancelled(booking, false)
+
+      verify { applicationRepository wasNot Called }
+    }
+
+    @Test
+    fun `if there are still live bookings for the application, do nothing`() {
+      val booking = BookingEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .withStatus(BookingStatus.confirmed)
+        .produce()
+
+      every { applicationRepository.save(any()) } returns application
+      every { service.bookingRepository.findAllByApplication(application) } returns listOf(booking)
+
+      service.lastBookingCancelled(booking, true)
+
+      verify { applicationRepository wasNot Called }
+    }
+
+    @Test
+    fun `if there are no live bookings for the application, change status to AWAITING_PLACEMENT`() {
+      val booking = BookingEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .produce()
+      val cancellations = mutableListOf(
+        CancellationEntityFactory()
+          .withDefaults()
+          .withBooking(booking)
+          .produce(),
+      )
+      val bookingWithCancellation = booking.copy(cancellations = cancellations)
+
+      every { applicationRepository.save(any()) } returns application
+      every { bookingRepository.findAllByApplication(application) } returns listOf(bookingWithCancellation)
+
+      service.lastBookingCancelled(booking, true)
+
+      verify { applicationRepository.save(application) }
+
+      assertThat(application.status).isEqualTo(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
+    }
+  }
+
+  @Nested
+  inner class SpaceBookingCancelled {
+    val application = ApprovedPremisesApplicationEntityFactory()
+      .withDefaults()
+      .withStatus(ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED)
+      .produce()
+
+    @Test
+    fun `if not linked to application, do nothing`() {
+      val booking = Cas1SpaceBookingEntityFactory()
+        .withApplication(null)
+        .produce()
+
+      service.spaceBookingCancelled(booking)
+
+      verify { applicationRepository wasNot Called }
+    }
+
+    @Test
+    fun `if cancellation not triggered by user request operation do nothing`() {
+      val booking = Cas1SpaceBookingEntityFactory()
+        .withApplication(application)
+        .produce()
+
+      every { cas1SpaceBookingRepository.findAllByApplication(application) } returns listOf(booking)
+
+      service.spaceBookingCancelled(
+        spaceBooking = booking,
+        isUserRequestedWithdrawal = false,
+      )
+
+      verify { applicationRepository wasNot Called }
+    }
+
+    @Test
+    fun `if there are still live bookings for the application, do nothing`() {
+      val booking = Cas1SpaceBookingEntityFactory()
+        .withApplication(application)
+        .produce()
+
+      every { applicationRepository.save(any()) } returns application
+      every { cas1SpaceBookingRepository.findAllByApplication(application) } returns listOf(booking)
+
+      service.spaceBookingCancelled(booking)
+
+      verify { applicationRepository wasNot Called }
+    }
+
+    @Test
+    fun `if there are no live bookings for the application, change status to AWAITING_PLACEMENT`() {
+      val cancelledBooking = Cas1SpaceBookingEntityFactory()
+        .withApplication(application)
+        .withCancellationOccurredAt(LocalDate.now())
+        .produce()
+
+      every { applicationRepository.save(any()) } returns application
+      every { cas1SpaceBookingRepository.findAllByApplication(application) } returns listOf(cancelledBooking)
+
+      service.spaceBookingCancelled(cancelledBooking)
+
+      verify { applicationRepository.save(application) }
+
+      assertThat(application.status).isEqualTo(ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT)
     }
   }
 }


### PR DESCRIPTION
- Move CAS1 booking functionality, when withdrawing a booking from BookingService to `Cas1ApplicationStatusService`.
- Add functionality in `Cas1SpaceBookingService`  -`withdraw` to update the application status for the withdrawn booking.
- Implement the processing to change the application status for a withdrawn / cancelled booking in `Cas1ApplicationSatusService`.



Consideration to be given to whether a space booking being withdrawn as part of 
`Cas1WithdrawableTreeOperations` should instigate a change to the associated application’s status.

A failing test : 
`Withdrawing a match request for original app dates cascades to applicable booking entity and updates the application status`
demonstrates the withdrawal of a Space Booking when traversing the associated entity tree for a withdrawn placement request.   
The initial behaviour saw the application status change to `AWAITING_PLACEMENT`, because of the cancelled Space Booking, rather than the expected `PENDING_PLACEMENT_REQUEST` because both the placement request and the space booking had been cancelled (the space booking last).

An additional, optional parameter on the `Cas1ApplicationStatusService.spaceBookingCancelled `function, `isWithdrawableTreeOperation`, can be employed to leave the application status unchanged.  
`Cas1SpaceBookingService.withdraw`, which sets the value `isWithdrawableTreeOperation` may need refined and the name of the parameter itself changed to something more suitable.