### PR TITLE
APS-1543: Added non-arrival information to API returning a space booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -219,6 +219,7 @@ data class Cas1SpaceBookingEntity(
 ) {
   fun isActive() = !isCancelled()
   fun isCancelled() = cancellationOccurredAt != null
+  fun hasNonArrival() = nonArrivalConfirmedAt != null
   fun hasArrival() = actualArrivalDateTime != null
   override fun toString() = "Cas1SpaceBookingEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1KeyWorkerA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingNonArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -67,6 +68,7 @@ class Cas1SpaceBookingTransformer(
       otherBookingsInPremisesForCrn = otherBookingsAtPremiseForCrn.map { it.toSpaceBookingDate() },
       cancellation = jpa.extractCancellation(),
       requestForPlacementId = jpa.placementRequest?.placementApplication?.id ?: jpa.placementRequest?.id,
+      nonArrival = jpa.extractNonArrival(),
       deliusEventNumber = jpa.deliusEventNumber,
     )
   }
@@ -106,6 +108,23 @@ class Cas1SpaceBookingTransformer(
         recordedAt = recordedAt,
         reason = cancellationReasonTransformer.transformJpaToApi(reason),
         reasonNotes = cancellationReasonNotes,
+      )
+    } else {
+      null
+    }
+  }
+
+  private fun Cas1SpaceBookingEntity.extractNonArrival(): Cas1SpaceBookingNonArrival? {
+    return if (hasNonArrival()) {
+      Cas1SpaceBookingNonArrival(
+        confirmedAt = nonArrivalConfirmedAt,
+        reason = nonArrivalReason!!.let {
+          NamedId(
+            id = it.id,
+            name = it.name,
+          )
+        },
+        notes = nonArrivalNotes,
       )
     } else {
       null

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -321,6 +321,8 @@ components:
             $ref: '#/components/schemas/Cas1SpaceBookingDates'
         cancellation:
           $ref: '#/components/schemas/Cas1SpaceBookingCancellation'
+        nonArrival:
+          $ref: '#/components/schemas/Cas1SpaceBookingNonArrival'
         deliusEventNumber:
           type: string
       required:
@@ -437,6 +439,16 @@ components:
         - occurredAt
         - recordedAt
         - reason
+    Cas1SpaceBookingNonArrival:
+      type: object
+      properties:
+        confirmedAt:
+          type: string
+          format: date-time
+        reason:
+          $ref: '_shared.yml#/components/schemas/NamedId'
+        notes:
+          type: string
     Cas1NewArrival:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6521,6 +6521,8 @@ components:
             $ref: '#/components/schemas/Cas1SpaceBookingDates'
         cancellation:
           $ref: '#/components/schemas/Cas1SpaceBookingCancellation'
+        nonArrival:
+          $ref: '#/components/schemas/Cas1SpaceBookingNonArrival'
         deliusEventNumber:
           type: string
       required:
@@ -6637,6 +6639,16 @@ components:
         - occurredAt
         - recordedAt
         - reason
+    Cas1SpaceBookingNonArrival:
+      type: object
+      properties:
+        confirmedAt:
+          type: string
+          format: date-time
+        reason:
+          $ref: '#/components/schemas/NamedId'
+        notes:
+          type: string
     Cas1NewArrival:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
@@ -98,6 +99,8 @@ class Cas1SpaceBookingTransformerTest {
 
       val cancellationReason = CancellationReasonEntityFactory().produce()
 
+      val nonArrivalReason = NonArrivalReasonEntityFactory().produce()
+
       val criteria = listOf(
         CharacteristicEntityFactory().produce(),
         CharacteristicEntityFactory().produce(),
@@ -117,6 +120,9 @@ class Cas1SpaceBookingTransformerTest {
         .withCancellationReason(cancellationReason)
         .withCancellationReasonNotes("some extra info on cancellation")
         .withCriteria(criteria)
+        .withNonArrivalConfirmedAt(Instant.parse("2024-01-20T10:10:10.00Z"))
+        .withNonArrivalReason(nonArrivalReason)
+        .withNonArrivalNotes("some information on the non arrival")
         .withDeliusEventNumber("97")
         .produce()
 
@@ -173,13 +179,20 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.canonicalDepartureDate).isEqualTo(spaceBooking.expectedDepartureDate)
       assertThat(result.createdAt).isEqualTo(spaceBooking.createdAt.toInstant())
       assertThat(result.tier).isEqualTo("A")
+
       assertThat(result.keyWorkerAllocation!!.keyWorker.name).isEqualTo("Mr Key Worker")
       assertThat(result.keyWorkerAllocation!!.keyWorker.code).isEqualTo("K123")
       assertThat(result.keyWorkerAllocation!!.allocatedAt).isEqualTo(LocalDate.parse("2007-12-03"))
+
       assertThat(result.cancellation!!.occurredAt).isEqualTo(LocalDate.parse("2039-12-28"))
       assertThat(result.cancellation!!.recordedAt).isEqualTo(Instant.parse("2023-12-29T11:25:10.00Z"))
       assertThat(result.cancellation!!.reason).isEqualTo(expectedCancellationReason)
       assertThat(result.cancellation!!.reasonNotes).isEqualTo("some extra info on cancellation")
+
+      assertThat(result.nonArrival!!.confirmedAt).isEqualTo(Instant.parse("2024-01-20T10:10:10Z"))
+      assertThat(result.nonArrival!!.reason!!.id).isEqualTo(spaceBooking.nonArrivalReason!!.id)
+      assertThat(result.nonArrival!!.notes).isEqualTo("some information on the non arrival")
+
       assertThat(result.deliusEventNumber).isEqualTo("97")
 
       assertThat(result.otherBookingsInPremisesForCrn).hasSize(1)


### PR DESCRIPTION
A previous PR / piece of work captured Non arrival information for a space booking. 

This PR provides the way to retrieve that captured information.