### PR TITLE
Use CasResult in StaffMemberService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 .idea/
 .gradle/
+.kotlin/
 build/
 bin/
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -30,12 +30,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.serviceScopeM
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import java.time.Instant
 import java.time.LocalDate
@@ -271,10 +270,10 @@ class Cas1SpaceBookingService(
     }
 
     val staffMemberResponse = staffMemberService.getStaffMemberByCode(keyWorker.staffCode, premises!!.qCode)
-    if (staffMemberResponse !is AuthorisableActionResult.Success) {
+    if (staffMemberResponse !is CasResult.Success) {
       return "$.keyWorker.staffCode" hasSingleValidationError "notFound"
     }
-    val assignedKeyWorker = extractEntityFromAuthorisableActionResult(staffMemberResponse)
+    val assignedKeyWorker = extractEntityFromCasResult(staffMemberResponse)
     val assignedKeyWorkerName = "${assignedKeyWorker.name.forename} ${assignedKeyWorker.name.surname}"
 
     existingCas1SpaceBooking!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -1729,9 +1729,9 @@ class PremisesTest {
 
     @ParameterizedTest
     @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Get Approved Premises Staff where delius team cannot be found returns 500 when use has one of roles MANAGER, MATCHER`(role: UserRole) {
-      givenAUser(roles = listOf(role)) { userEntity, jwt ->
-        val qCode = "NOTFOUND"
+    fun `Get premises staff where delius team cannot be found returns 404`(role: UserRole) {
+      givenAUser(roles = listOf(role)) { _, jwt ->
+        val qCode = "NON_EXISTENT_TEAM_QCODE"
 
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1740,7 +1740,7 @@ class PremisesTest {
         }
 
         wiremockServer.stubFor(
-          WireMock.get(WireMock.urlEqualTo("/secure/teams/$qCode/staff"))
+          WireMock.get(urlEqualTo("/secure/teams/$qCode/staff"))
             .willReturn(
               WireMock.aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -1753,9 +1753,9 @@ class PremisesTest {
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
-          .is5xxServerError
+          .is4xxClientError
           .expectBody()
-          .jsonPath("$.detail").isEqualTo("No team found for QCode: ${premises.qCode}")
+          .jsonPath("$.detail").isEqualTo("No Team with an ID of NON_EXISTENT_TEAM_QCODE could be found")
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -332,7 +332,7 @@ class BookingServiceTest {
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
       every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-      every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.Success(keyWorker)
+      every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns CasResult.Success(keyWorker)
 
       val result = bookingService.getBooking(bookingEntity.id)
 
@@ -372,7 +372,7 @@ class BookingServiceTest {
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
       every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-      every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.NotFound("Staff Code", keyWorker.code)
+      every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns CasResult.NotFound("Staff Code", keyWorker.code)
       mockkStatic(Sentry::class)
       every { Sentry.captureException(any()) } returns SentryId.EMPTY_ID
 
@@ -392,7 +392,7 @@ class BookingServiceTest {
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
       every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-      every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.NotFound("QCode", premises.qCode)
+      every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns CasResult.NotFound("QCode", premises.qCode)
 
       assertThatExceptionOfType(InternalServerErrorProblem::class.java)
         .isThrownBy { bookingService.getBooking(bookingEntity.id) }
@@ -405,7 +405,7 @@ class BookingServiceTest {
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
       every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-      every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.Unauthorised()
+      every { mockStaffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns CasResult.Unauthorised()
 
       assertThatExceptionOfType(ForbiddenProblem::class.java)
         .isThrownBy { bookingService.getBooking(bookingEntity.id) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -56,7 +56,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.SpaceAvailability
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
@@ -1332,7 +1331,7 @@ class Cas1SpaceBookingServiceTest {
     fun setup() {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
-      every { staffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.Success(keyWorker)
+      every { staffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns CasResult.Success(keyWorker)
     }
 
     @Test
@@ -1373,7 +1372,7 @@ class Cas1SpaceBookingServiceTest {
 
     @Test
     fun `Returns validation error if no staff record exists with the given staff code`() {
-      every { staffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns AuthorisableActionResult.NotFound()
+      every { staffMemberService.getStaffMemberByCode(keyWorker.code, premises.qCode) } returns CasResult.NotFound()
 
       val result = service.recordKeyWorkerAssignedForBooking(
         premisesId = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 
 class StaffMemberServiceTest {
@@ -35,10 +35,10 @@ class StaffMemberServiceTest {
 
       val result = staffMemberService.getStaffMemberByCode(staffMembers[2].code, qCode)
 
-      assertThat(result is AuthorisableActionResult.Success).isTrue
-      result as AuthorisableActionResult.Success
+      assertThat(result is CasResult.Success).isTrue
+      result as CasResult.Success
 
-      assertThat(result.entity).isEqualTo(staffMembers[2])
+      assertThat(result.value).isEqualTo(staffMembers[2])
     }
   }
 
@@ -53,7 +53,7 @@ class StaffMemberServiceTest {
 
     val result = staffMemberService.getStaffMemberByCode("code", qCode)
 
-    assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
+    assertThat(result is CasResult.Unauthorised).isTrue
   }
 
   @Test
@@ -67,11 +67,11 @@ class StaffMemberServiceTest {
 
     val result = staffMemberService.getStaffMemberByCode("code", qCode)
 
-    assertThat(result is AuthorisableActionResult.NotFound).isTrue
-    result as AuthorisableActionResult.NotFound
+    assertThat(result is CasResult.NotFound).isTrue
+    result as CasResult.NotFound
 
     assertThat(result.id).isEqualTo(qCode)
-    assertThat(result.entityType).isEqualTo("QCode")
+    assertThat(result.entityType).isEqualTo("Team")
   }
 
   @Test
@@ -87,8 +87,8 @@ class StaffMemberServiceTest {
 
     val result = staffMemberService.getStaffMemberByCode("code", qCode)
 
-    assertThat(result is AuthorisableActionResult.NotFound).isTrue
-    result as AuthorisableActionResult.NotFound
+    assertThat(result is CasResult.NotFound).isTrue
+    result as CasResult.NotFound
 
     assertThat(result.id).isEqualTo("code")
     assertThat(result.entityType).isEqualTo("Staff Code")


### PR DESCRIPTION
This commit removes the deprecated AuthorisableActionResult from StaffMemberService, replacing it with CasResult