### PR TITLE
Switch swagger documentation to auto generated.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -49,6 +49,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/health/**", permitAll)
         authorize(HttpMethod.GET, "/swagger-ui/**", permitAll)
         authorize(HttpMethod.GET, "/v3/api-docs/**", permitAll)
+        authorize(HttpMethod.GET, "/v3/api-docs.yaml", permitAll)
         authorize(HttpMethod.GET, "/api.yml", permitAll)
         authorize(HttpMethod.GET, "/cas1-api.yml", permitAll)
         authorize(HttpMethod.GET, "/cas2-api.yml", permitAll)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
@@ -1,0 +1,118 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+
+@Configuration
+class SwaggerConfiguration {
+
+  @Bean
+  @Primary
+  fun customOpenAPI(): OpenAPI {
+    return OpenAPI()
+      .info(
+        Info()
+          .title("Approved Premises")
+          .version("1.0.0")
+          .description("Swagger Documentation for Approved Premises API"),
+      )
+  }
+
+  @Bean
+  fun allCas(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("allCas")
+      .displayName("All CAS")
+      .pathsToMatch("/**")
+      .build()
+  }
+
+  @Bean
+  fun shared(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("shared")
+      .displayName("Shared")
+      .pathsToMatch("/**")
+      .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas3/**")
+      .build()
+  }
+
+  @Bean
+  fun events(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("domainEvents")
+      .displayName("Domain Events")
+      .pathsToMatch("/events/**")
+      .build()
+  }
+
+  @Bean
+  fun cas2Events(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS2DomainEvents")
+      .displayName("CAS2 Domain Events")
+      .pathsToMatch("/events/cas2/**")
+      .build()
+  }
+
+  @Bean
+  fun cas1Shared(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS1Shared")
+      .displayName("CAS1 & Shared")
+      .pathsToMatch("/**", "/**/cas1/**")
+      .pathsToExclude("/**/cas2/**", "/**/cas3/**")
+      .build()
+  }
+
+  @Bean
+  fun cas2Shared(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS2Shared")
+      .displayName("CAS2 & Shared")
+      .pathsToMatch("/**", "/**/cas2/**")
+      .pathsToExclude("/**/cas1/**", "/**/cas3/**")
+      .build()
+  }
+
+  @Bean
+  fun cas3Shared(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS3Shared")
+      .displayName("CAS3 & Shared")
+      .pathsToMatch("/**", "/**/cas3/**")
+      .pathsToExclude("/**/cas1/**", "/**/cas2/**")
+      .build()
+  }
+
+  @Bean
+  fun cas1Only(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS1")
+      .displayName("CAS1")
+      .pathsToMatch("/**/cas1/**")
+      .build()
+  }
+
+  @Bean
+  fun cas2Only(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS2")
+      .displayName("CAS2")
+      .pathsToMatch("/**/cas2/**")
+      .build()
+  }
+
+  @Bean
+  fun cas3(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS3")
+      .displayName("CAS3")
+      .pathsToMatch("/**/cas3/**")
+      .build()
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,19 +108,7 @@ spring:
 
 springdoc:
   swagger-ui:
-    urls:
-      - name: API
-        url: "api.yml"
-      - name: CAS1 API
-        url: "cas1-api.yml"
-      - name: CAS2 API
-        url: "cas2-api.yml"
-      - name: Domain events
-        url: "domain-events-api.yml"
-      - name: CAS2 Domain events
-        url: "cas2-domain-events-api.yml"
-      - name: CAS3 API
-        url: "cas3-api.yml"
+    urls-primary-name: "All CAS"
 
 server:
   port: 8080


### PR DESCRIPTION
This is the first PR in moving away from the manually writted openAPI spec files. This generates the swagger documentation automatically, from the code that is generated from the spec files. There are extra group filters added, which will be more refined later in the migration process. (once we have package structure etc).

There should be no noticeable difference to the user, however this  is needed so we can test the UI generation from this output.
image one is the auto-generated documents, image two is taken from existing in preprod.
<img width="520" alt="image" src="https://github.com/user-attachments/assets/ae9f0780-4f50-483e-81bc-6d8809900316">

<img width="509" alt="image" src="https://github.com/user-attachments/assets/21d0815c-ffbe-4b12-a290-c3981d70607a">

