### PR TITLE
Fix test stability issue

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
@@ -56,10 +56,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
     )
     val otherUser = givenAUser().first
     val roomCriteriaOfInterest = Cas1SpaceBookingEntity.Constants.CRITERIA_CHARACTERISTIC_PROPERTY_NAMES_OF_INTEREST.map {
-      characteristicEntityFactory.produceAndPersist {
-        withModelScope(listOf("*", "room").random())
-        withPropertyName(it)
-      }
+      characteristicRepository.findByPropertyName(it, ServiceName.approvedPremises.value)!!
     }
     val roomCriteriaNotOfInterest = listOf(
       characteristicEntityFactory.produceAndPersist {


### PR DESCRIPTION
Before this commit we saw intermittent

duplicate key value violates unique constraint "characteristics_property_name_service_scope_model_scope_key"

due to the use of random model scopes sometimes clashing with existing database entries.