### PR TITLE
APS-1524: Add Parent-Child relationship to Departure Reasons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/DepartureReasonTransformer.kt
@@ -11,5 +11,6 @@ class DepartureReasonTransformer() {
     name = jpa.name,
     isActive = jpa.isActive,
     serviceScope = jpa.serviceScope,
+    parentReasonId = jpa.parentReasonId?.id,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -70,6 +70,10 @@ class Cas1SpaceBookingTransformer(
       requestForPlacementId = jpa.placementRequest?.placementApplication?.id ?: jpa.placementRequest?.id,
       nonArrival = jpa.extractNonArrival(),
       deliusEventNumber = jpa.deliusEventNumber,
+      departureReason = jpa.departureReason?.let {
+        val (id, name) = jpa.departureReason!!.generateParentChildName()
+        NamedId(id, name)
+      } ?: null,
     )
   }
 

--- a/src/main/resources/db/migration/all/20241114110241__update_departure_reasons_for_breach_recall.sql
+++ b/src/main/resources/db/migration/all/20241114110241__update_departure_reasons_for_breach_recall.sql
@@ -1,0 +1,17 @@
+ALTER TABLE departure_reasons ADD parent_reason_id UUID NULL;
+ALTER TABLE departure_reasons ADD CONSTRAINT parent_reason_fk FOREIGN KEY (parent_reason_id) REFERENCES departure_reasons (id);
+
+INSERT INTO departure_reasons(id, name, is_active, service_scope, legacy_delius_reason_code, parent_reason_id)
+SELECT 'd3e43ec3-02f4-4b96-a464-69dc74099259', 'Breach / Recall', TRUE, 'approved-premises', NULL, NULL
+WHERE NOT EXISTS (
+    SELECT id FROM departure_reasons where id = 'd3e43ec3-02f4-4b96-a464-69dc74099259'
+);
+
+UPDATE departure_reasons
+    SET
+        name = upper(substring(SUBSTRING(name, '\((.+)\)') from 1 for 1)) || substring(SUBSTRING(name, '\((.+)\)') from 2),
+        parent_reason_id = 'd3e43ec3-02f4-4b96-a464-69dc74099259'
+WHERE
+    NAME LIKE 'Breach / recall %' AND
+    service_scope = 'approved-premises';
+

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1307,6 +1307,9 @@ components:
           example: Admitted to Hospital
         serviceScope:
           type: string
+        parentReasonId:
+          type: string
+          format: uuid
         isActive:
           type: boolean
       required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5672,6 +5672,9 @@ components:
           example: Admitted to Hospital
         serviceScope:
           type: string
+        parentReasonId:
+          type: string
+          format: uuid
         isActive:
           type: boolean
       required:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2334,6 +2334,9 @@ components:
           example: Admitted to Hospital
         serviceScope:
           type: string
+        parentReasonId:
+          type: string
+          format: uuid
         isActive:
           type: boolean
       required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1898,6 +1898,9 @@ components:
           example: Admitted to Hospital
         serviceScope:
           type: string
+        parentReasonId:
+          type: string
+          format: uuid
         isActive:
           type: boolean
       required:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1359,6 +1359,9 @@ components:
           example: Admitted to Hospital
         serviceScope:
           type: string
+        parentReasonId:
+          type: string
+          format: uuid
         isActive:
           type: boolean
       required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureReasonEntityFactory.kt
@@ -13,6 +13,7 @@ class DepartureReasonEntityFactory : Factory<DepartureReasonEntity> {
   private var isActive: Yielded<Boolean> = { true }
   private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
   private var legacyDeliusCategoryCode: Yielded<String> = { randomStringUpperCase(1) }
+  private var parentReasonId: Yielded<DepartureReasonEntity?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -34,11 +35,16 @@ class DepartureReasonEntityFactory : Factory<DepartureReasonEntity> {
     this.legacyDeliusCategoryCode = { legacyDeliusCategoryCode }
   }
 
+  fun withParentReasonId(parentDepartureReason: DepartureReasonEntity) = apply {
+    this.parentReasonId = { parentDepartureReason }
+  }
+
   override fun produce(): DepartureReasonEntity = DepartureReasonEntity(
     id = this.id(),
     name = this.name(),
     isActive = this.isActive(),
     serviceScope = this.serviceScope(),
     legacyDeliusReasonCode = this.legacyDeliusCategoryCode(),
+    parentReasonId = this.parentReasonId(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -818,6 +818,7 @@ class Cas1SpaceBookingServiceTest {
       isActive = true,
       serviceScope = "approved-premises",
       legacyDeliusReasonCode = "legacyDeliusReasonCode",
+      parentReasonId = null,
     )
     private val departureReasonWithInvalidScope = DepartureReasonEntity(
       id = UUID.randomUUID(),
@@ -825,6 +826,7 @@ class Cas1SpaceBookingServiceTest {
       isActive = true,
       serviceScope = "temporary-accommodation",
       legacyDeliusReasonCode = "legacyDeliusReasonCode",
+      parentReasonId = null,
     )
     private val departureMoveOnCategory = MoveOnCategoryEntity(
       id = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -268,6 +268,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       isActive = true,
       serviceScope = "approved-premises",
       legacyDeliusReasonCode = "legacyDeliusReasonCode",
+      parentReasonId = null,
     )
     private val moveOnCategory = MoveOnCategoryEntity(
       id = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -761,6 +761,7 @@ class BookingTransformerTest {
             isActive = true,
             serviceScope = "*",
             legacyDeliusReasonCode = "A",
+            parentReasonId = null,
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
@@ -939,6 +940,7 @@ class BookingTransformerTest {
             isActive = true,
             serviceScope = "*",
             legacyDeliusReasonCode = "A",
+            parentReasonId = null,
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
@@ -1154,6 +1156,7 @@ class BookingTransformerTest {
             isActive = true,
             serviceScope = "*",
             legacyDeliusReasonCode = "A",
+            parentReasonId = null,
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
@@ -1373,6 +1376,7 @@ class BookingTransformerTest {
             isActive = true,
             serviceScope = "*",
             legacyDeliusReasonCode = "A",
+            parentReasonId = null,
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
@@ -1583,6 +1587,7 @@ class BookingTransformerTest {
             isActive = true,
             serviceScope = "*",
             legacyDeliusReasonCode = "A",
+            parentReasonId = null,
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
@@ -1609,6 +1614,7 @@ class BookingTransformerTest {
             isActive = true,
             serviceScope = "*",
             legacyDeliusReasonCode = "A",
+            parentReasonId = null,
           ),
           moveOnCategory = MoveOnCategoryEntity(
             id = UUID.fromString("3fc011f3-81ae-46fa-a066-84de8423ab87"),


### PR DESCRIPTION
Add Parent-Child relationship to Departure Reasons

- Added parent_reason_id to API, entity and table
- Created a new parent 'Breach / Recall' departure reason
- Populated the parent_reason_id field for children of the new parent with the new record's Id 
- Updated the child records to remove 'Breach / recall' text
- Implemented a change to the Cas1SpaceBookingTransformer to provide a composite name of parent and child 'Breach / recall' departure resons