### PR TITLE
APS-1645 - Temporarily readd users.delius_staff_identifier

### DIFF
--- a/src/main/resources/db/migration/all/20241204095849__temporarily_readd_users_staff_identifier.sql
+++ b/src/main/resources/db/migration/all/20241204095849__temporarily_readd_users_staff_identifier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN delius_staff_identifier TEXT DEFAULT -1;


### PR DESCRIPTION
This is to avoid errors during the rollout of the related to change to production, as live code will still expect this column to exist.