### PR TITLE
APS-1199: Removed CAS1_MANAGER role from service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -49,15 +49,6 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
     ),
   ),
 
-  @Deprecated("This role is no longer available for assignment on the UI and should be removed")
-  CAS1_MANAGER(
-    ServiceName.approvedPremises,
-    ApprovedPremisesUserRole.manager,
-    listOf(
-      UserPermission.CAS1_BOOKING_CHANGE_DATES,
-    ),
-  ),
-
   @Deprecated("This role is no longer available for assignment on the UI and should be removed. It has been superseded by CAS1_FUTURE_MANAGER")
   CAS1_LEGACY_MANAGER(
     ServiceName.approvedPremises,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AbstractUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AbstractUsersSeedJob.kt
@@ -38,7 +38,7 @@ abstract class AbstractUsersSeedJob(
 
     val roles = roleNames.mapNotNull {
       try {
-        parseUserRole(it)
+        UserRole.valueOf(it)
       } catch (_: Exception) {
         unknownRoles += it
         null
@@ -89,18 +89,6 @@ abstract class AbstractUsersSeedJob(
     row.qualifications.forEach {
       userService.addQualificationToUser(user, it)
     }
-  }
-
-  private fun parseUserRole(value: String) = when (value) {
-    "APPLICANT" -> UserRole.CAS1_APPLICANT
-    "ASSESSOR" -> UserRole.CAS1_ASSESSOR
-    "MANAGER" -> UserRole.CAS1_MANAGER
-    "MATCHER" -> UserRole.CAS1_MATCHER
-    "ROLE_ADMIN" -> UserRole.CAS1_ADMIN
-    "WORKFLOW_MANAGER" -> UserRole.CAS1_WORKFLOW_MANAGER
-    else -> UserRole.valueOf(value)
-  }.let {
-    if (useRolesForServices.contains(it.service)) it else null
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -211,7 +211,7 @@ class ApplicationService(
         UserRole.CAS1_WORKFLOW_MANAGER,
         UserRole.CAS1_ASSESSOR,
         UserRole.CAS1_MATCHER,
-        UserRole.CAS1_MANAGER,
+        UserRole.CAS1_FUTURE_MANAGER,
       ) &&
       offenderService.canAccessOffender(deliusUsername, applicationEntity.crn)
     ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -281,7 +281,7 @@ class BookingService(
     eventNumber: String?,
     bookingId: UUID = UUID.randomUUID(),
   ): AuthorisableActionResult<ValidatableActionResult<BookingEntity>> {
-    if (user != null && (!user.hasAnyRole(UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER))) {
+    if (user != null && (!user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_MATCHER))) {
       return AuthorisableActionResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -79,7 +79,7 @@ class UserAccessService(
   }
 
   fun userCanManagePremisesBookings(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_WORKFLOW_MANAGER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MATCHER, UserRole.CAS1_WORKFLOW_MANAGER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -123,7 +123,7 @@ class UserAccessService(
     userCanManagePremisesLostBeds(userService.getUserForRequest(), premises)
 
   fun userCanManagePremisesLostBeds(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -132,7 +132,7 @@ class UserAccessService(
     userCanViewPremisesStaff(userService.getUserForRequest(), premises)
 
   fun userCanViewPremisesStaff(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MATCHER)
+    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_LEGACY_MANAGER, UserRole.CAS1_MATCHER)
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3154,7 +3154,6 @@ components:
       enum:
         - assessor
         - matcher
-        - manager
         - legacy_manager
         - future_manager
         - workflow_manager

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7485,7 +7485,6 @@ components:
       enum:
         - assessor
         - matcher
-        - manager
         - legacy_manager
         - future_manager
         - workflow_manager

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4266,7 +4266,6 @@ components:
       enum:
         - assessor
         - matcher
-        - manager
         - legacy_manager
         - future_manager
         - workflow_manager

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3745,7 +3745,6 @@ components:
       enum:
         - assessor
         - matcher
-        - manager
         - legacy_manager
         - future_manager
         - workflow_manager

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3253,7 +3253,6 @@ components:
       enum:
         - assessor
         - matcher
-        - manager
         - legacy_manager
         - future_manager
         - workflow_manager

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -113,7 +113,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
   lateinit var referrerProbationArea: String
 
   lateinit var assessorDetails: Pair<UserEntity, String>
-  lateinit var managerDetails: Pair<UserEntity, String>
+  lateinit var futureManagerDetails: Pair<UserEntity, String>
   lateinit var workflowManagerDetails: Pair<UserEntity, String>
   lateinit var matcherDetails: Pair<UserEntity, String>
   lateinit var appealManagerDetails: Pair<UserEntity, String>
@@ -157,7 +157,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
         }
       },
     )
-    managerDetails = givenAUser(roles = listOf(UserRole.CAS1_MANAGER))
+    futureManagerDetails = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
     workflowManagerDetails = givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER))
     matcherDetails = givenAUser(roles = listOf(UserRole.CAS1_MATCHER))
     appealManagerDetails = givenAUser(roles = listOf(UserRole.CAS1_APPEALS_MANAGER))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -1271,7 +1271,7 @@ class ApplicationTest : IntegrationTestBase() {
 
   @Test
   fun `Get single offline application returns 200 with correct body`() {
-    givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
+    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { userEntity, jwt ->
       givenAnOffender { offenderDetails, _ ->
         val offlineApplicationEntity = offlineApplicationEntityFactory.produceAndPersist {
           withCrn(offenderDetails.otherIds.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -82,8 +82,8 @@ class BookingTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER"])
-    fun `Get a booking returns OK with the correct body when user has one of roles MANAGER, MATCHER`(
+    @EnumSource(value = UserRole::class, names = ["CAS1_LEGACY_MANAGER", "CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
+    fun `Get a booking returns OK with the correct body when user has one of roles LEGACY_MANAGER, FUTURE_MANAGER, MATCHER`(
       role: UserRole,
     ) {
       givenAUser(roles = listOf(role)) { _, jwt ->
@@ -133,7 +133,7 @@ class BookingTest : IntegrationTestBase() {
 
     @Test
     fun `Get a booking belonging to another premises returns not found`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
         givenAnOffender(
           offenderDetailsConfigBlock = {
             withNomsNumber(null)
@@ -166,8 +166,8 @@ class BookingTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_LEGACY_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER"])
-    fun `Get a booking for an Approved Premises returns OK with the correct body when user has one of roles LEGACY_MANAGER, MANAGER, MATCHER`(
+    @EnumSource(value = UserRole::class, names = ["CAS1_LEGACY_MANAGER", "CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
+    fun `Get a booking for an Approved Premises returns OK with the correct body when user has one of roles LEGACY_MANAGER, FUTURE_MANAGER, MATCHER`(
       role: UserRole,
     ) {
       givenAUser(roles = listOf(role)) { userEntity, jwt ->
@@ -236,7 +236,7 @@ class BookingTest : IntegrationTestBase() {
 
     @Test
     fun `Get a booking for an Approved Premises returns OK with the correct body when the NOMS number is null`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
         givenAnOffender(
           offenderDetailsConfigBlock = {
             withNomsNumber(null)
@@ -378,8 +378,8 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
-  fun `Get all Bookings on Premises without any Bookings returns empty list when user has one of roles MANAGER, MATCHER`(
+  @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
+  fun `Get all Bookings on Premises without any Bookings returns empty list when user has one of roles FUTURE_MANAGER, MATCHER`(
     role: UserRole,
   ) {
     givenAUser(roles = listOf(role)) { _, jwt ->
@@ -400,8 +400,8 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
-  fun `Get all Bookings returns OK with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
+  fun `Get all Bookings returns OK with correct body when user has one of roles FUTURE_MANAGER, MATCHER`(role: UserRole) {
     givenAUser(roles = listOf(role)) { _, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -3288,8 +3288,8 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
-  fun `Create Extension on Approved Premises Booking returns OK with expected body, updates departureDate on Booking entity when user has one of roles MANAGER, MATCHER`(
+  @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
+  fun `Create Extension on Approved Premises Booking returns OK with expected body, updates departureDate on Booking entity when user has one of roles FUTURE_MANAGER, MATCHER`(
     role: UserRole,
   ) {
     givenAUser(roles = listOf(role)) { userEntity, jwt ->
@@ -3326,7 +3326,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Extension on Approved Premises Booking returns OK when a booking has no bed`() {
-    givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { userEntity, jwt ->
+    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { userEntity, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()
       apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, "QCODE")
 
@@ -3351,7 +3351,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Approved Premises Extension returns OK when another booking for the same bed overlaps with the new departure date`() {
-    givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()
       apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, "QCODE")
 
@@ -3394,7 +3394,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Approved Premises Extension returns OK when another booking for the same bed overlaps with the updated booking's turnaround time`() {
-    givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()
       apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, "QCODE")
 
@@ -3439,7 +3439,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Approved Premises Extension returns OK when a lost bed for the same bed overlaps with the new departure date`() {
-    givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
       val keyWorker = ContextStaffMemberFactory().produce()
       apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, "QCODE")
 
@@ -3566,8 +3566,8 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
-  fun `Create AP Date Change with MANAGER or MATCHER role returns 200, persists date change`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
+  fun `Create AP Date Change with FUTURE_MANAGER or MATCHER role returns 200, persists date change`(role: UserRole) {
     govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
 
     givenAUser(roles = listOf(role)) { userEntity, jwt ->
@@ -3634,8 +3634,8 @@ class BookingTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
-  fun `Create Confirmation on Approved Premises Booking returns OK with correct body when user has one of roles MANAGER, MATCHER`(
+  @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
+  fun `Create Confirmation on Approved Premises Booking returns OK with correct body when user has one of roles FUTURE_MANAGER, MATCHER`(
     role: UserRole,
   ) {
     givenAUser(roles = listOf(role)) { userEntity, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CacheClearTest.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class CacheClearTest : IntegrationTestBase() {
   @Test
   fun `Clearing a regular cache results in upstream calls being made again`() {
-    givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
       val premisesId = UUID.fromString("d687f947-ff80-431e-9c72-75f704730978")
       val qCode = "FOUND"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CalendarTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CalendarTest.kt
@@ -23,7 +23,7 @@ class CalendarTest : InitialiseDatabasePerClassTestBase() {
   }
 
   @Test
-  fun `Requesting Calendar for CAS1 Premises without CAS1_MATCHER or CAS1_MANAGER role returns 403`() {
+  fun `Requesting Calendar for CAS1 Premises without CAS1_MATCHER or CAS1_FUTURE_MANAGER role returns 403`() {
     givenAUser { _, jwt ->
       givenAnApprovedPremisesBed { bed ->
         webTestClient.get()
@@ -37,8 +37,8 @@ class CalendarTest : InitialiseDatabasePerClassTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `Requesting Calendar for CAS1 Premises with CAS1_MATCHER or CAS1_MANAGER returns 200 with correct body`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+  fun `Requesting Calendar for CAS1 Premises with CAS1_FUTURE_MATCHER or CAS1_MATCHER returns 200 with correct body`(role: UserRole) {
     givenAUser(
       roles = listOf(role),
     ) { _, jwt ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -110,7 +110,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
   lateinit var referrerProbationArea: String
 
   lateinit var assessorDetails: Pair<UserEntity, String>
-  lateinit var managerDetails: Pair<UserEntity, String>
+  lateinit var futureManagerDetails: Pair<UserEntity, String>
   lateinit var workflowManagerDetails: Pair<UserEntity, String>
   lateinit var matcherDetails: Pair<UserEntity, String>
   lateinit var appealManagerDetails: Pair<UserEntity, String>
@@ -141,7 +141,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
         ),
       ),
     )
-    managerDetails = givenAUser(roles = listOf(UserRole.CAS1_MANAGER))
+    futureManagerDetails = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
     workflowManagerDetails = givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER))
     matcherDetails = givenAUser(roles = listOf(UserRole.CAS1_MATCHER))
     appealManagerDetails = givenAUser(roles = listOf(UserRole.CAS1_APPEALS_MANAGER))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -1728,7 +1728,7 @@ class PremisesTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
     fun `Get premises staff where delius team cannot be found returns 404`(role: UserRole) {
       givenAUser(roles = listOf(role)) { _, jwt ->
         val qCode = "NON_EXISTENT_TEAM_QCODE"
@@ -1795,8 +1795,8 @@ class PremisesTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Get Approved Premises Staff for Approved Premises returns 200 with correct body when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+    fun `Get Approved Premises Staff for Approved Premises returns 200 with correct body when user has one of roles FUTURE_MANAGER, MATCHER`(role: UserRole) {
       givenAUser(roles = listOf(role)) { userEntity, jwt ->
         val qCode = "FOUND"
 
@@ -1846,9 +1846,9 @@ class PremisesTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
     @Disabled
-    fun `Get Approved Premises Staff caches response when user has one of roles MANAGER, MATCHER`(role: UserRole) {
+    fun `Get Approved Premises Staff caches response when user has one of roles FUTURE_MANAGER, MATCHER`(role: UserRole) {
       givenAUser(roles = listOf(role)) { userEntity, jwt ->
         val qCode = "FOUND"
 
@@ -2023,7 +2023,7 @@ class PremisesTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER" ])
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER" ])
     fun `Get Premises Summary by ID that does not exist returns 404`(role: UserRole) {
       givenAUser(roles = listOf(role)) { _, jwt ->
         val id = UUID.randomUUID()
@@ -2037,7 +2037,7 @@ class PremisesTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
     fun `Get Premises Summary by ID returns OK with correct body`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
         bookings.forEach {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -368,7 +368,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role returns full list ordered by name`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               webTestClient.get()
@@ -400,7 +400,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role returns list filtered by region`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               val apArea = givenAnApArea()
@@ -449,7 +449,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role returns list filtered by user's AP area`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               val apArea = givenAnApArea()
@@ -500,7 +500,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role returns list filtered by user's CRU management area`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               val apArea = givenAnApArea()
@@ -559,7 +559,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role returns paginated list ordered by name`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               webTestClient.get()
@@ -591,11 +591,11 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role allows filtering by roles`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER, UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_FUTURE_MANAGER)) { future_manager, _ ->
           givenAUser { _, _ ->
             givenAUser(roles = listOf(role)) { _, jwt ->
               webTestClient.get()
-                .uri("/users?roles=matcher,manager")
+                .uri("/users?roles=matcher,future_manager")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
@@ -604,7 +604,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
                 .expectBody()
                 .json(
                   objectMapper.writeValueAsString(
-                    listOf(matcher, manager).map {
+                    listOf(matcher, future_manager).map {
                       userTransformer.transformJpaToApi(it, ServiceName.approvedPremises)
                     },
                   ),
@@ -736,7 +736,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET user summary with an approved role returns full list ordered by name`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               webTestClient.get()
@@ -768,7 +768,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET user summary with an approved role returns list filtered by region`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               val apArea = givenAnApArea()
@@ -815,7 +815,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role returns list filtered by user's AP area`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               val apArea = givenAnApArea()
@@ -864,7 +864,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role returns paginated list ordered by name`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { manager, _ ->
           givenAUser { userWithNoRole, _ ->
             givenAUser(roles = listOf(role)) { requestUser, jwt ->
               webTestClient.get()
@@ -896,11 +896,11 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = ["CAS1_WORKFLOW_MANAGER", "CAS1_JANITOR", "CAS1_USER_MANAGER"])
     fun `GET to users with an approved role allows filtering by roles`(role: UserRole) {
       givenAUser(roles = listOf(UserRole.CAS1_MATCHER, UserRole.CAS1_MATCHER)) { matcher, _ ->
-        givenAUser(roles = listOf(UserRole.CAS1_MANAGER, UserRole.CAS1_MANAGER, UserRole.CAS1_MANAGER)) { manager, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_FUTURE_MANAGER)) { future_manager, _ ->
           givenAUser { _, _ ->
             givenAUser(roles = listOf(role)) { _, jwt ->
               webTestClient.get()
-                .uri("/users/summary?roles=matcher,manager")
+                .uri("/users/summary?roles=matcher,future_manager")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
@@ -909,7 +909,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
                 .expectBody()
                 .json(
                   objectMapper.writeValueAsString(
-                    listOf(matcher, manager).map {
+                    listOf(matcher, future_manager).map {
                       userTransformer.transformJpaToSummaryApi(it)
                     },
                   ),
@@ -1187,7 +1187,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_JANITOR", "CAS1_USER_MANAGER"], mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER", "CAS1_JANITOR", "CAS1_USER_MANAGER"], mode = EnumSource.Mode.EXCLUDE)
     fun `Updating a user without an approved role is forbidden`(role: UserRole) {
       givenAUser(roles = listOf(role)) { _, jwt ->
         val id = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/OutOfServiceBedTest.kt
@@ -723,8 +723,8 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Get All Out-Of-Service Beds On Premises returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+    fun `Get All Out-Of-Service Beds On Premises returns OK with correct body when user has one of roles FUTURE_MANAGER, MATCHER`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -836,7 +836,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
     fun `Get Out-Of-Service Bed for non-existent out-of-service bed returns 404`(role: UserRole) {
       givenAUser(roles = listOf(role)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
@@ -854,8 +854,8 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Get Out-Of-Service Bed returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+    fun `Get Out-Of-Service Bed returns OK with correct body when user has one of roles FUTURE_MANAGER, MATCHER`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -930,7 +930,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Create Out-Of-Service Beds returns 400 Bad Request if the bed ID does not reference a bed on the premises`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { _, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion { givenAProbationRegion() }
@@ -961,8 +961,8 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Create Out-Of-Service Beds returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+    fun `Create Out-Of-Service Beds returns OK with correct body when user has one of roles FUTURE_MANAGER, MATCHER`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1040,7 +1040,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Create Out-Of-Service Bed succeeds even if overlapping with Booking`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion { givenAProbationRegion() }
@@ -1124,7 +1124,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Create Out-Of-Service Beds for current day does not break GET all Premises endpoint`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion { givenAProbationRegion() }
@@ -1174,7 +1174,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Create Out-Of-Service Bed returns 409 Conflict when An out-of-service bed for the same bed overlaps`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1231,7 +1231,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @SuppressWarnings("UnusedPrivateProperty")
     @Test
     fun `Create Out-Of-Service Bed returns OK with correct body when only cancelled out-of-service beds for the same bed overlap`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1454,8 +1454,8 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
-    fun `Update Out-Of-Service Beds returns OK with correct body when user has one of roles FUTURE_MANAGER, MANAGER, MATCHER`(role: UserRole) {
+    @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+    fun `Update Out-Of-Service Beds returns OK with correct body when user has one of roles FUTURE_MANAGER, MATCHER`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1568,7 +1568,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Update Out-Of-Service Beds succeeds even if overlapping with Booking`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         val premises = approvedPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion { givenAProbationRegion() }
@@ -1628,7 +1628,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Update Out-Of-Service Beds returns OK with correct body when only cancelled bookings for the same bed overlap`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { offenderDetails, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1753,7 +1753,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Update Out-Of-Service Beds returns 409 Conflict when An out-of-service bed for the same bed overlaps`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
@@ -1822,7 +1822,7 @@ class OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @SuppressWarnings("UnusedPrivateProperty")
     @Test
     fun `Update Out-Of-Service Beds returns OK with correct body when only cancelled out-of-service beds for the same bed overlap`() {
-      givenAUser(roles = listOf(UserRole.CAS1_MANAGER)) { user, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { _, _ ->
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedScaffoldingTest.kt
@@ -71,7 +71,7 @@ class SeedScaffoldingTest : SeedTestBase() {
       "malformed",
       """
 deliusUsername,roles,qualifications
-RogerSmith,CAS1_MANAGER,
+RogerSmith,CAS1_FUTURE_MANAGER,
 ,
       """.trimIndent(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
@@ -192,7 +192,7 @@ class SeedUsersTest : SeedTestBase() {
   }
 
   @Test
-  fun `Attempting to assign legacy roles to a user succeeds`() {
+  fun `Attempting to assign untyped roles to a user succeeds`() {
     userEntityFactory.produceAndPersist {
       withDeliusUsername("KNOWN-USER")
       withYieldedProbationRegion { givenAProbationRegion() }
@@ -204,7 +204,7 @@ class SeedUsersTest : SeedTestBase() {
         listOf(
           UserRoleAssignmentsSeedCsvRowFactory()
             .withDeliusUsername("KNOWN-USER")
-            .withUntypedRoles(listOf("APPLICANT", "ASSESSOR", "MANAGER", "MATCHER", "ROLE_ADMIN", "WORKFLOW_MANAGER"))
+            .withUntypedRoles(listOf("CAS1_APPLICANT", "CAS1_ASSESSOR", "CAS1_FUTURE_MANAGER", "CAS1_MATCHER", "CAS1_ADMIN", "CAS1_WORKFLOW_MANAGER"))
             .withTypedQualifications(listOf(UserQualification.PIPE))
             .produce(),
         ),
@@ -219,7 +219,7 @@ class SeedUsersTest : SeedTestBase() {
     assertThat(persistedUser!!.roles.map(UserRoleAssignmentEntity::role)).containsExactlyInAnyOrder(
       UserRole.CAS1_APPLICANT,
       UserRole.CAS1_ASSESSOR,
-      UserRole.CAS1_MANAGER,
+      UserRole.CAS1_FUTURE_MANAGER,
       UserRole.CAS1_MATCHER,
       UserRole.CAS1_ADMIN,
       UserRole.CAS1_WORKFLOW_MANAGER,
@@ -291,7 +291,7 @@ class SeedUsersTest : SeedTestBase() {
             description = randomStringMultiCaseWithNumbers(10),
           ),
         ),
-        expectedRoles = listOf(UserRole.CAS1_ADMIN, UserRole.CAS1_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER),
+        expectedRoles = listOf(UserRole.CAS1_ADMIN, UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR, UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER),
         expectedQualifications = listOf(UserQualification.EMERGENCY, UserQualification.LAO),
       ),
       SeedInfo(
@@ -301,7 +301,7 @@ class SeedUsersTest : SeedTestBase() {
             description = randomStringMultiCaseWithNumbers(10),
           ),
         ),
-        expectedRoles = listOf(UserRole.CAS1_MANAGER),
+        expectedRoles = listOf(UserRole.CAS1_FUTURE_MANAGER),
         expectedQualifications = listOf(),
       ),
       SeedInfo(
@@ -379,7 +379,7 @@ class SeedUsersTest : SeedTestBase() {
             description = randomStringMultiCaseWithNumbers(10),
           ),
         ),
-        expectedRoles = listOf(UserRole.CAS1_ADMIN, UserRole.CAS1_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR),
+        expectedRoles = listOf(UserRole.CAS1_ADMIN, UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_ASSESSOR),
         expectedQualifications = listOf(UserQualification.EMERGENCY, UserQualification.LAO),
       ),
       SeedInfo(
@@ -389,7 +389,7 @@ class SeedUsersTest : SeedTestBase() {
             description = randomStringMultiCaseWithNumbers(10),
           ),
         ),
-        expectedRoles = listOf(UserRole.CAS1_MANAGER),
+        expectedRoles = listOf(UserRole.CAS1_FUTURE_MANAGER),
         expectedQualifications = listOf(),
       ),
       SeedInfo(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -2510,9 +2510,9 @@ class ApplicationServiceTest {
   @ParameterizedTest
   @EnumSource(
     value = UserRole::class,
-    names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_MANAGER"],
+    names = ["CAS1_WORKFLOW_MANAGER", "CAS1_ASSESSOR", "CAS1_MATCHER", "CAS1_FUTURE_MANAGER"],
   )
-  fun `getOfflineApplicationForUsername where user has one of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER but does not pass LAO check returns Unauthorised result`(
+  fun `getOfflineApplicationForUsername where user has one of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, FUTURE_MANAGER but does not pass LAO check returns Unauthorised result`(
     role: UserRole,
   ) {
     val distinguishedName = "SOMEPERSON"
@@ -2548,12 +2548,12 @@ class ApplicationServiceTest {
   }
 
   @Test
-  fun `getOfflineApplicationForUsername where user has any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, MANAGER and passes LAO check returns Success result with entity from db`() {
+  fun `getOfflineApplicationForUsername where user has any of roles WORKFLOW_MANAGER, ASSESSOR, MATCHER, FUTURE_MANAGER and passes LAO check returns Success result with entity from db`() {
     listOf(
       UserRole.CAS1_WORKFLOW_MANAGER,
       UserRole.CAS1_ASSESSOR,
       UserRole.CAS1_MATCHER,
-      UserRole.CAS1_MANAGER,
+      UserRole.CAS1_FUTURE_MANAGER,
     ).forEach { role ->
       val distinguishedName = "SOMEPERSON"
       val userId = UUID.fromString("239b5e41-f83e-409e-8fc0-8f1e058d417e")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2793,7 +2793,7 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking returns FieldValidationError if Departure Date is before Arrival Date`(role: UserRole) {
       user.addRoleForUnitTest(role)
 
@@ -2814,7 +2814,7 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking returns FieldValidationError if Bed does not exist`(role: UserRole) {
       user.addRoleForUnitTest(role)
 
@@ -2835,7 +2835,7 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking returns FieldValidationError if Bed does not belong to an Approved Premise`(role: UserRole) {
       user.addRoleForUnitTest(role)
 
@@ -2868,7 +2868,7 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking returns FieldValidationError if Bed does not belong to the provided Premise`(role: UserRole) {
       user.addRoleForUnitTest(role)
 
@@ -2892,7 +2892,7 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking returns FieldValidationError if eventNumber is null`(role: UserRole) {
       user.addRoleForUnitTest(role)
 
@@ -2909,7 +2909,7 @@ class BookingServiceTest {
 
     @Test
     fun `createApprovedPremisesAdHocBooking succeeds when creating a double Booking`() {
-      user.addRoleForUnitTest(UserRole.CAS1_MANAGER)
+      user.addRoleForUnitTest(UserRole.CAS1_FUTURE_MANAGER)
 
       every { mockCas1ApplicationStatusService.bookingMade(bookingEntity) } returns Unit
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf(
@@ -2956,7 +2956,7 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking saves Booking and creates Domain Event when associated Application is an Online Application`(role: UserRole) {
       user.addRoleForUnitTest(role)
 
@@ -3004,7 +3004,7 @@ class BookingServiceTest {
 
     @Test
     fun `createApprovedPremisesAdHocBooking saves Booking and creates Domain Event when associated Application is an Online Application and no Bed ID is provided`() {
-      user.addRoleForUnitTest(UserRole.CAS1_MANAGER)
+      user.addRoleForUnitTest(UserRole.CAS1_FUTURE_MANAGER)
 
       val existingApplication = ApprovedPremisesApplicationEntityFactory()
         .withCrn(crn)
@@ -3050,9 +3050,9 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking saves Booking and creates Domain Event when associated Application is an Offline Application`(role: UserRole) {
-      user.addRoleForUnitTest(UserRole.CAS1_MANAGER)
+      user.addRoleForUnitTest(UserRole.CAS1_FUTURE_MANAGER)
 
       val existingOfflineApplication = OfflineApplicationEntityFactory()
         .withCrn(crn)
@@ -3093,9 +3093,9 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking saves Booking and creates Domain Event when associated Application is an Offline Application without an eventNumber`(role: UserRole) {
-      user.addRoleForUnitTest(UserRole.CAS1_MANAGER)
+      user.addRoleForUnitTest(UserRole.CAS1_FUTURE_MANAGER)
 
       val existingOfflineApplication = OfflineApplicationEntityFactory()
         .withCrn(crn)
@@ -3137,7 +3137,7 @@ class BookingServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER"])
     fun `createApprovedPremisesAdHocBooking saves Booking and creates an Offline Application when neither an Offline Application or normal Application are present`(role: UserRole) {
       user.addRoleForUnitTest(role)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -453,8 +453,8 @@ class UserAccessServiceTest {
   inner class UserCanManagePremisesBookings {
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
-    fun `userCanManagePremisesBookings returns true if the given premises is a CAS1 premises and the user has either the MANAGER or MATCHER user role`(
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_MATCHER", "CAS1_WORKFLOW_MANAGER"])
+    fun `userCanManagePremisesBookings returns true if the given premises is a CAS1 premises and the user has either the FUTURE_MANAGER or MATCHER user role`(
       role: UserRole,
     ) {
       currentRequestIsFor(ServiceName.approvedPremises)
@@ -586,8 +586,8 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `currentUserCanManagePremisesBookings returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+  fun `currentUserCanManagePremisesBookings returns true if the given premises is an Approved Premises and the current user has either the FUTURE_MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
     user.addRoleForUnitTest(role)
@@ -629,8 +629,8 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `userCanManagePremisesLostBeds returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+  fun `userCanManagePremisesLostBeds returns true if the given premises is an Approved Premises and the user has either the FUTURE_MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
     user.addRoleForUnitTest(role)
@@ -672,8 +672,8 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `currentUserCanManagePremisesLostBeds returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+  fun `currentUserCanManagePremisesLostBeds returns true if the given premises is an Approved Premises and the current user has either the FUTURE_MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
     user.addRoleForUnitTest(role)
@@ -715,8 +715,8 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `userCanManagePremisesOutOfServiceBed returns true if the given premises is an Approved Premises and the user has one of the FUTURE_MANAGER, MANAGER or MATCHER user roles`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+  fun `userCanManagePremisesOutOfServiceBed returns true if the given premises is an Approved Premises and the user has one of the FUTURE_MANAGER or MATCHER user roles`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
     user.addRoleForUnitTest(role)
@@ -758,8 +758,8 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `currentUserCanManagePremisesOutOfServiceBed returns true if the given premises is an Approved Premises and the current user has one of the FUTURE_MANAGER, MANAGER or MATCHER user roles`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+  fun `currentUserCanManagePremisesOutOfServiceBed returns true if the given premises is an Approved Premises and the current user has one of the FUTURE_MANAGER or MATCHER user roles`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
     user.addRoleForUnitTest(role)
@@ -867,8 +867,8 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `userCanViewPremisesStaff returns true if the given premises is an Approved Premises and the user has either the MANAGER or MATCHER user role`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+  fun `userCanViewPremisesStaff returns true if the given premises is an Approved Premises and the user has either the FUTURE_MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
     user.addRoleForUnitTest(role)
@@ -910,8 +910,8 @@ class UserAccessServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_MANAGER", "CAS1_MATCHER" ])
-  fun `currentUserCanViewPremisesStaff returns true if the given premises is an Approved Premises and the current user has either the MANAGER or MATCHER user role`(role: UserRole) {
+  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER", "CAS1_MATCHER" ])
+  fun `currentUserCanViewPremisesStaff returns true if the given premises is an Approved Premises and the current user has either the FUTURE_MANAGER or MATCHER user role`(role: UserRole) {
     currentRequestIsFor(ServiceName.approvedPremises)
 
     user.addRoleForUnitTest(role)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -1208,7 +1208,7 @@ class UserServiceTest {
         .withDefaults()
         .produce()
 
-      userService.removeRoleFromUser(user, UserRole.CAS1_MANAGER)
+      userService.removeRoleFromUser(user, UserRole.CAS1_FUTURE_MANAGER)
 
       verify { mockUserRoleAssignmentRepository wasNot Called }
     }
@@ -1221,7 +1221,7 @@ class UserServiceTest {
 
       val managerRoleAssignment = UserRoleAssignmentEntityFactory()
         .withUser(user)
-        .withRole(UserRole.CAS1_MANAGER)
+        .withRole(UserRole.CAS1_FUTURE_MANAGER)
         .withId(UUID.randomUUID())
         .produce()
 
@@ -1236,7 +1236,7 @@ class UserServiceTest {
 
       every { mockUserRoleAssignmentRepository.delete(managerRoleAssignment) } returns Unit
 
-      userService.removeRoleFromUser(user, UserRole.CAS1_MANAGER)
+      userService.removeRoleFromUser(user, UserRole.CAS1_FUTURE_MANAGER)
 
       verify { mockUserRoleAssignmentRepository.delete(managerRoleAssignment) }
     }
@@ -1249,7 +1249,7 @@ class UserServiceTest {
 
       val managerRoleAssignment = UserRoleAssignmentEntityFactory()
         .withUser(user)
-        .withRole(UserRole.CAS1_MANAGER)
+        .withRole(UserRole.CAS1_FUTURE_MANAGER)
         .withId(UUID.randomUUID())
         .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -208,7 +208,6 @@ class UserTransformerTest {
         "CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA",
         "CAS1_FUTURE_MANAGER",
         "CAS1_WORKFLOW_MANAGER",
-        "CAS1_MANAGER",
         "CAS1_LEGACY_MANAGER",
         "CAS1_REPORT_VIEWER",
         "CAS1_USER_MANAGER",


### PR DESCRIPTION
Removed CAS1_MANAGER role from service
Substituted CAS1_MANAGER with CAS1_FUTURE_MANAGER where applicable, to ensure continuity of service for users.