### PR TITLE
Show bearer token in logs when running locally

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RequestResponseLoggingFilter.kt
@@ -81,18 +81,23 @@ class RequestResponseLoggingFilter(
   private fun logRequest(
     requestWrapper: ContentCachingRequestWrapper,
   ) {
+    val request = requestWrapper.request
     log.info("Request {}", String(requestWrapper.contentAsByteArray))
+
+    if (request is HttpServletRequest) {
+      log.trace("Authorization: {}", request.getHeader("authorization"))
+    }
   }
 
   private fun logResponse(
     responseWrapper: ContentCachingResponseWrapper,
   ) {
+    log.info("Response Headers {}", responseWrapper.headerNames.map { "$it:  ${responseWrapper.getHeaders(it)}" })
     val contentType = responseWrapper.contentType
     if (contentType == "application/json") {
       log.info("Response Body {}", String(responseWrapper.contentAsByteArray))
     } else {
       log.info("Response Body not logged as content type is $contentType")
     }
-    log.info("Response Headers {}", responseWrapper.headerNames.map { "$it:  ${responseWrapper.getHeaders(it)}" })
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RequestResponseLoggingFilter.kt
@@ -14,17 +14,25 @@ import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import org.springframework.web.util.ContentCachingRequestWrapper
 import org.springframework.web.util.ContentCachingResponseWrapper
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import java.io.IOException
 
 @Component
 @ConditionalOnProperty(name = ["log-request-response"])
-class RequestResponseLoggingFilter(val sentryService: SentryService) : OncePerRequestFilter() {
+class RequestResponseLoggingFilter(
+  val sentryService: SentryService,
+  val environmentService: EnvironmentService,
+) : OncePerRequestFilter() {
 
   var log: Logger = LoggerFactory.getLogger(this::class.java)
 
   @PostConstruct
   fun logStartup() {
+    if(environmentService.isNotATestEnvironment()) {
+      error("Request/Response logging is enabled. This should only be enabled in local environments")
+    }
+    
     sentryService.captureErrorMessage("Request/Response logging is enabled. This should only be enabled in local environments")
   }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -58,5 +58,8 @@ feature-flags:
   get-documents-from-ap-delius: true
   get-offences-from-ap-delius: false
 
+# allows us to see the JWT token to simplify local API invocation
+logging.level.uk.gov.justice.digital.hmpps.approvedpremisesapi.config.RequestResponseLoggingFilter: TRACE
+
 # allows us to see the request URL and method for upstream requests
 logging.level.reactor.netty.http.client.HttpClientConnect: DEBUG


### PR DESCRIPTION
Output Bearer Token when running locally
This commit updates the RequestResponseLoggingFilter to output the caller’s bearer token when running locally.

We are protected from this being enabled in production environments in multiple ways:

1. The RequestResponseLoggingFilter is disabled by default
2. On startup the RequestResponseLoggingFilter checks which profles we’re using and will error (stopping startup) if we’re in a non-test environment
3. The RequestResponseLoggingFilter will always create a Sentry alert when it runs. This wll be visible if somehow this was running in an environment connected to sentry
4. The Bearer token is logged at TRACE level, which is not enabled by default