### PR TITLE
APS-1625 - Deprecate and stop populating Booking.keyworker

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
@@ -35,7 +35,6 @@ class BookingsController(
     val apiBooking = bookingTransformer.transformJpaToApi(
       bookingAndPersons.booking,
       bookingAndPersons.personInfo,
-      bookingAndPersons.staffMember,
     )
 
     return ResponseEntity.ok(apiBooking)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -331,6 +331,7 @@ data class BookingEntity(
   var crn: String,
   var arrivalDate: LocalDate,
   var departureDate: LocalDate,
+  @Deprecated(message = "This is a legacy CAS1-only field that is no longer captured and will be removed once bookings have been fully migrated to space bookings")
   var keyWorkerStaffCode: String?,
   @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY)
   var arrivals: MutableList<ArrivalEntity>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import java.time.LocalDate
@@ -23,7 +22,6 @@ import java.time.LocalDate
 @Component
 class BookingTransformer(
   private val personTransformer: PersonTransformer,
-  private val staffMemberTransformer: StaffMemberTransformer,
   private val arrivalTransformer: ArrivalTransformer,
   private val departureTransformer: DepartureTransformer,
   private val nonArrivalTransformer: NonArrivalTransformer,
@@ -53,7 +51,7 @@ class BookingTransformer(
     )
   }
 
-  fun transformJpaToApi(jpa: BookingEntity, personInfo: PersonInfoResult, staffMember: StaffMember?): Booking {
+  fun transformJpaToApi(jpa: BookingEntity, personInfo: PersonInfoResult): Booking {
     val hasNonZeroDayTurnaround = jpa.turnaround != null && jpa.turnaround!!.workingDayCount != 0
 
     return Booking(
@@ -62,7 +60,8 @@ class BookingTransformer(
       arrivalDate = jpa.arrivalDate,
       departureDate = jpa.departureDate,
       serviceName = enumConverterFactory.getConverter(ServiceName::class.java).convert(jpa.service) ?: throw InternalServerErrorProblem("Could not convert '${jpa.service}' to a ServiceName"),
-      keyWorker = staffMember?.let(staffMemberTransformer::transformDomainToApi),
+      // key worker is a legacy CAS1 only field that is no longer populated. This will be removed once migration to space bookings is complete
+      keyWorker = null,
       status = determineStatus(jpa),
       arrival = arrivalTransformer.transformJpaToApi(jpa.arrival),
       departure = departureTransformer.transformJpaToApi(jpa.departure),

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -494,7 +494,10 @@ components:
           type: string
           format: date-time
         keyWorker:
-          $ref: '#/components/schemas/StaffMember'
+          deprecated: true
+          description: KeyWorker is a legacy field only used by CAS1. It is not longer being captured or populated
+          allOf:
+            - $ref: '#/components/schemas/StaffMember'
         serviceName:
           $ref: '#/components/schemas/ServiceName'
         bed:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4825,7 +4825,10 @@ components:
           type: string
           format: date-time
         keyWorker:
-          $ref: '#/components/schemas/StaffMember'
+          deprecated: true
+          description: KeyWorker is a legacy field only used by CAS1. It is not longer being captured or populated
+          allOf:
+            - $ref: '#/components/schemas/StaffMember'
         serviceName:
           $ref: '#/components/schemas/ServiceName'
         bed:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1606,7 +1606,10 @@ components:
           type: string
           format: date-time
         keyWorker:
-          $ref: '#/components/schemas/StaffMember'
+          deprecated: true
+          description: KeyWorker is a legacy field only used by CAS1. It is not longer being captured or populated
+          allOf:
+            - $ref: '#/components/schemas/StaffMember'
         serviceName:
           $ref: '#/components/schemas/ServiceName'
         bed:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1085,7 +1085,10 @@ components:
           type: string
           format: date-time
         keyWorker:
-          $ref: '#/components/schemas/StaffMember'
+          deprecated: true
+          description: KeyWorker is a legacy field only used by CAS1. It is not longer being captured or populated
+          allOf:
+            - $ref: '#/components/schemas/StaffMember'
         serviceName:
           $ref: '#/components/schemas/ServiceName'
         bed:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -568,7 +568,10 @@ components:
           type: string
           format: date-time
         keyWorker:
-          $ref: '#/components/schemas/StaffMember'
+          deprecated: true
+          description: KeyWorker is a legacy field only used by CAS1. It is not longer being captured or populated
+          allOf:
+            - $ref: '#/components/schemas/StaffMember'
         serviceName:
           $ref: '#/components/schemas/ServiceName'
         bed:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -93,12 +93,8 @@ class BookingTest : IntegrationTestBase() {
             withYieldedProbationRegion { probationRegion }
           }
 
-          val keyWorker = ContextStaffMemberFactory().produce()
-          apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
-
           val booking = bookingEntityFactory.produceAndPersist {
             withPremises(premises)
-            withStaffKeyWorkerCode(keyWorker.code)
             withCrn(offenderDetails.otherIds.crn)
             withServiceName(ServiceName.approvedPremises)
           }
@@ -115,7 +111,6 @@ class BookingTest : IntegrationTestBase() {
                 bookingTransformer.transformJpaToApi(
                   booking,
                   PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
-                  keyWorker,
                 ),
               ),
             )
@@ -182,12 +177,8 @@ class BookingTest : IntegrationTestBase() {
             withYieldedProbationRegion { probationRegion }
           }
 
-          val keyWorker = ContextStaffMemberFactory().produce()
-          apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
-
           val booking = bookingEntityFactory.produceAndPersist {
             withPremises(premises)
-            withStaffKeyWorkerCode(keyWorker.code)
             withCrn(offenderDetails.otherIds.crn)
             withServiceName(ServiceName.approvedPremises)
           }
@@ -204,7 +195,6 @@ class BookingTest : IntegrationTestBase() {
                 bookingTransformer.transformJpaToApi(
                   booking,
                   PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
-                  keyWorker,
                 ),
               ),
             )
@@ -220,12 +210,8 @@ class BookingTest : IntegrationTestBase() {
           withYieldedProbationRegion { probationRegion }
         }
 
-        val keyWorker = ContextStaffMemberFactory().produce()
-        apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
-
         val booking = bookingEntityFactory.produceAndPersist {
           withPremises(premises)
-          withStaffKeyWorkerCode(keyWorker.code)
           withCrn("SOME-CRN")
           withServiceName(ServiceName.approvedPremises)
         }
@@ -242,7 +228,6 @@ class BookingTest : IntegrationTestBase() {
               bookingTransformer.transformJpaToApi(
                 booking,
                 PersonInfoResult.NotFound("SOME-CRN"),
-                keyWorker,
               ),
             ),
           )
@@ -262,12 +247,8 @@ class BookingTest : IntegrationTestBase() {
             withYieldedProbationRegion { probationRegion }
           }
 
-          val keyWorker = ContextStaffMemberFactory().produce()
-          apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
-
           val booking = bookingEntityFactory.produceAndPersist {
             withPremises(premises)
-            withStaffKeyWorkerCode(keyWorker.code)
             withCrn(offenderDetails.otherIds.crn)
             withNomsNumber(null)
             withServiceName(ServiceName.approvedPremises)
@@ -285,7 +266,6 @@ class BookingTest : IntegrationTestBase() {
                 bookingTransformer.transformJpaToApi(
                   booking,
                   PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, null),
-                  keyWorker,
                 ),
               ),
             )
@@ -295,7 +275,7 @@ class BookingTest : IntegrationTestBase() {
 
     @Test
     fun `Get a booking for an Temporary Accommodation Premises returns OK with the correct body`() {
-      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
         givenAnOffender { offenderDetails, inmateDetails ->
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -331,7 +311,6 @@ class BookingTest : IntegrationTestBase() {
                 bookingTransformer.transformJpaToApi(
                   booking,
                   PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
-                  null,
                 ),
               ),
             )
@@ -341,8 +320,8 @@ class BookingTest : IntegrationTestBase() {
 
     @Test
     fun `Get a booking for a Temporary Accommodation Premises not in the user's region returns 403 Forbidden`() {
-      givenAUser { userEntity, jwt ->
-        givenAnOffender { offenderDetails, inmateDetails ->
+      givenAUser { _, jwt ->
+        givenAnOffender { offenderDetails, _ ->
           val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
             withYieldedProbationRegion { probationRegion }
@@ -403,7 +382,7 @@ class BookingTest : IntegrationTestBase() {
   fun `Get all Bookings on Premises without any Bookings returns empty list when user has one of roles MANAGER, MATCHER`(
     role: UserRole,
   ) {
-    givenAUser(roles = listOf(role)) { userEntity, jwt ->
+    givenAUser(roles = listOf(role)) { _, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion { probationRegion }
@@ -423,7 +402,7 @@ class BookingTest : IntegrationTestBase() {
   @ParameterizedTest
   @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
   fun `Get all Bookings returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
-    givenAUser(roles = listOf(role)) { userEntity, jwt ->
+    givenAUser(roles = listOf(role)) { _, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -432,12 +411,8 @@ class BookingTest : IntegrationTestBase() {
           }
         }
 
-        val keyWorker = ContextStaffMemberFactory().produce()
-        apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
-
         val bookings = bookingEntityFactory.produceAndPersistMultiple(5) {
           withPremises(premises)
-          withStaffKeyWorkerCode(keyWorker.code)
           withCrn(offenderDetails.otherIds.crn)
         }
 
@@ -472,7 +447,6 @@ class BookingTest : IntegrationTestBase() {
             bookingTransformer.transformJpaToApi(
               it,
               PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
-              keyWorker,
             )
           },
         )
@@ -491,7 +465,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Bookings returns OK with correct body when person details for a booking could not be found`() {
-    givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
+    givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { _, jwt ->
       val premises = approvedPremisesEntityFactory.produceAndPersist {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withYieldedProbationRegion {
@@ -499,12 +473,8 @@ class BookingTest : IntegrationTestBase() {
         }
       }
 
-      val keyWorker = ContextStaffMemberFactory().produce()
-      apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
-
       val booking = bookingEntityFactory.produceAndPersist {
         withPremises(premises)
-        withStaffKeyWorkerCode(keyWorker.code)
         withCrn("SOME-CRN")
         withServiceName(ServiceName.approvedPremises)
       }
@@ -514,7 +484,6 @@ class BookingTest : IntegrationTestBase() {
           bookingTransformer.transformJpaToApi(
             booking,
             PersonInfoResult.NotFound("SOME-CRN"),
-            keyWorker,
           ),
         ),
       )
@@ -532,8 +501,8 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Get all Bookings returns OK with correct body when inmate details for a booking could not be found`() {
-    givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { userEntity, jwt ->
-      givenAnOffender(mockServerErrorForPrisonApi = true) { offenderDetails, inmateDetails ->
+    givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { _, jwt ->
+      givenAnOffender(mockServerErrorForPrisonApi = true) { offenderDetails, _ ->
 
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -542,12 +511,8 @@ class BookingTest : IntegrationTestBase() {
           }
         }
 
-        val keyWorker = ContextStaffMemberFactory().produce()
-        apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
-
         val booking = bookingEntityFactory.produceAndPersist {
           withPremises(premises)
-          withStaffKeyWorkerCode(keyWorker.code)
           withCrn(offenderDetails.otherIds.crn)
           withServiceName(ServiceName.approvedPremises)
         }
@@ -561,7 +526,6 @@ class BookingTest : IntegrationTestBase() {
                 offenderDetailSummary = offenderDetails,
                 inmateDetail = null,
               ),
-              keyWorker,
             ),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -101,8 +101,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
@@ -114,7 +112,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.GetBookingForPremisesResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
@@ -134,7 +131,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.DomainEvent
 
 class BookingServiceTest {
   private val mockPremisesService = mockk<PremisesService>()
-  private val mockStaffMemberService = mockk<StaffMemberService>()
   private val mockOffenderService = mockk<OffenderService>()
   private val mockDomainEventService = mockk<DomainEventService>()
   private val mockCas3DomainEventService = mockk<Cas3DomainEventService>()
@@ -170,7 +166,6 @@ class BookingServiceTest {
   fun createBookingService(): BookingService {
     return BookingService(
       premisesService = mockPremisesService,
-      staffMemberService = mockStaffMemberService,
       offenderService = mockOffenderService,
       domainEventService = mockDomainEventService,
       cas3DomainEventService = mockCas3DomainEventService,
@@ -312,12 +307,9 @@ class BookingServiceTest {
       .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
       .produce()
 
-    val keyWorker = ContextStaffMemberFactory().produce()
-
     private val bookingEntity = BookingEntityFactory()
       .withArrivalDate(LocalDate.parse("2022-08-25"))
       .withPremises(premises)
-      .withStaffKeyWorkerCode(keyWorker.code)
       .produce()
 
     private val personInfo = PersonInfoResult.Success.Full(
@@ -332,14 +324,13 @@ class BookingServiceTest {
       every { mockUserService.getUserForRequest() } returns user
       every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
       every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-      every { mockStaffMemberService.getStaffMemberByCodeForPremise(keyWorker.code, premises.qCode) } returns CasResult.Success(keyWorker)
 
       val result = bookingService.getBooking(bookingEntity.id)
 
       assertThat(result is AuthorisableActionResult.Success).isTrue()
       result as AuthorisableActionResult.Success
 
-      assertThat(result.entity).isEqualTo(BookingService.BookingAndPersons(bookingEntity, personInfo, keyWorker))
+      assertThat(result.entity).isEqualTo(BookingService.BookingAndPersons(bookingEntity, personInfo))
     }
 
     @Test
@@ -364,78 +355,6 @@ class BookingServiceTest {
       val result = bookingService.getBooking(bookingEntity.id)
 
       assertThat(result is AuthorisableActionResult.Unauthorised).isTrue()
-    }
-
-    @Test
-    fun `handles a missing keyworker`() {
-      every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
-      every { mockUserService.getUserForRequest() } returns user
-      every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
-      every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-      every { mockStaffMemberService.getStaffMemberByCodeForPremise(keyWorker.code, premises.qCode) } returns CasResult.NotFound("Staff Code", keyWorker.code)
-      mockkStatic(Sentry::class)
-      every { Sentry.captureException(any()) } returns SentryId.EMPTY_ID
-
-      val result = bookingService.getBooking(bookingEntity.id)
-
-      assertThat(result is AuthorisableActionResult.Success).isTrue()
-      result as AuthorisableActionResult.Success
-
-      assertThat(result.entity).isEqualTo(BookingService.BookingAndPersons(bookingEntity, personInfo, null))
-
-      verify { Sentry.captureException(any()) }
-    }
-
-    @Test
-    fun `throws an error when all staff members for a Qcode cannot be found`() {
-      every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
-      every { mockUserService.getUserForRequest() } returns user
-      every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
-      every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-      every { mockStaffMemberService.getStaffMemberByCodeForPremise(keyWorker.code, premises.qCode) } returns CasResult.NotFound("QCode", premises.qCode)
-
-      assertThatExceptionOfType(InternalServerErrorProblem::class.java)
-        .isThrownBy { bookingService.getBooking(bookingEntity.id) }
-        .withMessage("Internal Server Error: Unable to get staff for QCode ${premises.qCode}")
-    }
-
-    @Test
-    fun `throws ForbiddenProblem when the upstream service returns Unauthorised`() {
-      every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
-      every { mockUserService.getUserForRequest() } returns user
-      every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
-      every { mockOffenderService.getPersonInfoResult(bookingEntity.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-      every { mockStaffMemberService.getStaffMemberByCodeForPremise(keyWorker.code, premises.qCode) } returns CasResult.Unauthorised()
-
-      assertThatExceptionOfType(ForbiddenProblem::class.java)
-        .isThrownBy { bookingService.getBooking(bookingEntity.id) }
-    }
-
-    @Test
-    fun `throws IllegalStateException if the premises is not an Approved Premises`() {
-      val otherPremises = TemporaryAccommodationPremisesEntityFactory()
-        .withYieldedProbationRegion {
-          ProbationRegionEntityFactory()
-            .withYieldedApArea { ApAreaEntityFactory().produce() }
-            .produce()
-        }
-        .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-        .produce()
-
-      val otherBooking = BookingEntityFactory()
-        .withArrivalDate(LocalDate.parse("2022-08-25"))
-        .withPremises(otherPremises)
-        .withStaffKeyWorkerCode(keyWorker.code)
-        .produce()
-
-      every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns otherBooking
-      every { mockUserService.getUserForRequest() } returns user
-      every { mockUserAccessService.userCanViewBooking(user, otherBooking) } returns true
-      every { mockOffenderService.getPersonInfoResult(otherBooking.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) } returns personInfo
-
-      assertThatExceptionOfType(IllegalStateException::class.java)
-        .isThrownBy { bookingService.getBooking(bookingEntity.id) }
-        .withMessage("Booking has a Key Worker specified but Premises is not an ApprovedPremises")
     }
   }
 
@@ -865,7 +784,6 @@ class BookingServiceTest {
 
       assertThat(result).isInstanceOf(ValidatableActionResult.GeneralValidationError::class.java)
       assertThat((result as ValidatableActionResult.GeneralValidationError).message).isEqualTo("CAS3 booking arrival not supported here, preferred method is createCas3Arrival")
-      verify(exactly = 0) { mockStaffMemberService.getStaffMemberByCodeForPremise(any(), any()) }
       verify(exactly = 0) {
         mockCas3DomainEventService.savePersonArrivedEvent(bookingEntity, user)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -53,8 +53,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedTransformer
@@ -65,7 +63,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TurnaroundTransformer
 import java.time.Instant
 import java.time.LocalDate
@@ -74,7 +71,6 @@ import java.util.UUID
 
 class BookingTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
-  private val mockStaffMemberTransformer = mockk<StaffMemberTransformer>()
   private val mockArrivalTransformer = mockk<ArrivalTransformer>()
   private val mockNonArrivalTransformer = mockk<NonArrivalTransformer>()
   private val mockCancellationTransformer = mockk<CancellationTransformer>()
@@ -88,7 +84,6 @@ class BookingTransformerTest {
 
   private val bookingTransformer = BookingTransformer(
     mockPersonTransformer,
-    mockStaffMemberTransformer,
     mockArrivalTransformer,
     mockDepartureTransformer,
     mockNonArrivalTransformer,
@@ -160,16 +155,6 @@ class BookingTransformerTest {
     status = null,
   )
 
-  private val staffMember = StaffMember(
-    code = "STAFF",
-    keyWorker = true,
-    name = PersonName(
-      forename = "first",
-      middleName = null,
-      surname = "last",
-    ),
-  )
-
   private val offenderDetails = OffenderDetailsSummaryFactory()
     .withCrn("crn")
     .withFirstName("first")
@@ -187,12 +172,6 @@ class BookingTransformerTest {
     every { mockCancellationTransformer.transformJpaToApi(null) } returns null
     every { mockConfirmationTransformer.transformJpaToApi(null) } returns null
     every { mockDepartureTransformer.transformJpaToApi(null) } returns null
-
-    every { mockStaffMemberTransformer.transformDomainToApi(staffMember) } returns uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
-      code = "789",
-      keyWorker = true,
-      name = "first last",
-    )
 
     every { mockPersonTransformer.transformModelToPersonApi(PersonInfoResult.Success.Full("crn", offenderDetails, inmateDetail)) } returns FullPerson(
       type = PersonType.fullPerson,
@@ -221,7 +200,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       awaitingArrivalBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      null,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -300,7 +278,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       awaitingArrivalBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      null,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -348,7 +325,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       awaitingArrivalBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      null,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -409,7 +385,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       nonArrivalBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      null,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -480,7 +455,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       arrivalBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      staffMember,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -501,11 +475,7 @@ class BookingTransformerTest {
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
-        keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
-          code = "789",
-          keyWorker = true,
-          name = "first last",
-        ),
+        keyWorker = null,
         status = BookingStatus.arrived,
         arrival = Arrival(
           bookingId = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3"),
@@ -557,7 +527,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       cancellationBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      null,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -676,7 +645,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       cancellationBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      null,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -819,7 +787,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       departedBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      staffMember,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -840,11 +807,7 @@ class BookingTransformerTest {
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
-        keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
-          code = "789",
-          keyWorker = true,
-          name = "first last",
-        ),
+        keyWorker = null,
         status = BookingStatus.departed,
         arrival = Arrival(
           bookingId = bookingId,
@@ -1012,7 +975,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       departedBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      staffMember,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -1033,11 +995,7 @@ class BookingTransformerTest {
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
-        keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
-          code = "789",
-          keyWorker = true,
-          name = "first last",
-        ),
+        keyWorker = null,
         status = BookingStatus.closed,
         arrival = Arrival(
           bookingId = bookingId,
@@ -1231,7 +1189,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       departedBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      staffMember,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -1252,11 +1209,7 @@ class BookingTransformerTest {
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = departedAt.toLocalDate(),
-        keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
-          code = "789",
-          keyWorker = true,
-          name = "first last",
-        ),
+        keyWorker = null,
         status = BookingStatus.departed,
         arrival = Arrival(
           bookingId = bookingId,
@@ -1451,7 +1404,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       departedBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      staffMember,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -1472,11 +1424,7 @@ class BookingTransformerTest {
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = departedAt.toLocalDate(),
-        keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
-          code = "789",
-          keyWorker = true,
-          name = "first last",
-        ),
+        keyWorker = null,
         status = BookingStatus.closed,
         arrival = Arrival(
           bookingId = bookingId,
@@ -1704,7 +1652,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       departedBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      staffMember,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -1725,11 +1672,7 @@ class BookingTransformerTest {
         ),
         arrivalDate = LocalDate.parse("2022-08-10"),
         departureDate = LocalDate.parse("2022-08-30"),
-        keyWorker = uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember(
-          code = "789",
-          keyWorker = true,
-          name = "first last",
-        ),
+        keyWorker = null,
         status = BookingStatus.closed,
         arrival = Arrival(
           bookingId = bookingId,
@@ -1852,7 +1795,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       confirmationBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      null,
     )
 
     assertThat(transformedBooking).isEqualTo(
@@ -1953,7 +1895,6 @@ class BookingTransformerTest {
     val transformedBooking = bookingTransformer.transformJpaToApi(
       awaitingArrivalBooking,
       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-      null,
     )
 
     assertThat(transformedBooking).isEqualTo(


### PR DESCRIPTION
`Booking.keyWorker` is only used by CAS1, and CAS1 is no longer populating it, or showing it on the UI. It will be replaced by `SpaceBooking.keyWorker`

```
select service from bookings where key_worker_staff_code IS NOT NULL group by service;
-- success --
service
-----------------
approved-premises
-- activity count = 1
```

Given this, this commit marks it as deprecated and stops populating it when retrieving a booking.