### PR TITLE
APS-1580: Updated Get Non Arrival Reasons to exclude inactive records

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -165,7 +165,7 @@ class ReferenceDataController(
   }
 
   override fun referenceDataNonArrivalReasonsGet(): ResponseEntity<List<NonArrivalReason>> {
-    val reasons = nonArrivalReasonRepository.findAll()
+    val reasons = nonArrivalReasonRepository.findAll().filter { it.isActive }
 
     return ResponseEntity.ok(reasons.map(nonArrivalReasonTransformer::transformJpaToApi))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -831,6 +831,30 @@ class ReferenceDataTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Get NonArrival Reasons returns only reasons which are active`() {
+    nonArrivalReasonRepository.deleteAll()
+
+    val activeNonArrivalReasons = nonArrivalReasonEntityFactory.produceAndPersistMultiple(10)
+    nonArrivalReasonEntityFactory.produceAndPersistMultiple(10) {
+      withIsActive(false)
+    }
+    val expectedJson = objectMapper.writeValueAsString(
+      activeNonArrivalReasons.map(nonArrivalReasonTransformer::transformJpaToApi),
+    )
+
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/reference-data/non-arrival-reasons")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedJson)
+  }
+
+  @Test
   fun `Get Probation Delivery Units returns 200 with correct body`() {
     probationDeliveryUnitRepository.deleteAll()
 


### PR DESCRIPTION
Added filter to only return active Non Arrival Reason records. 