### PR TITLE
CAS-1258 Extend the response for API for bedspace search to include personType

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.jdbc.core.ResultSetExtractor
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import java.sql.ResultSet
 import java.time.LocalDate
 import java.util.UUID
@@ -449,6 +450,7 @@ data class CharacteristicNames(
 data class TemporaryAccommodationBedSearchResultOverlap(
   val name: String,
   val crn: String,
+  val personType: PersonType,
   val sex: String?,
   val days: Int,
   val premisesId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchAttributes
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
@@ -210,6 +211,7 @@ class BedSearchService(
     return TemporaryAccommodationBedSearchResultOverlap(
       name = getNameFromPersonSummaryInfoResult(personSummaryInfo),
       crn = overlappedBooking.crn,
+      personType = getPersonType(personSummaryInfo),
       sex = personSummaryInfo.tryGetDetails { it.gender },
       days = bookingDuration countOverlappingDays queryDuration,
       premisesId = overlappedBooking.premisesId,
@@ -226,5 +228,13 @@ class BedSearchService(
         it.isActive && it.matches(ServiceName.temporaryAccommodation.value, modelScope)
       }.map { it.id }.toList()
     } ?: emptyList()
+  }
+
+  private fun getPersonType(
+    personSummaryInfo: PersonSummaryInfoResult,
+  ): PersonType = when (personSummaryInfo) {
+    is PersonSummaryInfoResult.Success.Full -> PersonType.fullPerson
+    is PersonSummaryInfoResult.Success.Restricted -> PersonType.restrictedPerson
+    is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> PersonType.unknownPerson
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedSearchResultTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BedSearchResultTransformer.kt
@@ -95,6 +95,7 @@ class BedSearchResultTransformer {
         ApiTemporaryAccommodationBedSearchResultOverlap(
           name = it.name,
           crn = it.crn,
+          personType = it.personType,
           days = it.days,
           bookingId = it.bookingId,
           roomId = it.roomId,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4346,6 +4346,8 @@ components:
           type: string
         sex:
           type: string
+        personType:
+          $ref: '#/components/schemas/PersonType'
         days:
           type: integer
         bookingId:
@@ -4360,6 +4362,7 @@ components:
       required:
         - name
         - crn
+        - personType
         - days
         - bookingId
         - roomId

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8677,6 +8677,8 @@ components:
           type: string
         sex:
           type: string
+        personType:
+          $ref: '#/components/schemas/PersonType'
         days:
           type: integer
         bookingId:
@@ -8691,6 +8693,7 @@ components:
       required:
         - name
         - crn
+        - personType
         - days
         - bookingId
         - roomId

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5458,6 +5458,8 @@ components:
           type: string
         sex:
           type: string
+        personType:
+          $ref: '#/components/schemas/PersonType'
         days:
           type: integer
         bookingId:
@@ -5472,6 +5474,7 @@ components:
       required:
         - name
         - crn
+        - personType
         - days
         - bookingId
         - roomId

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4937,6 +4937,8 @@ components:
           type: string
         sex:
           type: string
+        personType:
+          $ref: '#/components/schemas/PersonType'
         days:
           type: integer
         bookingId:
@@ -4951,6 +4953,7 @@ components:
       required:
         - name
         - crn
+        - personType
         - days
         - bookingId
         - roomId

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4444,6 +4444,8 @@ components:
           type: string
         sex:
           type: string
+        personType:
+          $ref: '#/components/schemas/PersonType'
         days:
           type: integer
         bookingId:
@@ -4458,6 +4460,7 @@ components:
       required:
         - name
         - crn
+        - personType
         - days
         - bookingId
         - roomId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -223,9 +223,11 @@ class ApplicationTest : IntegrationTestBase() {
                 }
 
               apDeliusContextAddResponseToUserAccessCall(
-                CaseAccessFactory()
-                  .withCrn(offenderDetails.otherIds.crn)
-                  .produce(),
+                listOf(
+                  CaseAccessFactory()
+                    .withCrn(offenderDetails.otherIds.crn)
+                    .produce(),
+                ),
                 userEntity.deliusUsername,
               )
 
@@ -296,9 +298,11 @@ class ApplicationTest : IntegrationTestBase() {
                 )
 
               apDeliusContextAddResponseToUserAccessCall(
-                CaseAccessFactory()
-                  .withCrn(offenderDetails.otherIds.crn)
-                  .produce(),
+                listOf(
+                  CaseAccessFactory()
+                    .withCrn(offenderDetails.otherIds.crn)
+                    .produce(),
+                ),
                 assessorUser.deliusUsername,
               )
 
@@ -375,9 +379,11 @@ class ApplicationTest : IntegrationTestBase() {
                 createTempApplicationEntity(applicationSchema, otherUser, offenderDetails, probationRegion, null)
 
               apDeliusContextAddResponseToUserAccessCall(
-                CaseAccessFactory()
-                  .withCrn(offenderDetails.otherIds.crn)
-                  .produce(),
+                listOf(
+                  CaseAccessFactory()
+                    .withCrn(offenderDetails.otherIds.crn)
+                    .produce(),
+                ),
                 referrerUser.deliusUsername,
               )
 
@@ -476,9 +482,11 @@ class ApplicationTest : IntegrationTestBase() {
           val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, userEntity, "TEAM1")
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -734,9 +742,11 @@ class ApplicationTest : IntegrationTestBase() {
             val application = produceAndPersistBasicApplication(crn, otherUser, "TEAM1")
 
             apDeliusContextAddResponseToUserAccessCall(
-              CaseAccessFactory()
-                .withCrn(offenderDetails.otherIds.crn)
-                .produce(),
+              listOf(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+              ),
               userEntity.deliusUsername,
             )
 
@@ -762,9 +772,11 @@ class ApplicationTest : IntegrationTestBase() {
           val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, userEntity, "TEAM1")
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -889,9 +901,11 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -951,9 +965,11 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -1012,9 +1028,11 @@ class ApplicationTest : IntegrationTestBase() {
             }
 
             apDeliusContextAddResponseToUserAccessCall(
-              CaseAccessFactory()
-                .withCrn(offenderDetails.otherIds.crn)
-                .produce(),
+              listOf(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+              ),
               userEntity.deliusUsername,
             )
 
@@ -1077,9 +1095,11 @@ class ApplicationTest : IntegrationTestBase() {
           }
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             createdByUser.deliusUsername,
           )
 
@@ -1180,9 +1200,11 @@ class ApplicationTest : IntegrationTestBase() {
             }
 
             apDeliusContextAddResponseToUserAccessCall(
-              CaseAccessFactory()
-                .withCrn(offenderDetails.otherIds.crn)
-                .produce(),
+              listOf(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+              ),
               userEntity.deliusUsername,
             )
 
@@ -1226,9 +1248,11 @@ class ApplicationTest : IntegrationTestBase() {
             }
 
             apDeliusContextAddResponseToUserAccessCall(
-              CaseAccessFactory()
-                .withCrn(offenderDetails.otherIds.crn)
-                .produce(),
+              listOf(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+              ),
               userEntity.deliusUsername,
             )
 
@@ -1254,9 +1278,11 @@ class ApplicationTest : IntegrationTestBase() {
         }
 
         apDeliusContextAddResponseToUserAccessCall(
-          CaseAccessFactory()
-            .withCrn(offenderDetails.otherIds.crn)
-            .produce(),
+          listOf(
+            CaseAccessFactory()
+              .withCrn(offenderDetails.otherIds.crn)
+              .produce(),
+          ),
           userEntity.deliusUsername,
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -305,9 +305,11 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             )
 
             apDeliusContextAddResponseToUserAccessCall(
-              CaseAccessFactory()
-                .withCrn(offenderDetails.otherIds.crn)
-                .produce(),
+              listOf(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+              ),
               user.deliusUsername,
             )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1292,9 +1292,11 @@ class PlacementRequestsTest : IntegrationTestBase() {
               )
 
               apDeliusContextAddResponseToUserAccessCall(
-                CaseAccessFactory()
-                  .withCrn(offenderDetails.otherIds.crn)
-                  .produce(),
+                listOf(
+                  CaseAccessFactory()
+                    .withCrn(offenderDetails.otherIds.crn)
+                    .produce(),
+                ),
                 user.deliusUsername,
               )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -2047,9 +2047,11 @@ class PremisesTest {
               .produce(),
           )
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(it.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(it.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
         }
@@ -2107,9 +2109,11 @@ class PremisesTest {
               .produce(),
           )
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(it.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(it.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -157,9 +157,11 @@ class ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -259,9 +261,11 @@ class ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -341,9 +345,11 @@ class ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -427,9 +433,11 @@ class ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -548,9 +556,11 @@ class ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -644,9 +654,11 @@ class ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -740,9 +752,11 @@ class ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -803,9 +817,11 @@ class ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -398,9 +398,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -470,9 +472,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -545,9 +549,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -619,9 +625,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -683,9 +691,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
           )
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -797,9 +807,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -896,9 +908,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -996,9 +1010,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
           assessment.schemaUpToDate = true
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -1078,9 +1094,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -1160,9 +1178,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -1264,9 +1284,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -1348,9 +1370,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -1436,9 +1460,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -1557,9 +1583,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -1661,9 +1689,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -1726,9 +1756,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
             .produce()
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             userEntity.deliusUsername,
           )
 
@@ -3416,9 +3448,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
           }
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 
@@ -3697,9 +3731,11 @@ class Cas3ReportsTest : IntegrationTestBase() {
           }
 
           apDeliusContextAddResponseToUserAccessCall(
-            CaseAccessFactory()
-              .withCrn(offenderDetails.otherIds.crn)
-              .produce(),
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
             user.deliusUsername,
           )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BedSearchServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
@@ -692,6 +693,7 @@ class BedSearchServiceTest {
           TemporaryAccommodationBedSearchResultOverlap(
             name = caseSummary.name.forename,
             sex = caseSummary.gender,
+            personType = PersonType.fullPerson,
             crn = overlapBookingsSearchResult.crn,
             days = 7,
             premisesId = overlapBookingsSearchResult.premisesId,


### PR DESCRIPTION
This PR CAS-1258 is to:

- Extend the response for API for bedspace search to include personType 
- Change the apDeliusContextAddListCaseSummaryToBulkResponse to accept list of case summries