### PR TITLE
APS-1545 - Add sanity check to booking to space booking migration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -63,6 +63,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
@@ -229,6 +230,7 @@ class SeedService(
           getBean(DepartureReasonRepository::class),
           getBean(MoveOnCategoryRepository::class),
           getBean(NonArrivalReasonRepository::class),
+          getBean(EnvironmentService::class),
         )
 
         SeedFileType.approvedPremisesSpacePlanningDryRun -> Cas1PlanSpacePlanningDryRunSeedJob(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -79,6 +79,10 @@ class Cas1BookingToSpaceBookingSeedJob(
   private fun migratePremise(premisesId: UUID) {
     val premises = approvedPremisesRepository.findByIdOrNull(premisesId) ?: error("Premises with id $premisesId not found")
 
+    if (!premises.supportsSpaceBookings) {
+      error("premise ${premises.name} doesn't support space bookings, can't migrate bookings")
+    }
+
     log.info("Deleting all existing migrated space bookings for premises ${premises.name}")
     val deletedCount = spaceBookingRepository.deleteByPremisesIdAndMigratedFromBookingIsNotNull(premisesId)
     log.info("Have deleted $deletedCount existing migrated space bookings")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Deli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
@@ -48,6 +49,7 @@ class Cas1BookingToSpaceBookingSeedJob(
   private val departureReasonRepository: DepartureReasonRepository,
   private val moveOnCategoryRepository: MoveOnCategoryRepository,
   private val nonArrivalReasonReasonEntity: NonArrivalReasonRepository,
+  private val environmentService: EnvironmentService,
 ) : SeedJob<Cas1BookingToSpaceBookingSeedCsvRow>(
   id = UUID.randomUUID(),
   requiredHeaders = setOf(
@@ -60,6 +62,12 @@ class Cas1BookingToSpaceBookingSeedJob(
   override fun deserializeRow(columns: Map<String, String>) = Cas1BookingToSpaceBookingSeedCsvRow(
     premisesId = UUID.fromString(columns["premises_id"]!!.trim()),
   )
+
+  override fun preSeed() {
+    if (environmentService.isProd()) {
+      error("Cannot run seed job in prod")
+    }
+  }
 
   override fun processRow(row: Cas1BookingToSpaceBookingSeedCsvRow) {
     transactionTemplate.executeWithoutResult {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApprovedPremises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApprovedPremises.kt
@@ -6,11 +6,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 
 fun IntegrationTestBase.givenAnApprovedPremises(
   name: String = randomStringMultiCaseWithNumbers(8),
+  supportsSpaceBookings: Boolean = false,
 ): ApprovedPremisesEntity {
   return approvedPremisesEntityFactory
     .produceAndPersist {
       withName(name)
       withProbationRegion(probationRegionEntityFactory.produceAndPersist())
       withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+      withSupportsSpaceBookings(supportsSpaceBookings)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
@@ -31,7 +31,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
-class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
+class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
 
   @Autowired
   lateinit var cas1SpaceBookingTestRepository: Cas1SpaceBookingTestRepository
@@ -45,7 +45,10 @@ class Cas1BookingToSpaceBookingSeedJobTest : SeedTestBase() {
   @SuppressWarnings("LongMethod")
   @Test
   fun `Migrate bookings, removing existing`() {
-    val premises = givenAnApprovedPremises("Premises 1")
+    val premises = givenAnApprovedPremises(
+      name = "Premises 1",
+      supportsSpaceBookings = true,
+    )
     val otherUser = givenAUser().first
     val roomCriteria1 = characteristicEntityFactory.produceAndPersist { withModelScope("*") }
     val roomCriteria2 = characteristicEntityFactory.produceAndPersist { withModelScope("room") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.seed.cas1
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingToSpaceBookingSeedCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingToSpaceBookingSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
+import java.util.UUID
+
+class Cas1BookingToSpaceBookingSeedJobTest {
+
+  val approvedPremisesRepository = mockk<ApprovedPremisesRepository>()
+
+  val seedJob = Cas1BookingToSpaceBookingSeedJob(
+    approvedPremisesRepository = approvedPremisesRepository,
+    spaceBookingRepository = mockk<Cas1SpaceBookingRepository>(),
+    bookingRepository = mockk<BookingRepository>(),
+    domainEventRepository = mockk<DomainEventRepository>(),
+    domainEventService = mockk<DomainEventService>(),
+    userRepository = mockk<UserRepository>(),
+    transactionTemplate = mockk<TransactionTemplate>(),
+    cas1DeliusBookingImportRepository = mockk<Cas1DeliusBookingImportRepository>(),
+    departureReasonRepository = mockk<DepartureReasonRepository>(),
+    moveOnCategoryRepository = mockk<MoveOnCategoryRepository>(),
+    nonArrivalReasonReasonEntity = mockk<NonArrivalReasonRepository>(),
+    environmentService = mockk<EnvironmentService>(),
+  )
+
+  @Test
+  fun `fails if premise doesn't support space booking`() {
+    val premiseId = UUID.randomUUID()
+
+    every { approvedPremisesRepository.findByIdOrNull(premiseId) } returns
+      ApprovedPremisesEntityFactory()
+        .withSupportsSpaceBookings(false)
+        .withDefaults()
+        .produce()
+
+    assertThrows<RuntimeException> {
+      seedJob.processRow(Cas1BookingToSpaceBookingSeedCsvRow(premiseId))
+    }
+  }
+}


### PR DESCRIPTION
This PR adds some sanity checks to the booking to space booking seed job in preparation for changing the job to delete bookings after they have been migrated:

1. Block execution of the job in production
2. Ensure the related premise can support space bookings