### PR TITLE
APS-1627: Add staffMember to keyworker assigned domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
@@ -229,6 +229,7 @@ class Cas1SpaceBookingManagementDomainEventService(
 
   fun keyWorkerAssigned(
     updatedCas1SpaceBooking: Cas1SpaceBookingEntity,
+    assignedKeyWorker: StaffMember,
     assignedKeyWorkerName: String,
     previousKeyWorkerName: String?,
   ) {
@@ -258,6 +259,7 @@ class Cas1SpaceBookingManagementDomainEventService(
             applicationId = applicationId,
             applicationUrl = cas1SpaceBookingManagementConfig.applicationUrlTemplate.resolve("id", applicationId.toString()),
             bookingId = updatedCas1SpaceBooking.id,
+            keyWorker = assignedKeyWorker,
             personReference = PersonReference(
               crn = updatedCas1SpaceBooking.crn,
               noms = offenderDetails?.nomsId ?: "Unknown NOMS Id",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.toKotlinDatePeriod
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssignKeyWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NonArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingResidency
@@ -287,7 +288,12 @@ class Cas1SpaceBookingService(
       return "$.keyWorker.staffCode" hasSingleValidationError "notFound"
     }
     val assignedKeyWorker = extractEntityFromCasResult(staffMemberResponse)
-    val assignedKeyWorkerName = "${assignedKeyWorker.name.forename} ${assignedKeyWorker.name.surname}"
+    val assignedKeyWorkerAsStaffMember = StaffMember(
+      staffCode = assignedKeyWorker.code,
+      forenames = assignedKeyWorker.name.forenames(),
+      surname = assignedKeyWorker.name.surname,
+    )
+    val assignedKeyWorkerName = "${assignedKeyWorker.name.forenames()} ${assignedKeyWorker.name.surname}"
 
     existingCas1SpaceBooking!!
 
@@ -301,6 +307,7 @@ class Cas1SpaceBookingService(
 
     cas1SpaceBookingManagementDomainEventService.keyWorkerAssigned(
       existingCas1SpaceBooking,
+      assignedKeyWorkerAsStaffMember,
       assignedKeyWorkerName,
       previousKeyWorkerName,
     )

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1279,6 +1279,8 @@ components:
           $ref: '#/components/schemas/ApplicationUrl'
         bookingId:
           $ref: '#/components/schemas/BookingId'
+        keyWorker:
+          $ref: '#/components/schemas/StaffMember'
         personReference:
           $ref: '#/components/schemas/PersonReference'
         deliusEventNumber:
@@ -1301,6 +1303,7 @@ components:
         - applicationId
         - applicationUrl
         - bookingId
+        - keyWorker
         - personReference
         - deliusEventNumber
         - premises

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingKeyWorkerAssignedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/BookingKeyWorkerAssignedFactory.kt
@@ -5,6 +5,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingKeyWorkerAssigned
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
 import java.util.UUID
@@ -12,6 +13,7 @@ import java.util.UUID
 class BookingKeyWorkerAssignedFactory : Factory<BookingKeyWorkerAssigned> {
   private var applicationId: Yielded<UUID> = { UUID.randomUUID() }
   private var applicationUrl: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
+  private var keyWorker: Yielded<StaffMember> = { StaffMemberFactory().produce() }
   private var bookingId: Yielded<UUID> = { UUID.randomUUID() }
   private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
   private var deliusEventNumber: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
@@ -41,6 +43,10 @@ class BookingKeyWorkerAssignedFactory : Factory<BookingKeyWorkerAssigned> {
     this.bookingId = { bookingId }
   }
 
+  fun withKeyWorker(keyWorker: StaffMember) = apply {
+    this.keyWorker = { keyWorker }
+  }
+
   fun withPremises(premises: Premises) = apply {
     this.premises = { premises }
   }
@@ -67,6 +73,7 @@ class BookingKeyWorkerAssignedFactory : Factory<BookingKeyWorkerAssigned> {
     personReference = this.personReference(),
     deliusEventNumber = this.deliusEventNumber(),
     bookingId = this.bookingId(),
+    keyWorker = this.keyWorker(),
     premises = this.premises(),
     arrivalDate = this.arrivalDate(),
     departureDate = this.departureDate(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -1452,7 +1452,7 @@ class Cas1SpaceBookingServiceTest {
       val updatedSpaceBookingCaptor = slot<Cas1SpaceBookingEntity>()
 
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
-      every { cas1SpaceBookingManagementDomainEventService.keyWorkerAssigned(any(), any(), any()) } returns Unit
+      every { cas1SpaceBookingManagementDomainEventService.keyWorkerAssigned(any(), any(), any(), any()) } returns Unit
 
       val result = service.recordKeyWorkerAssignedForBooking(
         premisesId = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -414,7 +414,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       .withDefaults()
       .produce()
 
-    val keyWorker = StaffDetailFactory.staffDetail(deliusUsername = null)
+    private val keyWorker = StaffDetailFactory.staffDetail(deliusUsername = null)
 
     private val keyWorkerName = keyWorker.name.deliusName()
     private val previousKeyWorkerName = "Previous $keyWorkerName"
@@ -460,6 +460,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
       service.keyWorkerAssigned(
         spaceBookingWithoutKeyWorker,
+        assignedKeyWorker = keyWorker.toStaffMember(),
         assignedKeyWorkerName = keyWorkerName,
         previousKeyWorkerName = null,
       )
@@ -479,6 +480,10 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       val domainEventEventDetails = domainEvent.data.eventDetails
       assertThat(domainEventEventDetails.previousKeyWorkerName).isEqualTo(null)
       assertThat(domainEventEventDetails.assignedKeyWorkerName).isEqualTo(keyWorkerName)
+      val domainEventKeyWorker = domainEventEventDetails.keyWorker
+      assertThat(domainEventKeyWorker.staffCode).isEqualTo(keyWorker.code)
+      assertThat(domainEventKeyWorker.surname).isEqualTo(keyWorker.name.surname)
+      assertThat(domainEventKeyWorker.forenames).isEqualTo(keyWorker.name.forenames())
     }
 
     @Test
@@ -487,6 +492,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
       service.keyWorkerAssigned(
         spaceBookingWithKeyWorker,
+        assignedKeyWorker = keyWorker.toStaffMember(),
         assignedKeyWorkerName = keyWorkerName,
         previousKeyWorkerName = previousKeyWorkerName,
       )
@@ -516,6 +522,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
 
       service.keyWorkerAssigned(
         spaceBookingWithKeyWorker,
+        assignedKeyWorker = keyWorker.toStaffMember(),
         assignedKeyWorkerName = keyWorkerName,
         previousKeyWorkerName = previousKeyWorkerName,
       )


### PR DESCRIPTION
Added `keyWorker` to the domain event generated when a keyworker is assigned to a booking. 

- updated the domain events API to add `keyWorker` - staffMember type
- Add the keyworker to `BookingKeyWorkerAssigned` envelope
- uses the already obtained staff record (mapped to `staffMember`) saving an additional call 
