### PR TITLE
APS-1544 - Add CAS1 find and book private beta roles to api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -14,6 +14,8 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_VIEW_ASSIGNED_ASSESSMENTS,
     ),
   ),
+
+  @Deprecated("This role will be removed in the future. Superseded by CRU_MEMBER")
   CAS1_MATCHER(
     ServiceName.approvedPremises,
     ApprovedPremisesUserRole.matcher,
@@ -40,6 +42,7 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_BOOKING_CHANGE_DATES,
     ),
   ),
+
   CAS1_FUTURE_MANAGER(
     ServiceName.approvedPremises,
     ApprovedPremisesUserRole.futureManager,
@@ -62,7 +65,7 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
     permissions = emptyList(),
   ),
 
-  @Deprecated("This role will be removed in the future")
+  @Deprecated("This role will be removed in the future. Superseded by Assessor, CRU Member and Future Manager")
   CAS1_WORKFLOW_MANAGER(
     ServiceName.approvedPremises,
     ApprovedPremisesUserRole.workflowManager,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -56,6 +56,12 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
     ),
   ),
 
+  CAS1_AP_MANAGER_FIND_AND_BOOK_BETA(
+    ServiceName.approvedPremises,
+    ApprovedPremisesUserRole.apManagerFindAndBookBeta,
+    permissions = emptyList(),
+  ),
+
   @Deprecated("This role will be removed in the future")
   CAS1_WORKFLOW_MANAGER(
     ServiceName.approvedPremises,
@@ -103,6 +109,13 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_VIEW_OUT_OF_SERVICE_BEDS,
     ),
   ),
+
+  CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA(
+    ServiceName.approvedPremises,
+    ApprovedPremisesUserRole.cruMemberFindAndBookBeta,
+    permissions = emptyList(),
+  ),
+
   CAS1_APPLICANT(ServiceName.approvedPremises, ApprovedPremisesUserRole.applicant),
 
   @Deprecated("This role will be removed in the future")

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3139,8 +3139,10 @@ components:
         - manager
         - legacy_manager
         - future_manager
+        - ap_manager_find_and_book_beta
         - workflow_manager
         - cru_member
+        - cru_member_find_and_book_beta
         - applicant
         - role_admin
         - report_viewer

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7504,8 +7504,10 @@ components:
         - manager
         - legacy_manager
         - future_manager
+        - ap_manager_find_and_book_beta
         - workflow_manager
         - cru_member
+        - cru_member_find_and_book_beta
         - applicant
         - role_admin
         - report_viewer

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4166,8 +4166,10 @@ components:
         - manager
         - legacy_manager
         - future_manager
+        - ap_manager_find_and_book_beta
         - workflow_manager
         - cru_member
+        - cru_member_find_and_book_beta
         - applicant
         - role_admin
         - report_viewer

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3730,8 +3730,10 @@ components:
         - manager
         - legacy_manager
         - future_manager
+        - ap_manager_find_and_book_beta
         - workflow_manager
         - cru_member
+        - cru_member_find_and_book_beta
         - applicant
         - role_admin
         - report_viewer

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3191,8 +3191,10 @@ components:
         - manager
         - legacy_manager
         - future_manager
+        - ap_manager_find_and_book_beta
         - workflow_manager
         - cru_member
+        - cru_member_find_and_book_beta
         - applicant
         - role_admin
         - report_viewer


### PR DESCRIPTION
Add placeholders for find and book beta roles:

* CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA
* CAS1_AP_MANAGER_FIND_AND_BOOK_BETA

This is required to push out an updated API definition for the UI to add these roles to the admin ui.