### PR TITLE
APS-1565: Updated Get Placement Request to consider Space Bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/PlacementRequestService.kt
@@ -410,6 +410,7 @@ class PlacementRequestService(
 
   data class PlacementRequestAndCancellations(
     val placementRequest: PlacementRequestEntity,
+    @Deprecated("This is not currently used by the UI and does not cater for SpaceBooking cancellations")
     val cancellations: List<CancellationEntity>,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingSummaryTransformer.kt
@@ -13,5 +13,6 @@ class BookingSummaryTransformer {
     arrivalDate = jpa.arrivalDate,
     departureDate = jpa.departureDate,
     createdAt = jpa.createdAt.toInstant(),
+    type = BookingSummary.Type.legacy,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingSummaryTransformer.kt
@@ -13,5 +13,6 @@ class Cas1SpaceBookingSummaryTransformer {
     arrivalDate = jpa.canonicalArrivalDate,
     departureDate = jpa.canonicalDepartureDate,
     createdAt = jpa.createdAt.toInstant(),
+    type = BookingSummary.Type.space,
   )
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -736,6 +736,11 @@ components:
         createdAt:
           type: string
           format: date-time
+        type:
+          type: string
+          enum:
+            - space
+            - legacy
       required:
         - id
         - premisesId
@@ -743,6 +748,7 @@ components:
         - arrivalDate
         - departureDate
         - createdAt
+        - type
     Person:
       type: object
       properties:
@@ -4150,6 +4156,8 @@ components:
         - type: object
           properties:
             cancellations:
+              deprecated: true
+              description: Not used by UI. Space Booking cancellations to be provided if cancellations are required in future.
               type: array
               items:
                 $ref: '#/components/schemas/Cancellation'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5067,6 +5067,11 @@ components:
         createdAt:
           type: string
           format: date-time
+        type:
+          type: string
+          enum:
+            - space
+            - legacy
       required:
         - id
         - premisesId
@@ -5074,6 +5079,7 @@ components:
         - arrivalDate
         - departureDate
         - createdAt
+        - type
     Person:
       type: object
       properties:
@@ -8481,6 +8487,8 @@ components:
         - type: object
           properties:
             cancellations:
+              deprecated: true
+              description: Not used by UI. Space Booking cancellations to be provided if cancellations are required in future.
               type: array
               items:
                 $ref: '#/components/schemas/Cancellation'

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1818,6 +1818,11 @@ components:
         createdAt:
           type: string
           format: date-time
+        type:
+          type: string
+          enum:
+            - space
+            - legacy
       required:
         - id
         - premisesId
@@ -1825,6 +1830,7 @@ components:
         - arrivalDate
         - departureDate
         - createdAt
+        - type
     Person:
       type: object
       properties:
@@ -5232,6 +5238,8 @@ components:
         - type: object
           properties:
             cancellations:
+              deprecated: true
+              description: Not used by UI. Space Booking cancellations to be provided if cancellations are required in future.
               type: array
               items:
                 $ref: '#/components/schemas/Cancellation'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1327,6 +1327,11 @@ components:
         createdAt:
           type: string
           format: date-time
+        type:
+          type: string
+          enum:
+            - space
+            - legacy
       required:
         - id
         - premisesId
@@ -1334,6 +1339,7 @@ components:
         - arrivalDate
         - departureDate
         - createdAt
+        - type
     Person:
       type: object
       properties:
@@ -4741,6 +4747,8 @@ components:
         - type: object
           properties:
             cancellations:
+              deprecated: true
+              description: Not used by UI. Space Booking cancellations to be provided if cancellations are required in future.
               type: array
               items:
                 $ref: '#/components/schemas/Cancellation'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -810,6 +810,11 @@ components:
         createdAt:
           type: string
           format: date-time
+        type:
+          type: string
+          enum:
+            - space
+            - legacy
       required:
         - id
         - premisesId
@@ -817,6 +822,7 @@ components:
         - arrivalDate
         - departureDate
         - createdAt
+        - type
     Person:
       type: object
       properties:
@@ -4224,6 +4230,8 @@ components:
         - type: object
           properties:
             cancellations:
+              deprecated: true
+              description: Not used by UI. Space Booking cancellations to be provided if cancellations are required in future.
               type: array
               items:
                 $ref: '#/components/schemas/Cancellation'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingSummaryTransformerTest.kt
@@ -56,6 +56,7 @@ class BookingSummaryTransformerTest {
         arrivalDate = booking.arrivalDate,
         departureDate = booking.departureDate,
         createdAt = booking.createdAt.toInstant(),
+        type = BookingSummary.Type.legacy,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestBookingSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestBookingSummaryTransformerTest.kt
@@ -91,6 +91,7 @@ class PlacementRequestBookingSummaryTransformerTest {
       booking.arrivalDate,
       booking.departureDate,
       booking.createdAt.toInstant(),
+      BookingSummary.Type.legacy,
     )
 
     every { bookingSummaryTransformer.transformJpaToApi(booking) } returns bookingSummary
@@ -103,6 +104,7 @@ class PlacementRequestBookingSummaryTransformerTest {
     assertThat(result!!.arrivalDate).isEqualTo(booking.arrivalDate)
     assertThat(result!!.departureDate).isEqualTo(booking.departureDate)
     assertThat(result!!.createdAt).isEqualTo(booking.createdAt.toInstant())
+    assertThat(result!!.type).isEqualTo(BookingSummary.Type.legacy)
   }
 
   @Test
@@ -114,6 +116,7 @@ class PlacementRequestBookingSummaryTransformerTest {
       spaceBooking.canonicalArrivalDate,
       spaceBooking.canonicalDepartureDate,
       spaceBooking.createdAt.toInstant(),
+      BookingSummary.Type.space,
     )
 
     var placementWithSpaceBooking = placementRequest.copy(
@@ -131,6 +134,7 @@ class PlacementRequestBookingSummaryTransformerTest {
     assertThat(result!!.arrivalDate).isEqualTo(spaceBooking.canonicalArrivalDate)
     assertThat(result!!.departureDate).isEqualTo(spaceBooking.canonicalDepartureDate)
     assertThat(result!!.createdAt).isEqualTo(spaceBooking.createdAt.toInstant())
+    assertThat(result!!.type).isEqualTo(BookingSummary.Type.space)
   }
 
   @Test


### PR DESCRIPTION
Updated Get Placement Request to consider Space Bookings

- Marked `PlacementRequestDetail` cancellations as deprecated.  Cancellations aren't used by the UI.
- Added `type` to BookingSummary which indicates type of booking - `legacy` / `space`