### PR TITLE
Cas2bail/cba56 add application origin

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -93,6 +93,7 @@ data class Cas2ApplicationEntity(
   var hdcEligibilityDate: LocalDate? = null,
   var conditionalReleaseDate: LocalDate? = null,
   var telephoneNumber: String? = null,
+  var applicationOrigin: String? = null,
 ) {
   override fun toString() = "Cas2ApplicationEntity: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationSummaryEntity.kt
@@ -55,4 +55,6 @@ data class Cas2ApplicationSummaryEntity(
   var latestStatusUpdateStatusId: String? = null,
   @Column(name = "referring_prison_code")
   val prisonCode: String,
+  @Column(name = "application_origin")
+  var applicationOrigin: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummaryRepository
@@ -117,7 +118,7 @@ class ApplicationService(
     }
   }
 
-  fun createApplication(crn: String, user: NomisUserEntity, jwt: String) =
+  fun createApplication(crn: String, user: NomisUserEntity, jwt: String, applicationOrigin: ApplicationOrigin? = null) =
     validated<Cas2ApplicationEntity> {
       val offenderDetailsResult = offenderService.getOffenderByCrn(crn)
 
@@ -148,6 +149,7 @@ class ApplicationService(
           schemaUpToDate = true,
           nomsNumber = offenderDetails.otherIds.nomsNumber,
           telephoneNumber = null,
+          applicationOrigin = applicationOrigin?.toString(),
         ),
       )
 
@@ -290,6 +292,7 @@ class ApplicationService(
         hdcEligibilityDate = submitApplication.hdcEligibilityDate
         conditionalReleaseDate = submitApplication.conditionalReleaseDate
         telephoneNumber = submitApplication.telephoneNumber
+        applicationOrigin = submitApplication.applicationOrigin?.toString()
       }
     } catch (error: UpstreamApiException) {
       return AuthorisableActionResult.Success(
@@ -345,6 +348,7 @@ class ApplicationService(
                 username = application.createdByUser.nomisUsername,
               ),
             ),
+            applicationOrigin = application.applicationOrigin
           ),
         ),
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -348,7 +348,7 @@ class ApplicationService(
                 username = application.createdByUser.nomisUsername,
               ),
             ),
-            applicationOrigin = application.applicationOrigin
+            applicationOrigin = application.applicationOrigin,
           ),
         ),
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -21,7 +23,10 @@ class ApplicationsTransformer(
   private val assessmentsTransformer: AssessmentsTransformer,
 ) {
 
-  fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult): Cas2Application {
+  fun transformJpaToApi(
+    jpa: Cas2ApplicationEntity,
+    personInfo: PersonInfoResult
+  ): Cas2Application {
     return Cas2Application(
       id = jpa.id,
       person = personTransformer.transformModelToPersonApi(personInfo),
@@ -37,15 +42,15 @@ class ApplicationsTransformer(
       telephoneNumber = jpa.telephoneNumber,
       assessment = if (jpa.assessment != null) assessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
       timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
+      applicationOrigin = getApplicationOrigin(jpa.applicationOrigin)
     )
   }
 
   fun transformJpaSummaryToSummary(
     jpaSummary: Cas2ApplicationSummaryEntity,
     personName: String,
-  ): uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary {
-    return uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
-      .Cas2ApplicationSummary(
+  ): Cas2ApplicationSummary {
+    return Cas2ApplicationSummary(
         id = jpaSummary.id,
         createdByUserId = UUID.fromString(jpaSummary.userId),
         createdByUserName = jpaSummary.userName,
@@ -58,6 +63,7 @@ class ApplicationsTransformer(
         crn = jpaSummary.crn,
         nomsNumber = jpaSummary.nomsNumber,
         personName = personName,
+        applicationOrigin = getApplicationOrigin(jpaSummary.applicationOrigin),
       )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary
@@ -25,7 +24,7 @@ class ApplicationsTransformer(
 
   fun transformJpaToApi(
     jpa: Cas2ApplicationEntity,
-    personInfo: PersonInfoResult
+    personInfo: PersonInfoResult,
   ): Cas2Application {
     return Cas2Application(
       id = jpa.id,
@@ -42,7 +41,7 @@ class ApplicationsTransformer(
       telephoneNumber = jpa.telephoneNumber,
       assessment = if (jpa.assessment != null) assessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
       timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
-      applicationOrigin = getApplicationOrigin(jpa.applicationOrigin)
+      applicationOrigin = getApplicationOrigin(jpa.applicationOrigin),
     )
   }
 
@@ -51,20 +50,20 @@ class ApplicationsTransformer(
     personName: String,
   ): Cas2ApplicationSummary {
     return Cas2ApplicationSummary(
-        id = jpaSummary.id,
-        createdByUserId = UUID.fromString(jpaSummary.userId),
-        createdByUserName = jpaSummary.userName,
-        createdAt = jpaSummary.createdAt.toInstant(),
-        submittedAt = jpaSummary.submittedAt?.toInstant(),
-        status = getStatusFromSummary(jpaSummary),
-        latestStatusUpdate = statusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(jpaSummary),
-        type = "CAS2",
-        hdcEligibilityDate = jpaSummary.hdcEligibilityDate,
-        crn = jpaSummary.crn,
-        nomsNumber = jpaSummary.nomsNumber,
-        personName = personName,
-        applicationOrigin = getApplicationOrigin(jpaSummary.applicationOrigin),
-      )
+      id = jpaSummary.id,
+      createdByUserId = UUID.fromString(jpaSummary.userId),
+      createdByUserName = jpaSummary.userName,
+      createdAt = jpaSummary.createdAt.toInstant(),
+      submittedAt = jpaSummary.submittedAt?.toInstant(),
+      status = getStatusFromSummary(jpaSummary),
+      latestStatusUpdate = statusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(jpaSummary),
+      type = "CAS2",
+      hdcEligibilityDate = jpaSummary.hdcEligibilityDate,
+      crn = jpaSummary.crn,
+      nomsNumber = jpaSummary.nomsNumber,
+      personName = personName,
+      applicationOrigin = getApplicationOrigin(jpaSummary.applicationOrigin),
+    )
   }
 
   private fun getStatus(entity: Cas2ApplicationEntity): ApplicationStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
@@ -37,6 +38,7 @@ class SubmissionsTransformer(
       telephoneNumber = jpa.telephoneNumber,
       timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
       assessment = assessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!),
+      applicationOrigin = getApplicationOrigin(jpa.applicationOrigin),
     )
   }
 
@@ -52,6 +54,19 @@ class SubmissionsTransformer(
       submittedAt = jpaSummary.submittedAt?.toInstant(),
       crn = jpaSummary.crn,
       nomsNumber = jpaSummary.nomsNumber,
+      applicationOrigin = getApplicationOrigin(jpaSummary.applicationOrigin),
     )
+  }
+
+
+}
+
+//shared function between SubmissionsTransformer and ApplicationsTransformer
+fun getApplicationOrigin(origin: String?): ApplicationOrigin? {
+  return when (origin) {
+    "courtBail" -> ApplicationOrigin.courtBail
+    "prisonBail" -> ApplicationOrigin.prisonBail
+    "homeDetentionCurfew" -> ApplicationOrigin.homeDetentionCurfew
+    else -> null
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/SubmissionsTransformer.kt
@@ -57,11 +57,9 @@ class SubmissionsTransformer(
       applicationOrigin = getApplicationOrigin(jpaSummary.applicationOrigin),
     )
   }
-
-
 }
 
-//shared function between SubmissionsTransformer and ApplicationsTransformer
+// shared function between SubmissionsTransformer and ApplicationsTransformer
 fun getApplicationOrigin(origin: String?): ApplicationOrigin? {
   return when (origin) {
     "courtBail" -> ApplicationOrigin.courtBail

--- a/src/main/resources/db/migration/all/20241211120314__add_application_origin_to_application_and_application_summary_views.sql
+++ b/src/main/resources/db/migration/all/20241211120314__add_application_origin_to_application_and_application_summary_views.sql
@@ -1,0 +1,58 @@
+-- add application origin to the cas2 application table
+ALTER TABLE cas_2_applications
+    ADD application_origin TEXT NULL;
+
+-- include application origin in the cas 2 application view
+DROP VIEW IF EXISTS cas_2_application_summary CASCADE;
+CREATE OR REPLACE VIEW cas_2_application_summary AS
+SELECT a.id,
+       a.crn,
+       a.noms_number,
+       CAST(a.created_by_user_id AS TEXT),
+       nu.name,
+       a.created_at,
+       a.submitted_at,
+       a.hdc_eligibility_date,
+       asu.label,
+       CAST(asu.status_id AS TEXT),
+       a.referring_prison_code,
+       a.conditional_release_date,
+       asu.created_at AS status_created_at,
+       a.abandoned_at,
+       a.application_origin
+FROM cas_2_applications a
+         LEFT JOIN (SELECT DISTINCT ON (application_id) su.application_id, su.label, su.status_id, su.created_at
+                    FROM cas_2_status_updates su
+                    ORDER BY su.application_id, su.created_at DESC) as asu
+                   ON a.id = asu.application_id
+         JOIN nomis_users nu ON nu.id = a.created_by_user_id;
+
+-- include application origin in the cas 2 application summary view
+DROP VIEW IF EXISTS cas_2_application_live_summary CASCADE;
+CREATE OR REPLACE VIEW cas_2_application_live_summary AS
+SELECT a.id,
+       a.crn,
+       a.noms_number,
+       a.created_by_user_id,
+       a.name,
+       a.created_at,
+       a.submitted_at,
+       a.hdc_eligibility_date,
+       a.label,
+       a.status_id,
+       a.referring_prison_code,
+       a.abandoned_at,
+       a.application_origin
+FROM cas_2_application_summary a
+WHERE (a.conditional_release_date IS NULL OR a.conditional_release_date >= current_date)
+    AND a.abandoned_at IS NULL
+    AND a.status_id IS NULL
+   OR (a.status_id = '004e2419-9614-4c1e-a207-a8418009f23d' AND
+       a.status_created_at > (current_date - INTERVAL '32 DAY')) -- Referral withdrawn
+   OR (a.status_id = 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9' AND
+       a.status_created_at > (current_date - INTERVAL '32 DAY')) -- Referral cancelled
+   OR (a.status_id = '89458555-3219-44a2-9584-c4f715d6b565' AND
+       a.status_created_at > (current_date - INTERVAL '32 DAY')) -- Awaiting arrival
+   OR (a.status_id NOT IN ('004e2419-9614-4c1e-a207-a8418009f23d',
+                           'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9',
+                           '89458555-3219-44a2-9584-c4f715d6b565'));

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1737,6 +1737,8 @@ components:
               type: array
               items:
                 $ref: '_shared.yml#/components/schemas/Cas2TimelineEvent'
+            applicationOrigin:
+              $ref: '_shared.yml#/components/schemas/ApplicationOrigin'
           required:
             - createdBy
             - schemaVersion
@@ -1774,6 +1776,8 @@ components:
         assessment:
           type: object
           $ref: '_shared.yml#/components/schemas/Cas2Assessment'
+        applicationOrigin:
+          $ref: '_shared.yml#/components/schemas/ApplicationOrigin'
       required:
         - id
         - person
@@ -1938,6 +1942,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        applicationOrigin:
+          $ref: '_shared.yml#/components/schemas/ApplicationOrigin'
       required:
         - type
         - id
@@ -2056,6 +2062,8 @@ components:
         submittedAt:
           type: string
           format: date-time
+        applicationOrigin:
+          $ref: '_shared.yml#/components/schemas/ApplicationOrigin'
       required:
         - createdByUserId
         - status
@@ -2358,6 +2366,8 @@ components:
           format: date
         telephoneNumber:
           type: string
+        applicationOrigin:
+          $ref: '_shared.yml#/components/schemas/ApplicationOrigin'
       required:
         - translatedDocument
         - applicationId
@@ -4932,3 +4942,9 @@ components:
         - sharedProperty
         - singleOccupancy
         - wheelchairAccessible
+    ApplicationOrigin:
+      type: string
+      enum:
+        - courtBail
+        - prisonBail
+        - homeDetentionCurfew

--- a/src/main/resources/static/cas2-domain-events-api.yml
+++ b/src/main/resources/static/cas2-domain-events-api.yml
@@ -141,6 +141,8 @@ components:
               $ref: '#/components/schemas/Cas2StaffMember'
           required:
             - staffMember
+        applicationOrigin:
+          type: string
       required:
         - applicationId
         - applicationUrl

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6020,6 +6020,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2TimelineEvent'
+            applicationOrigin:
+              $ref: '#/components/schemas/ApplicationOrigin'
           required:
             - createdBy
             - schemaVersion
@@ -6057,6 +6059,8 @@ components:
         assessment:
           type: object
           $ref: '#/components/schemas/Cas2Assessment'
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - id
         - person
@@ -6221,6 +6225,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - type
         - id
@@ -6339,6 +6345,8 @@ components:
         submittedAt:
           type: string
           format: date-time
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - createdByUserId
         - status
@@ -6641,6 +6649,8 @@ components:
           format: date
         telephoneNumber:
           type: string
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - translatedDocument
         - applicationId
@@ -9215,3 +9225,9 @@ components:
         - sharedProperty
         - singleOccupancy
         - wheelchairAccessible
+    ApplicationOrigin:
+      type: string
+      enum:
+        - courtBail
+        - prisonBail
+        - homeDetentionCurfew

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2849,6 +2849,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2TimelineEvent'
+            applicationOrigin:
+              $ref: '#/components/schemas/ApplicationOrigin'
           required:
             - createdBy
             - schemaVersion
@@ -2886,6 +2888,8 @@ components:
         assessment:
           type: object
           $ref: '#/components/schemas/Cas2Assessment'
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - id
         - person
@@ -3050,6 +3054,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - type
         - id
@@ -3168,6 +3174,8 @@ components:
         submittedAt:
           type: string
           format: date-time
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - createdByUserId
         - status
@@ -3470,6 +3478,8 @@ components:
           format: date
         telephoneNumber:
           type: string
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - translatedDocument
         - applicationId
@@ -6044,6 +6054,12 @@ components:
         - sharedProperty
         - singleOccupancy
         - wheelchairAccessible
+    ApplicationOrigin:
+      type: string
+      enum:
+        - courtBail
+        - prisonBail
+        - homeDetentionCurfew
     Cas1PremisesBasicSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2328,6 +2328,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2TimelineEvent'
+            applicationOrigin:
+              $ref: '#/components/schemas/ApplicationOrigin'
           required:
             - createdBy
             - schemaVersion
@@ -2365,6 +2367,8 @@ components:
         assessment:
           type: object
           $ref: '#/components/schemas/Cas2Assessment'
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - id
         - person
@@ -2529,6 +2533,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - type
         - id
@@ -2647,6 +2653,8 @@ components:
         submittedAt:
           type: string
           format: date-time
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - createdByUserId
         - status
@@ -2949,6 +2957,8 @@ components:
           format: date
         telephoneNumber:
           type: string
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - translatedDocument
         - applicationId
@@ -5523,3 +5533,9 @@ components:
         - sharedProperty
         - singleOccupancy
         - wheelchairAccessible
+    ApplicationOrigin:
+      type: string
+      enum:
+        - courtBail
+        - prisonBail
+        - homeDetentionCurfew

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1836,6 +1836,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2TimelineEvent'
+            applicationOrigin:
+              $ref: '#/components/schemas/ApplicationOrigin'
           required:
             - createdBy
             - schemaVersion
@@ -1873,6 +1875,8 @@ components:
         assessment:
           type: object
           $ref: '#/components/schemas/Cas2Assessment'
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - id
         - person
@@ -2037,6 +2041,8 @@ components:
           type: string
         nomsNumber:
           type: string
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - type
         - id
@@ -2155,6 +2161,8 @@ components:
         submittedAt:
           type: string
           format: date-time
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - createdByUserId
         - status
@@ -2457,6 +2465,8 @@ components:
           format: date
         telephoneNumber:
           type: string
+        applicationOrigin:
+          $ref: '#/components/schemas/ApplicationOrigin'
       required:
         - translatedDocument
         - applicationId
@@ -5031,3 +5041,9 @@ components:
         - sharedProperty
         - singleOccupancy
         - wheelchairAccessible
+    ApplicationOrigin:
+      type: string
+      enum:
+        - courtBail
+        - prisonBail
+        - homeDetentionCurfew

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -150,6 +150,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     hdcEligibilityDate = this.hdcEligibilityDate(),
     conditionalReleaseDate = this.conditionalReleaseDate(),
     preferredAreas = this.preferredAreas(),
-    applicationOrigin = this.applicationOrigin().toString()
+    applicationOrigin = this.applicationOrigin().toString(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
@@ -39,6 +40,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var preferredAreas: Yielded<String?> = { null }
   private var hdcEligibilityDate: Yielded<LocalDate?> = { null }
   private var conditionalReleaseDate: Yielded<LocalDate?> = { null }
+  private var applicationOrigin: Yielded<ApplicationOrigin?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -124,6 +126,10 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.conditionalReleaseDate = { conditionalReleaseDate }
   }
 
+  fun withApplicationOrigin(applicationOrigin: ApplicationOrigin) = apply {
+    this.applicationOrigin = { applicationOrigin }
+  }
+
   override fun produce(): Cas2ApplicationEntity = Cas2ApplicationEntity(
     id = this.id(),
     crn = this.crn(),
@@ -144,5 +150,6 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     hdcEligibilityDate = this.hdcEligibilityDate(),
     conditionalReleaseDate = this.conditionalReleaseDate(),
     preferredAreas = this.preferredAreas(),
+    applicationOrigin = this.applicationOrigin().toString()
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -471,8 +471,6 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             Assertions.assertThat(responseBody).anyMatch {
               prisonBailApplicationEntity.applicationOrigin == it.applicationOrigin.toString()
             }
-
-
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
@@ -396,6 +397,82 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
             Assertions.assertThat(responseBody[1].createdAt)
               .isEqualTo(firstApplicationEntity.createdAt.toInstant())
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get all applications returns 200 with correct body including applicationOrigin`() {
+      givenACas2PomUser { userEntity, jwt ->
+        givenACas2PomUser { otherUser, _ ->
+          givenAnOffender { offenderDetails, _ ->
+            cas2ApplicationJsonSchemaRepository.deleteAll()
+
+            val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+              withAddedAt(OffsetDateTime.now())
+              withId(UUID.randomUUID())
+            }
+
+            // court bail application
+            val courtBailApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(applicationSchema)
+              withCreatedByUser(userEntity)
+              withCrn(offenderDetails.otherIds.crn)
+              withData("{}")
+              withCreatedAt(OffsetDateTime.parse("2024-01-03T16:10:00+01:00"))
+              withApplicationOrigin(ApplicationOrigin.courtBail)
+            }
+
+            // prison bail application
+            val prisonBailApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(applicationSchema)
+              withCreatedByUser(userEntity)
+              withCrn(offenderDetails.otherIds.crn)
+              withData("{}")
+              withCreatedAt(OffsetDateTime.parse("2024-01-03T16:10:00+01:00"))
+              withApplicationOrigin(ApplicationOrigin.prisonBail)
+            }
+
+            // hdc application
+            val hdcApplicationEntity = cas2ApplicationEntityFactory.produceAndPersist {
+              withApplicationSchema(applicationSchema)
+              withCreatedByUser(userEntity)
+              withCrn(offenderDetails.otherIds.crn)
+              withData("{}")
+              withCreatedAt(OffsetDateTime.parse("2024-02-29T09:00:00+01:00"))
+              withSubmittedAt(OffsetDateTime.now())
+              withApplicationOrigin(ApplicationOrigin.homeDetentionCurfew)
+            }
+
+            val rawResponseBody = webTestClient.get()
+              .uri("/cas2/applications")
+              .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.cas2.value)
+              .exchange()
+              .expectStatus()
+              .isOk
+              .returnResult<String>()
+              .responseBody
+              .blockFirst()
+
+            val responseBody =
+              objectMapper.readValue(rawResponseBody, object : TypeReference<List<Cas2ApplicationSummary>>() {})
+
+            // check application origin is persisted and returned correctly
+            Assertions.assertThat(responseBody).anyMatch {
+              courtBailApplicationEntity.applicationOrigin == it.applicationOrigin.toString()
+            }
+
+            Assertions.assertThat(responseBody).anyMatch {
+              hdcApplicationEntity.applicationOrigin == it.applicationOrigin.toString()
+            }
+
+            Assertions.assertThat(responseBody).anyMatch {
+              prisonBailApplicationEntity.applicationOrigin == it.applicationOrigin.toString()
+            }
+
+
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/ApplicationServiceTest.kt
@@ -1324,9 +1324,94 @@ class ApplicationServiceTest {
       val validatableActionResult = result.entity as ValidatableActionResult.Success
       val persistedApplication = validatableActionResult.entity
 
-
       assertThat(persistedApplication.applicationOrigin).isEqualTo(ApplicationOrigin.courtBail.toString())
-      //TODO when we implement application origin into domain events
+      // TODO when we implement application origin into domain events
+      // and send email we'll need similar verify functions to the method above.
+    }
+
+    @Test
+    fun `returns Success and null for application origin correctly`() {
+      val newestSchema = Cas2ApplicationJsonSchemaEntityFactory().produce()
+
+      val application = Cas2ApplicationEntityFactory()
+        .withApplicationSchema(newestSchema)
+        .withId(applicationId)
+        .withCreatedByUser(user)
+        .withSubmittedAt(null)
+        .withApplicationOrigin(ApplicationOrigin.courtBail)
+        .produce()
+        .apply {
+          schemaUpToDate = true
+        }
+
+      val submitCas2BailApplication = SubmitCas2Application(
+        translatedDocument = {},
+        applicationId = applicationId,
+        preferredAreas = "Leeds | Bradford",
+        hdcEligibilityDate = hdcEligibilityDate,
+        conditionalReleaseDate = conditionalReleaseDate,
+        telephoneNumber = "123",
+      )
+
+      every {
+        mockApplicationRepository.findByIdOrNull(applicationId)
+      } returns application
+      every { mockJsonSchemaService.checkSchemaOutdated(application) } returns
+        application
+      every { mockJsonSchemaService.validate(newestSchema, application.data!!) } returns true
+
+      val inmateDetail = InmateDetailFactory()
+        .withAssignedLivingUnit(
+          AssignedLivingUnit(
+            agencyId = "BRI",
+            locationId = 1234,
+            description = "description",
+            agencyName = "HMP Bristol",
+          ),
+        )
+        .produce()
+
+      every {
+        mockOffenderService.getInmateDetailByNomsNumber(
+          application.crn,
+          application.nomsNumber.toString(),
+        )
+      } returns AuthorisableActionResult.Success(inmateDetail)
+
+      every { mockNotifyConfig.templates.cas2ApplicationSubmitted } returns "abc123"
+      every { mockNotifyConfig.emailAddresses.cas2Assessors } returns "exampleAssessorInbox@example.com"
+      every { mockNotifyConfig.emailAddresses.cas2ReplyToId } returns "def456"
+      every { mockEmailNotificationService.sendEmail(any(), any(), any(), any()) } just Runs
+
+      every { mockApplicationRepository.save(any()) } answers {
+        it.invocation.args[0]
+          as Cas2ApplicationEntity
+      }
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withGender("male")
+        .withCrn(application.crn)
+        .produce()
+
+      every { mockOffenderService.getOffenderByCrn(application.crn) } returns AuthorisableActionResult.Success(
+        offenderDetails,
+      )
+
+      every { mockAssessmentService.createCas2Assessment(any()) } returns any()
+
+      every { mockObjectMapper.writeValueAsString(any()) } returns any()
+
+      val result = applicationService.submitApplication(submitCas2BailApplication, user)
+
+      assertThat(result is AuthorisableActionResult.Success).isTrue
+      result as AuthorisableActionResult.Success
+
+      assertThat(result.entity is ValidatableActionResult.Success).isTrue
+      val validatableActionResult = result.entity as ValidatableActionResult.Success
+      val persistedApplication = validatableActionResult.entity
+
+      assertThat(persistedApplication.applicationOrigin).isNull()
+      // TODO when we implement application origin into domain events
       // and send email we'll need similar verify functions to the method above.
     }
   }


### PR DESCRIPTION
1. We've added applicationOrigin to the Cas2ApplicationEntity and Cas2ApplicationSummaryEntity.
2. There is an API enum which has three values: courtBail, prisonBail, homeDetentionCurfew
3. The createApplication function in ApplicationService has a nullable parameter (applicationOrigin) which has a default value of null so as not to interfere with the current Cas2 service.
4. We added a migration to alter the table and summary views.
5. Added some integration and unit tests.


ADR for this change - https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/5338431579/ADR+CAS2+Data+Change+-+Application+Origin