### PR TITLE
APS-1658 - Add ability to record a space booking id against a timeline note

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -49,6 +49,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AppealService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
@@ -58,6 +59,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntitiesWithNotes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AppealTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DocumentTransformer
@@ -86,6 +88,8 @@ class ApplicationsController(
   private val requestForPlacementService: RequestForPlacementService,
   private val withdrawableTransformer: WithdrawableTransformer,
   private val featureFlagService: FeatureFlagService,
+  private val applicationTimelineNoteService: ApplicationTimelineNoteService,
+  private val applicationTimelineNoteTransformer: ApplicationTimelineNoteTransformer,
 ) : ApplicationsApiDelegate {
 
   override fun applicationsGet(xServiceName: ServiceName?): ResponseEntity<List<ApplicationSummary>> {
@@ -304,8 +308,9 @@ class ApplicationsController(
     body: NewApplicationTimelineNote,
   ): ResponseEntity<ApplicationTimelineNote> {
     val user = userService.getUserForRequest()
-    val savedNote = applicationService.addNoteToApplication(applicationId, body.note, user)
-    return ResponseEntity.ok(savedNote)
+    val savedNote = applicationTimelineNoteService.saveApplicationTimelineNote(applicationId, body.note, user)
+
+    return ResponseEntity.ok(applicationTimelineNoteTransformer.transformJpaToApi(savedNote))
   }
 
   override fun applicationsApplicationIdWithdrawalPost(applicationId: UUID, body: NewWithdrawal): ResponseEntity<Unit> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -25,4 +26,6 @@ data class ApplicationTimelineNoteEntity(
   val createdBy: UserEntity?,
   val createdAt: OffsetDateTime,
   val body: String,
+  @Column(name = "cas1_space_booking_id")
+  val cas1SpaceBookingId: UUID?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
@@ -43,6 +44,7 @@ class Cas1AutoScript(
   private val environmentService: EnvironmentService,
   private val premisesService: PremisesService,
   private val bookingRepository: BookingRepository,
+  private val applicationTimelineNoteService: ApplicationTimelineNoteService,
 ) {
 
   @Transactional
@@ -267,7 +269,7 @@ class Cas1AutoScript(
 
     extractEntityFromCasResult(updateResult)
 
-    applicationService.addNoteToApplication(
+    applicationTimelineNoteService.saveApplicationTimelineNote(
       applicationId = newApplicationEntity.id,
       note = "Application automatically created by Cas1 Auto Script",
       user = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromValidatableActionResult
 import java.util.UUID
@@ -34,6 +35,7 @@ import java.util.UUID
 class Cas1DuplicateApplicationSeedJob(
   private val applicationService: ApplicationService,
   private val offenderService: OffenderService,
+  private val applicationTimelineNoteService: ApplicationTimelineNoteService,
 ) : SeedJob<Cas1DuplicateApplicationSeedCsvRow>(
   requiredHeaders = setOf(
     "application_id",
@@ -104,7 +106,7 @@ class Cas1DuplicateApplicationSeedJob(
       createdByUser,
     )
 
-    applicationService.addNoteToApplication(
+    applicationTimelineNoteService.saveApplicationTimelineNote(
       applicationId = newApplicationEntity.id,
       note = "Application automatically created by Application Support by duplicating existing application ${sourceApplication.id}",
       user = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1RedactAssessmentDetailsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1RedactAssessmentDetailsSeedJob.kt
@@ -7,14 +7,14 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import java.util.UUID
 
 @Component
 class Cas1RemoveAssessmentDetailsSeedJob(
   private val assessmentRepository: AssessmentRepository,
   private val objectMapper: ObjectMapper,
-  private val applicationService: ApplicationService,
+  private val applicationTimelineNoteService: ApplicationTimelineNoteService,
 ) : SeedJob<Cas1RemoveAssessmentDetailsSeedCsvRow>(
   requiredHeaders = setOf(
     "assessment_id",
@@ -36,7 +36,7 @@ class Cas1RemoveAssessmentDetailsSeedJob(
     assessmentRepository.save(assessment)
 
     if (assessment.data != null || assessment.document != null) {
-      applicationService.addNoteToApplication(
+      applicationTimelineNoteService.saveApplicationTimelineNote(
         applicationId = assessment.application.id,
         note = "Assessment details redacted",
         user = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UpdateEventNumberSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UpdateEventNumberSeedJob.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import java.util.UUID
 
 /**
@@ -34,7 +34,7 @@ import java.util.UUID
  */
 @Component
 class Cas1UpdateEventNumberSeedJob(
-  private val applicationService: ApplicationService,
+  private val applicationTimelineNoteService: ApplicationTimelineNoteService,
   private val applicationRepository: ApplicationRepository,
   private val domainEventRepository: DomainEventRepository,
   private val objectMapper: ObjectMapper,
@@ -80,7 +80,7 @@ class Cas1UpdateEventNumberSeedJob(
 
     updateDomainEvents(applicationId, updatedEventNumber)
 
-    applicationService.addNoteToApplication(
+    applicationTimelineNoteService.saveApplicationTimelineNote(
       applicationId = row.applicationId,
       note = "Application Support have updated application to use event number '$updatedEventNumber'. Previous event number was '$previousEventNumber'",
       user = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1WithdrawPlacementRequestSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1WithdrawPlacementRequestSeedJob.kt
@@ -4,7 +4,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
@@ -17,7 +17,7 @@ import java.util.UUID
 @Component
 class Cas1WithdrawPlacementRequestSeedJob(
   private val placementRequestService: PlacementRequestService,
-  private val applicationService: ApplicationService,
+  private val applicationTimelineNoteService: ApplicationTimelineNoteService,
 ) : SeedJob<Cas1WithdrawPlacementRequestSeedSeedCsvRow>(
   requiredHeaders = setOf(
     "placement_request_id",
@@ -54,7 +54,7 @@ class Cas1WithdrawPlacementRequestSeedJob(
     extractEntityFromCasResult(result).placementRequest
 
     val reasonDescription = withdrawalReason.name.javaConstantNameToSentence()
-    applicationService.addNoteToApplication(
+    applicationTimelineNoteService.saveApplicationTimelineNote(
       applicationId = placementRequest.application.id,
       note = "The Match Request for arrival date ${placementRequest.expectedArrival.toUiFormat()} has " +
         "been withdrawn by Application Support as the CRU has indicated that it is no longer required. " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -6,7 +6,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationTimelineNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -941,15 +940,6 @@ class ApplicationService(
     return noteEntities.map {
       applicationTimelineNoteTransformer.transformToTimelineEvents(it)
     }
-  }
-
-  fun addNoteToApplication(
-    applicationId: UUID,
-    note: String,
-    user: UserEntity?,
-  ): ApplicationTimelineNote {
-    val savedNote = applicationTimelineNoteService.saveApplicationTimelineNote(applicationId, note, user)
-    return applicationTimelineNoteTransformer.transformJpaToApi(savedNote)
   }
 
   private fun getPrisonName(personInfo: PersonInfoResult.Success.Full): String? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
@@ -15,7 +15,12 @@ class ApplicationTimelineNoteService(
   fun getApplicationTimelineNotesByApplicationId(applicationId: UUID): List<ApplicationTimelineNoteEntity> =
     applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(applicationId)
 
-  fun saveApplicationTimelineNote(applicationId: UUID, note: String, user: UserEntity?): ApplicationTimelineNoteEntity {
+  fun saveApplicationTimelineNote(
+    applicationId: UUID,
+    note: String,
+    user: UserEntity?,
+    cas1SpaceBookingId: UUID? = null,
+  ): ApplicationTimelineNoteEntity {
     return applicationTimelineNoteRepository.save(
       ApplicationTimelineNoteEntity(
         id = UUID.randomUUID(),
@@ -23,6 +28,7 @@ class ApplicationTimelineNoteService(
         createdBy = user,
         createdAt = OffsetDateTime.now(),
         body = note,
+        cas1SpaceBookingId = cas1SpaceBookingId,
       ),
     )
   }

--- a/src/main/resources/db/migration/all/20241205110116__add_space_booking_id_to_timeline_note.sql
+++ b/src/main/resources/db/migration/all/20241205110116__add_space_booking_id_to_timeline_note.sql
@@ -1,0 +1,2 @@
+ALTER TABLE application_timeline_notes ADD cas1_space_booking_id uuid NULL;
+ALTER TABLE application_timeline_notes ADD CONSTRAINT application_timeline_notes_cas1_space_bookings_fk FOREIGN KEY (cas1_space_booking_id) REFERENCES cas1_space_bookings(id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
@@ -20,6 +20,7 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
   private var createdBy: Yielded<UserEntity?>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var body: Yielded<String> = { randomStringUpperCase(12) }
+  private var cas1SpaceBookingId: Yielded<UUID?> = { null }
 
   fun withDefaults() = apply {
   }
@@ -50,5 +51,6 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
     createdBy = this.createdBy?.invoke(),
     createdAt = this.createdAt(),
     body = this.body(),
+    cas1SpaceBookingId = this.cas1SpaceBookingId(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1RedactAssessmentDetailsSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1RedactAssessmentDetailsSeedJobTest.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 
 class Cas1RedactAssessmentDetailsSeedJobTest {
@@ -13,7 +13,7 @@ class Cas1RedactAssessmentDetailsSeedJobTest {
   val service = Cas1RemoveAssessmentDetailsSeedJob(
     assessmentRepository = mockk<AssessmentRepository>(),
     objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper(),
-    applicationService = mockk<ApplicationService>(),
+    applicationTimelineNoteService = mockk<ApplicationTimelineNoteService>(),
   )
 
   @SuppressWarnings("MaxLineLength")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationTimelineNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationTimelineNoteServiceTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTimelineNoteEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class ApplicationTimelineNoteServiceTest {
+  @MockK
+  private lateinit var applicationTimelineNoteRepository: ApplicationTimelineNoteRepository
+
+  @InjectMockKs
+  private lateinit var service: ApplicationTimelineNoteService
+
+  @Nested
+  inner class SaveApplicationTimelineNote {
+
+    @Test
+    fun `Add Note To Application`() {
+      val applicationId = UUID.randomUUID()
+      val note = "the note"
+      val user = UserEntityFactory().withDefaults().produce()
+
+      every { applicationTimelineNoteRepository.save(any()) } returns ApplicationTimelineNoteEntityFactory().produce()
+
+      service.saveApplicationTimelineNote(
+        applicationId,
+        note,
+        user,
+      )
+
+      val savedTimelineNoteCaptor = slot<ApplicationTimelineNoteEntity>()
+      verify(exactly = 1) {
+        applicationTimelineNoteRepository.save(capture(savedTimelineNoteCaptor))
+      }
+
+      val savedTimelineNote = savedTimelineNoteCaptor.captured
+      assertThat(savedTimelineNote.applicationId).isEqualTo(applicationId)
+      assertThat(savedTimelineNote.body).isEqualTo("the note")
+      assertThat(savedTimelineNote.createdBy).isEqualTo(user)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationTimelineNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationTimelineNoteServiceTest.kt
@@ -33,6 +33,7 @@ class ApplicationTimelineNoteServiceTest {
       val applicationId = UUID.randomUUID()
       val note = "the note"
       val user = UserEntityFactory().withDefaults().produce()
+      val spaceBookingId = UUID.randomUUID()
 
       every { applicationTimelineNoteRepository.save(any()) } returns ApplicationTimelineNoteEntityFactory().produce()
 
@@ -40,6 +41,7 @@ class ApplicationTimelineNoteServiceTest {
         applicationId,
         note,
         user,
+        spaceBookingId,
       )
 
       val savedTimelineNoteCaptor = slot<ApplicationTimelineNoteEntity>()
@@ -51,6 +53,7 @@ class ApplicationTimelineNoteServiceTest {
       assertThat(savedTimelineNote.applicationId).isEqualTo(applicationId)
       assertThat(savedTimelineNote.body).isEqualTo("the note")
       assertThat(savedTimelineNote.createdBy).isEqualTo(user)
+      assertThat(savedTimelineNote.cas1SpaceBookingId).isEqualTo(spaceBookingId)
     }
   }
 }


### PR DESCRIPTION
This PR removes `ApplicationService. addNoteToApplication` and redirects all calls to the `ApplicationTimelineNoteService`, as the extra layer of indirection had no value and complicates changes

It then adds `cas1_space_booking_id` to the timeline note table