### PR TITLE
Tidy Cas1BookingDomainEventService and add Integration Test for Booking Amended Domain Event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -20,6 +20,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.BookingSummaryForAvailability
 import java.time.Instant
 import java.time.LocalDate
@@ -335,6 +336,14 @@ data class BookingEntity(
 
   val arrival: ArrivalEntity?
     get() = arrivals.maxByOrNull { it.createdAt }
+
+  val cas1ApplicationFacade: Cas1ApplicationFacade
+    get() {
+      if (offlineApplication == null && application !is ApprovedPremisesApplicationEntity) {
+        error("Can only return CAS1 application facade for bookings linked to CAS1 applications")
+      }
+      return Cas1ApplicationFacade(application as ApprovedPremisesApplicationEntity?, offlineApplication)
+    }
 
   fun isInCancellableStateCas1() = !isCancelled && !hasArrivals()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationFacade.kt
@@ -20,4 +20,7 @@ class Cas1ApplicationFacade(
 
   val submittedAt: OffsetDateTime
     get() = application?.submittedAt ?: offlineApplication!!.createdAt
+
+  val eventNumber: String?
+    get() = application?.eventNumber ?: offlineApplication!!.eventNumber
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -22,10 +22,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService
@@ -275,8 +275,7 @@ class Cas1BookingDomainEventService(
   ) = bookingCancelled(
     CancellationInfo(
       bookingId = booking.id,
-      application = booking.application as ApprovedPremisesApplicationEntity?,
-      offlineApplication = booking.offlineApplication,
+      applicationFacade = booking.cas1ApplicationFacade,
       cancellationId = cancellation.id,
       crn = booking.crn,
       cancelledAt = cancellation.date,
@@ -295,8 +294,7 @@ class Cas1BookingDomainEventService(
     bookingCancelled(
       CancellationInfo(
         bookingId = spaceBooking.id,
-        application = spaceBooking.application,
-        offlineApplication = spaceBooking.offlineApplication,
+        applicationFacade = spaceBooking.applicationFacade,
         cancellationId = null,
         crn = spaceBooking.crn,
         cancelledAt = spaceBooking.cancellationOccurredAt!!,
@@ -327,11 +325,8 @@ class Cas1BookingDomainEventService(
 
     val staffDetails = getStaffDetails(user.deliusUsername)
 
-    val application = cancellationInfo.application
-    val offlineApplication = cancellationInfo.offlineApplication
-
-    val applicationId = application?.id ?: offlineApplication?.id as UUID
-    val eventNumber = application?.eventNumber ?: offlineApplication?.eventNumber as String
+    val applicationId = cancellationInfo.applicationFacade.id
+    val eventNumber = cancellationInfo.applicationFacade.eventNumber!!
 
     domainEventService.saveBookingCancelledEvent(
       DomainEvent(
@@ -387,8 +382,7 @@ class Cas1BookingDomainEventService(
 
   private data class CancellationInfo(
     val bookingId: UUID,
-    val application: ApprovedPremisesApplicationEntity?,
-    val offlineApplication: OfflineApplicationEntity?,
+    val applicationFacade: Cas1ApplicationFacade,
     val crn: String,
     val premises: ApprovedPremisesEntity,
     val cancellationId: UUID?,


### PR DESCRIPTION
This is in preparation for moving the 'booking changed' domain event logic into the `Cas1BookingDomainEventService`