### PR TITLE
Improve Risk Datasource Error Message

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/datasource/OffenderRisksDataSource.kt
@@ -125,7 +125,14 @@ class OffenderRisksDataSource(
   }
 
   private fun <T> recordAndReturnError(targetInfo: String, cause: Throwable, value: T? = null): RiskWithStatus<T> {
-    sentryService.captureException(RuntimeException("Error occurred obtaining Risks for $targetInfo", cause))
+    sentryService.captureException(
+      CannotDetermineRiskException(
+        message = "An error occurred obtaining Risks for $targetInfo. Returning RiskWithStatus(status=Error). This does not necessarily block processing",
+        cause = cause,
+      ),
+    )
     return RiskWithStatus(status = RiskStatus.Error, value)
   }
+
+  private class CannotDetermineRiskException(message: String, cause: Throwable) : RuntimeException(message, cause)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/OffenderRisksDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/datasource/OffenderRisksDataSourceTest.kt
@@ -74,13 +74,13 @@ class OffenderRisksDataSourceTest {
     assertThat(result.mappa.status).isEqualTo(RiskStatus.Error)
     assertThat(result.flags.status).isEqualTo(RiskStatus.Error)
 
-    var exceptions = mutableListOf<RuntimeException>()
+    val exceptions = mutableListOf<RuntimeException>()
     verify { mockSentryService.captureException(capture(exceptions)) }
 
-    assertThat(exceptions[0].message).isEqualTo("Error occurred obtaining Risks for getRoshRatings, crn: a-crn")
-    assertThat(exceptions[1].message).isEqualTo("Error occurred obtaining Risks for toMappa, body: null")
-    assertThat(exceptions[2].message).isEqualTo("Error occurred obtaining Risks for getTier, crn: a-crn")
-    assertThat(exceptions[3].message).isEqualTo("Error occurred obtaining Risks for toRiskFlags, body: null")
+    assertThat(exceptions[0].message).isEqualTo("An error occurred obtaining Risks for getRoshRatings, crn: a-crn. Returning RiskWithStatus(status=Error). This does not necessarily block processing")
+    assertThat(exceptions[1].message).isEqualTo("An error occurred obtaining Risks for toMappa, body: null. Returning RiskWithStatus(status=Error). This does not necessarily block processing")
+    assertThat(exceptions[2].message).isEqualTo("An error occurred obtaining Risks for getTier, crn: a-crn. Returning RiskWithStatus(status=Error). This does not necessarily block processing")
+    assertThat(exceptions[3].message).isEqualTo("An error occurred obtaining Risks for toRiskFlags, body: null. Returning RiskWithStatus(status=Error). This does not necessarily block processing")
   }
 
   @Test
@@ -103,10 +103,10 @@ class OffenderRisksDataSourceTest {
     assertThat(result.mappa.status).isEqualTo(RiskStatus.Error)
     assertThat(result.flags.status).isEqualTo(RiskStatus.Error)
 
-    var exceptions = mutableListOf<RuntimeException>()
+    val exceptions = mutableListOf<RuntimeException>()
     verify { mockSentryService.captureException(capture(exceptions)) }
 
-    assertThat(exceptions[0].message).isEqualTo("Error occurred obtaining Risks for getRoshRatings, crn: a-crn")
+    assertThat(exceptions[0].message).isEqualTo("An error occurred obtaining Risks for getRoshRatings, crn: a-crn. Returning RiskWithStatus(status=Error). This does not necessarily block processing")
     assertThat(exceptions[0].cause.toString()).isEqualTo("java.lang.RuntimeException: Unable to complete GET request to /rosh/a-crn")
   }
 


### PR DESCRIPTION
Before this commit the `OffenderRisksDataSource` recorded a RuntimeException in sentry if risks couldn’t be loaded. The error message implied that processing of the thread had failed/errored because of this error, but that’s typically not the case as the calling code can continue if risks arne’t known (and will error itself if it can’t).