### PR TITLE
APS-1594: Add departure information when Getting Space Booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -211,6 +211,7 @@ data class Cas1SpaceBookingEntity(
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "departure_move_on_category_id")
   var departureMoveOnCategory: MoveOnCategoryEntity?,
+  var departureNotes: String?,
   /**
    * Users are asked to specify when a cancelled occurred which may not necessarily
    * be the same as when it was recorded in the system

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -243,6 +243,7 @@ data class Cas1SpaceBookingEntity(
 ) {
   fun isActive() = !isCancelled()
   fun isCancelled() = cancellationOccurredAt != null
+  fun hasDeparted() = actualDepartureDateTime != null
   fun hasNonArrival() = nonArrivalConfirmedAt != null
   fun hasArrival() = actualArrivalDateTime != null
   fun isResident(day: LocalDate) = canonicalArrivalDate <= day && canonicalDepartureDate > day

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -118,6 +118,7 @@ class Cas1BookingToSpaceBookingSeedJob(
         cancellationReasonNotes = booking.cancellation?.otherReason,
         departureMoveOnCategory = null,
         departureReason = null,
+        departureNotes = null,
         criteria = booking.getEssentialRoomCriteria(),
         nonArrivalReason = null,
         nonArrivalConfirmedAt = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -127,6 +127,7 @@ class Cas1SpaceBookingService(
         cancellationReasonNotes = null,
         departureMoveOnCategory = null,
         departureReason = null,
+        departureNotes = null,
         criteria = characteristics,
         nonArrivalConfirmedAt = null,
         nonArrivalNotes = null,
@@ -343,6 +344,7 @@ class Cas1SpaceBookingService(
     existingCas1SpaceBooking.canonicalDepartureDate = LocalDate.ofInstant(cas1NewDeparture.departureDateTime, ZoneId.systemDefault())
     existingCas1SpaceBooking.departureReason = departureReason
     existingCas1SpaceBooking.departureMoveOnCategory = moveOnCategory
+    existingCas1SpaceBooking.departureNotes = cas1NewDeparture.notes
 
     val result = cas1SpaceBookingRepository.save(existingCas1SpaceBooking)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -74,6 +74,7 @@ class Cas1SpaceBookingTransformer(
         val (id, name) = jpa.departureReason!!.generateParentChildName()
         NamedId(id, name)
       } ?: null,
+      departureNotes = jpa.departureNotes,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1KeyWorkerA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDeparture
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingNonArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
@@ -70,11 +71,7 @@ class Cas1SpaceBookingTransformer(
       requestForPlacementId = jpa.placementRequest?.placementApplication?.id ?: jpa.placementRequest?.id,
       nonArrival = jpa.extractNonArrival(),
       deliusEventNumber = jpa.deliusEventNumber,
-      departureReason = jpa.departureReason?.let {
-        val (id, name) = jpa.departureReason!!.generateParentChildName()
-        NamedId(id, name)
-      } ?: null,
-      departureNotes = jpa.departureNotes,
+      departure = jpa.extractDeparture(),
     )
   }
 
@@ -130,6 +127,19 @@ class Cas1SpaceBookingTransformer(
           )
         },
         notes = nonArrivalNotes,
+      )
+    } else {
+      null
+    }
+  }
+
+  private fun Cas1SpaceBookingEntity.extractDeparture(): Cas1SpaceBookingDeparture? {
+    return if (hasDeparted()) {
+      Cas1SpaceBookingDeparture(
+        reason = NamedId(departureReason!!.id, departureReason!!.name),
+        parentReason = departureReason!!.parentReasonId?.let { NamedId(it.id, it.name) },
+        moveOnCategory = departureMoveOnCategory?.let { NamedId(it.id, it.name) },
+        notes = departureNotes,
       )
     } else {
       null

--- a/src/main/resources/db/migration/all/20241121081817__add_departure_notes_to_space_booking.sql
+++ b/src/main/resources/db/migration/all/20241121081817__add_departure_notes_to_space_booking.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_space_bookings ADD departure_notes TEXT NULL;

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -316,6 +316,8 @@ components:
           $ref: '_shared.yml#/components/schemas/NamedId'
         departureMoveOnCategory:
           $ref: '_shared.yml#/components/schemas/NamedId'
+        departureNotes:
+          type: string
         createdAt:
           type: string
           format: date-time

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -312,12 +312,8 @@ components:
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date
-        departureReason:
-          $ref: '_shared.yml#/components/schemas/NamedId'
-        departureMoveOnCategory:
-          $ref: '_shared.yml#/components/schemas/NamedId'
-        departureNotes:
-          type: string
+        departure:
+          $ref: '#/components/schemas/Cas1SpaceBookingDeparture'
         createdAt:
           type: string
           format: date-time
@@ -430,6 +426,19 @@ components:
       required:
         - keyWorker
         - allocatedAt
+    Cas1SpaceBookingDeparture:
+      type: object
+      properties:
+        reason:
+          $ref: '_shared.yml#/components/schemas/NamedId'
+        parentReason:
+          $ref: '_shared.yml#/components/schemas/NamedId'
+        moveOnCategory:
+          $ref: '_shared.yml#/components/schemas/NamedId'
+        notes:
+          type: string
+      required:
+        - reason
     Cas1SpaceBookingCancellation:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6577,6 +6577,8 @@ components:
           $ref: '#/components/schemas/NamedId'
         departureMoveOnCategory:
           $ref: '#/components/schemas/NamedId'
+        departureNotes:
+          type: string
         createdAt:
           type: string
           format: date-time

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6573,12 +6573,8 @@ components:
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date
-        departureReason:
-          $ref: '#/components/schemas/NamedId'
-        departureMoveOnCategory:
-          $ref: '#/components/schemas/NamedId'
-        departureNotes:
-          type: string
+        departure:
+          $ref: '#/components/schemas/Cas1SpaceBookingDeparture'
         createdAt:
           type: string
           format: date-time
@@ -6691,6 +6687,19 @@ components:
       required:
         - keyWorker
         - allocatedAt
+    Cas1SpaceBookingDeparture:
+      type: object
+      properties:
+        reason:
+          $ref: '#/components/schemas/NamedId'
+        parentReason:
+          $ref: '#/components/schemas/NamedId'
+        moveOnCategory:
+          $ref: '#/components/schemas/NamedId'
+        notes:
+          type: string
+      required:
+        - reason
     Cas1SpaceBookingCancellation:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -45,6 +45,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var cancellationReasonNotes: Yielded<String?> = { null }
   private var departureReason: Yielded<DepartureReasonEntity?> = { null }
   private var departureMoveOnCategory: Yielded<MoveOnCategoryEntity?> = { null }
+  private var departureNotes: Yielded<String?> = { null }
   private var criteria: Yielded<List<CharacteristicEntity>> = { emptyList() }
   private var nonArrivalConfirmedAt: Yielded<Instant?> = { null }
   private var nonArrivalReason: Yielded<NonArrivalReasonEntity?> = { null }
@@ -52,7 +53,6 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var migratedFromBooking: Yielded<BookingEntity?> = { null }
   private var migratedManagementInfoFrom: Yielded<ManagementInfoSource?> = { null }
   private var deliusEventNumber: Yielded<String?> = { null }
-  private var departureNotes: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -52,6 +52,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var migratedFromBooking: Yielded<BookingEntity?> = { null }
   private var migratedManagementInfoFrom: Yielded<ManagementInfoSource?> = { null }
   private var deliusEventNumber: Yielded<String?> = { null }
+  private var departureNotes: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -199,6 +200,10 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.criteria = { criteria.toList() }
   }
 
+  fun withDepartureNotes(departureNotes: String?) = apply {
+    this.departureNotes = { departureNotes }
+  }
+
   override fun produce() = Cas1SpaceBookingEntity(
     id = this.id(),
     premises = this.premises(),
@@ -223,6 +228,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     cancellationReasonNotes = cancellationReasonNotes(),
     departureReason = this.departureReason(),
     departureMoveOnCategory = this.departureMoveOnCategory(),
+    departureNotes = this.departureNotes(),
     criteria = this.criteria(),
     nonArrivalConfirmedAt = this.nonArrivalConfirmedAt(),
     nonArrivalNotes = this.nonArrivalNotes(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -1424,6 +1424,7 @@ class Cas1SpaceBookingTest {
             departureDateTime = LocalDateTime.now().toInstant(ZoneOffset.UTC),
             reasonId = departureReasonId,
             moveOnCategoryId = departureMoveOnCategoryId,
+            notes = "these are departure notes",
           ),
         )
         .exchange()
@@ -1467,6 +1468,7 @@ class Cas1SpaceBookingTest {
             departureDateTime = LocalDateTime.now().toInstant(ZoneOffset.UTC),
             reasonId = departureReasonId,
             moveOnCategoryId = null,
+            notes = null,
           ),
         )
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -849,6 +849,8 @@ class Cas1SpaceBookingServiceTest {
       legacyDeliusCategoryCode = "legacyDeliusReasonCode",
     )
 
+    private val departureNotes = "these are departure notes"
+
     private val existingSpaceBooking = Cas1SpaceBookingEntityFactory()
       .withActualArrivalDateTime(LocalDateTime.now().minusDays(1).toInstant(ZoneOffset.UTC))
       .produce()
@@ -1091,6 +1093,7 @@ class Cas1SpaceBookingServiceTest {
     fun `Returns success if the space booking has already recorded departure information that matches the received departure information`() {
       val reasonId = UUID.randomUUID()
       val moveOnCategoryId = UUID.randomUUID()
+      val departureNotes = "these are departure notes"
       val existingSpaceBookingWithDepartureInfo = existingSpaceBooking.copy(
         actualDepartureDateTime = actualDepartureDate,
         departureReason = DepartureReasonEntityFactory()
@@ -1106,7 +1109,7 @@ class Cas1SpaceBookingServiceTest {
       val result = service.recordDepartureForBooking(
         premisesId = UUID.randomUUID(),
         bookingId = UUID.randomUUID(),
-        cas1NewDeparture = Cas1NewDeparture(actualDepartureDate, reasonId, moveOnCategoryId),
+        cas1NewDeparture = Cas1NewDeparture(actualDepartureDate, reasonId, moveOnCategoryId, departureNotes),
       )
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
@@ -1126,6 +1129,7 @@ class Cas1SpaceBookingServiceTest {
       assertThat(existingSpaceBookingWithDepartureInfo.actualDepartureDateTime?.toLocalDate()).isEqualTo(extractedResult.canonicalDepartureDate)
       assertThat(existingSpaceBookingWithDepartureInfo.departureReason).isEqualTo(extractedResult.departureReason)
       assertThat(existingSpaceBookingWithDepartureInfo.departureMoveOnCategory).isEqualTo(extractedResult.departureMoveOnCategory)
+      assertThat(existingSpaceBookingWithDepartureInfo.departureNotes).isEqualTo(extractedResult.departureNotes)
     }
 
     @Test
@@ -1142,6 +1146,7 @@ class Cas1SpaceBookingServiceTest {
           departureDateTime = actualDepartureDate,
           reasonId = UUID.randomUUID(),
           moveOnCategoryId = UUID.randomUUID(),
+          notes = "these are departure notes",
         ),
       )
 
@@ -1163,6 +1168,7 @@ class Cas1SpaceBookingServiceTest {
       assertThat(actualDepartureDate.toLocalDate()).isEqualTo(updatedSpaceBooking.canonicalDepartureDate)
       assertThat(departureReason).isEqualTo(updatedSpaceBooking.departureReason)
       assertThat(departureMoveOnCategory).isEqualTo(updatedSpaceBooking.departureMoveOnCategory)
+      assertThat(departureNotes).isEqualTo(updatedSpaceBooking.departureNotes)
     }
 
     @Test


### PR DESCRIPTION
Two parts to this ticket. 

1. Remedy the issue that departure notes (provided when recording a departure) was not being persisted. 
2. Provide departure information when retrieving a space booking.  This includes providing granular information when a parent-child departure reason is recorded, and departure notes.

 
Departure Notes not being persisted :

- Migration script to add departure_notes to table
- Added departureNotes to entity
- Added departureNotes to the Cas1SpaceBooking returned when getting a space booking


Provide Departure Information when retrieving a space booking : 

- Created a Cas1SpaceBookingDeparture object which contains information relating to departure
- Provides distinct information on parent departure reason, if it exists
- Now includes notes, which had been omitted originally 