### PR TITLE
APS-1545 - Booking to Space Booking - remove old DateChanges

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -352,7 +352,7 @@ data class BookingEntity(
   var offlineApplication: OfflineApplicationEntity?,
   @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY)
   var extensions: MutableList<ExtensionEntity>,
-  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
   var dateChanges: MutableList<DateChangeEntity>,
   @ManyToOne
   @JoinColumn(name = "premises_id")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
@@ -163,6 +163,10 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       withReason(cancellationReason)
       withOtherReason("cancellation other reason")
     }
+    dateChangeEntityFactory.produceAndPersist {
+      withBooking(booking2LegacyCas1ManagementInfo)
+      withChangedByUser(booking2CreatedByUser)
+    }
 
     val offlineApplication = givenAnOfflineApplication(
       crn = "CRN3",


### PR DESCRIPTION
When a Booking is removed as part of the Space Booking migration, any DateChange entries related to the old booking should also be removed. Otherwise a FK reference error will occur. Note that date changes are captured as domain events, so this data will still be available for space bookings.