### PR TITLE
Add method to quickly recycle CasResult error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/CasResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/CasResult.kt
@@ -16,7 +16,13 @@ import java.util.UUID
  */
 sealed interface CasResult<SuccessType> {
   data class Success<SuccessType>(val value: SuccessType) : CasResult<SuccessType>
-  sealed interface Error<SuccessType> : CasResult<SuccessType>
+  sealed interface Error<SuccessType> : CasResult<SuccessType> {
+    // This is safe as the generic is irrelevant on Error types
+    @Suppress("UNCHECKED_CAST")
+    fun <R> reviseType(): CasResult<R> {
+      return this as Error<R>
+    }
+  }
   data class FieldValidationError<SuccessType>(val validationMessages: Map<String, String>) : Error<SuccessType>
   data class GeneralValidationError<SuccessType>(val message: String) : Error<SuccessType>
   data class ConflictError<SuccessType>(val conflictingEntityId: UUID, val message: String) : Error<SuccessType>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementApplicationService.kt
@@ -396,8 +396,8 @@ class PlacementApplicationService(
           placementApplicationDecisionEnvelope.decisionSummary,
         )
 
-      if (placementRequestResult is AuthorisableActionResult.NotFound) {
-        return CasResult.NotFound(placementRequestResult.entityType, placementRequestResult.id)
+      if (placementRequestResult is CasResult.Error) {
+        return placementRequestResult.reviseType()
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -191,10 +191,10 @@ class PlacementRequestService(
   fun createPlacementRequestsFromPlacementApplication(
     placementApplicationEntity: PlacementApplicationEntity,
     notes: String?,
-  ): AuthorisableActionResult<List<PlacementRequestEntity>> {
+  ): CasResult<List<PlacementRequestEntity>> {
     val placementRequirements = placementRequirementsRepository.findTopByApplicationOrderByCreatedAtDesc(
       placementApplicationEntity.application,
-    ) ?: return AuthorisableActionResult.NotFound(
+    ) ?: return CasResult.NotFound(
       "Placement Requirements",
       placementApplicationEntity.application.id.toString(),
     )
@@ -202,7 +202,7 @@ class PlacementRequestService(
     val placementDateEntities = placementDateRepository.findAllByPlacementApplication(placementApplicationEntity)
 
     if (placementDateEntities.isEmpty()) {
-      return AuthorisableActionResult.NotFound(
+      return CasResult.NotFound(
         "Placement Dates for Placement Application",
         placementApplicationEntity.id.toString(),
       )
@@ -233,7 +233,7 @@ class PlacementRequestService(
       placementRequest
     }
 
-    return AuthorisableActionResult.Success(placementRequests)
+    return CasResult.Success(placementRequests)
   }
 
   fun createPlacementRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -346,7 +346,7 @@ class PlacementApplicationServiceTest {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every {
         placementRequestService.createPlacementRequestsFromPlacementApplication(any(), any())
-      } returns AuthorisableActionResult.Success(emptyList())
+      } returns CasResult.Success(emptyList())
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
 
       every { cas1PlacementApplicationEmailService.placementApplicationAccepted(any()) } returns Unit


### PR DESCRIPTION
Sometimes in a service we want to return a `CasResult.Error` ‘as is’ back to the caller. Before this commit we would have to ‘rebuild’ the `CasResult` specific type to make the generic arguments happy, despite the SuccessType generic not being used anyway in the `CasResult.Error` hierarchy. This was verbose and forced us to reassert information that was already in the original error, typically loosing context.

This commit adds a `reviseType` function to `CasResult.Error` to allow us to directly use the `CasResult.Error` instance by forcefully changing its generic.

It also makes use of the function in `PlacementApplicationService` to provide a working example.