### PR TITLE
Arrival and Departure domain events displaying on timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/domainevents/DomainEventDescriber.kt
@@ -16,10 +16,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.javaConstantNameToSentence
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiDateTimeFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toWeekAndDayDurationString
 import java.time.LocalDate
-import java.time.ZoneOffset
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
@@ -125,7 +127,7 @@ class DomainEventDescriber(
 
   private fun buildPersonArrivedDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getPersonArrivedEvent(domainEventSummary.id())
-    return event.describe { "The person moved into the premises on ${LocalDate.ofInstant(it.eventDetails.arrivedAt, ZoneOffset.UTC).toUiFormat()}" }
+    return event.describe { "The person moved into the premises on ${LocalDateTime.ofInstant(it.eventDetails.arrivedAt, ZoneId.systemDefault()).toUiDateTimeFormat()}" }
   }
 
   private fun buildPersonNotArrivedDescription(domainEventSummary: DomainEventSummary): String? {
@@ -135,7 +137,7 @@ class DomainEventDescriber(
 
   private fun buildPersonDepartedDescription(domainEventSummary: DomainEventSummary): String? {
     val event = domainEventService.getPersonDepartedEvent(domainEventSummary.id())
-    return event.describe { "The person moved out of the premises on ${LocalDate.ofInstant(it.eventDetails.departedAt, ZoneOffset.UTC).toUiFormat()}" }
+    return event.describe { "The person moved out of the premises on ${LocalDateTime.ofInstant(it.eventDetails.departedAt, ZoneId.systemDefault()).toUiDateTimeFormat()}" }
   }
 
   private fun buildBookingNotMadeDescription(domainEventSummary: DomainEventSummary): String? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingManagementDomainEventService.kt
@@ -79,7 +79,7 @@ class Cas1SpaceBookingManagementDomainEventService(
         applicationId = applicationId,
         crn = updatedCas1SpaceBooking.crn,
         nomsNumber = offenderDetails?.nomsId,
-        occurredAt = actualArrivalDateTime,
+        occurredAt = OffsetDateTime.now().toInstant(),
         cas1SpaceBookingId = updatedCas1SpaceBooking.id,
         bookingId = null,
         data = PersonArrivedEnvelope(
@@ -186,7 +186,7 @@ class Cas1SpaceBookingManagementDomainEventService(
         applicationId = applicationId,
         crn = departedCas1SpaceBooking.crn,
         nomsNumber = offenderDetails?.nomsId,
-        occurredAt = actualDepartureDateTime,
+        occurredAt = OffsetDateTime.now().toInstant(),
         cas1SpaceBookingId = departedCas1SpaceBooking.id,
         bookingId = null,
         data = PersonDepartedEnvelope(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
 val cas1UiExtendedDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEEE d MMMM yyyy")
+val cas1UiExtendedDateTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEEE d MMMM yyyy HH:mm")
 val cas2UiExtendedDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM y")
 val cas1UiTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("ha")
 val cas2UiTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("h:mma")
@@ -80,6 +81,7 @@ infix fun ClosedRange<LocalDate>.countOverlappingDays(other: ClosedRange<LocalDa
 }
 
 fun LocalDate.toUiFormat(): String = this.format(cas1UiExtendedDateFormat)
+fun LocalDateTime.toUiDateTimeFormat(): String = this.format(cas1UiExtendedDateTimeFormat)
 
 fun LocalDate.toCas2UiFormat(): String = this.format(cas2UiExtendedDateFormat)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/domainevents/DomainEventDescriberTest.kt
@@ -78,11 +78,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toInstant
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiDateTimeFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
-import java.time.ZoneOffset
 import java.util.UUID
 
 class DomainEventDescriberTest {
@@ -158,8 +160,8 @@ class DomainEventDescriberTest {
   }
 
   @ParameterizedTest
-  @CsvSource(value = ["2024-01-01", "2024-01-02"])
-  fun `Returns expected description for person arrived event`(arrivalDate: LocalDate) {
+  @CsvSource(value = ["2024-01-01T12:34:00", "2024-05-02T13:44:00", "2024-12-02T00:00:00"])
+  fun `Returns expected description for person arrived event`(arrivalDate: LocalDateTime) {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED)
 
     every { mockDomainEventService.getPersonArrivedEvent(any()) } returns buildDomainEvent {
@@ -168,14 +170,14 @@ class DomainEventDescriberTest {
         timestamp = Instant.now(),
         eventType = EventType.personArrived,
         eventDetails = PersonArrivedFactory()
-          .withArrivedAt(arrivalDate.atTime(12, 34, 56).toInstant(ZoneOffset.UTC))
+          .withArrivedAt(arrivalDate.toInstant())
           .produce(),
       )
     }
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("The person moved into the premises on ${arrivalDate.toUiFormat()}")
+    assertThat(result).isEqualTo("The person moved into the premises on ${arrivalDate.toUiDateTimeFormat()}")
   }
 
   @ParameterizedTest
@@ -200,8 +202,8 @@ class DomainEventDescriberTest {
   }
 
   @ParameterizedTest
-  @CsvSource(value = ["2024-04-01", "2024-04-02"])
-  fun `Returns expected description for person departed event`(departureDate: LocalDate) {
+  @CsvSource(value = ["2024-04-01T09:32:00", "2024-04-02T15:33:00", "2024-12-02T00:00:00"])
+  fun `Returns expected description for person departed event`(departureDate: LocalDateTime) {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED)
 
     every { mockDomainEventService.getPersonDepartedEvent(any()) } returns buildDomainEvent {
@@ -210,14 +212,14 @@ class DomainEventDescriberTest {
         timestamp = Instant.now(),
         eventType = EventType.personDeparted,
         eventDetails = PersonDepartedFactory()
-          .withDepartedAt(departureDate.atTime(12, 34, 56).toInstant(ZoneOffset.UTC))
+          .withDepartedAt(departureDate.toInstant())
           .produce(),
       )
     }
 
     val result = domainEventDescriber.getDescription(domainEventSummary)
 
-    assertThat(result).isEqualTo("The person moved out of the premises on ${departureDate.toUiFormat()}")
+    assertThat(result).isEqualTo("The person moved out of the premises on ${departureDate.toUiDateTimeFormat()}")
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingManagementDomainEventServiceTest.kt
@@ -155,7 +155,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       assertThat(domainEvent.cas1SpaceBookingId).isEqualTo(spaceBooking.id)
       assertThat(domainEvent.crn).isEqualTo(spaceBooking.crn)
       assertThat(domainEvent.nomsNumber).isEqualTo(caseSummary.nomsId)
-      assertThat(domainEvent.occurredAt).isEqualTo(Instant.parse("2023-03-12T11:30:00Z"))
+      assertThat(domainEvent.occurredAt).isWithinTheLastMinute()
       val data = domainEvent.data.eventDetails
       assertThat(data.previousExpectedDepartureOn).isNull()
       assertThat(data.applicationId).isEqualTo(application.id)
@@ -333,7 +333,7 @@ class Cas1SpaceBookingManagementDomainEventServiceTest {
       assertThat(domainEvent.cas1SpaceBookingId).isEqualTo(departedSpaceBooking.id)
       assertThat(domainEvent.crn).isEqualTo(departedSpaceBooking.crn)
       assertThat(domainEvent.nomsNumber).isEqualTo(caseSummary.nomsId)
-      assertThat(domainEvent.occurredAt).isEqualTo(Instant.parse("2023-11-06T01:30:30Z"))
+      assertThat(domainEvent.occurredAt).isWithinTheLastMinute()
       val domainEventEventDetails = domainEvent.data.eventDetails
       assertThat(domainEventEventDetails.applicationId).isEqualTo(application.id)
       assertThat(domainEventEventDetails.applicationUrl).isEqualTo("http://frontend/applications/${application.id}")


### PR DESCRIPTION
Corrects issue where the `occurredAt` timestamp was being set to the arrival date / departure date rather than the system's  timestamp. 
Updated the timeline output (DomainEventDescriber) to include the time in the generated output, to display, for an arrival / departure.