### PR TITLE
APS-1564: Update CRU Dashboard to consider space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -90,6 +90,15 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
             WHERE
               bnm.placement_request_id = pq.id
           ) THEN 'unableToMatch'
+          WHEN EXISTS (
+            SELECT 
+                1 
+            FROM 
+                cas1_space_bookings sb 
+            WHERE
+                sb.placement_request_id = pq.id AND
+                sb.cancellation_occurred_at IS NULL
+          ) THEN 'matched'    
           ELSE 'notMatched'
         END
       ) = :status)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestBookingSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestBookingSummaryTransformer.kt
@@ -1,19 +1,29 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingSummaryTransformer
 
 class PlacementRequestBookingSummaryTransformer(
   private val bookingSummaryTransformer: BookingSummaryTransformer,
+  private val cas1SpaceBookingSummaryTransformer: Cas1SpaceBookingSummaryTransformer,
 ) {
 
   fun getBookingSummary(placementRequest: PlacementRequestEntity): BookingSummary? {
-    val booking = placementRequest.booking
+    return placementRequest.booking?.let {
+      getBookingSummary(placementRequest.booking!!)
+    } ?: getSpaceBookingSummary(placementRequest.spaceBookings)
+  }
 
-    if (booking != null && !booking.isCancelled) {
+  private fun getBookingSummary(booking: BookingEntity): BookingSummary? {
+    if (!booking.isCancelled) {
       return bookingSummaryTransformer.transformJpaToApi(booking)
     }
-
     return null
   }
+
+  private fun getSpaceBookingSummary(bookings: List<Cas1SpaceBookingEntity>): BookingSummary? =
+    bookings.firstOrNull { !it.isCancelled() }?.let { booking -> cas1SpaceBookingSummaryTransformer.transformJpaToApi(booking) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
@@ -5,15 +5,20 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementReque
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingSummaryTransformer
 
 @Component
 class PlacementRequestDetailTransformer(
   private val placementRequestTransformer: PlacementRequestTransformer,
   private val cancellationTransformer: CancellationTransformer,
   bookingSummaryTransformer: BookingSummaryTransformer,
+  cas1SpaceBookingSummaryTransformer: Cas1SpaceBookingSummaryTransformer,
   private val applicationTransformer: ApplicationsTransformer,
 ) {
-  val placementRequestBookingSummaryTransformer = PlacementRequestBookingSummaryTransformer(bookingSummaryTransformer)
+  val placementRequestBookingSummaryTransformer = PlacementRequestBookingSummaryTransformer(
+    bookingSummaryTransformer,
+    cas1SpaceBookingSummaryTransformer,
+  )
 
   fun transformJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult, cancellations: List<CancellationEntity>): PlacementRequestDetail {
     val placementRequest = placementRequestTransformer.transformJpaToApi(jpa, personInfo)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Characteristi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingSummaryTransformer
 
 @Component
 class PlacementRequestTransformer(
@@ -24,9 +25,13 @@ class PlacementRequestTransformer(
   private val assessmentTransformer: AssessmentTransformer,
   private val userTransformer: UserTransformer,
   bookingSummaryTransformer: BookingSummaryTransformer,
+  cas1SpaceBookingSummaryTransformer: Cas1SpaceBookingSummaryTransformer,
 ) {
 
-  val placementRequestBookingSummaryTransformer = PlacementRequestBookingSummaryTransformer(bookingSummaryTransformer)
+  val placementRequestBookingSummaryTransformer = PlacementRequestBookingSummaryTransformer(
+    bookingSummaryTransformer,
+    cas1SpaceBookingSummaryTransformer,
+  )
 
   fun transformJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult): PlacementRequest {
     return PlacementRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingSummaryTransformer.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+
+@Component
+class Cas1SpaceBookingSummaryTransformer {
+  fun transformJpaToApi(jpa: Cas1SpaceBookingEntity) = BookingSummary(
+    id = jpa.id,
+    premisesId = jpa.premises.id,
+    premisesName = jpa.premises.name,
+    arrivalDate = jpa.canonicalArrivalDate,
+    departureDate = jpa.canonicalDepartureDate,
+    createdAt = jpa.createdAt.toInstant(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequestEntityFactory.kt
@@ -63,6 +63,10 @@ class PlacementRequestEntityFactory : Factory<PlacementRequestEntity> {
     this.booking = { BookingEntityFactory().apply(configuration).produce() }
   }
 
+  fun withSpaceBookings(bookings: MutableList<Cas1SpaceBookingEntity>) = apply {
+    this.spaceBookings = { bookings }
+  }
+
   fun withApplication(application: ApprovedPremisesApplicationEntity) = apply {
     this.application = { application }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestBookingSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestBookingSummaryTransformerTest.kt
@@ -1,0 +1,161 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingSummaryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestBookingSummaryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingSummaryTransformer
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class PlacementRequestBookingSummaryTransformerTest {
+
+  private val bookingSummaryTransformer = mockk<BookingSummaryTransformer>()
+  private val cas1SpaceBookingSummaryTransformer = mockk<Cas1SpaceBookingSummaryTransformer>()
+
+  private val placementRequestBookingSummaryTransformer = PlacementRequestBookingSummaryTransformer(
+    bookingSummaryTransformer,
+    cas1SpaceBookingSummaryTransformer,
+  )
+
+  val application = ApprovedPremisesApplicationEntityFactory()
+    .withCreatedByUser(
+      UserEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
+        .produce(),
+    )
+    .produce()
+
+  val assessment = ApprovedPremisesAssessmentEntityFactory()
+    .withApplication(application)
+    .produce()
+
+  val placementRequirements = PlacementRequirementsEntityFactory()
+    .withApplication(application)
+    .withAssessment(assessment)
+    .produce()
+
+  val premises = ApprovedPremisesEntityFactory()
+    .withDefaults()
+    .produce()
+
+  val booking = BookingEntityFactory()
+    .withId(UUID.randomUUID())
+    .withPremises(premises)
+    .withArrivalDate(LocalDate.now().minusDays(10))
+    .withDepartureDate(LocalDate.now().plusDays(5))
+    .withCreatedAt(OffsetDateTime.now())
+    .produce()
+
+  val placementRequest =
+    PlacementRequestEntityFactory()
+      .withPlacementRequirements(placementRequirements)
+      .withApplication(application)
+      .withAssessment(assessment)
+      .withBooking(booking)
+      .withSpaceBookings(mutableListOf())
+      .produce()
+
+  val spaceBooking = Cas1SpaceBookingEntityFactory()
+    .withId(UUID.randomUUID())
+    .withPremises(premises)
+    .withCanonicalArrivalDate(LocalDate.now().minusDays(10))
+    .withCanonicalDepartureDate(LocalDate.now().plusDays(5))
+    .withCreatedAt(OffsetDateTime.now())
+    .produce()
+
+  @Test
+  fun `Transforms placement request booking summary correctly when booking is legacy booking`() {
+    val bookingSummary = BookingSummary(
+      booking.id,
+      booking.premises.id,
+      booking.premises.name,
+      booking.arrivalDate,
+      booking.departureDate,
+      booking.createdAt.toInstant(),
+    )
+
+    every { bookingSummaryTransformer.transformJpaToApi(booking) } returns bookingSummary
+
+    var result = placementRequestBookingSummaryTransformer.getBookingSummary(placementRequest)
+
+    assertThat(result!!.id).isEqualTo(booking.id)
+    assertThat(result!!.premisesId).isEqualTo(booking.premises.id)
+    assertThat(result!!.premisesName).isEqualTo(booking.premises.name)
+    assertThat(result!!.arrivalDate).isEqualTo(booking.arrivalDate)
+    assertThat(result!!.departureDate).isEqualTo(booking.departureDate)
+    assertThat(result!!.createdAt).isEqualTo(booking.createdAt.toInstant())
+  }
+
+  @Test
+  fun `Transforms placement request booking summary correctly when booking is space booking`() {
+    val spaceBookingSummary = BookingSummary(
+      spaceBooking.id,
+      spaceBooking.premises.id,
+      spaceBooking.premises.name,
+      spaceBooking.canonicalArrivalDate,
+      spaceBooking.canonicalDepartureDate,
+      spaceBooking.createdAt.toInstant(),
+    )
+
+    var placementWithSpaceBooking = placementRequest.copy(
+      booking = null,
+      spaceBookings = mutableListOf(spaceBooking),
+    )
+
+    every { cas1SpaceBookingSummaryTransformer.transformJpaToApi(spaceBooking) } returns spaceBookingSummary
+
+    var result = placementRequestBookingSummaryTransformer.getBookingSummary(placementWithSpaceBooking)
+
+    assertThat(result!!.id).isEqualTo(spaceBooking.id)
+    assertThat(result!!.premisesId).isEqualTo(spaceBooking.premises.id)
+    assertThat(result!!.premisesName).isEqualTo(spaceBooking.premises.name)
+    assertThat(result!!.arrivalDate).isEqualTo(spaceBooking.canonicalArrivalDate)
+    assertThat(result!!.departureDate).isEqualTo(spaceBooking.canonicalDepartureDate)
+    assertThat(result!!.createdAt).isEqualTo(spaceBooking.createdAt.toInstant())
+  }
+
+  @Test
+  fun `Transform placement request booking summary returns null when no space bookings`() {
+    val placementWithSpaceBooking = placementRequest.copy(
+      booking = null,
+    )
+
+    val result = placementRequestBookingSummaryTransformer.getBookingSummary(placementWithSpaceBooking)
+
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `Transform placement request booking summary returns null when no active space bookings`() {
+    val placementWithCancelledSpaceBooking = placementRequest.copy(
+      booking = null,
+      spaceBookings = mutableListOf(
+        spaceBooking.copy(
+          cancellationOccurredAt = LocalDate.now(),
+        ),
+      ),
+    )
+    val result = placementRequestBookingSummaryTransformer.getBookingSummary(placementWithCancelledSpaceBooking)
+
+    assertThat(result).isNull()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -45,6 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingSummaryTransformer
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -56,6 +57,7 @@ class PlacementRequestTransformerTest {
   private val mockRisksTransformer = mockk<RisksTransformer>()
   private val mockUserTransformer = mockk<UserTransformer>()
   private val mockBookingSummaryTransformer = mockk<BookingSummaryTransformer>()
+  private val mockCas1SpaceBookingSummaryTransformer = mockk<Cas1SpaceBookingSummaryTransformer>()
 
   private val placementRequestTransformer = PlacementRequestTransformer(
     mockPersonTransformer,
@@ -63,6 +65,7 @@ class PlacementRequestTransformerTest {
     mockAssessmentTransformer,
     mockUserTransformer,
     mockBookingSummaryTransformer,
+    mockCas1SpaceBookingSummaryTransformer,
   )
 
   private val offenderDetailSummary = OffenderDetailsSummaryFactory().produce()


### PR DESCRIPTION
Update CRU Dashboard to consider space bookings

Updated dashboard SQL (`allForDashboard`) to recognise space bookings in placement requests and `cancelled` and `matched` status' 

Updated `PlacementRequestTransformer` to handle providing a booking summary for Space Bookings as well as legacy bookings