### PR TITLE
Remove camel case value from BedSearchAttribute enum

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BedSearchService.kt
@@ -146,8 +146,8 @@ class BedSearchService(
 
     val premisesCharacteristicsPropertyNames = propertyBedAttributes?.map {
       when (it) {
-        BedSearchAttributes.singleOccupancy, BedSearchAttributes.SINGLE_OCCUPANCY -> BedSearchAttributes.SINGLE_OCCUPANCY.value
-        BedSearchAttributes.sharedProperty, BedSearchAttributes.SHARED_PROPERTY -> BedSearchAttributes.SHARED_PROPERTY.value
+        BedSearchAttributes.SINGLE_OCCUPANCY -> BedSearchAttributes.SINGLE_OCCUPANCY.value
+        BedSearchAttributes.SHARED_PROPERTY -> BedSearchAttributes.SHARED_PROPERTY.value
         else -> ""
       }
     }
@@ -156,7 +156,7 @@ class BedSearchService(
 
     val roomCharacteristicsPropertyNames = propertyBedAttributes?.map {
       when (it) {
-        BedSearchAttributes.wheelchairAccessible, BedSearchAttributes.WHEELCHAIR_ACCESSIBLE -> BedSearchAttributes.WHEELCHAIR_ACCESSIBLE.value
+        BedSearchAttributes.WHEELCHAIR_ACCESSIBLE -> BedSearchAttributes.WHEELCHAIR_ACCESSIBLE.value
         else -> ""
       }
     }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4925,13 +4925,7 @@ components:
         - isSharedProperty
         - isSingleOccupancy
         - isWheelchairAccessible
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible
       x-enum-varnames:
         - SHARED_PROPERTY
         - SINGLE_OCCUPANCY
         - WHEELCHAIR_ACCESSIBLE
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9208,13 +9208,7 @@ components:
         - isSharedProperty
         - isSingleOccupancy
         - isWheelchairAccessible
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible
       x-enum-varnames:
         - SHARED_PROPERTY
         - SINGLE_OCCUPANCY
         - WHEELCHAIR_ACCESSIBLE
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6100,16 +6100,10 @@ components:
         - isSharedProperty
         - isSingleOccupancy
         - isWheelchairAccessible
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible
       x-enum-varnames:
         - SHARED_PROPERTY
         - SINGLE_OCCUPANCY
         - WHEELCHAIR_ACCESSIBLE
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible
     Cas1PremisesBasicSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5516,13 +5516,7 @@ components:
         - isSharedProperty
         - isSingleOccupancy
         - isWheelchairAccessible
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible
       x-enum-varnames:
         - SHARED_PROPERTY
         - SINGLE_OCCUPANCY
         - WHEELCHAIR_ACCESSIBLE
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -5024,13 +5024,7 @@ components:
         - isSharedProperty
         - isSingleOccupancy
         - isWheelchairAccessible
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible
       x-enum-varnames:
         - SHARED_PROPERTY
         - SINGLE_OCCUPANCY
         - WHEELCHAIR_ACCESSIBLE
-        - sharedProperty
-        - singleOccupancy
-        - wheelchairAccessible

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -996,7 +996,7 @@ class BedSearchTest : IntegrationTestBase() {
         val beds = createPremisesAndBedsWithCharacteristics(
           localAuthorityArea,
           searchPdu,
-          BedSearchAttributes.sharedProperty,
+          BedSearchAttributes.SHARED_PROPERTY,
         )
 
         val expextedPremisesOneBedOne = beds.first()
@@ -1015,7 +1015,7 @@ class BedSearchTest : IntegrationTestBase() {
               durationDays = 84,
               serviceName = "temporary-accommodation",
               probationDeliveryUnits = listOf(searchPdu.id),
-              attributes = listOf(BedSearchAttributes.sharedProperty),
+              attributes = listOf(BedSearchAttributes.SHARED_PROPERTY),
             ),
           )
           .exchange()
@@ -1107,7 +1107,7 @@ class BedSearchTest : IntegrationTestBase() {
         val beds = createPremisesAndBedsWithCharacteristics(
           localAuthorityArea,
           searchPdu,
-          BedSearchAttributes.singleOccupancy,
+          BedSearchAttributes.SINGLE_OCCUPANCY,
         )
 
         val expextedPremisesOneBedOne = beds.first()
@@ -1126,7 +1126,7 @@ class BedSearchTest : IntegrationTestBase() {
               durationDays = 84,
               serviceName = "temporary-accommodation",
               probationDeliveryUnits = listOf(searchPdu.id),
-              attributes = listOf(BedSearchAttributes.singleOccupancy),
+              attributes = listOf(BedSearchAttributes.SINGLE_OCCUPANCY),
             ),
           )
           .exchange()
@@ -1218,7 +1218,7 @@ class BedSearchTest : IntegrationTestBase() {
         val beds = createPremisesAndBedsWithCharacteristics(
           localAuthorityArea,
           searchPdu,
-          BedSearchAttributes.wheelchairAccessible,
+          BedSearchAttributes.WHEELCHAIR_ACCESSIBLE,
         )
 
         val expextedPremisesOneBedOne = beds.first()
@@ -1235,7 +1235,7 @@ class BedSearchTest : IntegrationTestBase() {
               durationDays = 84,
               serviceName = "temporary-accommodation",
               probationDeliveryUnits = listOf(searchPdu.id),
-              attributes = listOf(BedSearchAttributes.wheelchairAccessible),
+              attributes = listOf(BedSearchAttributes.WHEELCHAIR_ACCESSIBLE),
             ),
           )
           .exchange()
@@ -2015,19 +2015,19 @@ class BedSearchTest : IntegrationTestBase() {
       )
 
       when (bedSearchAttribute) {
-        BedSearchAttributes.singleOccupancy, BedSearchAttributes.SINGLE_OCCUPANCY -> beds = listOf(
+        BedSearchAttributes.SINGLE_OCCUPANCY -> beds = listOf(
           singleOccupancyBedOne,
           premisesSingleOccupancyWomenOnlyBedOne,
           premisesSingleOccupancyWheelchairAccessibleBedOne,
         )
 
-        BedSearchAttributes.sharedProperty, BedSearchAttributes.SHARED_PROPERTY -> beds = listOf(
+        BedSearchAttributes.SHARED_PROPERTY -> beds = listOf(
           sharedPropertyBedOne,
           premisesSharedPropertyMenOnlyBedOne,
           premisesSharedPropertyWheelchairAccessibleBedOne,
         )
 
-        BedSearchAttributes.wheelchairAccessible, BedSearchAttributes.WHEELCHAIR_ACCESSIBLE ->
+        BedSearchAttributes.WHEELCHAIR_ACCESSIBLE ->
           beds =
             listOf(premisesSharedPropertyWheelchairAccessibleBedOne, premisesSingleOccupancyWheelchairAccessibleBedOne)
       }


### PR DESCRIPTION
The UI has been updated to use the correct enum values, so we can remove these.