### PR TITLE
APS-1254: Update Space Booking Departure API , moveOnCategory no longer mandatory

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
@@ -11,6 +11,10 @@ import java.util.UUID
 
 @Repository
 interface MoveOnCategoryRepository : JpaRepository<MoveOnCategoryEntity, UUID> {
+  companion object Constants {
+    val NOT_APPLICABLE_MOVE_ON_CATEGORY_ID: UUID = UUID.fromString("ea3d79b0-1ee5-47ff-a7ae-b0d964ca7626")
+  }
+
   @Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.serviceScope IN (:serviceName, '*')")
   fun findAllByServiceScope(serviceName: String): List<MoveOnCategoryEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository.Constants.NOT_APPLICABLE_MOVE_ON_CATEGORY_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
@@ -311,7 +312,7 @@ class Cas1SpaceBookingService(
       "$.cas1NewDeparture.reasonId" hasValidationError "doesNotExist"
     }
 
-    val moveOnCategory = moveOnCategoryRepository.findByIdOrNull(cas1NewDeparture.moveOnCategoryId)
+    val moveOnCategory = moveOnCategoryRepository.findByIdOrNull(cas1NewDeparture.moveOnCategoryId ?: NOT_APPLICABLE_MOVE_ON_CATEGORY_ID)
     if (moveOnCategory == null || !moveOnCategory.serviceScopeMatches("approved-premises")) {
       "$.cas1NewDeparture.moveOnCategoryId" hasValidationError "doesNotExist"
     }

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -484,7 +484,6 @@ components:
       required:
         - departureDateTime
         - reasonId
-        - moveOnCategoryId
     Cas1AssignKeyWorker:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6687,7 +6687,6 @@ components:
       required:
         - departureDateTime
         - reasonId
-        - moveOnCategoryId
     Cas1AssignKeyWorker:
       type: object
       properties:


### PR DESCRIPTION
Changed the Space Booking Departure API 

- moveOnCategory no longer mandatory 
- when no moveOnCategory is supplied the system defaults to the 'Not Applicable' move on category to ensure ongoing compatibility with Probation Integration for which this field is mandatory.