### PR TITLE
APS-1601 - Add seed job to import delius booking data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Repository
+interface Cas1DeliusBookingImportRepository : JpaRepository<Cas1DeliusBookingImportEntity, UUID>
+
+@Entity
+@Table(name = "cas1_delius_booking_import")
+data class Cas1DeliusBookingImportEntity(
+  @Id
+  val bookingId: UUID,
+  val crn: String,
+  val eventNumber: String,
+  val keyWorkerStaffCode: String?,
+  val keyWorkerForename: String?,
+  val keyWorkerMiddleName: String?,
+  val keyWorkerSurname: String?,
+  val departureReasonCode: String?,
+  val moveOnCategoryCode: String?,
+  val moveOnCategoryDescription: String?,
+  val expectedArrivalDate: LocalDate,
+  val arrivalDate: LocalDate?,
+  val expectedDepartureDate: LocalDate,
+  val departureDate: LocalDate?,
+  val nonArrivalDate: LocalDate?,
+  val nonArrivalContactDatetime: LocalDateTime?,
+  val nonArrivalReasonCode: String?,
+  val nonArrivalReasonDescription: String?,
+  val nonArrivalNotes: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
@@ -17,6 +17,12 @@ abstract class SeedJob<RowType>(
     }
   }
 
+  open fun preSeed() {
+    // by default do nothing
+  }
+  open fun postSeed() {
+    // by default do nothing
+  }
   abstract fun deserializeRow(columns: Map<String, String>): RowType
   abstract fun processRow(row: RowType)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
@@ -1,0 +1,149 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+class Cas1ImportDeliusBookingDataSeedJob(
+  private val jdbcTemplate: NamedParameterJdbcTemplate,
+  private val cas1DeliusBookingImportRepository: Cas1DeliusBookingImportRepository,
+) : SeedJob<Cas1DeliusBookingManagementDataRow>(
+  id = UUID.randomUUID(),
+  requiredHeaders = setOf(
+    "BOOKING_ID",
+    "CRN",
+    "EVENT_NUMBER",
+    "KEY_WORKER_STAFF_CODE",
+    "KEY_WORKER_FORENAME",
+    "KEY_WORKER_MIDDLE_NAME",
+    "KEY_WORKER_SURNAME",
+    "DEPARTURE_REASON_CODE",
+    "MOVE_ON_CATEGORY_CODE",
+    "MOVE_ON_CATEGORY_DESCRIPTION",
+    "EXPECTED_ARRIVAL_DATE",
+    "ARRIVAL_DATE",
+    "EXPECTED_DEPARTURE_DATE",
+    "DEPARTURE_DATE",
+    "NON_ARRIVAL_DATE",
+    "NON_ARRIVAL_CONTACT_DATETIME_LIST",
+    "NON_ARRIVAL_REASON_CODE",
+    "NON_ARRIVAL_REASON_DESCRIPTION",
+    "NON_ARRIVAL_NOTES",
+  ),
+  runInTransaction = false,
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  private companion object {
+    val DELIUS_IMPORT_DATE_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss")
+  }
+
+  override fun preSeed() {
+    log.info("Clearing table cas1_delius_booking_import before seeding new data")
+    jdbcTemplate.update("TRUNCATE cas1_delius_booking_import", emptyMap<String, String>())
+  }
+
+  override fun deserializeRow(columns: Map<String, String>) = Cas1DeliusBookingManagementDataRow(
+    bookingId = UUID.fromString(columns["BOOKING_ID"]!!.trim()),
+    crn = columns.stringOrNull("CRN")!!,
+    eventNumber = columns.stringOrNull("EVENT_NUMBER")!!,
+    keyWorkerStaffCode = columns.stringOrNull("KEY_WORKER_STAFF_CODE"),
+    keyWorkerForename = columns.stringOrNull("KEY_WORKER_FORENAME"),
+    keyWorkerMiddleName = columns.stringOrNull("KEY_WORKER_MIDDLE_NAME"),
+    keyWorkerSurname = columns.stringOrNull("KEY_WORKER_SURNAME"),
+    departureReasonCode = columns.stringOrNull("DEPARTURE_REASON_CODE"),
+    moveOnCategoryCode = columns.stringOrNull("MOVE_ON_CATEGORY_CODE"),
+    moveOnCategoryDescription = columns.stringOrNull("MOVE_ON_CATEGORY_DESCRIPTION"),
+    expectedArrivalDate = columns.dateFromUtcDateTime("EXPECTED_ARRIVAL_DATE")!!,
+    arrivalDate = columns.dateFromUtcDateTime("ARRIVAL_DATE"),
+    expectedDepartureDate = columns.dateFromUtcDateTime("EXPECTED_DEPARTURE_DATE")!!,
+    departureDate = columns.dateFromUtcDateTime("DEPARTURE_DATE"),
+    nonArrivalDate = columns.dateFromUtcDateTime("NON_ARRIVAL_DATE"),
+    nonArrivalContactDateTime = columns.dateTimeFromList("NON_ARRIVAL_CONTACT_DATETIME_LIST"),
+    nonArrivalReasonCode = columns.stringOrNull("NON_ARRIVAL_REASON_CODE"),
+    nonArrivalReasonDescription = columns.stringOrNull("NON_ARRIVAL_REASON_DESCRIPTION"),
+    nonArrivalNotes = columns.stringOrNull("NON_ARRIVAL_NOTES"),
+  )
+
+  private fun Map<String, String>.stringOrNull(label: String?) = this[label]?.trim()?.ifBlank { null }
+
+  private fun Map<String, String>.dateTimeFromList(label: String?): LocalDateTime? {
+    val dateTimeList = stringOrNull(label)
+    if (dateTimeList.isNullOrBlank()) {
+      return null
+    }
+
+    val lastDateTime = dateTimeList.split(",").last()
+    return LocalDateTime.parse(lastDateTime, DELIUS_IMPORT_DATE_TIME_FORMATTER)
+  }
+
+  private fun Map<String, String>.dateFromUtcDateTime(label: String?): LocalDate? {
+    val dateTime = stringOrNull(label)
+    if (dateTime.isNullOrBlank()) {
+      return null
+    }
+
+    return LocalDate.parse(dateTime.substring(startIndex = 0, endIndex = 10))
+  }
+
+  override fun processRow(row: Cas1DeliusBookingManagementDataRow) {
+    cas1DeliusBookingImportRepository.save(
+      Cas1DeliusBookingImportEntity(
+        row.bookingId,
+        row.crn,
+        row.eventNumber,
+        row.keyWorkerStaffCode,
+        row.keyWorkerForename,
+        row.keyWorkerMiddleName,
+        row.keyWorkerSurname,
+        row.departureReasonCode,
+        row.moveOnCategoryCode,
+        row.moveOnCategoryDescription,
+        row.expectedArrivalDate,
+        row.arrivalDate,
+        row.expectedDepartureDate,
+        row.departureDate,
+        row.nonArrivalDate,
+        row.nonArrivalContactDateTime,
+        row.nonArrivalReasonCode,
+        row.nonArrivalReasonDescription,
+        row.nonArrivalNotes,
+      ),
+    )
+  }
+
+  override fun postSeed() {
+    log.info(
+      "Seeding complete. Note that the reported row count may be lower than the number of lines in the CSV file. This is because" +
+        "some CSV rows have line breaks in 'notes' values",
+    )
+  }
+}
+
+data class Cas1DeliusBookingManagementDataRow(
+  val bookingId: UUID,
+  val crn: String,
+  val eventNumber: String,
+  val keyWorkerStaffCode: String?,
+  val keyWorkerForename: String?,
+  val keyWorkerMiddleName: String?,
+  val keyWorkerSurname: String?,
+  val departureReasonCode: String?,
+  val moveOnCategoryCode: String?,
+  val moveOnCategoryDescription: String?,
+  val expectedArrivalDate: LocalDate,
+  val arrivalDate: LocalDate?,
+  val expectedDepartureDate: LocalDate,
+  val departureDate: LocalDate?,
+  val nonArrivalDate: LocalDate?,
+  val nonArrivalContactDateTime: LocalDateTime?,
+  val nonArrivalReasonCode: String?,
+  val nonArrivalReasonDescription: String?,
+  val nonArrivalNotes: String?,
+)

--- a/src/main/resources/db/migration/all/20241122150114__add_cas1_delius_booking_import.sql
+++ b/src/main/resources/db/migration/all/20241122150114__add_cas1_delius_booking_import.sql
@@ -1,0 +1,22 @@
+CREATE TABLE cas1_delius_booking_import (
+    booking_id uuid NOT NULL,
+    crn text NOT NULL,
+    event_number text NOT NULL,
+    key_worker_staff_code text NULL,
+    key_worker_forename text NULL,
+    key_worker_middle_name text NULL,
+    key_worker_surname text NULL,
+    departure_reason_code text NULL,
+    move_on_category_code text NULL,
+    move_on_category_description text NULL,
+    expected_arrival_date date NOT NULL,
+    arrival_date date NULL,
+    expected_departure_date date NOT NULL,
+    departure_date date NULL,
+    non_arrival_date date NULL,
+    non_arrival_contact_datetime timestamptz NULL,
+    non_arrival_reason_code text NULL,
+    non_arrival_reason_description text NULL,
+    non_arrival_notes text NULL,
+    CONSTRAINT cas1_delius_booking_import_pk PRIMARY KEY (booking_id)
+);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3829,6 +3829,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
+        - approved_premises_import_delius_booking_management_data
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8160,6 +8160,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
+        - approved_premises_import_delius_booking_management_data
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4941,6 +4941,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
+        - approved_premises_import_delius_booking_management_data
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4420,6 +4420,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
+        - approved_premises_import_delius_booking_management_data
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3903,6 +3903,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
+        - approved_premises_import_delius_booking_management_data
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusBookingDataSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusBookingDataSeedJobTest.kt
@@ -1,0 +1,192 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SeedCas1ImportDeliusBookingDataSeedJobTest : SeedTestBase() {
+
+  @Autowired
+  lateinit var cas1DeliusBookingImportRepository: Cas1DeliusBookingImportRepository
+
+  @Test
+  fun `Row with only mandatory fields can be processed`() {
+    val bookingId = UUID.randomUUID()
+
+    withCsv(
+      csvName = "valid-csv",
+      contents = listOf(
+        Cas1DeliusBookingManagementDataRowRaw(
+          bookingId = bookingId.toString(),
+          crn = "CRN1",
+          eventNumber = "1",
+          expectedArrivalDate = "2024-06-15 00:00:00",
+          expectedDepartureDate = "2025-09-12 00:00:00",
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesImportDeliusBookingManagementData, "valid-csv.csv")
+
+    val bookingImport = cas1DeliusBookingImportRepository.findAll()[0]
+
+    assertThat(bookingImport.bookingId).isEqualTo(bookingId)
+    assertThat(bookingImport.crn).isEqualTo("CRN1")
+    assertThat(bookingImport.eventNumber).isEqualTo("1")
+    assertThat(bookingImport.keyWorkerStaffCode).isNull()
+    assertThat(bookingImport.keyWorkerForename).isNull()
+    assertThat(bookingImport.keyWorkerMiddleName).isNull()
+    assertThat(bookingImport.keyWorkerSurname).isNull()
+    assertThat(bookingImport.departureReasonCode).isNull()
+    assertThat(bookingImport.moveOnCategoryCode).isNull()
+    assertThat(bookingImport.moveOnCategoryDescription).isNull()
+    assertThat(bookingImport.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 6, 15))
+    assertThat(bookingImport.arrivalDate).isNull()
+    assertThat(bookingImport.expectedDepartureDate).isEqualTo(LocalDate.of(2025, 9, 12))
+    assertThat(bookingImport.departureDate).isNull()
+    assertThat(bookingImport.nonArrivalDate).isNull()
+    assertThat(bookingImport.nonArrivalContactDatetime).isNull()
+    assertThat(bookingImport.nonArrivalReasonCode).isNull()
+    assertThat(bookingImport.nonArrivalReasonDescription).isNull()
+    assertThat(bookingImport.nonArrivalNotes).isNull()
+  }
+
+  @Test
+  fun `Row with all available fields can be processed`() {
+    val bookingId = UUID.randomUUID()
+
+    withCsv(
+      csvName = "valid-csv",
+      contents = listOf(
+        Cas1DeliusBookingManagementDataRowRaw(
+          bookingId = bookingId.toString(),
+          crn = "CRN2",
+          eventNumber = "2",
+          keyWorkerStaffCode = "kw1",
+          keyWorkerForename = "kwForename",
+          keyWorkerMiddleName = "kwMiddle",
+          keyWorkerSurname = "kwSurname",
+          departureReasonCode = "drc",
+          moveOnCategoryCode = "mocc",
+          moveOnCategoryDescription = "moccDescription",
+          expectedArrivalDate = "2024-06-16 00:00:00",
+          arrivalDate = "2024-06-17 00:00:00",
+          expectedDepartureDate = "2025-09-13 00:00:00",
+          departureDate = "2025-09-12 00:00:00",
+          nonArrivalDate = "2021-01-01 00:00:00",
+          nonArrivalContactDateTimeList = "2023-07-17 00:00:00,2023-07-17 11:36:02",
+          nonArrivalReasonCode = "non arrival reason code",
+          nonArrivalReasonDescription = "non arrival reason description",
+          nonArrivalNotes = "non arrival notes",
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesImportDeliusBookingManagementData, "valid-csv.csv")
+
+    val bookingImport = cas1DeliusBookingImportRepository.findAll()[0]
+
+    assertThat(bookingImport.bookingId).isEqualTo(bookingId)
+    assertThat(bookingImport.crn).isEqualTo("CRN2")
+    assertThat(bookingImport.eventNumber).isEqualTo("2")
+    assertThat(bookingImport.keyWorkerStaffCode).isEqualTo("kw1")
+    assertThat(bookingImport.keyWorkerForename).isEqualTo("kwForename")
+    assertThat(bookingImport.keyWorkerMiddleName).isEqualTo("kwMiddle")
+    assertThat(bookingImport.keyWorkerSurname).isEqualTo("kwSurname")
+    assertThat(bookingImport.departureReasonCode).isEqualTo("drc")
+    assertThat(bookingImport.moveOnCategoryCode).isEqualTo("mocc")
+    assertThat(bookingImport.moveOnCategoryDescription).isEqualTo("moccDescription")
+    assertThat(bookingImport.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 6, 16))
+    assertThat(bookingImport.arrivalDate).isEqualTo(LocalDate.of(2024, 6, 17))
+    assertThat(bookingImport.expectedDepartureDate).isEqualTo(LocalDate.of(2025, 9, 13))
+    assertThat(bookingImport.departureDate).isEqualTo(LocalDate.of(2025, 9, 12))
+    assertThat(bookingImport.nonArrivalDate).isEqualTo(LocalDate.of(2021, 1, 1))
+    assertThat(bookingImport.nonArrivalContactDatetime).isEqualTo(LocalDateTime.of(2023, 7, 17, 11, 36, 2, 0))
+    assertThat(bookingImport.nonArrivalReasonCode).isEqualTo("non arrival reason code")
+    assertThat(bookingImport.nonArrivalReasonDescription).isEqualTo("non arrival reason description")
+    assertThat(bookingImport.nonArrivalNotes).isEqualTo("non arrival notes")
+  }
+
+  private fun List<Cas1DeliusBookingManagementDataRowRaw>.toCsv(): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "BOOKING_ID",
+        "CRN",
+        "EVENT_NUMBER",
+        "KEY_WORKER_STAFF_CODE",
+        "KEY_WORKER_FORENAME",
+        "KEY_WORKER_MIDDLE_NAME",
+        "KEY_WORKER_SURNAME",
+        "DEPARTURE_REASON_CODE",
+        "MOVE_ON_CATEGORY_CODE",
+        "MOVE_ON_CATEGORY_DESCRIPTION",
+        "EXPECTED_ARRIVAL_DATE",
+        "ARRIVAL_DATE",
+        "EXPECTED_DEPARTURE_DATE",
+        "DEPARTURE_DATE",
+        "NON_ARRIVAL_DATE",
+        "NON_ARRIVAL_CONTACT_DATETIME_LIST",
+        "NON_ARRIVAL_REASON_CODE",
+        "NON_ARRIVAL_REASON_DESCRIPTION",
+        "NON_ARRIVAL_NOTES",
+      )
+      .newRow()
+
+    this.forEach {
+      builder
+        .withQuotedField(it.bookingId)
+        .withQuotedField(it.crn)
+        .withQuotedField(it.eventNumber)
+        .withQuotedField(it.keyWorkerStaffCode)
+        .withQuotedField(it.keyWorkerForename)
+        .withQuotedField(it.keyWorkerMiddleName)
+        .withQuotedField(it.keyWorkerSurname)
+        .withQuotedField(it.departureReasonCode)
+        .withQuotedField(it.moveOnCategoryCode)
+        .withQuotedField(it.moveOnCategoryDescription)
+        .withQuotedField(it.expectedArrivalDate)
+        .withQuotedField(it.arrivalDate)
+        .withQuotedField(it.expectedDepartureDate)
+        .withQuotedField(it.departureDate)
+        .withQuotedField(it.nonArrivalDate)
+        .withQuotedField(it.nonArrivalContactDateTimeList)
+        .withQuotedField(it.nonArrivalReasonCode)
+        .withQuotedField(it.nonArrivalReasonDescription)
+        .withQuotedField(it.nonArrivalNotes)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+
+  data class Cas1DeliusBookingManagementDataRowRaw(
+    val bookingId: String = "",
+    val crn: String = "",
+    val eventNumber: String = "",
+    val keyWorkerStaffCode: String = "",
+    val keyWorkerForename: String = "",
+    val keyWorkerMiddleName: String = "",
+    val keyWorkerSurname: String = "",
+    val departureReasonCode: String = "",
+    val moveOnCategoryCode: String = "",
+    val moveOnCategoryDescription: String = "",
+    val expectedArrivalDate: String = "",
+    val arrivalDate: String = "",
+    val expectedDepartureDate: String = "",
+    val departureDate: String = "",
+    val nonArrivalDate: String = "",
+    val nonArrivalContactDateTimeList: String = "",
+    val nonArrivalReasonCode: String = "",
+    val nonArrivalReasonDescription: String = "",
+    val nonArrivalNotes: String = "",
+  )
+}


### PR DESCRIPTION
We need to import a CSV of delius booking data to backfill space bookings, via`Cas1BookingToSpaceBookingSeedJob`. This commit adds a seed job to validate and subsequently import that data.

Given the target table is truncated before each run, and the high numbers of rows in the CSV file, this does not operate in a transaction.