### PR TITLE
Update getAssessmentForUser to use CasResult

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -47,6 +47,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransfor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.kebabCaseToPascalCase
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as ApiUserQualification
@@ -140,7 +141,7 @@ class TasksController(
 
     val taskInfo = when (toTaskType(taskType)) {
       TaskType.assessment -> {
-        val assessment = extractEntityFromAuthorisableActionResult(
+        val assessment = extractEntityFromCasResult(
           assessmentService.getAssessmentForUser(user, id),
         ) as ApprovedPremisesAssessmentEntity
         val offenderSummaries = getOffenderSummariesForCrns(listOf(assessment.application.crn), user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/assessmentservice/AcceptAssessmentTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
@@ -47,6 +48,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentClarificationNoteListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.AssessmentListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.ProbationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
@@ -189,9 +191,17 @@ class AcceptAssessmentTest {
 
     every { jsonSchemaServiceMock.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java) } returns ApprovedPremisesAssessmentJsonSchemaEntityFactory().produce()
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null, null)
-
-    assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+    assertThrows<ForbiddenProblem> {
+      assessmentService.acceptAssessment(
+        user,
+        assessmentId,
+        "{}",
+        placementRequirements,
+        null,
+        null,
+        null,
+      )
+    }
   }
 
   @Test
@@ -323,9 +333,17 @@ class AcceptAssessmentTest {
 
     every { offenderServiceMock.getOffenderByCrn(assessment.application.crn, user.deliusUsername) } returns AuthorisableActionResult.Unauthorised()
 
-    val result = assessmentService.acceptAssessment(user, assessmentId, "{\"test\": \"data\"}", placementRequirements, null, null, null)
-
-    assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+    assertThrows<ForbiddenProblem> {
+      assessmentService.acceptAssessment(
+        user,
+        assessmentId,
+        "{\"test\": \"data\"}",
+        placementRequirements,
+        null,
+        null,
+        null,
+      )
+    }
   }
 
   @Test


### PR DESCRIPTION
This changes getUserForRequest to return a CasResult rather than AuthorisableActionResult, which is now deprecated