### PR TITLE
APS-1689 Improve CAS1 Get Application LAO test coverage & remove use of deprecated function

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -125,7 +125,8 @@ class OffenderService(
 
    /*
     * this could be more efficient by only retrieving access information for CRNs where
-    * the corresponding [CaseSummary.hasLimitedAccess()] is true
+    * the corresponding [CaseSummary.hasLimitedAccess()] is true. A similar short-circuit
+    * was implemented in the new deprecated [getOffender()] function
     */
     val caseAccessByCrn = when (limitedAccessStrategy) {
       is LimitedAccessStrategy.IgnoreLimitedAccess -> emptyMap()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -16,11 +16,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import java.util.UUID
 
 @Service
@@ -167,7 +165,7 @@ class UserAccessService(
   private fun userCanViewApprovedPremisesApplicationCreatedBySomeoneElse(
     user: UserEntity,
     application: ApprovedPremisesApplicationEntity,
-  ) = offenderService.getOffenderByCrn(application.crn, user.deliusUsername, user.hasQualification(UserQualification.LAO)) is AuthorisableActionResult.Success
+  ) = offenderService.canAccessOffender(application.crn, user.cas1LimitedAccessStrategy())
 
   private fun userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse(
     user: UserEntity,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AppealsTest.kt
@@ -54,8 +54,19 @@ class AppealsTest : InitialiseDatabasePerClassTestBase() {
 
   @Test
   fun `Get appeal returns 403 when application is not accessible to user`() {
+    govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
     givenAUser { createdByUser, _ ->
-      givenAnAssessmentForApprovedPremises(createdByUser, createdByUser) { _, application ->
+      val offender = givenAnOffender(
+        offenderDetailsConfigBlock = {
+          withCurrentRestriction(true)
+        },
+      ).first
+      givenAnAssessmentForApprovedPremises(
+        allocatedToUser = createdByUser,
+        createdByUser = createdByUser,
+        crn = offender.otherIds.crn,
+      ) { _, application ->
         givenAUser(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { _, jwt ->
           webTestClient.get()
             .uri("/applications/${application.id}/appeals/${UUID.randomUUID()}")
@@ -152,8 +163,19 @@ class AppealsTest : InitialiseDatabasePerClassTestBase() {
 
   @Test
   fun `Create new appeal returns 403 when application is not accessible to user`() {
+    govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
     givenAUser { createdByUser, _ ->
-      givenAnAssessmentForApprovedPremises(createdByUser, createdByUser) { _, application ->
+      val offender = givenAnOffender(
+        offenderDetailsConfigBlock = {
+          withCurrentRestriction(true)
+        },
+      ).first
+      givenAnAssessmentForApprovedPremises(
+        allocatedToUser = createdByUser,
+        createdByUser = createdByUser,
+        crn = offender.otherIds.crn,
+      ) { _, application ->
         givenAUser(roles = listOf(UserRole.CAS1_APPEALS_MANAGER)) { _, jwt ->
           webTestClient.post()
             .uri("/applications/${application.id}/appeals")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -89,10 +89,18 @@ class PlacementApplicationsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `creating a placement application when the application does not belong to the user returns 401`() {
+    fun `creating a placement application when the application cannot be viewed by the user returns 401`() {
       givenAUser { _, jwt ->
         givenAUser { otherUser, _ ->
-          givenASubmittedApplication(createdByUser = otherUser) { application ->
+          val offender = givenAnOffender(
+            offenderDetailsConfigBlock = {
+              withCurrentRestriction(true)
+            },
+          ).first
+          givenASubmittedApplication(
+            createdByUser = otherUser,
+            crn = offender.otherIds.crn,
+          ) { application ->
             webTestClient.post()
               .uri("/placement-applications")
               .header("Authorization", "Bearer $jwt")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
@@ -35,8 +34,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_WORKFLOW_MANAGER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REFERRER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService.LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TemporaryAccommodationApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
@@ -1004,9 +1003,7 @@ class UserAccessServiceTest {
         .produce(),
     )
 
-    every { offenderService.getOffenderByCrn(application.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(
-      OffenderDetailsSummaryFactory().produce(),
-    )
+    every { offenderService.canAccessOffender(application.crn, LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess(user.deliusUsername)) } returns true
 
     assertThat(userAccessService.userCanViewApplication(user, application)).isTrue
   }
@@ -1030,7 +1027,7 @@ class UserAccessServiceTest {
         .produce(),
     )
 
-    every { offenderService.getOffenderByCrn(application.crn, user.deliusUsername) } returns AuthorisableActionResult.Unauthorised()
+    every { offenderService.canAccessOffender(application.crn, LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess(user.deliusUsername)) } returns false
 
     assertThat(userAccessService.userCanViewApplication(user, application)).isFalse
   }


### PR DESCRIPTION
This PR tidys up the CAS1 Get Application Tests to better reflect the implementation. It also changes the implementation to use the new `canAccessOffender ` function to check offender access