### PR TITLE
Improve local log output

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,9 @@ spring:
       host: localhost
       port: 6379
       password: ""
+  output:
+    ansi:
+      enabled: ALWAYS
 
 hmpps.sqs:
   provider: localstack
@@ -58,8 +61,10 @@ feature-flags:
   get-documents-from-ap-delius: true
   get-offences-from-ap-delius: true
 
-# allows us to see the JWT token to simplify local API invocation
-logging.level.uk.gov.justice.digital.hmpps.approvedpremisesapi.config.RequestResponseLoggingFilter: TRACE
 
-# allows us to see the request URL and method for upstream requests
-logging.level.reactor.netty.http.client.HttpClientConnect: DEBUG
+logging:
+  level:
+    # allows us to see the JWT token to simplify local API invocation
+    uk.gov.justice.digital.hmpps.approvedpremisesapi.config.RequestResponseLoggingFilter: TRACE
+    # allows us to see the request URL and method for upstream requests
+    reactor.netty.http.client.HttpClientConnect: DEBUG

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,7 +7,6 @@ spring:
   flyway:
     locations: classpath:db/migration/all,classpath:db/migration/local+dev+test,classpath:db/migration/local,classpath:db/migration/all-except-integration
   jpa:
-    show-sql: true
     database: postgresql
   data:
     redis:
@@ -64,6 +63,11 @@ feature-flags:
 
 logging:
   level:
+    # Log hibernate queries
+    org.hibernate.SQL: DEBUG
+    # Uncomment the two entries below to see SQL binding
+    #org.hibernate.orm.jdbc.bind: TRACE
+    #org.hibernate.type.descriptor.sql.BasicBinder: TRACE
     # allows us to see the JWT token to simplify local API invocation
     uk.gov.justice.digital.hmpps.approvedpremisesapi.config.RequestResponseLoggingFilter: TRACE
     # allows us to see the request URL and method for upstream requests


### PR DESCRIPTION
* Force color-coded logs in local deployments
* Format Hibernate logs in local deploys. Previously we used spring’s `show-sql: true` config to log hibernate SQL when deployed locally. This logged to STDOUT so wasn’t formatted in the same way as other logs.