### PR TITLE
APS-1498 - Spacebooking Key Worker Assigned at is always nullable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -220,6 +220,9 @@ data class Cas1SpaceBookingEntity(
   val crn: String,
   var keyWorkerStaffCode: String?,
   var keyWorkerName: String?,
+  /**
+   * For data imported from delius this can be null even if a key worker staff code is set
+   */
   var keyWorkerAssignedAt: Instant?,
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "departure_reason_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -91,14 +91,14 @@ class Cas1SpaceBookingTransformer(
     val staffCode = keyWorkerStaffCode
     val name = keyWorkerName
     val assignedAt = keyWorkerAssignedAt
-    return if (staffCode != null && name != null && assignedAt != null) {
+    return if (staffCode != null && name != null) {
       Cas1KeyWorkerAllocation(
         keyWorker = StaffMember(
           code = staffCode,
           keyWorker = true,
           name = name,
         ),
-        allocatedAt = assignedAt.toLocalDate(),
+        allocatedAt = assignedAt?.toLocalDate(),
       )
     } else {
       null
@@ -162,7 +162,7 @@ class Cas1SpaceBookingTransformer(
     tier = searchResult.tier,
     keyWorkerAllocation = searchResult.keyWorkerStaffCode?.let { staffCode ->
       Cas1KeyWorkerAllocation(
-        allocatedAt = searchResult.keyWorkerAssignedAt!!.toLocalDate(),
+        allocatedAt = searchResult.keyWorkerAssignedAt?.toLocalDate(),
         keyWorker = StaffMember(
           code = staffCode,
           keyWorker = true,

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -447,7 +447,6 @@ components:
           format: date
       required:
         - keyWorker
-        - allocatedAt
     Cas1SpaceBookingDeparture:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6551,7 +6551,6 @@ components:
           format: date
       required:
         - keyWorker
-        - allocatedAt
     Cas1SpaceBookingDeparture:
       type: object
       properties:


### PR DESCRIPTION
When we import key worker information from delius we do not have the data the keyworker is assigned at. This commit modifies the API model to ensure that this value is always potentially null when being returned