### PR TITLE
APS-1605 - Populate additional fields when migrating bookings to space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
@@ -25,7 +25,7 @@ interface DepartureReasonRepository : JpaRepository<DepartureReasonEntity, UUID>
   @Query("SELECT d FROM DepartureReasonEntity d WHERE d.isActive = true")
   fun findActive(): List<DepartureReasonEntity>
 
-  fun findByNameAndServiceScope(name: String, serviceScope: String): DepartureReasonEntity?
+  fun findByLegacyDeliusReasonCode(code: String): DepartureReasonEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/MoveOnCategoryEntity.kt
@@ -24,7 +24,7 @@ interface MoveOnCategoryRepository : JpaRepository<MoveOnCategoryEntity, UUID> {
   @Query("SELECT m FROM MoveOnCategoryEntity m WHERE m.isActive = true")
   fun findActive(): List<MoveOnCategoryEntity>
 
-  fun findByNameAndServiceScope(name: String, serviceScope: String): MoveOnCategoryEntity?
+  fun findByLegacyDeliusCategoryCode(code: String): MoveOnCategoryEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalReasonEntity.kt
@@ -11,6 +11,7 @@ import java.util.UUID
 @Repository
 interface NonArrivalReasonRepository : JpaRepository<NonArrivalReasonEntity, UUID> {
   fun findByName(name: String): NonArrivalReasonEntity?
+  fun findByLegacyDeliusReasonCode(it: String): NonArrivalReasonEntity?
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
@@ -6,11 +6,13 @@ import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @Repository
-interface Cas1DeliusBookingImportRepository : JpaRepository<Cas1DeliusBookingImportEntity, UUID>
+interface Cas1DeliusBookingImportRepository : JpaRepository<Cas1DeliusBookingImportEntity, UUID> {
+  fun findByBookingId(id: UUID): Cas1DeliusBookingImportEntity?
+}
 
 @Entity
 @Table(name = "cas1_delius_booking_import")
@@ -31,7 +33,7 @@ data class Cas1DeliusBookingImportEntity(
   val expectedDepartureDate: LocalDate?,
   val departureDate: LocalDate?,
   val nonArrivalDate: LocalDate?,
-  val nonArrivalContactDatetime: LocalDateTime?,
+  val nonArrivalContactDatetime: OffsetDateTime?,
   val nonArrivalReasonCode: String?,
   val nonArrivalReasonDescription: String?,
   val nonArrivalNotes: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
@@ -92,6 +92,12 @@ data class CaseSummaries(
 )
 
 data class ReferralDetail(
+  /*
+  Note that the time element is typically 00:00
+   */
   val arrivedAt: ZonedDateTime?,
+  /*
+  Note that the time element is typically 00:00
+   */
   val departedAt: ZonedDateTime?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -20,10 +20,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
@@ -59,7 +62,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeliusService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
@@ -222,8 +224,11 @@ class SeedService(
           getBean(DomainEventRepository::class),
           getBean(DomainEventService::class),
           getBean(UserRepository::class),
-          getBean(DeliusService::class),
           getBean(TransactionTemplate::class),
+          getBean(Cas1DeliusBookingImportRepository::class),
+          getBean(DepartureReasonRepository::class),
+          getBean(MoveOnCategoryRepository::class),
+          getBean(NonArrivalReasonRepository::class),
         )
 
         SeedFileType.approvedPremisesSpacePlanningDryRun -> Cas1PlanSpacePlanningDryRunSeedJob(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
@@ -7,6 +7,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Deli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
@@ -110,7 +112,9 @@ class Cas1ImportDeliusBookingDataSeedJob(
         row.expectedDepartureDate,
         row.departureDate,
         row.nonArrivalDate,
-        row.nonArrivalContactDateTime,
+        row.nonArrivalContactDateTime?.let {
+          ZonedDateTime.of(it, ZoneId.of("Europe/London")).toOffsetDateTime()
+        },
         row.nonArrivalReasonCode,
         row.nonArrivalReasonDescription,
         row.nonArrivalNotes,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -292,7 +292,7 @@ class Cas1SpaceBookingService(
 
     existingCas1SpaceBooking!!
 
-    val previousKeyWorkerName = existingCas1SpaceBooking.keyWorkerName ?: null
+    val previousKeyWorkerName = existingCas1SpaceBooking.keyWorkerName
 
     existingCas1SpaceBooking.keyWorkerStaffCode = assignedKeyWorker.code
     existingCas1SpaceBooking.keyWorkerName = assignedKeyWorkerName

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DepartureEntityFactory.kt
@@ -19,7 +19,7 @@ class DepartureEntityFactory : Factory<DepartureEntity> {
   private var reason: Yielded<DepartureReasonEntity>? = null
   private var moveOnCategory: Yielded<MoveOnCategoryEntity>? = null
   private var destinationProvider: Yielded<DestinationProviderEntity>? = null
-  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
   private var booking: Yielded<BookingEntity>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
 
@@ -47,7 +47,7 @@ class DepartureEntityFactory : Factory<DepartureEntity> {
     this.moveOnCategory = { moveOnCategory }
   }
 
-  fun withNotes(notes: String) = apply {
+  fun withNotes(notes: String?) = apply {
     this.notes = { notes }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusBookingDataSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusBookingDataSeedJobTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
@@ -109,7 +109,7 @@ class SeedCas1ImportDeliusBookingDataSeedJobTest : SeedTestBase() {
     assertThat(bookingImport.expectedDepartureDate).isEqualTo(LocalDate.of(2025, 9, 13))
     assertThat(bookingImport.departureDate).isEqualTo(LocalDate.of(2025, 9, 12))
     assertThat(bookingImport.nonArrivalDate).isEqualTo(LocalDate.of(2021, 1, 1))
-    assertThat(bookingImport.nonArrivalContactDatetime).isEqualTo(LocalDateTime.of(2023, 7, 17, 11, 36, 2, 0))
+    assertThat(bookingImport.nonArrivalContactDatetime).isEqualTo(OffsetDateTime.parse("2023-07-17T11:36:02+01:00"))
     assertThat(bookingImport.nonArrivalReasonCode).isEqualTo("non arrival reason code")
     assertThat(bookingImport.nonArrivalReasonDescription).isEqualTo("non arrival reason description")
     assertThat(bookingImport.nonArrivalNotes).isEqualTo("non arrival notes")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABooking.kt
@@ -3,11 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
 @SuppressWarnings("LongParameterList")
@@ -17,6 +21,12 @@ fun IntegrationTestBase.givenABooking(
   premises: PremisesEntity? = null,
   arrivalDate: LocalDate = LocalDate.now().randomDateBefore(14),
   departureDate: LocalDate = LocalDate.now().randomDateBefore(14),
+  departureReason: DepartureReasonEntity? = null,
+  departureNotes: String? = null,
+  departureMoveOnCategory: MoveOnCategoryEntity? = null,
+  nonArrivalReason: NonArrivalReasonEntity? = null,
+  nonArrivalConfirmedAt: OffsetDateTime? = null,
+  nonArrivalNotes: String? = null,
   adhoc: Boolean = false,
   actualArrivalDate: LocalDateTime? = null,
   actualDepartureDate: LocalDateTime? = null,
@@ -31,19 +41,33 @@ fun IntegrationTestBase.givenABooking(
   }
 
   actualArrivalDate?.let {
-    arrivalEntityFactory.produceAndPersist {
-      withBooking(booking)
-      withArrivalDate(actualArrivalDate.toLocalDate())
-      withArrivalDateTime(actualArrivalDate.toInstant(ZoneOffset.UTC))
-    }
+    booking.arrivals.add(
+      arrivalEntityFactory.produceAndPersist {
+        withBooking(booking)
+        withArrivalDate(actualArrivalDate.toLocalDate())
+        withArrivalDateTime(actualArrivalDate.toInstant(ZoneOffset.UTC))
+      },
+    )
   }
 
   actualDepartureDate?.let {
-    departureEntityFactory.produceAndPersist {
+    booking.departures.add(
+      departureEntityFactory.produceAndPersist {
+        withBooking(booking)
+        withDateTime(actualDepartureDate.atOffset(ZoneOffset.UTC))
+        withReason(departureReason ?: departureReasonEntityFactory.produceAndPersist())
+        withMoveOnCategory(departureMoveOnCategory ?: moveOnCategoryEntityFactory.produceAndPersist())
+        withNotes(departureNotes)
+      },
+    )
+  }
+
+  nonArrivalReason?.let {
+    booking.nonArrival = nonArrivalEntityFactory.produceAndPersist {
       withBooking(booking)
-      withDateTime(actualDepartureDate.atOffset(ZoneOffset.UTC))
-      withReason(departureReasonEntityFactory.produceAndPersist())
-      withMoveOnCategory(moveOnCategoryEntityFactory.produceAndPersist())
+      withReason(it)
+      withCreatedAt(nonArrivalConfirmedAt ?: OffsetDateTime.now())
+      withNotes(nonArrivalNotes ?: "default notes")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -14,9 +14,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulGetReferralDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ManagementInfoSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1SpaceBookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingToSpaceBookingSeedCsvRow
@@ -27,7 +28,6 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import java.time.ZonedDateTime
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
@@ -37,6 +37,9 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
 
   @Autowired
   lateinit var cas1BookingDomainEventSet: Cas1BookingDomainEventService
+
+  @Autowired
+  lateinit var deliusBookingImportRepository: Cas1DeliusBookingImportRepository
 
   @SuppressWarnings("LongMethod")
   @Test
@@ -70,11 +73,41 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
       booking1CreatedByUser,
       placementRequest1,
     )
-    apDeliusContextMockSuccessfulGetReferralDetails(
-      crn = "CRN1",
-      bookingId = booking1DeliusManagementInfo.id.toString(),
-      arrivedAt = ZonedDateTime.of(LocalDateTime.of(2024, 5, 2, 10, 15, 30, 0), ZoneOffset.systemDefault()),
-      departedAt = ZonedDateTime.of(LocalDateTime.of(2024, 5, 4, 18, 45, 20, 0), ZoneOffset.systemDefault()),
+
+    val departureReason1 = departureReasonEntityFactory.produceAndPersist {
+      withLegacyDeliusCategoryCode("dr1")
+    }
+
+    val moveOnCategory1 = moveOnCategoryEntityFactory.produceAndPersist {
+      withLegacyDeliusCategoryCode("moc1")
+    }
+
+    val nonArrivalReasonCode1 = nonArrivalReasonEntityFactory.produceAndPersist {
+      withLegacyDeliusReasonCode("narc1")
+    }
+
+    deliusBookingImportRepository.save(
+      Cas1DeliusBookingImportEntity(
+        bookingId = booking1DeliusManagementInfo.id,
+        crn = "irrelevant",
+        eventNumber = "irrelevant",
+        keyWorkerStaffCode = "kw001",
+        keyWorkerForename = "kay",
+        keyWorkerMiddleName = "m",
+        keyWorkerSurname = "werker",
+        departureReasonCode = "dr1",
+        moveOnCategoryCode = "moc1",
+        moveOnCategoryDescription = null,
+        expectedArrivalDate = LocalDate.of(3000, 1, 1),
+        arrivalDate = LocalDate.of(2024, 5, 2),
+        expectedDepartureDate = LocalDate.of(3001, 2, 2),
+        departureDate = LocalDate.of(2024, 5, 4),
+        nonArrivalDate = LocalDate.of(3000, 1, 1),
+        nonArrivalContactDatetime = OffsetDateTime.of(LocalDateTime.of(2024, 2, 1, 9, 58, 23), ZoneOffset.UTC),
+        nonArrivalReasonCode = "narc1",
+        nonArrivalReasonDescription = null,
+        nonArrivalNotes = "the non arrival notes",
+      ),
     )
 
     val application2 = givenACas1Application(createdByUser = otherUser, eventNumber = "50")
@@ -171,14 +204,14 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking1.expectedArrivalDate).isEqualTo(LocalDate.of(2024, 5, 1))
     assertThat(migratedBooking1.expectedDepartureDate).isEqualTo(LocalDate.of(2024, 5, 5))
     assertThat(migratedBooking1.actualArrivalDate).isEqualTo(LocalDate.parse("2024-05-02"))
-    assertThat(migratedBooking1.actualArrivalTime).isEqualTo(LocalTime.parse("10:15:30"))
+    assertThat(migratedBooking1.actualArrivalTime).isNull()
     assertThat(migratedBooking1.actualDepartureDate).isEqualTo(LocalDate.parse("2024-05-04"))
-    assertThat(migratedBooking1.actualDepartureTime).isEqualTo(LocalTime.parse("18:45:20"))
+    assertThat(migratedBooking1.actualDepartureTime).isNull()
     assertThat(migratedBooking1.canonicalArrivalDate).isEqualTo(LocalDate.of(2024, 5, 2))
     assertThat(migratedBooking1.canonicalDepartureDate).isEqualTo(LocalDate.of(2024, 5, 4))
     assertThat(migratedBooking1.crn).isEqualTo("CRN1")
-    assertThat(migratedBooking1.keyWorkerName).isNull()
-    assertThat(migratedBooking1.keyWorkerStaffCode).isNull()
+    assertThat(migratedBooking1.keyWorkerName).isEqualTo("kay werker")
+    assertThat(migratedBooking1.keyWorkerStaffCode).isEqualTo("kw001")
     assertThat(migratedBooking1.keyWorkerAssignedAt).isNull()
     assertThat(migratedBooking1.application!!.id).isEqualTo(application1.id)
     assertThat(migratedBooking1.offlineApplication).isNull()
@@ -186,12 +219,12 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking1.cancellationOccurredAt).isNull()
     assertThat(migratedBooking1.cancellationRecordedAt).isNull()
     assertThat(migratedBooking1.cancellationReasonNotes).isNull()
-    assertThat(migratedBooking1.departureReason).isNull()
-    assertThat(migratedBooking1.departureMoveOnCategory).isNull()
+    assertThat(migratedBooking1.departureReason).isEqualTo(departureReason1)
+    assertThat(migratedBooking1.departureMoveOnCategory).isEqualTo(moveOnCategory1)
     assertThat(migratedBooking1.criteria).containsOnly(roomCriteria1, roomCriteria2)
-    assertThat(migratedBooking1.nonArrivalReason).isNull()
-    assertThat(migratedBooking1.nonArrivalConfirmedAt).isNull()
-    assertThat(migratedBooking1.nonArrivalNotes).isNull()
+    assertThat(migratedBooking1.nonArrivalReason).isEqualTo(nonArrivalReasonCode1)
+    assertThat(migratedBooking1.nonArrivalConfirmedAt).isEqualTo(Instant.parse("2024-02-01T09:58:23.00Z"))
+    assertThat(migratedBooking1.nonArrivalNotes).isEqualTo("the non arrival notes")
     assertThat(migratedBooking1.deliusEventNumber).isEqualTo("25")
     assertThat(migratedBooking1.migratedFromBooking!!.id).isEqualTo(booking1DeliusManagementInfo.id)
     assertThat(migratedBooking1.migratedManagementInfoFrom).isEqualTo(ManagementInfoSource.DELIUS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingToSpaceBookingSeedCsvRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -83,6 +84,12 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
       application = application2,
       arrivalDate = LocalDate.of(2024, 6, 1),
       departureDate = LocalDate.of(2024, 6, 5),
+      departureReason = departureReasonEntityFactory.produceAndPersist(),
+      departureNotes = "the legacy departure notes",
+      departureMoveOnCategory = moveOnCategoryEntityFactory.produceAndPersist(),
+      nonArrivalReason = nonArrivalReasonEntityFactory.produceAndPersist(),
+      nonArrivalConfirmedAt = OffsetDateTime.of(LocalDateTime.of(2024, 5, 1, 2, 3, 4), ZoneOffset.UTC),
+      nonArrivalNotes = "the legacy non arrival notes",
       actualArrivalDate = LocalDateTime.of(2024, 6, 3, 20, 0, 5),
       actualDepartureDate = LocalDateTime.of(2024, 6, 6, 9, 48, 0),
     )
@@ -182,6 +189,9 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking1.departureReason).isNull()
     assertThat(migratedBooking1.departureMoveOnCategory).isNull()
     assertThat(migratedBooking1.criteria).containsOnly(roomCriteria1, roomCriteria2)
+    assertThat(migratedBooking1.nonArrivalReason).isNull()
+    assertThat(migratedBooking1.nonArrivalConfirmedAt).isNull()
+    assertThat(migratedBooking1.nonArrivalNotes).isNull()
     assertThat(migratedBooking1.deliusEventNumber).isEqualTo("25")
     assertThat(migratedBooking1.migratedFromBooking!!.id).isEqualTo(booking1DeliusManagementInfo.id)
     assertThat(migratedBooking1.migratedManagementInfoFrom).isEqualTo(ManagementInfoSource.DELIUS)
@@ -209,9 +219,13 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking2.cancellationOccurredAt).isEqualTo(LocalDate.of(2024, 1, 1))
     assertThat(migratedBooking2.cancellationRecordedAt).isEqualTo(LocalDateTime.of(2025, 1, 2, 3, 4, 5).toInstant(ZoneOffset.UTC))
     assertThat(migratedBooking2.cancellationReasonNotes).isEqualTo("cancellation other reason")
-    assertThat(migratedBooking2.departureReason).isNull()
-    assertThat(migratedBooking2.departureMoveOnCategory).isNull()
+    assertThat(migratedBooking2.departureReason).isEqualTo(booking2LegacyCas1ManagementInfo.departure!!.reason)
+    assertThat(migratedBooking2.departureMoveOnCategory).isEqualTo(booking2LegacyCas1ManagementInfo.departure!!.moveOnCategory)
+    assertThat(migratedBooking2.departureNotes).isEqualTo("the legacy departure notes")
     assertThat(migratedBooking2.criteria).isEmpty()
+    assertThat(migratedBooking2.nonArrivalReason).isEqualTo(booking2LegacyCas1ManagementInfo.nonArrival!!.reason)
+    assertThat(migratedBooking2.nonArrivalConfirmedAt).isEqualTo(Instant.parse("2024-05-01T02:03:04Z"))
+    assertThat(migratedBooking2.nonArrivalNotes).isEqualTo("the legacy non arrival notes")
     assertThat(migratedBooking2.deliusEventNumber).isEqualTo("50")
     assertThat(migratedBooking2.migratedFromBooking!!.id).isEqualTo(booking2LegacyCas1ManagementInfo.id)
     assertThat(migratedBooking2.migratedManagementInfoFrom).isEqualTo(ManagementInfoSource.LEGACY_CAS_1)
@@ -241,10 +255,13 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking3.cancellationReasonNotes).isNull()
     assertThat(migratedBooking3.departureReason).isNull()
     assertThat(migratedBooking3.departureMoveOnCategory).isNull()
+    assertThat(migratedBooking3.nonArrivalReason).isNull()
+    assertThat(migratedBooking3.nonArrivalConfirmedAt).isNull()
+    assertThat(migratedBooking3.nonArrivalNotes).isNull()
     assertThat(migratedBooking3.criteria).isEmpty()
     assertThat(migratedBooking3.deliusEventNumber).isEqualTo("75")
     assertThat(migratedBooking3.migratedFromBooking!!.id).isEqualTo(booking3OfflineApplication.id)
-    assertThat(migratedBooking3.migratedManagementInfoFrom).isNull()
+    assertThat(migratedBooking3.migratedManagementInfoFrom).isEqualTo(ManagementInfoSource.LEGACY_CAS_1)
 
     val migratedBooking4 = premiseSpaceBookings[3]
     assertThat(migratedBooking4.id).isEqualTo(booking4OfflineNoDomainEvent.id)
@@ -271,10 +288,13 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
     assertThat(migratedBooking4.cancellationReasonNotes).isNull()
     assertThat(migratedBooking4.departureReason).isNull()
     assertThat(migratedBooking4.departureMoveOnCategory).isNull()
+    assertThat(migratedBooking4.nonArrivalReason).isNull()
+    assertThat(migratedBooking4.nonArrivalConfirmedAt).isNull()
+    assertThat(migratedBooking4.nonArrivalNotes).isNull()
     assertThat(migratedBooking4.criteria).isEmpty()
     assertThat(migratedBooking4.deliusEventNumber).isNull()
     assertThat(migratedBooking4.migratedFromBooking!!.id).isEqualTo(booking4OfflineNoDomainEvent.id)
-    assertThat(migratedBooking4.migratedManagementInfoFrom).isNull()
+    assertThat(migratedBooking4.migratedManagementInfoFrom).isEqualTo(ManagementInfoSource.LEGACY_CAS_1)
   }
 
   private fun rowsToCsv(rows: List<Cas1BookingToSpaceBookingSeedCsvRow>): String {


### PR DESCRIPTION
* update the booking to space booking seed job to populate additional information from a legacy booking, if referral information can’t be located in Delius
* changes the booking to space booking seed job to retrieve delius data from the `cas1_delius_booking_import` table, instead of retreiving more limited data from the ap-and-delius API
