### PR TITLE
APS-1568: Ensure no active Bookings when creating a Space Booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -89,12 +89,16 @@ class Cas1SpaceBookingService(
     premises!!
     placementRequest!!
 
-    when (
-      val existingBooking =
-        cas1SpaceBookingRepository.findByPremisesIdAndPlacementRequestId(premisesId, placementRequestId)
-    ) {
-      null -> {}
-      else -> return existingBooking.id hasConflictError "A Space Booking already exists for this premises and placement request"
+    placementRequest.booking?.let {
+      if (it.isActive()) {
+        return it.id hasConflictError "A legacy Booking already exists for this premises and placement request"
+      }
+    }
+
+    cas1SpaceBookingRepository.findByPremisesIdAndPlacementRequestId(premisesId, placementRequestId)?.let {
+      if (it.isActive()) {
+        return it.id hasConflictError "A Space Booking already exists for this premises and placement request"
+      }
     }
 
     val durationInDays = arrivalDate.until(departureDate).toKotlinDatePeriod().days

--- a/src/main/resources/db/migration/all/20241125113607__drop_index_cas1_space_bookings_premises_id_placements_request_id.sql
+++ b/src/main/resources/db/migration/all/20241125113607__drop_index_cas1_space_bookings_premises_id_placements_request_id.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS cas1_space_bookings_premises_id_placement_request_id_idx;


### PR DESCRIPTION
Ensure there are no active legacy Bookings or active Space Bookings when creating a Space Booking.
Drop the cas1_space_bookings_premises_id_placement_request_id_idx index as it is not required.