### PR TITLE
APS-1583 - Optimise planning model creation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -127,11 +127,15 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
     LEFT JOIN FETCH b.criteria
     WHERE b.premises.id = :premisesId
     AND b.cancellationOccurredAt IS NULL 
-    AND b.canonicalArrivalDate <= :day 
-    AND b.canonicalDepartureDate > :day
+    AND b.canonicalArrivalDate <= :rangeEndInclusive
+    AND b.canonicalDepartureDate >= :rangeStartInclusive 
   """,
   )
-  fun findAllBookingsOnGivenDayWithCriteria(premisesId: UUID, day: LocalDate): List<Cas1SpaceBookingEntity>
+  fun findAllBookingsActiveWithinAGivenRangeWithCriteria(
+    premisesId: UUID,
+    rangeStartInclusive: LocalDate,
+    rangeEndInclusive: LocalDate,
+  ): List<Cas1SpaceBookingEntity>
 
   fun findAllByApplication(application: ApplicationEntity): List<Cas1SpaceBookingEntity>
 }
@@ -240,6 +244,7 @@ data class Cas1SpaceBookingEntity(
   fun isCancelled() = cancellationOccurredAt != null
   fun hasNonArrival() = nonArrivalConfirmedAt != null
   fun hasArrival() = actualArrivalDateTime != null
+  fun isResident(day: LocalDate) = canonicalArrivalDate <= day && canonicalDepartureDate > day
   override fun toString() = "Cas1SpaceBookingEntity:$id"
 }
 


### PR DESCRIPTION
Before this commit a database query was ran to retrieve space bookings applicable for each day being planned.

This commit instead loads all space bookings that are active across a given date range, and uses this to find each applicable booking for the day (as we already do for out of service bed records).

This significantly reduces the number of database queries required.

This change has been made in preparation for reusing the planning models to calculate capacity wrt. characteristics that are of interest for space booking planning