### PR TITLE
Add `FullPersonSummary.isRestricted` to the API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/CaseDetail.kt
@@ -19,8 +19,8 @@ data class CaseSummary(
   val gender: String?,
   val profile: Profile?,
   val manager: Manager,
-  val currentExclusion: Boolean?,
-  val currentRestriction: Boolean?,
+  val currentExclusion: Boolean,
+  val currentRestriction: Boolean,
 )
 
 data class Name(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -32,6 +32,7 @@ class PersonTransformer {
           crn = personSummaryInfo.crn,
           personType = PersonSummaryDiscriminator.fullPersonSummary,
           name = getNameFromPersonSummaryInfoResult(personSummaryInfo),
+          isRestricted = personSummaryInfo.summary.currentRestriction || personSummaryInfo.summary.currentExclusion,
         )
       }
       is PersonSummaryInfoResult.Success.Restricted -> {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4683,8 +4683,11 @@ components:
           properties:
             name:
               type: string
+            isRestricted:
+              type: boolean
           required:
             - name
+            - isRestricted
     RestrictedPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8966,8 +8966,11 @@ components:
           properties:
             name:
               type: string
+            isRestricted:
+              type: boolean
           required:
             - name
+            - isRestricted
     RestrictedPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5795,8 +5795,11 @@ components:
           properties:
             name:
               type: string
+            isRestricted:
+              type: boolean
           required:
             - name
+            - isRestricted
     RestrictedPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5274,8 +5274,11 @@ components:
           properties:
             name:
               type: string
+            isRestricted:
+              type: boolean
           required:
             - name
+            - isRestricted
     RestrictedPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4782,8 +4782,11 @@ components:
           properties:
             name:
               type: string
+            isRestricted:
+              type: boolean
           required:
             - name
+            - isRestricted
     RestrictedPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPersonSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
@@ -40,6 +42,7 @@ class PersonTransformerTest {
   @Nested
   inner class PersonSummaryInfoToPersonSummary {
 
+    @Test
     fun `map full person`() {
       val result = personTransformer.personSummaryInfoToPersonSummary(
         PersonSummaryInfoResult.Success.Full(
@@ -54,6 +57,30 @@ class PersonTransformerTest {
       assertThat(result.personType).isEqualTo(PersonSummaryDiscriminator.fullPersonSummary)
       assertThat(result).isInstanceOf(FullPersonSummary::class.java)
       assertThat((result as FullPersonSummary).name).isEqualTo("max power")
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+      "false, false, false",
+      "true, false, true",
+      "false, true, true",
+    )
+    fun `map full person is restricted`(
+      hasExclusion: Boolean,
+      hasRestriction: Boolean,
+      expectedIsRestricted: Boolean,
+    ) {
+      val result = personTransformer.personSummaryInfoToPersonSummary(
+        PersonSummaryInfoResult.Success.Full(
+          crn = "the crn",
+          summary = CaseSummaryFactory()
+            .withCurrentExclusion(hasExclusion)
+            .withCurrentRestriction(hasRestriction)
+            .produce(),
+        ),
+      )
+
+      assertThat((result as FullPersonSummary).isRestricted).isEqualTo(expectedIsRestricted)
     }
 
     @Test


### PR DESCRIPTION
This allows the UI to determine if an offender is an LAO, even if they have access to the offender. This matches a similar property on `FullPerson`