### PR TITLE
APS-1583 - Add CAS1 premise summary to capacity response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -64,11 +64,13 @@ class Cas1PremisesController(
   ): ResponseEntity<Cas1PremiseCapacity> {
     userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PREMISES_VIEW_CAPACITY)
 
+    val premiseSummaryInfo = cas1PremisesService.getPremisesSummary(premisesId)
+    val premiseCapacity = cas1PremisesService.getPremiseCapacity(premisesId, startDate, endDate)
+
     return ResponseEntity.ok().body(
       cas1PremiseCapacityTransformer.toCas1PremiseCapacitySummary(
-        extractEntityFromCasResult(
-          cas1PremisesService.getPremiseCapacity(premisesId, startDate, endDate),
-        ),
+        premiseSummaryInfo = extractEntityFromCasResult(premiseSummaryInfo),
+        premiseCapacity = extractEntityFromCasResult(premiseCapacity),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremiseCapacitySummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremiseCapacitySummaryTransformer.kt
@@ -5,16 +5,20 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacityForDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCharacteristicAvailability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningService.PremiseCapacitySummary
 
 @Component
-class Cas1PremiseCapacitySummaryTransformer {
+class Cas1PremiseCapacitySummaryTransformer(
+  val cas1PremisesTransformer: Cas1PremisesTransformer,
+) {
 
   fun toCas1PremiseCapacitySummary(
+    premiseSummaryInfo: Cas1PremisesService.Cas1PremisesSummaryInfo,
     premiseCapacity: PremiseCapacitySummary,
   ) = Cas1PremiseCapacity(
-    premisesId = premiseCapacity.premise.id,
+    premise = cas1PremisesTransformer.toPremiseSummary(premiseSummaryInfo),
     startDate = premiseCapacity.range.fromInclusive,
     endDate = premiseCapacity.range.toInclusive,
     capacity = premiseCapacity.byDay.map { it.toApiType() },

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -83,15 +83,15 @@ components:
           $ref: '_shared.yml#/components/schemas/ApArea'
         bedCount:
           type: integer
-          description: The total number of spaces in this premises
+          description: The total number of beds in this premises
           example: 22
         availableBeds:
           type: integer
-          description: The total number of spaces available right now
+          description: The total number of beds available at this moment in time
           example: 20
         outOfServiceBeds:
           type: integer
-          description: The total number of out of service beds
+          description: The total number of out of service beds at this moment in time
           example: 2
         supportsSpaceBookings:
           type: boolean
@@ -547,9 +547,8 @@ components:
     Cas1PremiseCapacity:
       type: object
       properties:
-        premisesId:
-          type: string
-          format: uuid
+        premise:
+          $ref: '#/components/schemas/Cas1PremisesSummary'
         startDate:
           type: string
           format: date
@@ -561,7 +560,7 @@ components:
           items:
             $ref: '#/components/schemas/Cas1PremiseCapacityForDay'
       required:
-        - premisesId
+        - premise
         - startDate
         - endDate
         - capacity

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6383,15 +6383,15 @@ components:
           $ref: '#/components/schemas/ApArea'
         bedCount:
           type: integer
-          description: The total number of spaces in this premises
+          description: The total number of beds in this premises
           example: 22
         availableBeds:
           type: integer
-          description: The total number of spaces available right now
+          description: The total number of beds available at this moment in time
           example: 20
         outOfServiceBeds:
           type: integer
-          description: The total number of out of service beds
+          description: The total number of out of service beds at this moment in time
           example: 2
         supportsSpaceBookings:
           type: boolean
@@ -6847,9 +6847,8 @@ components:
     Cas1PremiseCapacity:
       type: object
       properties:
-        premisesId:
-          type: string
-          format: uuid
+        premise:
+          $ref: '#/components/schemas/Cas1PremisesSummary'
         startDate:
           type: string
           format: date
@@ -6861,7 +6860,7 @@ components:
           items:
             $ref: '#/components/schemas/Cas1PremiseCapacityForDay'
       required:
-        - premisesId
+        - premise
         - startDate
         - endDate
         - capacity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -423,7 +423,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
         .isOk
         .returnResult(Cas1PremiseCapacity::class.java).responseBody.blockFirst()!!
 
-      assertThat(result.premisesId).isEqualTo(premises.id)
+      assertThat(result.premise.name).isEqualTo("the premises name")
       assertThat(result.capacity).hasSize(2)
     }
   }


### PR DESCRIPTION
This is has been added to avoid the UI having to make additional API calls for premise information