### PR TITLE
APS-1638 - CAS1 Domain Event Improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -235,6 +235,11 @@ data class Cas1SpaceBookingEntity(
   @JoinColumn(name = "non_arrival_reason_id")
   var nonArrivalReason: NonArrivalReasonEntity?,
   var nonArrivalNotes: String?,
+  /**
+   * All new bookings will have delius event number set, some legacy bookings do not
+   * have a value for this (because we didn't initially capture event number for
+   * offline applications)
+   */
   val deliusEventNumber: String?,
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "migrated_from_booking_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -256,6 +257,8 @@ data class Cas1SpaceBookingEntity(
   fun hasArrival() = actualArrivalDateTime != null
   fun isResident(day: LocalDate) = canonicalArrivalDate <= day && canonicalDepartureDate > day
   override fun toString() = "Cas1SpaceBookingEntity:$id"
+  val applicationFacade: Cas1ApplicationFacade
+    get() = Cas1ApplicationFacade(application, offlineApplication)
 }
 
 enum class ManagementInfoSource {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -22,7 +22,7 @@ interface OfflineApplicationRepository : JpaRepository<OfflineApplicationEntity,
  * 1. When bulk loading bookings already created in Delius into the approved premises, as part of go-live migrations
  * 2. When a manual (adhoc) booking was required for a CRN that didn't have an existing application in [ApprovedPremisesApplicationEntity]
  *
- * As creation of manual bookings is no longer supported, Offline Applications should no longer be created
+ * As creation of manual bookings is no longer supported, Offline Applications are no longer being created
  */
 @Entity
 @Table(name = "offline_applications")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationFacade.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Some CAS1 entities can be linked to either an [ApprovedPremisesApplicationEntity],
+ * or the now deprecated [OfflineApplicationEntity]
+ *
+ * This class provides a way to simplify access to fields from these types when either may be in use
+ */
+class Cas1ApplicationFacade(
+  val application: ApprovedPremisesApplicationEntity?,
+  val offlineApplication: OfflineApplicationEntity?,
+) {
+  val id: UUID
+    get() = application?.id ?: offlineApplication!!.id
+
+  val submittedAt: OffsetDateTime
+    get() = application?.submittedAt ?: offlineApplication!!.createdAt
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
@@ -66,8 +66,8 @@ class Cas1SpaceBookingManagementDomainEventService(
     val offenderDetails = getOffenderForCrn(updatedCas1SpaceBooking.crn)
     val keyWorker = getStaffMemberDetails(updatedCas1SpaceBooking.keyWorkerStaffCode)
     val eventNumber = updatedCas1SpaceBooking.deliusEventNumber!!
-    val applicationId = updatedCas1SpaceBooking.applicationIdForDomainEvent()
-    val applicationSubmittedAt = updatedCas1SpaceBooking.applicationSubmittedOnForDomainEvent()
+    val applicationId = updatedCas1SpaceBooking.applicationFacade.id
+    val applicationSubmittedAt = updatedCas1SpaceBooking.applicationFacade.submittedAt
 
     domainEventService.savePersonArrivedEvent(
       emit = false,
@@ -113,16 +113,17 @@ class Cas1SpaceBookingManagementDomainEventService(
     val domainEventId = UUID.randomUUID()
     val eventOccurredAt = OffsetDateTime.now().toInstant()
 
-    val application = updatedCas1SpaceBooking.application
+    val applicationId = updatedCas1SpaceBooking.applicationFacade.id
     val premises = mapApprovedPremisesEntityToPremises(updatedCas1SpaceBooking.premises)
     val offenderDetails = getOffenderForCrn(updatedCas1SpaceBooking.crn)
     val staffUser = getStaffMemberDetails(user.deliusStaffCode)
+    val eventNumber = updatedCas1SpaceBooking.deliusEventNumber!!
 
     domainEventService.savePersonNotArrivedEvent(
       emit = false,
       domainEvent = DomainEvent(
         id = domainEventId,
-        applicationId = application!!.id,
+        applicationId = applicationId,
         crn = updatedCas1SpaceBooking.crn,
         nomsNumber = offenderDetails?.nomsId,
         occurredAt = eventOccurredAt,
@@ -133,14 +134,14 @@ class Cas1SpaceBookingManagementDomainEventService(
           timestamp = eventOccurredAt,
           eventType = EventType.personNotArrived,
           eventDetails = PersonNotArrived(
-            applicationId = application!!.id,
-            applicationUrl = cas1SpaceBookingManagementConfig.applicationUrlTemplate.resolve("id", application.id.toString()),
+            applicationId = applicationId,
+            applicationUrl = cas1SpaceBookingManagementConfig.applicationUrlTemplate.resolve("id", applicationId.toString()),
             bookingId = updatedCas1SpaceBooking.id,
             personReference = PersonReference(
               crn = updatedCas1SpaceBooking.crn,
               noms = offenderDetails?.nomsId ?: "Unknown NOMS Id",
             ),
-            deliusEventNumber = application!!.eventNumber,
+            deliusEventNumber = eventNumber,
             premises = premises,
             expectedArrivalOn = updatedCas1SpaceBooking.canonicalArrivalDate,
             recordedBy = staffUser!!,
@@ -168,7 +169,7 @@ class Cas1SpaceBookingManagementDomainEventService(
 
     val domainEventId = UUID.randomUUID()
 
-    val applicationId = departedCas1SpaceBooking.applicationIdForDomainEvent()
+    val applicationId = departedCas1SpaceBooking.applicationFacade.id
     val premises = mapApprovedPremisesEntityToPremises(departedCas1SpaceBooking.premises)
     val offenderDetails = getOffenderForCrn(departedCas1SpaceBooking.crn)
     val keyWorker = getStaffMemberDetails(departedCas1SpaceBooking.keyWorkerStaffCode)
@@ -230,7 +231,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val domainEventId = UUID.randomUUID()
     val eventOccurredAt = OffsetDateTime.now().toInstant()
 
-    val applicationId = updatedCas1SpaceBooking.applicationIdForDomainEvent()
+    val applicationId = updatedCas1SpaceBooking.applicationFacade.id
     val premises = mapApprovedPremisesEntityToPremises(updatedCas1SpaceBooking.premises)
     val offenderDetails = getOffenderForCrn(updatedCas1SpaceBooking.crn)
     val eventNumber = updatedCas1SpaceBooking.deliusEventNumber!!
@@ -302,7 +303,4 @@ class Cas1SpaceBookingManagementDomainEventService(
       legacyApCode = aPEntity.qCode,
       localAuthorityAreaName = aPEntity.localAuthorityArea!!.name,
     )
-
-  fun Cas1SpaceBookingEntity.applicationIdForDomainEvent() = application?.id ?: offlineApplication!!.id
-  fun Cas1SpaceBookingEntity.applicationSubmittedOnForDomainEvent() = application?.submittedAt ?: offlineApplication!!.createdAt
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -193,7 +193,10 @@ class Cas1SpaceBookingService(
     val result = cas1SpaceBookingRepository.save(existingCas1SpaceBooking)
 
     cas1SpaceBookingManagementDomainEventService.arrivalRecorded(
-      existingCas1SpaceBooking,
+      Cas1SpaceBookingManagementDomainEventService.ArrivalInfo(
+        existingCas1SpaceBooking,
+        cas1NewArrival.arrivalDateTime,
+      ),
     )
 
     success(result)
@@ -355,9 +358,12 @@ class Cas1SpaceBookingService(
     val result = cas1SpaceBookingRepository.save(existingCas1SpaceBooking)
 
     cas1SpaceBookingManagementDomainEventService.departureRecorded(
-      existingCas1SpaceBooking,
-      departureReason!!,
-      moveOnCategory!!,
+      Cas1SpaceBookingManagementDomainEventService.DepartureInfo(
+        existingCas1SpaceBooking,
+        departureReason!!,
+        moveOnCategory!!,
+        cas1NewDeparture.departureDateTime,
+      ),
     )
 
     success(result)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -37,7 +37,7 @@ class Cas1SpaceBookingTransformer(
   ): Cas1SpaceBooking {
     val placementRequest = jpa.placementRequest
     val application = jpa.application
-    val applicationId = application?.id ?: jpa.offlineApplication!!.id
+    val applicationId = jpa.applicationFacade.id
     return Cas1SpaceBooking(
       id = jpa.id,
       applicationId = applicationId,

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -95,7 +95,8 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-                
+
+
 components:
   responses:
     401Response:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/cas1/Cas1ApplicationFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/cas1/Cas1ApplicationFacadeTest.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.entity.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas1ApplicationFacadeTest {
+
+  @Nested
+  inner class GetId {
+
+    @Test
+    fun `get from application if defined`() {
+      val appId = UUID.randomUUID()
+      val offlineAppId = UUID.randomUUID()
+
+      val facade = Cas1ApplicationFacade(
+        application = applicationFactory().withId(appId).produce(),
+        offlineApplication = offlineApplicationFactory().withId(offlineAppId).produce(),
+      )
+
+      assertThat(facade.id).isEqualTo(appId)
+    }
+
+    @Test
+    fun `get from offline application if application not defined`() {
+      val offlineAppId = UUID.randomUUID()
+
+      val facade = Cas1ApplicationFacade(
+        application = null,
+        offlineApplication = offlineApplicationFactory().withId(offlineAppId).produce(),
+      )
+
+      assertThat(facade.id).isEqualTo(offlineAppId)
+    }
+  }
+
+  @Nested
+  inner class GetEventNumber {
+
+    @Test
+    fun `get from application if defined`() {
+      val facade = Cas1ApplicationFacade(
+        application = applicationFactory().withSubmittedAt(OffsetDateTime.parse("2007-12-03T10:15:30+01:00")).produce(),
+        offlineApplication = offlineApplicationFactory().withCreatedAt(OffsetDateTime.parse("2008-12-03T10:15:30+01:00")).produce(),
+      )
+
+      assertThat(facade.submittedAt).isEqualTo(OffsetDateTime.parse("2007-12-03T10:15:30+01:00"))
+    }
+
+    @Test
+    fun `get from offline application if application not defined`() {
+      val facade = Cas1ApplicationFacade(
+        application = null,
+        offlineApplication = offlineApplicationFactory().withCreatedAt(OffsetDateTime.parse("2008-12-03T10:15:30+01:00")).produce(),
+      )
+
+      assertThat(facade.submittedAt).isEqualTo(OffsetDateTime.parse("2008-12-03T10:15:30+01:00"))
+    }
+  }
+
+  private fun applicationFactory() = ApprovedPremisesApplicationEntityFactory().withDefaults()
+  private fun offlineApplicationFactory() = OfflineApplicationEntityFactory()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -1210,7 +1210,7 @@ class Cas1SpaceBookingServiceTest {
       val updatedSpaceBookingCaptor = slot<Cas1SpaceBookingEntity>()
 
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
-      every { cas1SpaceBookingManagementDomainEventService.departureRecorded(any(), any(), any()) } returns Unit
+      every { cas1SpaceBookingManagementDomainEventService.departureRecorded(any()) } returns Unit
 
       val result = service.recordDepartureForBooking(
         premisesId = UUID.randomUUID(),
@@ -1242,7 +1242,7 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking2
       every { moveOnCategoryRepository.findByIdOrNull(NOT_APPLICABLE_MOVE_ON_CATEGORY_ID) } returns departureNotApplicableMoveOnCategory
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
-      every { cas1SpaceBookingManagementDomainEventService.departureRecorded(any(), any(), any()) } returns Unit
+      every { cas1SpaceBookingManagementDomainEventService.departureRecorded(any()) } returns Unit
 
       val result = service.recordDepartureForBooking(
         premisesId = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -129,7 +129,12 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
     fun `record arrival and emits domain event`() {
       val spaceBooking = spaceBookingFactory.withApplication(application).produce()
 
-      service.arrivalRecorded(spaceBooking)
+      service.arrivalRecorded(
+        Cas1SpaceBookingManagementDomainEventService.ArrivalInfo(
+          spaceBooking,
+          arrivalDate,
+        ),
+      )
 
       val domainEventArgument = slot<DomainEvent<PersonArrivedEnvelope>>()
 
@@ -174,7 +179,12 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
       val spaceBooking = spaceBookingFactory.withOfflineApplication(offlineApplication).produce()
 
-      service.arrivalRecorded(spaceBooking)
+      service.arrivalRecorded(
+        Cas1SpaceBookingManagementDomainEventService.ArrivalInfo(
+          spaceBooking,
+          arrivalDate,
+        ),
+      )
 
       val domainEventArgument = slot<DomainEvent<PersonArrivedEnvelope>>()
 
@@ -208,7 +218,12 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
         .withKeyworkerStaffCode(null)
         .produce()
 
-      service.arrivalRecorded(existingSpaceBooking)
+      service.arrivalRecorded(
+        Cas1SpaceBookingManagementDomainEventService.ArrivalInfo(
+          existingSpaceBooking,
+          arrivalDate,
+        ),
+      )
 
       val domainEventArgument = slot<DomainEvent<PersonArrivedEnvelope>>()
 
@@ -231,6 +246,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
     private val arrivedDate = LocalDateTime.now().toInstant(ZoneOffset.UTC)
     private val departedDate = LocalDate.now().plusMonths(3)
+    private val departedDateTime = departedDate.toLocalDateTime(ZoneOffset.UTC).toInstant()
 
     private val application = ApprovedPremisesApplicationEntityFactory()
       .withSubmittedAt(OffsetDateTime.parse("2024-10-01T12:00:00Z"))
@@ -259,7 +275,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       .withCanonicalArrivalDate(arrivedDate.toLocalDate())
       .withExpectedDepartureDate(departedDate)
       .withCanonicalDepartureDate(departedDate)
-      .withActualDepartureDateTime(departedDate.toLocalDateTime(ZoneOffset.UTC).toInstant())
+      .withActualDepartureDateTime(departedDateTime)
       .withKeyworkerStaffCode(keyWorker.code)
 
     private val departureReason = DepartureReasonEntity(
@@ -295,7 +311,14 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
     fun `record departure and emits domain event`() {
       val departedSpaceBooking = departedSpaceBookingFactory.withApplication(application).produce()
 
-      service.departureRecorded(departedSpaceBooking, departureReason, moveOnCategory)
+      service.departureRecorded(
+        Cas1SpaceBookingManagementDomainEventService.DepartureInfo(
+          departedSpaceBooking,
+          departureReason,
+          moveOnCategory,
+          departedDateTime,
+        ),
+      )
 
       val domainEventArgument = slot<DomainEvent<PersonDepartedEnvelope>>()
 
@@ -349,7 +372,14 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
       val departedSpaceBooking = departedSpaceBookingFactory.withOfflineApplication(offlineApplication).produce()
 
-      service.departureRecorded(departedSpaceBooking, departureReason, moveOnCategory)
+      service.departureRecorded(
+        Cas1SpaceBookingManagementDomainEventService.DepartureInfo(
+          departedSpaceBooking,
+          departureReason,
+          moveOnCategory,
+          departedDateTime,
+        ),
+      )
 
       val domainEventArgument = slot<DomainEvent<PersonDepartedEnvelope>>()
 


### PR DESCRIPTION
* updates the CAS1 Space Booking Domain Event service to remove the need to force non-nullness on arrival and departure dates, instead having the non-null values passed in as part of the function call
* introduces a Cas1ApplicationFacade to simplify how certain application properties are retrieved when an entity could be linked to an application or an offline application