### PR TITLE
APS-1654: Space Search filter on application gender

### DIFF
--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -200,6 +200,10 @@ components:
     Cas1SpaceSearchParameters:
       type: object
       properties:
+        applicationId:
+          type: string
+          format: uuid
+          description: The id of the application the space search is for
         startDate:
           type: string
           format: date

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6312,6 +6312,10 @@ components:
     Cas1SpaceSearchParameters:
       type: object
       properties:
+        applicationId:
+          type: string
+          format: uuid
+          description: The id of the application the space search is for
         startDate:
           type: string
           format: date


### PR DESCRIPTION
Space Search should filter premises based upon application's associated gender

First part of ticket APS-1654  
Requires the addition of applicationId to the space search parameters to be able to determine gender requirement from application.  
Added initially as optional, prior to requisite change in the UI after which it will be changed to be mandatory.