### PR TITLE
Add empty favicon

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/FaviconController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/FaviconController.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ResponseBody
+
+@Controller
+internal class FaviconController {
+  @GetMapping("favicon.ico")
+  @ResponseBody
+  fun returnNoFavicon() {
+    // deliberately empty
+  }
+}


### PR DESCRIPTION
This has been added to remove unhelpful warning logs when a favicon is requested