### PR TITLE
APS-167 - Only migrate criteria of interest to space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -148,7 +148,7 @@ class Cas1BookingToSpaceBookingSeedJob(
         departureMoveOnCategory = managementInfo.departureMoveOnCategory,
         departureReason = managementInfo.departureReason,
         departureNotes = managementInfo.departureNotes,
-        criteria = booking.getEssentialRoomCriteria().toMutableList(),
+        criteria = booking.getEssentialRoomCriteriaOfInterest().toMutableList(),
         nonArrivalReason = managementInfo.nonArrivalReason,
         nonArrivalConfirmedAt = managementInfo.nonArrivalConfirmedAt?.toInstant(),
         nonArrivalNotes = managementInfo.nonArrivalNotes,
@@ -244,8 +244,11 @@ class Cas1BookingToSpaceBookingSeedJob(
     val nonArrivalNotes: String?,
   )
 
-  private fun BookingEntity.getEssentialRoomCriteria() =
-    placementRequest?.placementRequirements?.essentialCriteria?.filter { it.isModelScopeRoom() }?.toList()
+  private fun BookingEntity.getEssentialRoomCriteriaOfInterest() =
+    placementRequest?.placementRequirements?.essentialCriteria
+      ?.filter { it.isModelScopeRoom() }
+      ?.filter { Cas1SpaceBookingEntity.Constants.CRITERIA_CHARACTERISTIC_PROPERTY_NAMES_OF_INTEREST.contains(it.propertyName) }
+      ?.toList()
       ?: emptyList()
 
   private fun DomainEvent<BookingMadeEnvelope>.getCreatedByUser(): UserEntity {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -25,9 +25,9 @@ import java.util.UUID
 
 class Cas1BookingToSpaceBookingSeedJobTest {
 
-  val approvedPremisesRepository = mockk<ApprovedPremisesRepository>()
+  private val approvedPremisesRepository = mockk<ApprovedPremisesRepository>()
 
-  val seedJob = Cas1BookingToSpaceBookingSeedJob(
+  private val seedJob = Cas1BookingToSpaceBookingSeedJob(
     approvedPremisesRepository = approvedPremisesRepository,
     spaceBookingRepository = mockk<Cas1SpaceBookingRepository>(),
     bookingRepository = mockk<BookingRepository>(),


### PR DESCRIPTION
When migrating bookings to space bookings, only populate the room critiera types that we will allow users to define when creating a space booking via the UI/API