### PR TITLE
Cas 665 exclude user notes from timeline for referrers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -152,7 +152,11 @@ class AssessmentService(
     }
   }
 
-  fun getAssessmentAndValidate(user: UserEntity, assessmentId: UUID): CasResult<AssessmentEntity> {
+  fun getAssessmentAndValidate(
+    user: UserEntity,
+    assessmentId: UUID,
+    forTimeline: Boolean = false,
+  ): CasResult<AssessmentEntity> {
     val assessment = assessmentRepository.findByIdOrNull(assessmentId)
       ?: return CasResult.NotFound(AssessmentEntity::class.simpleName, assessmentId.toString())
 
@@ -168,7 +172,9 @@ class AssessmentService(
       else -> throw RuntimeException("Assessment type '${assessment::class.qualifiedName}' is not currently supported")
     }
 
-    if (!userAccessService.userCanViewAssessment(user, assessment)) {
+    val isAuthorised = userAccessService.userCanViewAssessment(user, assessment) || (forTimeline && userAccessService.userCanViewApplication(user, assessment.application))
+
+    if (!isAuthorised) {
       return CasResult.Unauthorised()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistorySystemNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistorySystemNoteEntityFactory.kt
@@ -49,7 +49,7 @@ class AssessmentReferralHistorySystemNoteEntityFactory : Factory<AssessmentRefer
     assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an assessment"),
     createdAt = this.createdAt(),
     message = this.message(),
-    createdByUser = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy"),
+    createdByUser = this.createdBy?.invoke() ?: this.assessment?.invoke()!!.application.createdByUser,
     type = this.type(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistoryUserNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentReferralHistoryUserNoteEntityFactory.kt
@@ -42,6 +42,7 @@ class AssessmentReferralHistoryUserNoteEntityFactory : Factory<AssessmentReferra
     assessment = this.assessment?.invoke() ?: throw RuntimeException("Must provide an assessment"),
     createdAt = this.createdAt(),
     message = this.message(),
-    createdByUser = this.createdBy?.invoke() ?: throw RuntimeException("Must provide a createdBy"),
+    createdByUser = this.createdBy?.invoke() ?: this.assessment?.invoke()?.application?.createdByUser
+      ?: throw RuntimeException("Must provide a createdBy"),
   )
 }


### PR DESCRIPTION
This filters out any user notes from being visible to referrers, for when they are able to view the CAS3 timeline.