### PR TITLE
CAS-1260 - add assessment ID to application response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -40,73 +40,75 @@ class ApplicationsTransformer(
   private val cas1ApplicationUserDetailsTransformer: Cas1ApplicationUserDetailsTransformer,
   private val cas1CruManagementAreaTransformer: Cas1CruManagementAreaTransformer,
 ) {
-  fun transformJpaToApi(jpa: ApplicationEntity, personInfo: PersonInfoResult): Application {
-    val latestAssessment = jpa.getLatestAssessment()
+  @SuppressWarnings("TooGenericExceptionThrown")
+  fun transformJpaToApi(applicationEntity: ApplicationEntity, personInfo: PersonInfoResult): Application {
+    val latestAssessment = applicationEntity.getLatestAssessment()
 
-    return when (jpa) {
+    return when (applicationEntity) {
       is ApprovedPremisesApplicationEntity -> ApprovedPremisesApplication(
-        id = jpa.id,
+        id = applicationEntity.id,
         person = personTransformer.transformModelToPersonApi(personInfo),
-        createdByUserId = jpa.createdByUser.id,
-        schemaVersion = jpa.schemaVersion.id,
-        outdatedSchema = !jpa.schemaUpToDate,
-        createdAt = jpa.createdAt.toInstant(),
-        submittedAt = jpa.submittedAt?.toInstant(),
-        isWomensApplication = jpa.isWomensApplication,
-        isPipeApplication = jpa.isPipeApplication,
-        arrivalDate = jpa.arrivalDate?.toInstant(),
-        data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
-        document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
-        risks = if (jpa.riskRatings != null) {
+        createdByUserId = applicationEntity.createdByUser.id,
+        schemaVersion = applicationEntity.schemaVersion.id,
+        outdatedSchema = !applicationEntity.schemaUpToDate,
+        createdAt = applicationEntity.createdAt.toInstant(),
+        submittedAt = applicationEntity.submittedAt?.toInstant(),
+        isWomensApplication = applicationEntity.isWomensApplication,
+        isPipeApplication = applicationEntity.isPipeApplication,
+        arrivalDate = applicationEntity.arrivalDate?.toInstant(),
+        data = if (applicationEntity.data != null) objectMapper.readTree(applicationEntity.data) else null,
+        document = if (applicationEntity.document != null) objectMapper.readTree(applicationEntity.document) else null,
+        risks = if (applicationEntity.riskRatings != null) {
           risksTransformer.transformDomainToApi(
-            jpa.riskRatings!!,
-            jpa.crn,
+            applicationEntity.riskRatings!!,
+            applicationEntity.crn,
           )
         } else {
           null
         },
-        status = jpa.status.apiValue,
+        status = applicationEntity.status.apiValue,
         assessmentDecision = transformJpaDecisionToApi(latestAssessment?.decision),
         assessmentId = latestAssessment?.id,
         assessmentDecisionDate = latestAssessment?.submittedAt?.toLocalDate(),
         personStatusOnSubmission = personTransformer.inmateStatusToPersonInfoApiStatus(
-          InmateStatus.entries.firstOrNull { it.name == jpa.inmateInOutStatusOnSubmission },
+          InmateStatus.entries.firstOrNull { it.name == applicationEntity.inmateInOutStatusOnSubmission },
         ),
         type = "CAS1",
-        apArea = jpa.apArea?.let { apAreaTransformer.transformJpaToApi(it) },
-        cruManagementArea = jpa.cruManagementArea?. let { cas1CruManagementAreaTransformer.transformJpaToApi(it) },
-        applicantUserDetails = jpa.applicantUserDetails?.let { cas1ApplicationUserDetailsTransformer.transformJpaToApi(it) },
-        caseManagerIsNotApplicant = jpa.caseManagerIsNotApplicant,
-        caseManagerUserDetails = jpa.caseManagerUserDetails?.let { cas1ApplicationUserDetailsTransformer.transformJpaToApi(it) },
-        apType = jpa.apType.asApiType(),
+        apArea = applicationEntity.apArea?.let { apAreaTransformer.transformJpaToApi(it) },
+        cruManagementArea = applicationEntity.cruManagementArea?. let { cas1CruManagementAreaTransformer.transformJpaToApi(it) },
+        applicantUserDetails = applicationEntity.applicantUserDetails?.let { cas1ApplicationUserDetailsTransformer.transformJpaToApi(it) },
+        caseManagerIsNotApplicant = applicationEntity.caseManagerIsNotApplicant,
+        caseManagerUserDetails = applicationEntity.caseManagerUserDetails?.let { cas1ApplicationUserDetailsTransformer.transformJpaToApi(it) },
+        apType = applicationEntity.apType.asApiType(),
         genderForAp = GenderForAp.male,
       )
 
       is DomainTemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
-        id = jpa.id,
+        id = applicationEntity.id,
         person = personTransformer.transformModelToPersonApi(personInfo),
-        createdByUserId = jpa.createdByUser.id,
-        schemaVersion = jpa.schemaVersion.id,
-        outdatedSchema = !jpa.schemaUpToDate,
-        createdAt = jpa.createdAt.toInstant(),
-        submittedAt = jpa.submittedAt?.toInstant(),
-        arrivalDate = jpa.arrivalDate?.toInstant(),
-        data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
-        document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
-        risks = if (jpa.riskRatings != null) {
+        createdByUserId = applicationEntity.createdByUser.id,
+        schemaVersion = applicationEntity.schemaVersion.id,
+        outdatedSchema = !applicationEntity.schemaUpToDate,
+        createdAt = applicationEntity.createdAt.toInstant(),
+        submittedAt = applicationEntity.submittedAt?.toInstant(),
+        arrivalDate = applicationEntity.arrivalDate?.toInstant(),
+        data = if (applicationEntity.data != null) objectMapper.readTree(applicationEntity.data) else null,
+        document = if (applicationEntity.document != null) objectMapper.readTree(applicationEntity.document) else null,
+        risks = if (applicationEntity.riskRatings != null) {
           risksTransformer.transformDomainToApi(
-            jpa.riskRatings!!,
-            jpa.crn,
+            applicationEntity.riskRatings!!,
+            applicationEntity.crn,
           )
         } else {
           null
         },
-        status = getStatus(jpa, latestAssessment),
+        status = getStatus(applicationEntity, latestAssessment),
         type = "CAS3",
-        offenceId = jpa.offenceId,
+        offenceId = applicationEntity.offenceId,
+        assessmentId = latestAssessment?.id,
       )
 
-      else -> throw RuntimeException("Unrecognised application type when transforming: ${jpa::class.qualifiedName}")
+      else -> throw RuntimeException("Unrecognised application type when transforming: ${applicationEntity::class.qualifiedName}")
     }
   }
 

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1815,6 +1815,9 @@ components:
               format: date-time
             offenceId:
               type: string
+            assessmentId:
+              type: string
+              format: uuid
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6146,6 +6146,9 @@ components:
               format: date-time
             offenceId:
               type: string
+            assessmentId:
+              type: string
+              format: uuid
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2927,6 +2927,9 @@ components:
               format: date-time
             offenceId:
               type: string
+            assessmentId:
+              type: string
+              format: uuid
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2406,6 +2406,9 @@ components:
               format: date-time
             offenceId:
               type: string
+            assessmentId:
+              type: string
+              format: uuid
           required:
             - createdByUserId
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1914,6 +1914,9 @@ components:
               format: date-time
             offenceId:
               type: string
+            assessmentId:
+              type: string
+              format: uuid
           required:
             - createdByUserId
             - schemaVersion

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformerTest.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1ApplicationU
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
@@ -222,6 +223,17 @@ class ApplicationsTransformerTest {
     assertThat(result.risks).isNotNull
     assertThat(result.arrivalDate).isNull()
     assertThat(result.offenceId).isEqualTo(application.offenceId)
+    assertThat(result.assessmentId).isNull()
+  }
+
+  @Test
+  fun `transformJpaToApi populates assessmentId`() {
+    val application = temporaryAccommodationApplicationEntityFactory.withDefaults().produce()
+    val assessment = TemporaryAccommodationAssessmentEntityFactory().withApplication(application).produce()
+    application.assessments = mutableListOf(assessment)
+    val result = applicationsTransformer.transformJpaToApi(application, mockk()) as TemporaryAccommodationApplication
+
+    assertThat(result.assessmentId).isEqualTo(assessment.id)
   }
 
   @Test


### PR DESCRIPTION
There is work to enable a referrer to see non-user notes from the assessment timeline, so they need to have the assessment ID.