### PR TITLE
Change CAS3 bedspace search to use property name characteristics

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -139,22 +139,22 @@ class BedSearchService(
           return@validated fieldValidationError
         }
 
-        val premisesCharacteristicsNames = propertyBedAttributes?.map {
+        val premisesCharacteristicsPropertyNames = propertyBedAttributes?.map {
           when (it) {
-            BedSearchAttributes.singleOccupancy -> "Single occupancy"
-            BedSearchAttributes.sharedProperty -> "Shared property"
+            BedSearchAttributes.singleOccupancy -> "isSingleOccupancy"
+            BedSearchAttributes.sharedProperty -> "isSharedProperty"
             BedSearchAttributes.wheelchairAccessible -> ""
           }
         }
 
-        val premisesCharacteristicIds = getTemporaryAccommodationCharacteristicsIds(premisesCharacteristicsNames, "premises")
+        val premisesCharacteristicIds = getTemporaryAccommodationCharacteristicsIds(premisesCharacteristicsPropertyNames, "premises")
 
-        val roomCharacteristicsNames = when {
-          propertyBedAttributes?.contains(BedSearchAttributes.wheelchairAccessible) == true -> listOf("Wheelchair accessible")
+        val roomCharacteristicsPropertyNames = when {
+          propertyBedAttributes?.contains(BedSearchAttributes.wheelchairAccessible) == true -> listOf("isWheelchairAccessible")
           else -> null
         }
 
-        val roomCharacteristicIds = getTemporaryAccommodationCharacteristicsIds(roomCharacteristicsNames, "room")
+        val roomCharacteristicIds = getTemporaryAccommodationCharacteristicsIds(roomCharacteristicsPropertyNames, "room")
 
         val endDate = startDate.plusDays(durationInDays.toLong() - 1)
 
@@ -219,9 +219,9 @@ class BedSearchService(
     )
   }
 
-  private fun getTemporaryAccommodationCharacteristicsIds(characteristicsNames: List<String>?, modelScope: String): List<UUID> {
-    return characteristicsNames?.let {
-      val characteristics = characteristicService.getCharacteristicsByNames(characteristicsNames)
+  private fun getTemporaryAccommodationCharacteristicsIds(characteristicsPropertyNames: List<String>?, modelScope: String): List<UUID> {
+    return characteristicsPropertyNames?.let {
+      val characteristics = characteristicService.getCharacteristicsByPropertyNames(characteristicsPropertyNames, ServiceName.temporaryAccommodation)
       characteristics.filter {
         it.isActive && it.matches(ServiceName.temporaryAccommodation.value, modelScope)
       }.map { it.id }.toList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
@@ -30,9 +30,6 @@ class CharacteristicService(
   fun getCharacteristicsByPropertyNames(requiredCharacteristics: List<String>, serviceName: ServiceName) =
     characteristicRepository.findAllWherePropertyNameIn(requiredCharacteristics, serviceName.value)
 
-  fun getCharacteristicsByNames(requiredCharacteristics: List<String>) =
-    characteristicRepository.findAllWhereNameIn(requiredCharacteristics)
-
   fun serviceScopeMatches(characteristic: CharacteristicEntity, target: Any): Boolean {
     val targetService = getServiceForTarget(target) ?: return false
 


### PR DESCRIPTION
Change the CAS3 bedspace search to use property name characteristics column. when filter bedspaces by attributes