### PR TITLE
APS-1605 - Add getStaffDetailByCode service function

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
@@ -18,22 +18,20 @@ class StaffMemberServiceTest {
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
   private val staffMemberService = StaffMemberService(mockApDeliusContextApiClient)
 
-  private val qCode = "Qcode"
-
   @Nested
-  inner class GetStaffMemberByCode {
+  inner class GetStaffMemberByCodeForPremise {
     @Test
     fun `it returns a staff member`() {
       val staffMembers = ContextStaffMemberFactory().produceMany().take(5).toList()
 
-      every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Success(
+      every { mockApDeliusContextApiClient.getStaffMembers("qCode") } returns ClientResult.Success(
         status = HttpStatus.OK,
         body = StaffMembersPage(
           content = staffMembers,
         ),
       )
 
-      val result = staffMemberService.getStaffMemberByCodeForPremise(staffMembers[2].code, qCode)
+      val result = staffMemberService.getStaffMemberByCodeForPremise(staffMembers[2].code, "qCode")
 
       assertThat(result is CasResult.Success).isTrue
       result as CasResult.Success
@@ -43,34 +41,34 @@ class StaffMemberServiceTest {
   }
 
   @Test
-  fun `it returns Unauthorised when Delius returns Unauthorised`() {
-    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Failure.StatusCode(
+  fun `it returns Unauthorised when the Upstream API returns Unauthorised`() {
+    every { mockApDeliusContextApiClient.getStaffMembers("qCode") } returns ClientResult.Failure.StatusCode(
       HttpMethod.GET,
       "/staff-members/code",
       HttpStatus.UNAUTHORIZED,
       body = null,
     )
 
-    val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
+    val result = staffMemberService.getStaffMemberByCodeForPremise("code", "qCode")
 
     assertThat(result is CasResult.Unauthorised).isTrue
   }
 
   @Test
-  fun `it returns NotFound when Delius returns NotFound`() {
-    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Failure.StatusCode(
+  fun `it returns NotFound when the Upstream API returns NotFound`() {
+    every { mockApDeliusContextApiClient.getStaffMembers("qCode") } returns ClientResult.Failure.StatusCode(
       HttpMethod.GET,
       "/staff-members/code",
       HttpStatus.NOT_FOUND,
       body = null,
     )
 
-    val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
+    val result = staffMemberService.getStaffMemberByCodeForPremise("code", "qCode")
 
     assertThat(result is CasResult.NotFound).isTrue
     result as CasResult.NotFound
 
-    assertThat(result.id).isEqualTo(qCode)
+    assertThat(result.id).isEqualTo("qCode")
     assertThat(result.entityType).isEqualTo("Team")
   }
 
@@ -78,14 +76,14 @@ class StaffMemberServiceTest {
   fun `it returns a NotFound when a staff member for the QCode cannot me found`() {
     val staffMembers = ContextStaffMemberFactory().produceMany().take(5).toList()
 
-    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Success(
+    every { mockApDeliusContextApiClient.getStaffMembers("qCode") } returns ClientResult.Success(
       status = HttpStatus.OK,
       body = StaffMembersPage(
         content = staffMembers,
       ),
     )
 
-    val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
+    val result = staffMemberService.getStaffMemberByCodeForPremise("code", "qCode")
 
     assertThat(result is CasResult.NotFound).isTrue
     result as CasResult.NotFound

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -13,13 +13,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.BookingKeyWorkerAssignedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.model.PersonDepartedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
@@ -32,8 +29,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventServiceConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
@@ -51,7 +50,7 @@ import java.util.UUID
 class Cas1SpaceBookingManagementDomainEventServiceTest {
 
   @MockK
-  lateinit var apDeliusContextApiClient: ApDeliusContextApiClient
+  lateinit var staffMemberService: StaffMemberService
 
   @MockK
   lateinit var domainEventService: DomainEventService
@@ -119,8 +118,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       every { offenderService.getPersonSummaryInfoResults(any(), any()) } returns
         listOf(PersonSummaryInfoResult.Success.Full("THEBOOKINGCRN", caseSummary))
 
-      every { apDeliusContextApiClient.getStaffDetailByStaffCode(any()) } returns ClientResult.Success(
-        HttpStatus.OK,
+      every { staffMemberService.getStaffDetailByCode(any()) } returns CasResult.Success(
         keyWorker,
       )
     }
@@ -285,8 +283,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       every { offenderService.getPersonSummaryInfoResults(any(), any()) } returns
         listOf(PersonSummaryInfoResult.Success.Full("THEBOOKINGCRN", caseSummary))
 
-      every { apDeliusContextApiClient.getStaffDetailByStaffCode(any()) } returns ClientResult.Success(
-        HttpStatus.OK,
+      every { staffMemberService.getStaffDetailByCode(any()) } returns CasResult.Success(
         keyWorker,
       )
     }
@@ -426,8 +423,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       every { offenderService.getPersonSummaryInfoResults(any(), any()) } returns
         listOf(PersonSummaryInfoResult.Success.Full("THEBOOKINGCRN", caseSummary))
 
-      every { apDeliusContextApiClient.getStaffDetailByStaffCode(any()) } returns ClientResult.Success(
-        HttpStatus.OK,
+      every { staffMemberService.getStaffDetailByCode(any()) } returns CasResult.Success(
         keyWorker,
       )
     }


### PR DESCRIPTION
Before this commit domain event services were directly calling the `ap-and-delius` API client to retrieve keyworker information. This commit introduces a service function to retrieve keyworker information that uses `CasResult`, and uses it in the domain event service.