### PR TITLE
APS-1658 - Add seed job to update space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -17,6 +17,12 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SUITED_FOR_SEX_OFFENDERS
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toInstant
 import java.time.Instant
@@ -239,6 +245,10 @@ data class Cas1SpaceBookingEntity(
   @JoinColumn(name = "cancellation_reason_id")
   var cancellationReason: CancellationReasonEntity?,
   var cancellationReasonNotes: String?,
+  /**
+   * This is constrained to the characteristics with property names defined by
+   * [Constants.CRITERIA_CHARACTERISTIC_PROPERTY_NAMES_OF_INTEREST]
+   */
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
     name = "cas1_space_bookings_criteria",
@@ -265,6 +275,18 @@ data class Cas1SpaceBookingEntity(
   @Version
   var version: Long = 1,
 ) {
+
+  object Constants {
+    val CRITERIA_CHARACTERISTIC_PROPERTY_NAMES_OF_INTEREST = listOf(
+      CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+      CAS1_PROPERTY_NAME_ENSUITE,
+      CAS1_PROPERTY_NAME_SINGLE_ROOM,
+      CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+      CAS1_PROPERTY_NAME_SUITED_FOR_SEX_OFFENDERS,
+      CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED,
+    )
+  }
+
   fun isActive() = !isCancelled()
   fun isCancelled() = cancellationOccurredAt != null
   fun hasDeparted() = actualDepartureDate != null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -192,7 +192,7 @@ data class Cas1SpaceBookingEntity(
   val application: ApprovedPremisesApplicationEntity?,
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "offline_application_id")
-  var offlineApplication: OfflineApplicationEntity?,
+  val offlineApplication: OfflineApplicationEntity?,
   /**
    * Placement request will only be null for migrated [BookingEntity]s, where adhoc = true
    */
@@ -255,7 +255,7 @@ data class Cas1SpaceBookingEntity(
     joinColumns = [JoinColumn(name = "space_booking_id")],
     inverseJoinColumns = [JoinColumn(name = "characteristic_id")],
   )
-  val criteria: List<CharacteristicEntity>,
+  val criteria: MutableList<CharacteristicEntity>,
   var nonArrivalConfirmedAt: Instant?,
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "non_arrival_reason_id")
@@ -266,7 +266,7 @@ data class Cas1SpaceBookingEntity(
    * have a value for this (because we didn't initially capture event number for
    * offline applications)
    */
-  val deliusEventNumber: String?,
+  var deliusEventNumber: String?,
   /**
    * If a value is set, this space booking was migrated from a booking
    */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -52,12 +52,6 @@ interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
   fun findAllWherePropertyNameIn(names: List<String>, serviceName: String): List<CharacteristicEntity>
 
   @Query(
-    "SELECT c FROM CharacteristicEntity c " +
-      "WHERE c.name IN :names",
-  )
-  fun findAllWhereNameIn(names: List<String>): List<CharacteristicEntity>
-
-  @Query(
     """
       SELECT c.*
       FROM characteristics c

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedColumns.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedColumns.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+data class SeedColumns(
+  val columns: Map<String, String>,
+) {
+  fun stringOrNull(label: String?) = columns[label]?.trim()?.ifBlank { null }
+
+  fun uuidOrNull(label: String) = columns[label]?.let { UUID.fromString(it.trim()) }
+
+  fun dateTimeFromList(label: String?, formatter: DateTimeFormatter): LocalDateTime? {
+    val dateTimeList = stringOrNull(label)
+    if (dateTimeList.isNullOrBlank()) {
+      return null
+    }
+
+    val lastDateTime = dateTimeList.split(",").last()
+    return LocalDateTime.parse(lastDateTime, formatter)
+  }
+
+  fun dateFromUtcDateTime(label: String?): LocalDate? {
+    val dateTime = stringOrNull(label)
+    if (dateTime.isNullOrBlank()) {
+      return null
+    }
+
+    return LocalDate.parse(dateTime.substring(startIndex = 0, endIndex = 10))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedColumns.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedColumns.kt
@@ -8,26 +8,42 @@ import java.util.UUID
 data class SeedColumns(
   val columns: Map<String, String>,
 ) {
-  fun stringOrNull(label: String?) = columns[label]?.trim()?.ifBlank { null }
+  fun stringOrNull(label: String) = columns[label]?.trim()?.ifBlank { null }
 
   fun uuidOrNull(label: String) = columns[label]?.let { UUID.fromString(it.trim()) }
 
-  fun dateTimeFromList(label: String?, formatter: DateTimeFormatter): LocalDateTime? {
-    val dateTimeList = stringOrNull(label)
-    if (dateTimeList.isNullOrBlank()) {
-      return null
-    }
+  fun lastDateTimeFromList(label: String, formatter: DateTimeFormatter): LocalDateTime? {
+    val rawValue = stringOrNull(label) ?: return null
 
-    val lastDateTime = dateTimeList.split(",").last()
+    val lastDateTime = rawValue.split(",").last()
     return LocalDateTime.parse(lastDateTime, formatter)
   }
 
-  fun dateFromUtcDateTime(label: String?): LocalDate? {
-    val dateTime = stringOrNull(label)
-    if (dateTime.isNullOrBlank()) {
-      return null
-    }
+  fun dateFromUtcDateTime(label: String): LocalDate? {
+    val rawValue = stringOrNull(label) ?: return null
 
-    return LocalDate.parse(dateTime.substring(startIndex = 0, endIndex = 10))
+    return LocalDate.parse(rawValue.substring(startIndex = 0, endIndex = 10))
+  }
+
+  fun stringsFromList(label: String): List<String> {
+    val rawValue = stringOrNull(label) ?: return emptyList()
+
+    return rawValue.split(",")
+  }
+
+  fun yesNoBoolean(label: String): Boolean? {
+    val rawValue = stringOrNull(label)?.uppercase() ?: return null
+
+    return when (rawValue) {
+      "YES" -> {
+        true
+      }
+      "NO" -> {
+        false
+      }
+      else -> {
+        error("'$rawValue' is not a recognised boolean for '$label' (use yes | no)")
+      }
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1PlanSpacePlanningDryRunSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateEventNumberSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateSpaceBookingSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1WithdrawPlacementRequestSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas2.Cas2ApplicationsSeedJob
@@ -86,6 +87,7 @@ class SeedService(
         SeedFileType.approvedPremisesBookingToSpaceBooking -> getBean(Cas1BookingToSpaceBookingSeedJob::class)
         SeedFileType.approvedPremisesSpacePlanningDryRun -> getBean(Cas1PlanSpacePlanningDryRunSeedJob::class)
         SeedFileType.approvedPremisesImportDeliusBookingManagementData -> getBean(Cas1ImportDeliusBookingDataSeedJob::class)
+        SeedFileType.approvedPremisesUpdateSpaceBooking -> getBean(Cas1UpdateSpaceBookingSeedJob::class)
       }
 
       val seedStarted = LocalDateTime.now()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -148,7 +148,7 @@ class Cas1BookingToSpaceBookingSeedJob(
         departureMoveOnCategory = managementInfo.departureMoveOnCategory,
         departureReason = managementInfo.departureReason,
         departureNotes = managementInfo.departureNotes,
-        criteria = booking.getEssentialRoomCriteria(),
+        criteria = booking.getEssentialRoomCriteria().toMutableList(),
         nonArrivalReason = managementInfo.nonArrivalReason,
         nonArrivalConfirmedAt = managementInfo.nonArrivalConfirmedAt?.toInstant(),
         nonArrivalNotes = managementInfo.nonArrivalNotes,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
@@ -72,7 +72,7 @@ class Cas1ImportDeliusBookingDataSeedJob(
       expectedDepartureDate = seedColumns.dateFromUtcDateTime("EXPECTED_DEPARTURE_DATE"),
       departureDate = seedColumns.dateFromUtcDateTime("DEPARTURE_DATE"),
       nonArrivalDate = seedColumns.dateFromUtcDateTime("NON_ARRIVAL_DATE"),
-      nonArrivalContactDateTime = seedColumns.dateTimeFromList("NON_ARRIVAL_CONTACT_DATETIME_LIST", DELIUS_IMPORT_DATE_TIME_FORMATTER),
+      nonArrivalContactDateTime = seedColumns.lastDateTimeFromList("NON_ARRIVAL_CONTACT_DATETIME_LIST", DELIUS_IMPORT_DATE_TIME_FORMATTER),
       nonArrivalReasonCode = seedColumns.stringOrNull("NON_ARRIVAL_REASON_CODE"),
       nonArrivalReasonDescription = seedColumns.stringOrNull("NON_ARRIVAL_REASON_DESCRIPTION"),
       nonArrivalNotes = seedColumns.stringOrNull("NON_ARRIVAL_NOTES"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusBookingDataSeedJob.kt
@@ -5,6 +5,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedColumns
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -52,47 +53,30 @@ class Cas1ImportDeliusBookingDataSeedJob(
     jdbcTemplate.update("TRUNCATE cas1_delius_booking_import", emptyMap<String, String>())
   }
 
-  override fun deserializeRow(columns: Map<String, String>) = Cas1DeliusBookingManagementDataRow(
-    bookingId = UUID.fromString(columns["BOOKING_ID"]!!.trim()),
-    crn = columns.stringOrNull("CRN")!!,
-    eventNumber = columns.stringOrNull("EVENT_NUMBER")!!,
-    keyWorkerStaffCode = columns.stringOrNull("KEY_WORKER_STAFF_CODE"),
-    keyWorkerForename = columns.stringOrNull("KEY_WORKER_FORENAME"),
-    keyWorkerMiddleName = columns.stringOrNull("KEY_WORKER_MIDDLE_NAME"),
-    keyWorkerSurname = columns.stringOrNull("KEY_WORKER_SURNAME"),
-    departureReasonCode = columns.stringOrNull("DEPARTURE_REASON_CODE"),
-    moveOnCategoryCode = columns.stringOrNull("MOVE_ON_CATEGORY_CODE"),
-    moveOnCategoryDescription = columns.stringOrNull("MOVE_ON_CATEGORY_DESCRIPTION"),
-    expectedArrivalDate = columns.dateFromUtcDateTime("EXPECTED_ARRIVAL_DATE")!!,
-    arrivalDate = columns.dateFromUtcDateTime("ARRIVAL_DATE"),
-    expectedDepartureDate = columns.dateFromUtcDateTime("EXPECTED_DEPARTURE_DATE"),
-    departureDate = columns.dateFromUtcDateTime("DEPARTURE_DATE"),
-    nonArrivalDate = columns.dateFromUtcDateTime("NON_ARRIVAL_DATE"),
-    nonArrivalContactDateTime = columns.dateTimeFromList("NON_ARRIVAL_CONTACT_DATETIME_LIST"),
-    nonArrivalReasonCode = columns.stringOrNull("NON_ARRIVAL_REASON_CODE"),
-    nonArrivalReasonDescription = columns.stringOrNull("NON_ARRIVAL_REASON_DESCRIPTION"),
-    nonArrivalNotes = columns.stringOrNull("NON_ARRIVAL_NOTES"),
-  )
+  override fun deserializeRow(columns: Map<String, String>): Cas1DeliusBookingManagementDataRow {
+    val seedColumns = SeedColumns(columns)
 
-  private fun Map<String, String>.stringOrNull(label: String?) = this[label]?.trim()?.ifBlank { null }
-
-  private fun Map<String, String>.dateTimeFromList(label: String?): LocalDateTime? {
-    val dateTimeList = stringOrNull(label)
-    if (dateTimeList.isNullOrBlank()) {
-      return null
-    }
-
-    val lastDateTime = dateTimeList.split(",").last()
-    return LocalDateTime.parse(lastDateTime, DELIUS_IMPORT_DATE_TIME_FORMATTER)
-  }
-
-  private fun Map<String, String>.dateFromUtcDateTime(label: String?): LocalDate? {
-    val dateTime = stringOrNull(label)
-    if (dateTime.isNullOrBlank()) {
-      return null
-    }
-
-    return LocalDate.parse(dateTime.substring(startIndex = 0, endIndex = 10))
+    return Cas1DeliusBookingManagementDataRow(
+      bookingId = seedColumns.uuidOrNull("BOOKING_ID")!!,
+      crn = seedColumns.stringOrNull("CRN")!!,
+      eventNumber = seedColumns.stringOrNull("EVENT_NUMBER")!!,
+      keyWorkerStaffCode = seedColumns.stringOrNull("KEY_WORKER_STAFF_CODE"),
+      keyWorkerForename = seedColumns.stringOrNull("KEY_WORKER_FORENAME"),
+      keyWorkerMiddleName = seedColumns.stringOrNull("KEY_WORKER_MIDDLE_NAME"),
+      keyWorkerSurname = seedColumns.stringOrNull("KEY_WORKER_SURNAME"),
+      departureReasonCode = seedColumns.stringOrNull("DEPARTURE_REASON_CODE"),
+      moveOnCategoryCode = seedColumns.stringOrNull("MOVE_ON_CATEGORY_CODE"),
+      moveOnCategoryDescription = seedColumns.stringOrNull("MOVE_ON_CATEGORY_DESCRIPTION"),
+      expectedArrivalDate = seedColumns.dateFromUtcDateTime("EXPECTED_ARRIVAL_DATE")!!,
+      arrivalDate = seedColumns.dateFromUtcDateTime("ARRIVAL_DATE"),
+      expectedDepartureDate = seedColumns.dateFromUtcDateTime("EXPECTED_DEPARTURE_DATE"),
+      departureDate = seedColumns.dateFromUtcDateTime("DEPARTURE_DATE"),
+      nonArrivalDate = seedColumns.dateFromUtcDateTime("NON_ARRIVAL_DATE"),
+      nonArrivalContactDateTime = seedColumns.dateTimeFromList("NON_ARRIVAL_CONTACT_DATETIME_LIST", DELIUS_IMPORT_DATE_TIME_FORMATTER),
+      nonArrivalReasonCode = seedColumns.stringOrNull("NON_ARRIVAL_REASON_CODE"),
+      nonArrivalReasonDescription = seedColumns.stringOrNull("NON_ARRIVAL_REASON_DESCRIPTION"),
+      nonArrivalNotes = seedColumns.stringOrNull("NON_ARRIVAL_NOTES"),
+    )
   }
 
   override fun processRow(row: Cas1DeliusBookingManagementDataRow) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UpdateSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UpdateSpaceBookingSeedJob.kt
@@ -1,0 +1,109 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedColumns
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import java.util.UUID
+import kotlin.math.log
+
+@Service
+class Cas1UpdateSpaceBookingSeedJob(
+  val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
+  val characteristicRepository: CharacteristicRepository,
+) : SeedJob<Cas1UpdateSpaceBookingSeedJobCsvRow>(
+  requiredHeaders = setOf(
+    "space_booking_id",
+    "update_event_number",
+    "event_number",
+    "update_criteria",
+    "criteria",
+  ),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>): Cas1UpdateSpaceBookingSeedJobCsvRow {
+    val seedColumns = SeedColumns(columns)
+
+    return Cas1UpdateSpaceBookingSeedJobCsvRow(
+      spaceBookingId = seedColumns.uuidOrNull("space_booking_id")!!,
+      updateEventNumber = seedColumns.yesNoBoolean("update_event_number") ?: false,
+      eventNumber = seedColumns.stringOrNull("event_number"),
+      updateCriteria = seedColumns.yesNoBoolean("update_criteria") ?: false,
+      criteria = seedColumns.stringsFromList("criteria"),
+    )
+  }
+
+  override fun processRow(row: Cas1UpdateSpaceBookingSeedJobCsvRow) {
+    val id = row.spaceBookingId
+
+    val spaceBooking = cas1SpaceBookingRepository.findByIdOrNull(id) ?: error("Could not find space booking with id $id")
+
+    if (!row.updateEventNumber && !row.updateCriteria) {
+      error("Nothing to do")
+    }
+
+    if (row.updateEventNumber) {
+      updateEventNumber(row, spaceBooking)
+    }
+
+    if (row.updateCriteria) {
+      updateCriteria(row, spaceBooking)
+    }
+
+    cas1SpaceBookingRepository.save(spaceBooking)
+  }
+
+  private fun updateEventNumber(
+    row: Cas1UpdateSpaceBookingSeedJobCsvRow,
+    spaceBooking: Cas1SpaceBookingEntity,
+  ) {
+    requireNotNull(row.eventNumber) { "No event number specified" }
+    require(spaceBooking.application == null) { "Cannot update the event number for a booking linked to an application" }
+
+    spaceBooking.offlineApplication?.let {
+      require(it.eventNumber == null) {
+        "Cannot update the event number for a booking linked to an offline application with an event number"
+      }
+    }
+
+    log.info("Updating event number for space booking ${spaceBooking.id} to ${row.eventNumber}")
+
+    spaceBooking.deliusEventNumber = row.eventNumber
+  }
+
+  private fun updateCriteria(
+    row: Cas1UpdateSpaceBookingSeedJobCsvRow,
+    spaceBooking: Cas1SpaceBookingEntity,
+  ) {
+    val updatedCriteria = row.criteria
+    val allowedCriteria = Cas1SpaceBookingEntity.Constants.CRITERIA_CHARACTERISTIC_PROPERTY_NAMES_OF_INTEREST
+
+    val unexpectedCriteria = updatedCriteria.filter { !allowedCriteria.contains(it) }
+    if (unexpectedCriteria.size > 1) {
+      error("The following criteria are not supported - $unexpectedCriteria")
+    }
+
+    log.info("Updating criteria for space booking ${spaceBooking.id} to $updatedCriteria")
+
+    spaceBooking.criteria.clear()
+    if (updatedCriteria.isNotEmpty()) {
+      spaceBooking.criteria.addAll(
+        characteristicRepository.findAllWherePropertyNameIn(updatedCriteria, ServiceName.approvedPremises.value),
+      )
+    }
+  }
+}
+
+data class Cas1UpdateSpaceBookingSeedJobCsvRow(
+  val spaceBookingId: UUID,
+  val updateEventNumber: Boolean,
+  val eventNumber: String? = null,
+  val updateCriteria: Boolean,
+  val criteria: List<String> = emptyList(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -134,7 +134,7 @@ class Cas1SpaceBookingService(
         departureMoveOnCategory = null,
         departureReason = null,
         departureNotes = null,
-        criteria = characteristics,
+        criteria = characteristics.toMutableList(),
         nonArrivalConfirmedAt = null,
         nonArrivalNotes = null,
         nonArrivalReason = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
@@ -6,13 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SUITED_FOR_SEX_OFFENDERS
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningModelsFactory.Constants.CHARACTERISTIC_ALLOW_LIST
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningModelsFactory.Constants.DEFAULT_CHARACTERISTIC_WEIGHT
 import java.time.LocalDate
 
@@ -20,17 +14,7 @@ import java.time.LocalDate
 class SpacePlanningModelsFactory {
   object Constants {
     const val DEFAULT_CHARACTERISTIC_WEIGHT = 100
-    val CHARACTERISTIC_ALLOW_LIST = listOf(
-      CAS1_PROPERTY_NAME_ARSON_SUITABLE,
-      CAS1_PROPERTY_NAME_ENSUITE,
-      CAS1_PROPERTY_NAME_SINGLE_ROOM,
-      CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
-      CAS1_PROPERTY_NAME_SUITED_FOR_SEX_OFFENDERS,
-      CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED,
-    )
   }
-
-  fun characteristicsPropertyNamesOfInterest() = CHARACTERISTIC_ALLOW_LIST
 
   fun allBeds(
     premises: ApprovedPremisesEntity,
@@ -93,7 +77,7 @@ class SpacePlanningModelsFactory {
     .asSequence()
     .filter { it.isActive }
     .filter { it.isModelScopeRoom() }
-    .filter { CHARACTERISTIC_ALLOW_LIST.contains(it.propertyName) }
+    .filter { Cas1SpaceBookingEntity.Constants.CRITERIA_CHARACTERISTIC_PROPERTY_NAMES_OF_INTEREST.contains(it.propertyName) }
     .map { toCharacteristic(it) }
     .toSet()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
@@ -73,7 +74,7 @@ class SpacePlanningService(
         totalBedCount = bedStates.count { it.isActive() || it.isTemporarilyInactive() },
         availableBedCount = availableBeds.size,
         bookingCount = bookings.size,
-        characteristicAvailability = spacePlanningModelsFactory.characteristicsPropertyNamesOfInterest().map {
+        characteristicAvailability = Cas1SpaceBookingEntity.Constants.CRITERIA_CHARACTERISTIC_PROPERTY_NAMES_OF_INTEREST.map {
           determineCharacteristicAvailability(
             characteristicPropertyName = it,
             availableBeds = availableBeds,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3838,6 +3838,7 @@ components:
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
         - approved_premises_import_delius_booking_management_data
+        - approved_premises_update_space_booking
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8121,6 +8121,7 @@ components:
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
         - approved_premises_import_delius_booking_management_data
+        - approved_premises_update_space_booking
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4950,6 +4950,7 @@ components:
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
         - approved_premises_import_delius_booking_management_data
+        - approved_premises_update_space_booking
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4429,6 +4429,7 @@ components:
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
         - approved_premises_import_delius_booking_management_data
+        - approved_premises_update_space_booking
     MigrationJobRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3937,6 +3937,7 @@ components:
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
         - approved_premises_import_delius_booking_management_data
+        - approved_premises_update_space_booking
     MigrationJobRequest:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -48,7 +48,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var departureReason: Yielded<DepartureReasonEntity?> = { null }
   private var departureMoveOnCategory: Yielded<MoveOnCategoryEntity?> = { null }
   private var departureNotes: Yielded<String?> = { null }
-  private var criteria: Yielded<List<CharacteristicEntity>> = { emptyList() }
+  private var criteria: Yielded<MutableList<CharacteristicEntity>> = { emptyList<CharacteristicEntity>().toMutableList() }
   private var nonArrivalConfirmedAt: Yielded<Instant?> = { null }
   private var nonArrivalReason: Yielded<NonArrivalReasonEntity?> = { null }
   private var nonArrivalNotes: Yielded<String?> = { null }
@@ -171,7 +171,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.departureMoveOnCategory = { moveOnCategory }
   }
 
-  fun withCriteria(criteria: List<CharacteristicEntity>) = apply {
+  fun withCriteria(criteria: MutableList<CharacteristicEntity>) = apply {
     this.criteria = { criteria }
   }
 
@@ -192,7 +192,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   }
 
   fun withCriteria(vararg criteria: CharacteristicEntity) = apply {
-    this.criteria = { criteria.toList() }
+    this.criteria = { criteria.toMutableList() }
   }
 
   fun withDepartureNotes(departureNotes: String?) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1UpdateSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1UpdateSpaceBookingTest.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateSpaceBookingSeedJobCsvRow
+
+class SeedCas1UpdateSpaceBookingTest : SeedTestBase() {
+
+  @Test
+  fun `Update Space Booking event number and criteria and add notes`() {
+    val spaceBooking = givenACas1SpaceBooking(
+      crn = "CRN1",
+      deliusEventNumber = "101",
+      offlineApplication = givenAnOfflineApplication("CRN1", eventNumberSet = false),
+      criteria = listOf(
+        getCharacteristic(CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM),
+        getCharacteristic(CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE),
+      ),
+    )
+
+    withCsv(
+      "valid-csv",
+      rowsToCsv(
+        listOf(
+          Cas1UpdateSpaceBookingSeedJobCsvRow(
+            spaceBookingId = spaceBooking.id,
+            updateEventNumber = true,
+            eventNumber = "999",
+            updateCriteria = true,
+            criteria = listOf(
+              CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM,
+              CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED,
+            ),
+          ),
+        ),
+      ),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesUpdateSpaceBooking, "valid-csv.csv")
+
+    val updatedSpaceBooking = cas1SpaceBookingRepository.findById(spaceBooking.id).get()
+    assertThat(updatedSpaceBooking.deliusEventNumber).isEqualTo("999")
+    assertThat(updatedSpaceBooking.criteria).containsExactlyInAnyOrder(
+      getCharacteristic(CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM),
+      getCharacteristic(CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED),
+    )
+  }
+
+  private fun getCharacteristic(propertyName: String) =
+    characteristicRepository.findByPropertyName(propertyName, ServiceName.approvedPremises.value)!!
+
+  private fun rowsToCsv(rows: List<Cas1UpdateSpaceBookingSeedJobCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "space_booking_id",
+        "update_event_number",
+        "event_number",
+        "update_criteria",
+        "criteria",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.spaceBookingId.toString())
+        .withQuotedField(
+          if (it.updateEventNumber) {
+            "yes"
+          } else {
+            "no"
+          },
+        )
+        .withQuotedField(it.eventNumber.toString())
+        .withQuotedField(
+          if (it.updateCriteria) {
+            "yes"
+          } else {
+            "no"
+          },
+        )
+        .withQuotedField(it.criteria.joinToString(","))
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
@@ -4,25 +4,38 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 
+@SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.givenACas1SpaceBooking(
   crn: String,
   premises: ApprovedPremisesEntity? = null,
   application: ApprovedPremisesApplicationEntity? = null,
+  deliusEventNumber: String? = null,
+  offlineApplication: OfflineApplicationEntity? = null,
+  criteria: List<CharacteristicEntity>? = null,
 ): Cas1SpaceBookingEntity {
   val (user) = givenAUser()
-  val (placementRequest) = givenAPlacementRequest(
-    placementRequestAllocatedTo = user,
-    assessmentAllocatedTo = user,
-    createdByUser = user,
-    application = application,
-  )
+  val placementRequest = if (offlineApplication == null) {
+    givenAPlacementRequest(
+      placementRequestAllocatedTo = user,
+      assessmentAllocatedTo = user,
+      createdByUser = user,
+      application = application,
+    ).first
+  } else {
+    null
+  }
 
   return cas1SpaceBookingEntityFactory.produceAndPersist {
     withCrn(crn)
     withPlacementRequest(placementRequest)
-    withApplication(placementRequest.application)
+    withApplication(placementRequest?.application)
+    withOfflineApplication(offlineApplication)
     withCreatedBy(user)
+    withDeliusEventNumber(deliusEventNumber)
     withPremises(premises ?: givenAnApprovedPremises())
+    withCriteria(criteria?.toMutableList() ?: emptyList<CharacteristicEntity>().toMutableList())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOfflineApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOfflineApplication.kt
@@ -7,7 +7,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 fun IntegrationTestBase.givenAnOfflineApplication(
   crn: String,
   eventNumber: String? = randomStringMultiCaseWithNumbers(6),
+  eventNumberSet: Boolean = true,
 ) = offlineApplicationEntityFactory.produceAndPersist {
   withCrn(crn)
-  withEventNumber(eventNumber)
+  withEventNumber(
+    if (eventNumberSet) {
+      eventNumber
+    } else {
+      null
+    },
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1UpdateSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1UpdateSpaceBookingSeedJobTest.kt
@@ -1,0 +1,232 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.seed.cas1
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateSpaceBookingSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateSpaceBookingSeedJobCsvRow
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1UpdateSpaceBookingSeedJobTest {
+
+  private companion object {
+    val BOOKING_ID: UUID = UUID.fromString("46335983-2742-4736-8b6d-9113629a5286")
+  }
+
+  private val arsonSuitableCharacteristic = CharacteristicEntityFactory()
+    .withPropertyName(CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE)
+    .produce()
+
+  private val stepFreeCharacteristic = CharacteristicEntityFactory()
+    .withPropertyName(CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED)
+    .produce()
+
+  private val otherCharacteristic = CharacteristicEntityFactory()
+    .withPropertyName("otherCharacteristic")
+    .produce()
+
+  @MockK
+  private lateinit var cas1SpaceBookingRepository: Cas1SpaceBookingRepository
+
+  @MockK
+  private lateinit var characteristicRepository: CharacteristicRepository
+
+  @InjectMockKs
+  private lateinit var seedJob: Cas1UpdateSpaceBookingSeedJob
+
+  @Test
+  fun `error if space booking not found`() {
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns null
+
+    assertThatThrownBy {
+      seedJob.processRow(
+        Cas1UpdateSpaceBookingSeedJobCsvRow(
+          spaceBookingId = BOOKING_ID,
+          updateEventNumber = false,
+          updateCriteria = false,
+        ),
+      )
+    }.hasMessageContaining("Could not find space booking with id 46335983-2742-4736-8b6d-9113629a5286")
+  }
+
+  @Test
+  fun `error if no updates requested`() {
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns Cas1SpaceBookingEntityFactory().produce()
+
+    assertThatThrownBy {
+      seedJob.processRow(
+        Cas1UpdateSpaceBookingSeedJobCsvRow(
+          spaceBookingId = BOOKING_ID,
+          updateEventNumber = false,
+          updateCriteria = false,
+        ),
+      )
+    }.hasMessageContaining("Nothing to do")
+  }
+
+  @Test
+  fun `update event number error if no event number specified`() {
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns Cas1SpaceBookingEntityFactory().produce()
+
+    assertThatThrownBy {
+      seedJob.processRow(
+        Cas1UpdateSpaceBookingSeedJobCsvRow(
+          spaceBookingId = BOOKING_ID,
+          updateEventNumber = true,
+          eventNumber = null,
+          updateCriteria = false,
+        ),
+      )
+    }.hasMessageContaining("No event number specified")
+  }
+
+  @Test
+  fun `update event number error if linked to an application`() {
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns Cas1SpaceBookingEntityFactory()
+      .withApplication(ApprovedPremisesApplicationEntityFactory().withDefaults().produce())
+      .produce()
+
+    assertThatThrownBy {
+      seedJob.processRow(
+        Cas1UpdateSpaceBookingSeedJobCsvRow(
+          spaceBookingId = BOOKING_ID,
+          updateEventNumber = true,
+          eventNumber = "2",
+          updateCriteria = false,
+        ),
+      )
+    }.hasMessageContaining("Cannot update the event number for a booking linked to an application")
+  }
+
+  @Test
+  fun `update event number error if linked to an offline application with an event number`() {
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns Cas1SpaceBookingEntityFactory()
+      .withApplication(null)
+      .withOfflineApplication(OfflineApplicationEntityFactory().withEventNumber("1").produce())
+      .produce()
+
+    assertThatThrownBy {
+      seedJob.processRow(
+        Cas1UpdateSpaceBookingSeedJobCsvRow(
+          spaceBookingId = BOOKING_ID,
+          updateEventNumber = true,
+          eventNumber = "2",
+          updateCriteria = false,
+        ),
+      )
+    }.hasMessageContaining("Cannot update the event number for a booking linked to an offline application with an event number")
+  }
+
+  @Test
+  fun `update event number`() {
+    val spaceBooking = Cas1SpaceBookingEntityFactory()
+      .withDeliusEventNumber("1")
+      .withApplication(null)
+      .withOfflineApplication(OfflineApplicationEntityFactory().withEventNumber(null).produce())
+      .produce()
+
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns spaceBooking
+    every { cas1SpaceBookingRepository.save(spaceBooking) } returns spaceBooking
+
+    seedJob.processRow(
+      Cas1UpdateSpaceBookingSeedJobCsvRow(
+        spaceBookingId = BOOKING_ID,
+        updateEventNumber = true,
+        eventNumber = "2",
+        updateCriteria = false,
+      ),
+    )
+
+    assertThat(spaceBooking.deliusEventNumber).isEqualTo("2")
+  }
+
+  @Test
+  fun `update criteria error if unexpected criteria included`() {
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns Cas1SpaceBookingEntityFactory().produce()
+
+    assertThatThrownBy {
+      seedJob.processRow(
+        Cas1UpdateSpaceBookingSeedJobCsvRow(
+          spaceBookingId = BOOKING_ID,
+          updateEventNumber = false,
+          updateCriteria = true,
+          criteria = listOf(
+            "unexpectedProperty1",
+            CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+            CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+            "unexpectedProperty2",
+          ),
+        ),
+      )
+    }.hasMessageContaining("The following criteria are not supported - [unexpectedProperty1, unexpectedProperty2]")
+  }
+
+  @Test
+  fun `update criteria, removing some existing`() {
+    val spaceBooking = Cas1SpaceBookingEntityFactory()
+      .withCriteria(otherCharacteristic, stepFreeCharacteristic)
+      .produce()
+
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns spaceBooking
+    every {
+      characteristicRepository.findAllWherePropertyNameIn(
+        listOf(
+          CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+          CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+        ),
+        ServiceName.approvedPremises.value,
+      )
+    } returns listOf(arsonSuitableCharacteristic, stepFreeCharacteristic)
+    every { cas1SpaceBookingRepository.save(spaceBooking) } returns spaceBooking
+
+    seedJob.processRow(
+      Cas1UpdateSpaceBookingSeedJobCsvRow(
+        spaceBookingId = BOOKING_ID,
+        updateEventNumber = false,
+        updateCriteria = true,
+        criteria = listOf(
+          CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+          CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+        ),
+      ),
+    )
+
+    assertThat(spaceBooking.criteria).hasSize(2)
+    assertThat(spaceBooking.criteria).containsOnly(arsonSuitableCharacteristic, stepFreeCharacteristic)
+  }
+
+  @Test
+  fun `update criteria, remove all criteria`() {
+    val spaceBooking = Cas1SpaceBookingEntityFactory()
+      .withCriteria(otherCharacteristic, stepFreeCharacteristic)
+      .produce()
+
+    every { cas1SpaceBookingRepository.findByIdOrNull(BOOKING_ID) } returns spaceBooking
+    every { cas1SpaceBookingRepository.save(spaceBooking) } returns spaceBooking
+
+    seedJob.processRow(
+      Cas1UpdateSpaceBookingSeedJobCsvRow(
+        spaceBookingId = BOOKING_ID,
+        updateEventNumber = false,
+        updateCriteria = true,
+        criteria = emptyList(),
+      ),
+    )
+
+    assertThat(spaceBooking.criteria).isEmpty()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
@@ -330,14 +330,14 @@ class SpacePlanningModelsFactoryTest {
         .withCrn("booking1")
         .withCanonicalArrivalDate(LocalDate.of(2020, 4, 4))
         .withCanonicalDepartureDate(LocalDate.of(2020, 4, 5))
-        .withCriteria(listOf(characteristic1, characteristic2, characteristicPremise))
+        .withCriteria(mutableListOf(characteristic1, characteristic2, characteristicPremise))
         .produce()
 
       val booking2 = Cas1SpaceBookingEntityFactory()
         .withCrn("booking2")
         .withCanonicalArrivalDate(LocalDate.of(2020, 4, 4))
         .withCanonicalDepartureDate(LocalDate.of(2020, 4, 5))
-        .withCriteria(listOf(characteristicSingleRoom, characteristicDisabled, characteristicPremise, characteristicNotAllowed))
+        .withCriteria(mutableListOf(characteristicSingleRoom, characteristicDisabled, characteristicPremise, characteristicNotAllowed))
         .produce()
 
       val result = factory.spaceBookingsForDay(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
@@ -36,7 +36,7 @@ class Cas1SpaceBookingRequirementsTransformerTest {
 
     val spaceBooking = Cas1SpaceBookingEntityFactory()
       .withPlacementRequest(placementRequest)
-      .withCriteria(cas1EssentialSpaceCharacteristics)
+      .withCriteria(cas1EssentialSpaceCharacteristics.toMutableList())
       .produce()
 
     val result = transformer.transformJpaToApi(spaceBooking)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -143,7 +143,7 @@ class Cas1SpaceBookingTransformerTest {
         .withCancellationRecordedAt(Instant.parse("2023-12-29T11:25:10.00Z"))
         .withCancellationReason(cancellationReason)
         .withCancellationReasonNotes("some extra info on cancellation")
-        .withCriteria(criteria)
+        .withCriteria(criteria.toMutableList())
         .withNonArrivalConfirmedAt(Instant.parse("2024-01-20T10:10:10.00Z"))
         .withNonArrivalReason(nonArrivalReason)
         .withNonArrivalNotes("some information on the non arrival")
@@ -288,7 +288,7 @@ class Cas1SpaceBookingTransformerTest {
         .withCancellationOccurredAt(LocalDate.parse("2039-12-28"))
         .withCancellationRecordedAt(Instant.parse("2023-12-29T11:25:10.00Z"))
         .withCancellationReasonNotes("some extra info on cancellation")
-        .withCriteria(criteria)
+        .withCriteria(criteria.toMutableList())
         .produce()
 
       val expectedRequirements = Cas1SpaceBookingRequirements(


### PR DESCRIPTION
This commit adds a seed job that can update a space bookings event number, and associated characteristics.

An event number can only be updated if the space booking is linked to an offline application for which no event number is assigned. In all other scenarios the `Cas1UpdateEventNumberSeedJob` should be use to update the application’s event number which will cascade to the space booking (change to be made in a subsequent commit)