### PR TITLE
Seed Jobs should only use Spring Managed Instances

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AbstractUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AbstractUsersSeedJob.kt
@@ -15,7 +15,8 @@ import java.util.UUID
  *  roles/qualifications of pre-existing users, then consider
  *  using ApStaffUsersSeedJob.
  */
-class UsersSeedJob(
+@SuppressWarnings("TooGenericExceptionThrown", "TooGenericExceptionCaught")
+abstract class AbstractUsersSeedJob(
   private val useRolesForServices: List<ServiceName>,
   private val userService: UserService,
 ) : SeedJob<UsersSeedCsvRow>(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AllCasUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AllCasUsersSeedJob.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+
+class AllCasUsersSeedJob(userService: UserService) : AbstractUsersSeedJob(ServiceName.entries, userService)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -8,7 +8,6 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
@@ -48,10 +47,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1PlanSpacePlanningDryRunSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateEventNumberSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1WithdrawPlacementRequestSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2ApplicationsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.ExternalUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.NomisUsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas3.Cas3UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas3.TemporaryAccommodationBedspaceSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas3.TemporaryAccommodationPremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
@@ -110,13 +111,12 @@ class SeedService(
           getBean(BedRepository::class),
           getBean(CharacteristicRepository::class),
         )
-        SeedFileType.user -> UsersSeedJob(
-          ServiceName.entries,
+        SeedFileType.user -> AllCasUsersSeedJob(
           getBean(UserService::class),
         )
         SeedFileType.approvedPremisesApStaffUsers -> ApStaffUsersSeedJob(
           getBean(UserService::class),
-          seedLogger,
+          getBean(SeedLogger::class),
         )
         SeedFileType.nomisUsers -> NomisUsersSeedJob(
           getBean(NomisUserRepository::class),
@@ -133,12 +133,10 @@ class SeedService(
           getBean(JsonSchemaService::class),
           getBean(Cas2PersistedApplicationStatusFinder::class),
         )
-        SeedFileType.approvedPremisesUsers -> UsersSeedJob(
-          listOf(ServiceName.approvedPremises),
+        SeedFileType.approvedPremisesUsers -> Cas1UsersSeedJob(
           getBean(UserService::class),
         )
-        SeedFileType.temporaryAccommodationUsers -> UsersSeedJob(
-          listOf(ServiceName.temporaryAccommodation),
+        SeedFileType.temporaryAccommodationUsers -> Cas3UsersSeedJob(
           getBean(UserService::class),
         )
         SeedFileType.characteristics -> CharacteristicsSeedJob(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UsersSeedJob.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.AbstractUsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+
+class Cas1UsersSeedJob(userService: UserService) : AbstractUsersSeedJob(listOf(ServiceName.approvedPremises), userService)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas3/Cas3UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas3/Cas3UsersSeedJob.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas3
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.AbstractUsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+
+class Cas3UsersSeedJob(userService: UserService) : AbstractUsersSeedJob(listOf(ServiceName.temporaryAccommodation), userService)


### PR DESCRIPTION
This commit refactors seed jobs such that they only required spring manage instances on construction. This will then allow us to simplify the `SeedService` by converting all seed jobs into spring-managed components and delegate to spring when retreiving the required seed job.

To achieve this the `UserSeedJob` has been made abstract and specific usages of it in `SeedService` are sastified using context-specific seed job definitions.