### PR TITLE
Remove qualifications from restricted test users

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -155,7 +155,7 @@ class Cas1AutoScript(
           UserRole.CAS1_FUTURE_MANAGER,
           UserRole.CAS1_CRU_MEMBER,
         ),
-        qualifications = UserQualification.entries.toList(),
+        qualifications = emptyList(),
         documentation = "For local use in development and testing. This user has an exclusion (whitelisted) for LAO CRN X400000",
       ),
       SeedUser(
@@ -171,7 +171,7 @@ class Cas1AutoScript(
           UserRole.CAS1_APPEALS_MANAGER,
           UserRole.CAS1_FUTURE_MANAGER,
         ),
-        qualifications = UserQualification.entries.toList(),
+        qualifications = emptyList(),
         documentation = "For local use in development and testing. This user has a restriction (blacklisted) for LAO CRN X400001",
       ),
       SeedUser(


### PR DESCRIPTION
These users should not have the ‘Limited Access’ qualification, and instead access to LAO should be controlled by delius configuration