### PR TITLE
APS-1583 - Fix planning bug related to single rooms

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModels.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModels.kt
@@ -32,10 +32,15 @@ data class Room(
   val id: UUID,
   val label: String,
   val characteristics: Set<Characteristic>,
-)
+) {
+  fun characteristicsExcludingSingle() = characteristics.filter { !it.singleRoom }
+}
 
 data class SpaceBooking(
   val id: UUID,
   val label: String,
   val requiredRoomCharacteristics: Set<Characteristic>,
-)
+) {
+  fun requiresSingleRoom() = requiredRoomCharacteristics.any { it.singleRoom }
+  fun requiredRoomCharacteristicsExcludingSingle() = requiredRoomCharacteristics.filter { !it.singleRoom }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpaceDayPlannerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpaceDayPlannerTest.kt
@@ -408,6 +408,36 @@ class SpaceDayPlannerTest {
     )
   }
 
+  @Test
+  fun `Booking requiring a single room is put into a room with single room characteristic vs room with no characteristics`() {
+    val booking2 = booking("booking1", requiredCharacteristics = setOf(CHARACTERISTIC_SINGLE_ROOM))
+
+    val room1 = Room(UUID.randomUUID(), "room1", characteristics = setOf())
+    val room1Bed1 = bed("room1 bed1", room = room1)
+    val room1Bed2 = bed("room1 bed2", room = room1)
+    val room1Bed3 = bed("room1 bed3", room = room1)
+
+    val room2 = Room(UUID.randomUUID(), "room2", characteristics = setOf(CHARACTERISTIC_SINGLE_ROOM))
+    val room2Bed1 = bed("room2 bed1", room = room2)
+
+    assertPlanningOutcome(
+      beds = setOf(room1Bed1, room1Bed2, room1Bed3, room2Bed1),
+      bookings = setOf(booking2),
+      expected = """
+      Planned: 1
+    
+      | Bed             | Booking         | Characteristics                |
+      | --------------- | --------------- | ------------------------------ |
+      | room1 bed1      |                 |                                |
+      | room1 bed2      |                 |                                |
+      | room1 bed3      |                 |                                |
+      | room2 bed1      | booking1        | single(rb)                     |
+      
+      Unplanned: 0
+      """,
+    )
+  }
+
   private fun assertPlanningOutcome(
     beds: Set<Bed>,
     bookings: Set<SpaceBooking>,


### PR DESCRIPTION
This commit fixes a bug where a booking that requires a single room is sometimes placed into a room with multiple beds vs a room with a single bed and the ‘single bed characteristic’.

Whilst this was a legitimate bug, it does highlight a potential conflict in the order in whcih the following rules are applied:

1. Bookings are placed into rooms with the least surplus characteristics
2. If there are multiple competing rooms (after above goals are satisfied), single occupancy bookings will be placed into rooms with the least beds (ensuring minimum 'wastage' in these scenarios)

This can result in a single booking being put into a room with many beds because the single bed room has unrequired characteristics. This may not be desirable