### PR TITLE
updated swagger config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,8 +21,6 @@ configurations.matching { it.name == "detekt" }.all {
   }
 }
 
-val springDocVersion = "1.7.0"
-
 dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.0.2-beta-4")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
@@ -39,12 +37,7 @@ dependencies {
   implementation("com.google.guava:guava:33.3.1-jre")
   implementation("org.postgresql:postgresql:42.7.4")
 
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.5.0")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
-  implementation("org.springdoc:springdoc-openapi-starter-common:2.5.0")
-  implementation("org.springdoc:springdoc-openapi-ui:1.8.0")
-  implementation("org.springdoc:springdoc-openapi-kotlin:1.8.0")
-  implementation("org.springdoc:springdoc-openapi-data-rest:1.8.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 
   implementation("org.zalando:problem-spring-web-starter:0.29.1")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
@@ -10,6 +10,12 @@ import org.springframework.context.annotation.Primary
 @Configuration
 class SwaggerConfiguration {
 
+  companion object {
+    init {
+      io.swagger.v3.core.jackson.ModelResolver.enumsAsRef = true
+    }
+  }
+
   @Bean
   @Primary
   fun customOpenAPI(): OpenAPI {
@@ -37,25 +43,72 @@ class SwaggerConfiguration {
       .group("shared")
       .displayName("Shared")
       .pathsToMatch("/**")
-      .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas3/**")
+      .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas3/**", "/**/events/**")
+      .packagesToExclude(
+        "**.uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.**",
+      )
       .build()
   }
 
   @Bean
-  fun events(): GroupedOpenApi {
+  fun domainEvents(): GroupedOpenApi {
     return GroupedOpenApi.builder()
       .group("domainEvents")
       .displayName("Domain Events")
-      .pathsToMatch("/events/**")
+      .pathsToMatch("/**/events/**")
       .build()
   }
 
   @Bean
-  fun cas2Events(): GroupedOpenApi {
+  fun cas2DomainEvents(): GroupedOpenApi {
     return GroupedOpenApi.builder()
       .group("CAS2DomainEvents")
       .displayName("CAS2 Domain Events")
-      .pathsToMatch("/events/cas2/**")
+      .pathsToMatch("/**/events/cas2/**")
+      .build()
+  }
+
+  @Bean
+  fun cas1Only(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS1")
+      .displayName("CAS1")
+      .pathsToMatch("/**/cas1/**")
+      .pathsToExclude("/**/events/**", "**/cas2/**", "**/cas3/**")
+      .packagesToExclude(
+        "**.uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.**",
+        "**.cas2.**",
+        "**.cas3.**",
+      )
+      .build()
+  }
+
+  @Bean
+  fun cas2Only(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS2")
+      .displayName("CAS2")
+      .pathsToMatch("/**/cas2/**")
+      .pathsToExclude("/**/events/**", "**/cas1/**", "**/cas3/**")
+      .packagesToExclude(
+        "**.uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.**",
+        "**.cas1.**",
+        "**.cas3.**",
+      ).build()
+  }
+
+  @Bean
+  fun cas3Only(): GroupedOpenApi {
+    return GroupedOpenApi.builder()
+      .group("CAS3")
+      .displayName("CAS3")
+      .pathsToMatch("/**/cas3/**")
+      .pathsToExclude("/**/events/**", "/**/cas1/**", "/**/cas2/**")
+      .packagesToExclude(
+        "**.uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.**",
+        "**.cas1.**",
+        "**.cas2.**",
+      )
       .build()
   }
 
@@ -86,33 +139,6 @@ class SwaggerConfiguration {
       .displayName("CAS3 & Shared")
       .pathsToMatch("/**", "/**/cas3/**")
       .pathsToExclude("/**/cas1/**", "/**/cas2/**")
-      .build()
-  }
-
-  @Bean
-  fun cas1Only(): GroupedOpenApi {
-    return GroupedOpenApi.builder()
-      .group("CAS1")
-      .displayName("CAS1")
-      .pathsToMatch("/**/cas1/**")
-      .build()
-  }
-
-  @Bean
-  fun cas2Only(): GroupedOpenApi {
-    return GroupedOpenApi.builder()
-      .group("CAS2")
-      .displayName("CAS2")
-      .pathsToMatch("/**/cas2/**")
-      .build()
-  }
-
-  @Bean
-  fun cas3(): GroupedOpenApi {
-    return GroupedOpenApi.builder()
-      .group("CAS3")
-      .displayName("CAS3")
-      .pathsToMatch("/**/cas3/**")
       .build()
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,7 +108,7 @@ spring:
 
 springdoc:
   swagger-ui:
-    urls-primary-name: "All CAS"
+    urls-primary-name: "Shared"
 
 server:
   port: 8080


### PR DESCRIPTION
This PR sets the enums to be generated as reusable references, rather than inline. It was an issue for how the UI generates it's types. 

Also removed erroneous dependencies, and updated the exclusion filtering in the config