### PR TITLE
Limit space booking characteristics in the API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingRequirementsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingRequirementsTransformer.kt
@@ -1,17 +1,17 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 
 @Component
 class Cas1SpaceBookingRequirementsTransformer {
   fun transformJpaToApi(cas1SpaceBookingEntity: Cas1SpaceBookingEntity) = Cas1SpaceBookingRequirements(
-    essentialCharacteristics = cas1SpaceBookingEntity.criteria.map { it.asCas1SpaceCharacteristic() },
+    essentialCharacteristics = cas1SpaceBookingEntity.criteria.map { it.asCas1SpaceBookingCharacteristic() },
   )
 
-  private fun CharacteristicEntity.asCas1SpaceCharacteristic() =
-    Cas1SpaceCharacteristic.valueOf(this.propertyName!!)
+  private fun CharacteristicEntity.asCas1SpaceBookingCharacteristic() =
+    Cas1SpaceBookingCharacteristic.entries.first { it.value == this.propertyName }
 }

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -201,7 +201,6 @@ components:
           format: uuid
           example: 290fa58c-77b2-47e2-b729-4cd6b2ed1a78
         requirements:
-          type: object
           $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
       required:
         - arrivalDate
@@ -214,7 +213,7 @@ components:
         essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceBookingCharacteristic'
       required:
         - essentialCharacteristics
     Cas1SpaceSearchRequirements:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6305,7 +6305,6 @@ components:
           format: uuid
           example: 290fa58c-77b2-47e2-b729-4cd6b2ed1a78
         requirements:
-          type: object
           $ref: '#/components/schemas/Cas1SpaceBookingRequirements'
       required:
         - arrivalDate
@@ -6318,7 +6317,7 @@ components:
         essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceBookingCharacteristic'
       required:
         - essentialCharacteristics
     Cas1SpaceSearchRequirements:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -17,10 +17,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBookingCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NonArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummaryStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummaryDiscriminator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
@@ -232,8 +232,8 @@ class Cas1SpaceBookingTest {
           createdByUser = applicant,
         ) { placementRequest, application ->
           val essentialCharacteristics = listOf(
-            Cas1SpaceCharacteristic.hasBrailleSignage,
-            Cas1SpaceCharacteristic.hasTactileFlooring,
+            Cas1SpaceBookingCharacteristic.HAS_EN_SUITE,
+            Cas1SpaceBookingCharacteristic.IS_ARSON_SUITABLE,
           )
 
           placementRequest.placementRequirements = placementRequirementsFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingRequirementsTransformerTest.kt
@@ -5,12 +5,10 @@ import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingRequirementsTransformer
 
 @ExtendWith(MockKExtension::class)
@@ -20,31 +18,18 @@ class Cas1SpaceBookingRequirementsTransformerTest {
 
   @Test
   fun `Placement requirements are transformed correctly`() {
-    val cas1EssentialSpaceCharacteristics = Cas1SpaceCharacteristic.entries.map { it.toCharacteristicEntity() }
-    val cas1DesirableSpaceCharacteristics = Cas1SpaceCharacteristic.entries.map { it.toCharacteristicEntity() }
-
-    val placementRequirements = PlacementRequirementsEntityFactory()
-      .withDefaults()
-      .withEssentialCriteria(emptyList())
-      .withDesirableCriteria(cas1DesirableSpaceCharacteristics)
-      .produce()
-
-    val placementRequest = PlacementRequestEntityFactory()
-      .withDefaults()
-      .withPlacementRequirements(placementRequirements)
-      .produce()
+    val cas1EssentialSpaceCharacteristics = Cas1SpaceBookingCharacteristic.entries.map { it.toCharacteristicEntity() }
 
     val spaceBooking = Cas1SpaceBookingEntityFactory()
-      .withPlacementRequest(placementRequest)
       .withCriteria(cas1EssentialSpaceCharacteristics.toMutableList())
       .produce()
 
     val result = transformer.transformJpaToApi(spaceBooking)
 
-    assertThat(result.essentialCharacteristics).isEqualTo(Cas1SpaceCharacteristic.entries)
+    assertThat(result.essentialCharacteristics).isEqualTo(Cas1SpaceBookingCharacteristic.entries)
   }
 
-  private fun Cas1SpaceCharacteristic.toCharacteristicEntity() = CharacteristicEntityFactory()
+  private fun Cas1SpaceBookingCharacteristic.toCharacteristicEntity() = CharacteristicEntityFactory()
     .withName(this.value)
     .withPropertyName(this.value)
     .withServiceScope(ServiceName.approvedPremises.value)


### PR DESCRIPTION
This commit updates the create space booking api to make use of the new `Cas1SpaceBookingCharacteristic` type, which limits space bookings to 6 characteristics.