### PR TITLE
Emit CAS1 arrival and departure events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -145,11 +145,10 @@ class DomainEventService(
     )
 
   @Transactional
-  fun savePersonArrivedEvent(domainEvent: DomainEvent<PersonArrivedEnvelope>, emit: Boolean) =
+  fun savePersonArrivedEvent(domainEvent: DomainEvent<PersonArrivedEnvelope>) =
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
-      emit = emit,
     )
 
   @Transactional
@@ -161,11 +160,10 @@ class DomainEventService(
     )
 
   @Transactional
-  fun savePersonDepartedEvent(domainEvent: DomainEvent<PersonDepartedEnvelope>, emit: Boolean) =
+  fun savePersonDepartedEvent(domainEvent: DomainEvent<PersonDepartedEnvelope>) =
     saveAndEmit(
       domainEvent = domainEvent,
       eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
-      emit = emit,
     )
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
@@ -74,7 +74,6 @@ class Cas1SpaceBookingManagementDomainEventService(
     val actualArrivalDateTime = arrivalInfo.actualArrivalDate.atTime(arrivalInfo.actualArrivalTime).toInstant()
 
     domainEventService.savePersonArrivedEvent(
-      emit = false,
       domainEvent = DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
@@ -182,7 +181,6 @@ class Cas1SpaceBookingManagementDomainEventService(
     val actualDepartureDateTime = departureInfo.actualDepartureDate.atTime(departureInfo.actualDepartureTime).toInstant()
 
     domainEventService.savePersonDepartedEvent(
-      emit = false,
       domainEvent = DomainEvent(
         id = domainEventId,
         applicationId = applicationId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -1145,7 +1145,7 @@ class Cas1SpaceBookingTest {
     }
 
     @Test
-    fun `Recording arrival returns OK and creates a domain event`() {
+    fun `Recording arrival returns OK, creates and emits a domain event`() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
 
       val (user) = givenAUser()
@@ -1182,6 +1182,8 @@ class Cas1SpaceBookingTest {
         .exchange()
         .expectStatus()
         .isOk
+
+      domainEventAsserter.blockForEmittedDomainEvent(DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED)
       domainEventAsserter.assertDomainEventOfTypeStored(spaceBooking.application!!.id, DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED)
     }
 
@@ -1574,7 +1576,7 @@ class Cas1SpaceBookingTest {
     }
 
     @Test
-    fun `Recording departure returns OK and creates a domain event`() {
+    fun `Recording departure returns OK, creates and emits a domain event`() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
 
       val (user) = givenAUser()
@@ -1616,7 +1618,8 @@ class Cas1SpaceBookingTest {
         .exchange()
         .expectStatus()
         .isOk
-      domainEventAsserter.assertDomainEventOfTypeStored(spaceBooking.application!!.id, DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED)
+
+      domainEventAsserter.blockForEmittedDomainEvent(DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED)
     }
 
     @Test
@@ -1665,7 +1668,7 @@ class Cas1SpaceBookingTest {
     }
 
     @Test
-    fun `Recording departure returns OK and creates a domain event with 'Not Applicable' move on category if no category is supplied `() {
+    fun `Recording departure returns OK, creates and emits a domain event with 'Not Applicable' move on category if no category is supplied `() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
 
       val (user) = givenAUser()
@@ -1706,6 +1709,8 @@ class Cas1SpaceBookingTest {
         .exchange()
         .expectStatus()
         .isOk
+
+      domainEventAsserter.blockForEmittedDomainEvent(DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED)
       val domainEvent = domainEventAsserter.assertDomainEventOfTypeStored(spaceBooking.application!!.id, DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED)
       assertThat(domainEvent.data).contains("""moveOnCategory": {"id": "${NOT_APPLICABLE_MOVE_ON_CATEGORY_ID}""")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -548,9 +548,8 @@ class DomainEventServiceTest {
       }
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `savePersonArrivedEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
+    @Test
+    fun `savePersonArrivedEvent sends correct arguments to saveAndEmit`() {
       val id = UUID.randomUUID()
 
       val eventDetails = PersonArrivedFactory().produce()
@@ -563,15 +562,14 @@ class DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
-      domainEventServiceSpy.savePersonArrivedEvent(domainEvent, emit)
+      domainEventServiceSpy.savePersonArrivedEvent(domainEvent)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
-          emit,
         )
       }
     }
@@ -604,9 +602,8 @@ class DomainEventServiceTest {
       }
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `savePersonDepartedEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
+    @Test
+    fun `savePersonDepartedEvent sends correct arguments to saveAndEmit`() {
       val id = UUID.randomUUID()
 
       val eventDetails = PersonDepartedFactory().produce()
@@ -619,15 +616,14 @@ class DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
-      domainEventServiceSpy.savePersonDepartedEvent(domainEvent, emit)
+      domainEventServiceSpy.savePersonDepartedEvent(domainEvent)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
-          emit,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -115,7 +115,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
     @BeforeEach
     fun before() {
-      every { domainEventService.savePersonArrivedEvent(any(), any()) } just Runs
+      every { domainEventService.savePersonArrivedEvent(any()) } just Runs
 
       every { offenderService.getPersonSummaryInfoResults(any(), any()) } returns
         listOf(PersonSummaryInfoResult.Success.Full("THEBOOKINGCRN", caseSummary))
@@ -143,7 +143,6 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       verify(exactly = 1) {
         domainEventService.savePersonArrivedEvent(
           capture(domainEventArgument),
-          emit = false,
         )
       }
 
@@ -193,7 +192,6 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       verify(exactly = 1) {
         domainEventService.savePersonArrivedEvent(
           capture(domainEventArgument),
-          emit = false,
         )
       }
 
@@ -232,7 +230,6 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       verify(exactly = 1) {
         domainEventService.savePersonArrivedEvent(
           capture(domainEventArgument),
-          emit = false,
         )
       }
 
@@ -296,7 +293,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
     @BeforeEach
     fun before() {
-      every { domainEventService.savePersonDepartedEvent(any(), any()) } just Runs
+      every { domainEventService.savePersonDepartedEvent(any()) } just Runs
 
       every { offenderService.getPersonSummaryInfoResults(any(), any()) } returns
         listOf(PersonSummaryInfoResult.Success.Full("THEBOOKINGCRN", caseSummary))
@@ -324,10 +321,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       val domainEventArgument = slot<DomainEvent<PersonDepartedEnvelope>>()
 
       verify(exactly = 1) {
-        domainEventService.savePersonDepartedEvent(
-          capture(domainEventArgument),
-          emit = false,
-        )
+        domainEventService.savePersonDepartedEvent(capture(domainEventArgument))
       }
 
       val domainEvent = domainEventArgument.captured
@@ -385,10 +379,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       val domainEventArgument = slot<DomainEvent<PersonDepartedEnvelope>>()
 
       verify(exactly = 1) {
-        domainEventService.savePersonDepartedEvent(
-          capture(domainEventArgument),
-          emit = false,
-        )
+        domainEventService.savePersonDepartedEvent(capture(domainEventArgument))
       }
 
       val domainEvent = domainEventArgument.captured


### PR DESCRIPTION
Previously we disabled emitting CAS1 arrival and departure domain events because there was functionality available on the user interface to record arrivals and departures, but we did no want this being sent to delius as the functonality was incomplete.

There is no longer ‘record arrival/departure’ functionality available to users in prod so it’s safe to re-enable these domain events to support testing of space booking management.