### PR TITLE
APS-1642 - Remove staffIdentifier from domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/StaffDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/StaffDetail.kt
@@ -20,7 +20,6 @@ data class StaffDetail(
 
   fun toStaffMember() = StaffMember(
     staffCode = this.code,
-    staffIdentifier = -1L,
     forenames = this.name.forenames(),
     surname = this.name.surname,
     username = this.username,

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -647,12 +647,6 @@ components:
         staffCode:
           type: string
           example: N54A999
-        staffIdentifier:
-          deprecated: true
-          description: This field is not used by consumers and will be removed once consumers have been updated to not expect it
-          type: integer
-          format: int64
-          example: 1501234567
         forenames:
           type: string
           example: John

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/StaffMemberFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/StaffMemberFactory.kt
@@ -3,23 +3,17 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 
 class StaffMemberFactory : Factory<StaffMember> {
   private var staffCode: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
-  private var staffIdentifier: Yielded<Long> = { randomInt(1000, 5000).toLong() }
   private var forenames: Yielded<String> = { randomStringUpperCase(6) }
   private var surname: Yielded<String> = { randomStringUpperCase(6) }
   private var username: Yielded<String> = { randomStringUpperCase(8) }
 
   fun withStaffCode(staffCode: String) = apply {
     this.staffCode = { staffCode }
-  }
-
-  fun withStaffIdentifier(staffIdentifier: Long) = apply {
-    this.staffIdentifier = { staffIdentifier }
   }
 
   fun withForenames(forenames: String) = apply {
@@ -36,7 +30,6 @@ class StaffMemberFactory : Factory<StaffMember> {
 
   override fun produce(): StaffMember = StaffMember(
     staffCode = this.staffCode(),
-    staffIdentifier = this.staffIdentifier(),
     forenames = this.forenames(),
     surname = this.surname(),
     username = this.username(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/StaffDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/StaffDetailTest.kt
@@ -4,14 +4,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.PersonName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomLong
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 
 class StaffDetailTest {
   private val staffCode = randomStringMultiCaseWithNumbers(10).uppercase()
-  private val staffIdentifier = randomLong()
   private val forename = randomStringLowerCase(10)
   private val middleName = randomStringLowerCase(10)
   private val surname = randomStringUpperCase(10)
@@ -26,7 +24,6 @@ class StaffDetailTest {
     ).toStaffMember()
 
     assertThat(staffMember.staffCode).isEqualTo(staffCode)
-    assertThat(staffMember.staffIdentifier).isEqualTo(-1)
     assertThat(staffMember.forenames).isEqualTo(forename)
     assertThat(staffMember.surname).isEqualTo(surname)
     assertThat(staffMember.username).isEqualTo(username)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1478,7 +1478,6 @@ class AssessmentServiceTest {
       ApplicationAssessedAssessedBy(
         staffMember = StaffMember(
           staffCode = staffUserDetails.code,
-          staffIdentifier = -1,
           forenames = staffUserDetails.name.forenames(),
           surname = staffUserDetails.name.surname,
           username = staffUserDetails.username,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -390,7 +390,6 @@ class Cas1AssessmentDomainEventServiceTest {
     else ->
       staffDetails != null &&
         staffMember.staffCode == staffDetails.code &&
-        staffMember.staffIdentifier == -1L &&
         staffMember.forenames == staffDetails.name.forenames() &&
         staffMember.surname == staffDetails.name.surname &&
         staffMember.username == staffDetails.username

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -172,7 +172,6 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       assertThat(data.keyWorker!!.staffCode).isEqualTo(keyWorker.code)
       assertThat(data.keyWorker!!.surname).isEqualTo(keyWorker.name.surname)
       assertThat(data.keyWorker!!.forenames).isEqualTo(keyWorker.name.forenames())
-      assertThat(data.keyWorker!!.staffIdentifier).isEqualTo(-1)
     }
 
     @Test
@@ -361,7 +360,6 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       assertThat(domainEventKeyWorker.staffCode).isEqualTo(keyWorker.code)
       assertThat(domainEventKeyWorker.surname).isEqualTo(keyWorker.name.surname)
       assertThat(domainEventKeyWorker.forenames).isEqualTo(keyWorker.name.forenames())
-      assertThat(domainEventKeyWorker.staffIdentifier).isEqualTo(-1)
       val domainEventMoveOnCategory = domainEventEventDetails.destination.moveOnCategory
       assertThat(domainEventMoveOnCategory.id).isEqualTo(moveOnCategory.id)
       assertThat(domainEventMoveOnCategory.description).isEqualTo(moveOnCategory.name)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DomainEventTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DomainEventTransformerTest.kt
@@ -66,7 +66,6 @@ class DomainEventTransformerTest {
     val result = domainEventTransformer.toStaffMember(user)
 
     assertThat(result.staffCode).isEqualTo("theStaffCode")
-    assertThat(result.staffIdentifier).isEqualTo(-1L)
     assertThat(result.forenames).isEqualTo("theForenames")
     assertThat(result.surname).isEqualTo("theSurname")
     assertThat(result.username).isEqualTo("theUsername")
@@ -110,7 +109,6 @@ class DomainEventTransformerTest {
 
     val staffMember = result.staffMember
     assertThat(staffMember.staffCode).isEqualTo("theStaffCode")
-    assertThat(staffMember.staffIdentifier).isEqualTo(-1L)
     assertThat(staffMember.forenames).isEqualTo("theForenames theMiddleName")
     assertThat(staffMember.surname).isEqualTo("theSurname")
     assertThat(staffMember.username).isEqualTo("theUsername")
@@ -139,7 +137,6 @@ class DomainEventTransformerTest {
 
     val staffMember = result.staffMember
     assertThat(staffMember.staffCode).isEqualTo("theStaffCode")
-    assertThat(staffMember.staffIdentifier).isEqualTo(-1L)
     assertThat(staffMember.forenames).isEqualTo("theForenames")
     assertThat(staffMember.surname).isEqualTo("theSurname")
     assertThat(staffMember.username).isEqualTo("theUsername")


### PR DESCRIPTION
Receivers (ap-and-delius-context) are no longer expecting domain events `staff member` to include a staff identifier value. This commit removes that value as it is not required.