### PR TITLE
APS-1601 - Make cas1 delius import departure date optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
@@ -28,7 +28,7 @@ data class Cas1DeliusBookingImportEntity(
   val moveOnCategoryDescription: String?,
   val expectedArrivalDate: LocalDate,
   val arrivalDate: LocalDate?,
-  val expectedDepartureDate: LocalDate,
+  val expectedDepartureDate: LocalDate?,
   val departureDate: LocalDate?,
   val nonArrivalDate: LocalDate?,
   val nonArrivalContactDatetime: LocalDateTime?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
@@ -62,7 +62,7 @@ class Cas1ImportDeliusBookingDataSeedJob(
     moveOnCategoryDescription = columns.stringOrNull("MOVE_ON_CATEGORY_DESCRIPTION"),
     expectedArrivalDate = columns.dateFromUtcDateTime("EXPECTED_ARRIVAL_DATE")!!,
     arrivalDate = columns.dateFromUtcDateTime("ARRIVAL_DATE"),
-    expectedDepartureDate = columns.dateFromUtcDateTime("EXPECTED_DEPARTURE_DATE")!!,
+    expectedDepartureDate = columns.dateFromUtcDateTime("EXPECTED_DEPARTURE_DATE"),
     departureDate = columns.dateFromUtcDateTime("DEPARTURE_DATE"),
     nonArrivalDate = columns.dateFromUtcDateTime("NON_ARRIVAL_DATE"),
     nonArrivalContactDateTime = columns.dateTimeFromList("NON_ARRIVAL_CONTACT_DATETIME_LIST"),
@@ -120,8 +120,10 @@ class Cas1ImportDeliusBookingDataSeedJob(
 
   override fun postSeed() {
     log.info(
-      "Seeding complete. Note that the reported row count may be lower than the number of lines in the CSV file. This is because" +
-        "some CSV rows have line breaks in 'notes' values",
+      """
+        Seeding complete. Note that the reported row count may be lower than the number of lines in the CSV file. 
+        This is because some CSV rows have line breaks in 'notes' values
+      """.trimIndent(),
     )
   }
 }
@@ -139,7 +141,7 @@ data class Cas1DeliusBookingManagementDataRow(
   val moveOnCategoryDescription: String?,
   val expectedArrivalDate: LocalDate,
   val arrivalDate: LocalDate?,
-  val expectedDepartureDate: LocalDate,
+  val expectedDepartureDate: LocalDate?,
   val departureDate: LocalDate?,
   val nonArrivalDate: LocalDate?,
   val nonArrivalContactDateTime: LocalDateTime?,

--- a/src/main/resources/db/migration/all/20241125152438__make_delius_booking_import_exp_departure_date_nullable.sql
+++ b/src/main/resources/db/migration/all/20241125152438__make_delius_booking_import_exp_departure_date_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_delius_booking_import ALTER COLUMN expected_departure_date DROP NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusBookingDataSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusBookingDataSeedJobTest.kt
@@ -30,7 +30,6 @@ class SeedCas1ImportDeliusBookingDataSeedJobTest : SeedTestBase() {
           crn = "CRN1",
           eventNumber = "1",
           expectedArrivalDate = "2024-06-15 00:00:00",
-          expectedDepartureDate = "2025-09-12 00:00:00",
         ),
       ).toCsv(),
     )
@@ -51,7 +50,7 @@ class SeedCas1ImportDeliusBookingDataSeedJobTest : SeedTestBase() {
     assertThat(bookingImport.moveOnCategoryDescription).isNull()
     assertThat(bookingImport.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 6, 15))
     assertThat(bookingImport.arrivalDate).isNull()
-    assertThat(bookingImport.expectedDepartureDate).isEqualTo(LocalDate.of(2025, 9, 12))
+    assertThat(bookingImport.expectedDepartureDate).isNull()
     assertThat(bookingImport.departureDate).isNull()
     assertThat(bookingImport.nonArrivalDate).isNull()
     assertThat(bookingImport.nonArrivalContactDatetime).isNull()


### PR DESCRIPTION
This commit makes the value of cas1_delius_booking_import.expected_departure_date NULLABLE, are there is a single  record that does not not have a departure date set and will not have one set when the final import is ran