### PR TITLE
APS-1554 - For space search only return premises supporting space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -183,7 +183,8 @@ interface ApprovedPremisesRepository : JpaRepository<ApprovedPremisesEntity, UUI
               p.apCode,
               apArea.id,
               apArea.name,
-              CAST(COUNT(b) as int)
+              CAST(COUNT(b) as int),
+              p.supportsSpaceBookings
               )
         FROM 
           ApprovedPremisesEntity p
@@ -372,6 +373,7 @@ data class ApprovedPremisesBasicSummary(
   val apAreaId: UUID,
   val apAreaName: String,
   val bedCount: Int,
+  val supportsSpaceBookings: Boolean,
 )
 
 interface BookingSummary {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1SpaceSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1SpaceSearchRepository.kt
@@ -116,6 +116,7 @@ FROM
   ON p.probation_region_id = pr.id
   JOIN ap_areas aa
   ON pr.ap_area_id = aa.id
+  WHERE ap.supports_space_bookings = true
 ) AS result
 WHERE
   1 = 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesTransformer.kt
@@ -34,6 +34,7 @@ class Cas1PremisesTransformer(
       apCode = entity.apCode,
       apArea = NamedId(entity.apAreaId, entity.apAreaName),
       bedCount = entity.bedCount,
+      supportsSpaceBookings = entity.supportsSpaceBookings,
     )
   }
 }

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -17,11 +17,14 @@ components:
         bedCount:
           type: integer
           example: 22
+        supportsSpaceBookings:
+          type: boolean
       required:
         - id
         - name
         - apArea
         - bedCount
+        - supportsSpaceBookings
     Cas1PremisesSearchResultSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6222,11 +6222,14 @@ components:
         bedCount:
           type: integer
           example: 22
+        supportsSpaceBookings:
+          type: boolean
       required:
         - id
         - name
         - apArea
         - bedCount
+        - supportsSpaceBookings
     Cas1PremisesSearchResultSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -146,6 +146,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
         withGender(ApprovedPremisesGender.MAN)
         withYieldedProbationRegion { region1 }
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withSupportsSpaceBookings(false)
       }
 
       premises2WomanInArea2 = approvedPremisesEntityFactory.produceAndPersist {
@@ -153,6 +154,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
         withGender(ApprovedPremisesGender.WOMAN)
         withYieldedProbationRegion { region2 }
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withSupportsSpaceBookings(false)
       }
 
       premises3ManInArea2 = approvedPremisesEntityFactory.produceAndPersist {
@@ -160,9 +162,11 @@ class Cas1PremisesTest : IntegrationTestBase() {
         withGender(ApprovedPremisesGender.MAN)
         withYieldedProbationRegion { region2 }
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+        withSupportsSpaceBookings(true)
       }
     }
 
+    @SuppressWarnings("CyclomaticComplexMethod")
     @Test
     fun `Returns premises summaries with no filters applied`() {
       val (_, jwt) = givenAUser()
@@ -183,21 +187,24 @@ class Cas1PremisesTest : IntegrationTestBase() {
             it.name == "the premises name 1" &&
             it.apCode == premises1ManInArea1.apCode &&
             it.apArea.name == "the ap area name 1" &&
-            it.bedCount == 0
+            it.bedCount == 0 &&
+            it.supportsSpaceBookings == false
         }
         .anyMatch {
           it.id == premises2WomanInArea2.id &&
             it.name == "the premises name 2" &&
             it.apCode == premises2WomanInArea2.apCode &&
             it.apArea.name == "the ap area name 2" &&
-            it.bedCount == 0
+            it.bedCount == 0 &&
+            it.supportsSpaceBookings == false
         }
         .anyMatch {
           it.id == premises3ManInArea2.id &&
             it.name == "the premises name 3" &&
             it.apCode == premises3ManInArea2.apCode &&
             it.apArea.name == "the ap area name 2" &&
-            it.bedCount == 0
+            it.bedCount == 0 &&
+            it.supportsSpaceBookings == true
         }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -43,7 +43,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
   }
 
   @Test
-  fun `Search for Spaces returns OK with correct body`() {
+  fun `Search for Spaces returns OK with correct body, returning only premises supporting space bookings`() {
     postCodeDistrictFactory.produceAndPersist {
       withOutcode("SE1")
       withLatitude(-0.07)
@@ -58,6 +58,18 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         }
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
+        withSupportsSpaceBookings(true)
+      }
+
+      // premise that doesn't support space bookings
+      approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedProbationRegion { givenAProbationRegion() }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withLatitude((-0.01) - 0.08)
+        withLongitude((0.01) + 51.49)
+        withSupportsSpaceBookings(false)
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
@@ -111,6 +123,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         }
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
+        withSupportsSpaceBookings(true)
         // withGender(gender)
       }
 
@@ -121,6 +134,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         }
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
+        withSupportsSpaceBookings(true)
         // withGender(Gender.entries.first { it != gender })
       }
 
@@ -175,6 +189,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
         withCharacteristicsList(listOfNotNull(apType.asCharacteristicEntity()))
+        withSupportsSpaceBookings(true)
       }
 
       val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
@@ -185,6 +200,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
         withCharacteristicsList(listOfNotNull(ApType.entries.first { it != apType }.asCharacteristicEntity()))
+        withSupportsSpaceBookings(true)
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
@@ -243,6 +259,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
         withCharacteristicsList(listOfNotNull(ApType.entries[it - 1].asCharacteristicEntity()))
+        withSupportsSpaceBookings(true)
       }
 
       val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
@@ -253,6 +270,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
         withCharacteristicsList(listOfNotNull(ApType.entries[5].asCharacteristicEntity()))
+        withSupportsSpaceBookings(true)
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
@@ -329,6 +347,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
         withCharacteristicsList(listOf(characteristic.asCharacteristicEntity()))
+        withSupportsSpaceBookings(true)
       }
 
       expectedPremises.forEach {
@@ -350,6 +369,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
             Cas1SpaceCharacteristic.entries.first { it != characteristic }.asCharacteristicEntity(),
           ),
         )
+        withSupportsSpaceBookings(true)
       }
 
       unexpectedPremises.forEach {
@@ -413,6 +433,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
         withCharacteristicsList(Cas1SpaceCharacteristic.entries.slice(1..3).map { it.asCharacteristicEntity() })
+        withSupportsSpaceBookings(true)
       }
 
       expectedPremises.forEach {
@@ -434,6 +455,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
             Cas1SpaceCharacteristic.entries[it].asCharacteristicEntity(),
           ),
         )
+        withSupportsSpaceBookings(true)
       }
 
       unexpectedPremises.forEach {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesTransformerTest.kt
@@ -90,6 +90,7 @@ class Cas1PremisesTransformerTest {
         AP_AREA_ID,
         "the ap area name",
         12,
+        supportsSpaceBookings = false,
       )
 
       val result = transformer.toPremiseBasicSummary(premisesSummary)
@@ -100,6 +101,7 @@ class Cas1PremisesTransformerTest {
       assertThat(result.apArea.id).isEqualTo(AP_AREA_ID)
       assertThat(result.apArea.name).isEqualTo("the ap area name")
       assertThat(result.bedCount).isEqualTo(12)
+      assertThat(result.supportsSpaceBookings).isEqualTo(false)
     }
   }
 }


### PR DESCRIPTION
This PR updates the space search results to only shows premises where `supports_space_bookings` is true

This is shown from local testing (only SWSC test premises are returned)

![Screenshot 2024-11-14 at 15 03 01](https://github.com/user-attachments/assets/e3bb16a0-cac1-4afa-8646-617380e82af0)


It also adds 'supports space bookings' to the premise basic summary result to support UI filtering
