### PR TITLE
APS-1669 - booking to space booking keyworker fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -191,7 +191,7 @@ class Cas1BookingToSpaceBookingSeedJob(
     departedAtDate = departureDate,
     departedAtTime = null,
     keyWorkerStaffCode = keyWorkerStaffCode,
-    keyWorkerName = "$keyWorkerForename $keyWorkerSurname",
+    keyWorkerName = keyWorkerStaffCode?.let { "$keyWorkerForename $keyWorkerSurname" },
     departureReason = departureReasonCode?.let { reasonCode ->
       departureReasonRepository
         .findAllByServiceScope(ServiceName.approvedPremises.value)


### PR DESCRIPTION
Before this commit if no keyworker was defined in the delius data the keyworker name would be set to “null null”