### PR TITLE
APS-1635 - Fix space booking timeline url

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -58,7 +58,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-dev.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
-    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION: https://approved-premises-dev.hmpps.service.justice.gov.uk/manage/premises/#premisesId/bookings/#bookingId
+    URL-TEMPLATES_FRONTEND_CAS1_SPACE-BOOKING: https://approved-premises-dev.hmpps.service.justice.gov.uk/manage/premises/#premisesId/placements/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -49,7 +49,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-preprod.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-preprod.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
-    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/manage/premises/#premisesId/bookings/#bookingId
+    URL-TEMPLATES_FRONTEND_CAS1_SPACE-BOOKING: https://approved-premises-preprod.hmpps.service.justice.gov.uk/manage/premises/#premisesId/placements/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -50,7 +50,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
-    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/manage/premises/#premisesId/bookings/#bookingId
+    URL-TEMPLATES_FRONTEND_CAS1_SPACE-BOOKING: https://approved-premises.hmpps.service.justice.gov.uk/manage/premises/#premisesId/placements/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -44,7 +44,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id
     URL-TEMPLATES_FRONTEND_BOOKING: https://approved-premises-test.hmpps.service.justice.gov.uk/premises/#premisesId/bookings/#bookingId
-    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION: https://approved-premises-test.hmpps.service.justice.gov.uk/manage/premises/#premisesId/bookings/#bookingId
+    URL-TEMPLATES_FRONTEND_CAS1_SPACE-BOOKING: https://approved-premises-test.hmpps.service.justice.gov.uk/manage/premises/#premisesId/placements/#bookingId
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationTimelineTransformer.kt
@@ -17,7 +17,7 @@ class ApplicationTimelineTransformer(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.assessment}") private val assessmentUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,
-  @Value("\${url-templates.frontend.cas1.space-booking-made}") private val cas1SpaceBookingUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.frontend.cas1.space-booking}") private val cas1SpaceBookingUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.application-appeal}") private val appealUrlTemplate: UrlTemplate,
   private val domainEventDescriber: DomainEventDescriber,
   private val userTransformer: UserTransformer,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -253,7 +253,7 @@ url-templates:
     assessment: http://localhost:3000/assessments/#id
     booking: http://localhost:3000/premises/#premisesId/bookings/#bookingId
     cas1:
-      space-booking-made: http://localhost:3000/manage/premises/#premisesId/bookings/#bookingId
+      space-booking: http://localhost:3000/manage/premises/#premisesId/placements/#bookingId
     cas2:
       application: http://localhost:3000/applications/#id
       application-overview: http://localhost:3000/applications/#id/overview

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6411,6 +6411,7 @@ components:
           type: string
           format: date
         actualArrivalTime:
+          description: This value may not be defined even if an arrival date is
           type: string
           pattern: '^([01][0-9]|2[0-3]):([0-5][0-9])$'
           example: '23:15'
@@ -6423,6 +6424,7 @@ components:
           type: string
           format: date
         actualDepartureTime:
+          description: This value may not be defined even if a departure date is
           type: string
           pattern: '^([01][0-9]|2[0-3]):([0-5][0-9])$'
           example: '23:15'


### PR DESCRIPTION
When a link to a view space booking is shown on the timeline the wrong url was being used for local deploys. In all other deploys the configuration was incorrectly named in helm so was not used. This commit fixes those issues