### PR TITLE
APS-1654: Space Search filter premises on application gender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -310,6 +310,9 @@ WHERE taa.probation_region_id = :probationRegionId AND a.submitted_at IS NOT NUL
 }
 
 @Repository
+interface ApprovedPremiseApplicationRepository : JpaRepository<ApprovedPremisesApplicationEntity, UUID>
+
+@Repository
 interface LockableApplicationRepository : JpaRepository<LockableApplicationEntity, UUID> {
   @Query("SELECT a FROM LockableApplicationEntity a WHERE a.id = :id")
   @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -212,6 +212,8 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         genders:
+          description: gender is obtained from application's associated gender
+          deprecated: true
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Gender'
@@ -240,6 +242,7 @@ components:
         requirements:
           $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
       required:
+        - applicationId
         - startDate
         - durationInDays
         - targetPostcodeDistrict

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6256,6 +6256,8 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
         genders:
+          description: gender is obtained from application's associated gender
+          deprecated: true
           type: array
           items:
             $ref: '#/components/schemas/Gender'
@@ -6284,6 +6286,7 @@ components:
         requirements:
           $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
       required:
+        - applicationId
         - startDate
         - durationInDays
         - targetPostcodeDistrict

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -116,7 +116,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.submittedAt = { submittedAt }
   }
 
-  fun withIsWomensApplication(isWomensApplication: Boolean) = apply {
+  fun withIsWomensApplication(isWomensApplication: Boolean?) = apply {
     this.isWomensApplication = { isWomensApplication }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -13,12 +12,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
 import java.time.LocalDate
 
@@ -50,7 +50,9 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       withLongitude(51.48)
     }
 
-    givenAUser { _, jwt ->
+    givenAUser { user, jwt ->
+      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
+
       val premises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
         withYieldedProbationRegion { givenAProbationRegion() }
         withYieldedLocalAuthorityArea {
@@ -73,13 +75,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
+        applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
           spaceCharacteristics = null,
-          genders = null,
         ),
       )
 
@@ -105,17 +107,18 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
     }
   }
 
-  @Disabled("Only male APs are currently supported in the CAS1 service")
   @ParameterizedTest
   @EnumSource
-  fun `Filtering APs by gender only returns APs supporting that gender`(gender: Gender) {
+  fun `Filtering APs by gender only returns APs matching associated gender in application`(gender: ApprovedPremisesGender) {
     postCodeDistrictFactory.produceAndPersist {
       withOutcode("SE1")
       withLatitude(-0.07)
       withLongitude(51.48)
     }
 
-    givenAUser { _, jwt ->
+    givenAUser { user, jwt ->
+      val application = givenAnApplication(createdByUser = user, isWomensApplication = gender == ApprovedPremisesGender.WOMAN)
+
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
         withYieldedProbationRegion { givenAProbationRegion() }
         withYieldedLocalAuthorityArea {
@@ -124,7 +127,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
         withSupportsSpaceBookings(true)
-        // withGender(gender)
+        withGender(gender)
       }
 
       val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
@@ -135,17 +138,17 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withLatitude((it * -0.01) - 0.08)
         withLongitude((it * 0.01) + 51.49)
         withSupportsSpaceBookings(true)
-        // withGender(Gender.entries.first { it != gender })
+        withGender(ApprovedPremisesGender.entries.first { it != gender })
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
+        applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
           spaceCharacteristics = null,
-          genders = listOf(gender),
         ),
       )
 
@@ -180,7 +183,9 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       withLongitude(51.48)
     }
 
-    givenAUser { _, jwt ->
+    givenAUser { user, jwt ->
+      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
+
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
         withYieldedProbationRegion { givenAProbationRegion() }
         withYieldedLocalAuthorityArea {
@@ -204,13 +209,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
+        applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         requirements = Cas1SpaceSearchRequirements(
           apTypes = listOf(apType),
           spaceCharacteristics = null,
-          genders = null,
         ),
       )
 
@@ -250,7 +255,8 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       withLongitude(51.48)
     }
 
-    givenAUser { _, jwt ->
+    givenAUser { user, jwt ->
+      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(4) {
         withYieldedProbationRegion { givenAProbationRegion() }
         withYieldedLocalAuthorityArea {
@@ -274,13 +280,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
+        applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         requirements = Cas1SpaceSearchRequirements(
           apTypes = ApType.entries.slice(0..3),
           spaceCharacteristics = null,
-          genders = null,
         ),
       )
 
@@ -338,7 +344,9 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       withLongitude(51.48)
     }
 
-    givenAUser { _, jwt ->
+    givenAUser { user, jwt ->
+      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
+
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
         withYieldedProbationRegion { givenAProbationRegion() }
         withYieldedLocalAuthorityArea {
@@ -384,13 +392,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
+        applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
           spaceCharacteristics = listOf(characteristic),
-          genders = null,
         ),
       )
 
@@ -424,7 +432,9 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       withLongitude(51.48)
     }
 
-    givenAUser { _, jwt ->
+    givenAUser { user, jwt ->
+      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
+
       val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
         withYieldedProbationRegion { givenAProbationRegion() }
         withYieldedLocalAuthorityArea {
@@ -468,13 +478,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       }
 
       val searchParameters = Cas1SpaceSearchParameters(
+        applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
           spaceCharacteristics = Cas1SpaceCharacteristic.entries.slice(1..3),
-          genders = null,
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
@@ -8,19 +8,23 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 
+@Suppress("LongParameterList")
 fun IntegrationTestBase.givenACas1Application(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   submittedAt: OffsetDateTime? = null,
   eventNumber: String = randomInt(1, 9).toString(),
+  isWomensApplication: Boolean? = null,
   block: (application: ApplicationEntity) -> Unit = {},
-) = givenAnApplication(createdByUser, crn, submittedAt, eventNumber, block)
+) = givenAnApplication(createdByUser, crn, submittedAt, eventNumber, isWomensApplication, block)
 
+@Suppress("LongParameterList")
 fun IntegrationTestBase.givenAnApplication(
   createdByUser: UserEntity,
   crn: String = randomStringMultiCaseWithNumbers(8),
   submittedAt: OffsetDateTime? = null,
   eventNumber: String = randomInt(1, 9).toString(),
+  isWomensApplication: Boolean? = null,
   block: (application: ApplicationEntity) -> Unit = {},
 ): ApprovedPremisesApplicationEntity {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -33,6 +37,7 @@ fun IntegrationTestBase.givenAnApplication(
     withApplicationSchema(applicationSchema)
     withSubmittedAt(submittedAt)
     withEventNumber(eventNumber)
+    withIsWomensApplication(isWomensApplication)
   }
 
   block(application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceSearchResultsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceSearchResultsTransformerTest.kt
@@ -23,6 +23,7 @@ class Cas1SpaceSearchResultsTransformerTest {
   @Test
   fun `transformDomainToApi transforms correctly`() {
     val searchParameters = Cas1SpaceSearchParameters(
+      applicationId = UUID.randomUUID(),
       startDate = LocalDate.now(),
       durationInDays = 14,
       targetPostcodeDistrict = "AB1",


### PR DESCRIPTION
Space Search should filter premises based upon application's associated gender. 

`Cas1SpaceSearchRequirements` 
- `applicationId` is now mandatory 
- `genders` is deprecated

`Cas1SpaceSearchService.findSpaces`
- Gender is obtained from the associated application (via `applicationId`) `is_womens_application`
- modified the filter query to apply gender filter using `approved_premises.gender`