### PR TITLE
APS-1610: Add optimistic lock to Cas1 Space Bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToMany
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.persistence.Version
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -240,6 +241,8 @@ data class Cas1SpaceBookingEntity(
   val migratedFromBooking: BookingEntity?,
   @Enumerated(EnumType.STRING)
   val migratedManagementInfoFrom: ManagementInfoSource?,
+  @Version
+  var version: Long = 1,
 ) {
   fun isActive() = !isCancelled()
   fun isCancelled() = cancellationOccurredAt != null

--- a/src/main/resources/db/migration/all/20241128085222__add_optimistic_lock_to_space_booking.sql
+++ b/src/main/resources/db/migration/all/20241128085222__add_optimistic_lock_to_space_booking.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_space_bookings ADD COLUMN version BIGINT NOT NULL DEFAULT 1;


### PR DESCRIPTION
Add optimistic lock to Cas1 Space Bookings
Adds a version column to the entity and table which allows JPA @Version to detect concurrent amendments to the same record.
This approach is already in use on Bookings, Placement Applications, Placement Requests.