### PR TITLE
Increasing the length of generated strings

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
@@ -11,8 +11,8 @@ import java.util.UUID
 
 class ApAreaEntityFactory : Factory<ApAreaEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
-  private var identifier: Yielded<String> = { randomStringUpperCase(5) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var identifier: Yielded<String> = { randomStringUpperCase(10) }
   private var emailAddress: Yielded<String?> = { randomStringUpperCase(10) }
   private var notifyReplyToEmailId: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var defaultCruManagementArea: Yielded<Cas1CruManagementAreaEntity> = { Cas1CruManagementAreaEntityFactory().produce() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -25,7 +25,7 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
   private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity>? = null
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
-  private var apCode: Yielded<String> = { randomStringUpperCase(5) }
+  private var apCode: Yielded<String> = { randomStringUpperCase(10) }
   private var postcode: Yielded<String> = { randomPostCode() }
   private var latitude: Yielded<Double> = { randomDouble(53.50, 54.99) }
   private var longitude: Yielded<Double> = { randomDouble(-1.56, 1.10) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityAreaEntityFactory.kt
@@ -8,8 +8,8 @@ import java.util.UUID
 
 class LocalAuthorityAreaEntityFactory : Factory<LocalAuthorityAreaEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var identifier: Yielded<String> = { randomStringUpperCase(5) }
-  private var name: Yielded<String> = { randomStringUpperCase(5) }
+  private var identifier: Yielded<String> = { randomStringUpperCase(10) }
+  private var name: Yielded<String> = { randomStringUpperCase(10) }
 
   fun withName(name: String) = apply {
     this.name = { name }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/LocalAuthorityEntityFactory.kt
@@ -9,8 +9,8 @@ import java.util.UUID
 
 class LocalAuthorityEntityFactory : Factory<LocalAuthorityAreaEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var identifier: Yielded<String> = { randomStringUpperCase(5) }
-  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var identifier: Yielded<String> = { randomStringUpperCase(10) }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RegistrationClientResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RegistrationClientResponseFactory.kt
@@ -45,13 +45,13 @@ class RegistrationClientResponseFactory : Factory<Registration> {
   }
   private var registeringProbationArea: Yielded<RegistrationKeyValue> = {
     RegistrationKeyValue(
-      code = randomStringUpperCase(5),
+      code = randomStringUpperCase(10),
       description = randomStringUpperCase(20),
     )
   }
   private var registerLevel: Yielded<RegistrationKeyValue?> = {
     RegistrationKeyValue(
-      code = randomStringUpperCase(5),
+      code = randomStringUpperCase(10),
       description = randomStringUpperCase(20),
     )
   }
@@ -66,14 +66,14 @@ class RegistrationClientResponseFactory : Factory<Registration> {
   private var endDate: Yielded<LocalDate?> = { null }
   private var deregisteringOfficer: Yielded<RegistrationStaffHuman?> = {
     RegistrationStaffHuman(
-      code = randomStringUpperCase(5),
-      forenames = randomStringUpperCase(5),
-      surname = randomStringUpperCase(5),
+      code = randomStringUpperCase(10),
+      forenames = randomStringUpperCase(10),
+      surname = randomStringUpperCase(10),
     )
   }
   private var deregisteringProbationArea: Yielded<RegistrationKeyValue?> = {
     RegistrationKeyValue(
-      code = randomStringUpperCase(5),
+      code = randomStringUpperCase(10),
       description = randomStringUpperCase(20),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -193,7 +193,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     val email = "foo@bar.com"
     val telephoneNumber = "123445677"
     val borough = Borough(
-      code = randomStringMultiCaseWithNumbers(7),
+      code = randomStringMultiCaseWithNumbers(10),
       description = randomStringMultiCaseWithNumbers(10),
     )
 


### PR DESCRIPTION
some duplicate identifiers were causing test failures. They were only 5 characters long, so hoping increasing this will prevent it from happening.