### PR TITLE
APS-1707 - Add name to offline applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -386,6 +386,11 @@ class ApprovedPremisesApplicationEntity(
   var sentenceType: String?,
   var situation: String?,
   var arrivalDate: OffsetDateTime?,
+  /**
+   * The offender name. This should only be used for search purposes (i.e. SQL)
+   * If returning the offender name to the user, use the [OffenderService], which
+   * will consider any LAO restrictions
+   */
   var name: String,
   var targetLocation: String?,
   @Enumerated(value = EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -32,4 +32,10 @@ data class OfflineApplicationEntity(
   val service: String,
   val createdAt: OffsetDateTime,
   val eventNumber: String?,
+  /**
+   * The offender name. This should only be used for search purposes (i.e. SQL)
+   * If returning the offender name to the user, use the [OffenderService], which
+   * will consider any LAO restrictions
+   */
+  var name: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -284,6 +284,7 @@ class Cas1AutoScript(
     }
 
     val personInfo = getPersonInfo(crn)
+    val offenderDetail = personInfo.offenderDetailSummary
 
     val offlineApplication = applicationService.createOfflineApplication(
       OfflineApplicationEntity(
@@ -292,6 +293,7 @@ class Cas1AutoScript(
         service = ServiceName.approvedPremises.value,
         createdAt = OffsetDateTime.now(),
         eventNumber = "2",
+        name = "${offenderDetail.firstName.uppercase()} ${offenderDetail.surname.uppercase()}",
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1AutoScript.kt
@@ -8,10 +8,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -23,7 +27,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService.GetUserResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
@@ -42,9 +45,10 @@ class Cas1AutoScript(
   private val offenderService: OffenderService,
   private val cruManagementAreaRepository: Cas1CruManagementAreaRepository,
   private val environmentService: EnvironmentService,
-  private val premisesService: PremisesService,
+  private val approvedPremisesRepository: ApprovedPremisesRepository,
   private val bookingRepository: BookingRepository,
   private val applicationTimelineNoteService: ApplicationTimelineNoteService,
+  private val spaceBookingRepository: Cas1SpaceBookingRepository,
 ) {
 
   @Transactional
@@ -65,7 +69,7 @@ class Cas1AutoScript(
     createApplication(deliusUserName = "JIMSNOWLDAP", crn = "X320741")
     createApplication(deliusUserName = "LAOFULLACCESS", crn = "X400000")
     createApplication(deliusUserName = "LAOFULLACCESS", crn = "X400001")
-    createOfflineApplicationWithBooking(crn = "X320741")
+    createOfflineApplicationWithBooking(deliusUserName = "JIMSNOWLDAP", crn = "X320741")
   }
 
   fun scriptDev() {
@@ -83,10 +87,10 @@ class Cas1AutoScript(
     }
   }
 
-  private fun createOfflineApplicationWithBooking(crn: String) {
+  private fun createOfflineApplicationWithBooking(deliusUserName: String, crn: String) {
     seedLogger.info("Auto-scripting offline for CRN $crn")
     try {
-      createOfflineApplicationInternal(crn = crn)
+      createOfflineApplicationInternal(deliusUserName, crn)
     } catch (e: Exception) {
       seedLogger.error("Creating offline application with crn $crn failed", e)
     }
@@ -277,7 +281,7 @@ class Cas1AutoScript(
     )
   }
 
-  private fun createOfflineApplicationInternal(crn: String) {
+  private fun createOfflineApplicationInternal(deliusUserName: String, crn: String) {
     if (applicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises).isNotEmpty()) {
       seedLogger.info("Already have an offline CAS1 application for $crn, not seeding a new application")
       return
@@ -297,15 +301,15 @@ class Cas1AutoScript(
       ),
     )
 
-    val arrivalDate = LocalDate.of(2027, 1, 2)
-    val departureDate = LocalDate.of(2027, 1, 6)
+    val bookingArrivalDate = LocalDate.of(2027, 1, 2)
+    val bookingDepartureDate = LocalDate.of(2027, 1, 6)
 
     bookingRepository.save(
       BookingEntity(
         id = UUID.randomUUID(),
         crn = crn,
-        arrivalDate = arrivalDate,
-        departureDate = departureDate,
+        arrivalDate = bookingArrivalDate,
+        departureDate = bookingDepartureDate,
         keyWorkerStaffCode = null,
         arrivals = mutableListOf(),
         departures = mutableListOf(),
@@ -313,11 +317,11 @@ class Cas1AutoScript(
         cancellations = mutableListOf(),
         confirmation = null,
         extensions = mutableListOf(),
-        premises = premisesService.getAllPremisesForService(ServiceName.approvedPremises).first().getPremises(),
+        premises = approvedPremisesRepository.findAll().first(),
         bed = null,
         service = ServiceName.approvedPremises.value,
-        originalArrivalDate = arrivalDate,
-        originalDepartureDate = departureDate,
+        originalArrivalDate = bookingArrivalDate,
+        originalDepartureDate = bookingDepartureDate,
         createdAt = OffsetDateTime.now(),
         application = null,
         offlineApplication = offlineApplication,
@@ -327,6 +331,47 @@ class Cas1AutoScript(
         placementRequest = null,
         status = BookingStatus.confirmed,
         adhoc = true,
+      ),
+    )
+
+    val spaceBookingArrivalDate = LocalDate.of(2028, 5, 12)
+    val spaceBookingDepartureDate = LocalDate.of(2028, 7, 6)
+    val createdByUser = (userService.getExistingUserOrCreate(deliusUserName) as GetUserResponse.Success).user
+
+    spaceBookingRepository.save(
+      Cas1SpaceBookingEntity(
+        id = UUID.randomUUID(),
+        premises = approvedPremisesRepository.findAll().first { it.supportsSpaceBookings },
+        application = null,
+        offlineApplication = offlineApplication,
+        placementRequest = null,
+        createdBy = createdByUser,
+        createdAt = OffsetDateTime.now(),
+        expectedArrivalDate = spaceBookingArrivalDate,
+        expectedDepartureDate = spaceBookingDepartureDate,
+        actualArrivalDate = null,
+        actualArrivalTime = null,
+        actualDepartureDate = null,
+        actualDepartureTime = null,
+        canonicalArrivalDate = spaceBookingArrivalDate,
+        canonicalDepartureDate = spaceBookingDepartureDate,
+        crn = crn,
+        keyWorkerStaffCode = null,
+        keyWorkerName = null,
+        keyWorkerAssignedAt = null,
+        cancellationOccurredAt = null,
+        cancellationRecordedAt = null,
+        cancellationReason = null,
+        cancellationReasonNotes = null,
+        departureMoveOnCategory = null,
+        departureReason = null,
+        departureNotes = null,
+        criteria = emptyList<CharacteristicEntity>().toMutableList(),
+        nonArrivalConfirmedAt = null,
+        nonArrivalNotes = null,
+        nonArrivalReason = null,
+        deliusEventNumber = "2",
+        migratedManagementInfoFrom = null,
       ),
     )
   }

--- a/src/main/resources/db/migration/all/20241213153445__add_offline_application_name.sql
+++ b/src/main/resources/db/migration/all/20241213153445__add_offline_application_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE offline_applications ADD name text NULL;
+CREATE INDEX offline_applications_name_idx ON offline_applications (name);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
@@ -14,6 +14,7 @@ class OfflineApplicationEntityFactory : Factory<OfflineApplicationEntity> {
   private var service: Yielded<String> = { "approved-premises" }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var eventNumber: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
+  private var name: Yielded<String?> = { randomStringMultiCaseWithNumbers(10) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -41,5 +42,6 @@ class OfflineApplicationEntityFactory : Factory<OfflineApplicationEntity> {
     service = this.service(),
     createdAt = this.createdAt(),
     eventNumber = this.eventNumber(),
+    name = this.name(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OfflineApplicationEntityFactory.kt
@@ -36,6 +36,10 @@ class OfflineApplicationEntityFactory : Factory<OfflineApplicationEntity> {
     this.eventNumber = { eventNumber }
   }
 
+  fun withName(name: String?) = apply {
+    this.name = { name }
+  }
+
   override fun produce() = OfflineApplicationEntity(
     id = this.id(),
     crn = this.crn(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulStaffMembersCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -309,7 +310,7 @@ class Cas1SpaceBookingTest {
 
   @Nested
   inner class SearchForSpaceBookings : SpaceBookingIntegrationTestBase() {
-    lateinit var currentSpaceBooking2: Cas1SpaceBookingEntity
+    lateinit var currentSpaceBooking2OfflineApplication: Cas1SpaceBookingEntity
     lateinit var currentSpaceBooking3: Cas1SpaceBookingEntity
     lateinit var currentSpaceBooking4Restricted: Cas1SpaceBookingEntity
     lateinit var upcomingSpaceBookingWithKeyWorker: Cas1SpaceBookingEntity
@@ -336,7 +337,7 @@ class Cas1SpaceBookingTest {
         withKeyworkerAssignedAt(Instant.now())
       }
 
-      currentSpaceBooking2 = createSpaceBooking(crn = "CRN_CURRENT2", firstName = "curt", lastName = "rent 2", tier = "C") {
+      currentSpaceBooking2OfflineApplication = createSpaceBookingWithOfflineApplication(crn = "CRN_CURRENT2_OFFLINE", firstName = "curt", lastName = "rent 2") {
         withPremises(premisesWithBookings)
         withExpectedArrivalDate(LocalDate.parse("2026-02-02"))
         withExpectedDepartureDate(LocalDate.parse("2026-09-02"))
@@ -508,7 +509,7 @@ class Cas1SpaceBookingTest {
       assertThat(response[1].person.crn).isEqualTo("CRN_LEGACY_NO_ARRIVAL")
       assertThat(response[2].person.crn).isEqualTo("CRN_DEPARTED")
       assertThat(response[3].person.crn).isEqualTo("CRN_CURRENT1")
-      assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT2")
+      assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
       assertThat(response[5].person.crn).isEqualTo("CRN_CURRENT3")
       assertThat(response[6].person.crn).isEqualTo("CRN_CURRENT4")
       assertThat(response[7].person.crn).isEqualTo("CRN_UPCOMING")
@@ -564,7 +565,7 @@ class Cas1SpaceBookingTest {
 
       assertThat(response).hasSize(4)
       assertThat(response[0].person.crn).isEqualTo("CRN_CURRENT1")
-      assertThat(response[1].person.crn).isEqualTo("CRN_CURRENT2")
+      assertThat(response[1].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
       assertThat(response[2].person.crn).isEqualTo("CRN_CURRENT3")
       assertThat(response[3].person.crn).isEqualTo("CRN_CURRENT4")
     }
@@ -574,7 +575,7 @@ class Cas1SpaceBookingTest {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
 
       val response = webTestClient.get()
-        .uri("/cas1/premises/${premisesWithBookings.id}/space-bookings?crnOrName=CRN_CURRENT2&sortBy=canonicalArrivalDate&sortDirection=asc")
+        .uri("/cas1/premises/${premisesWithBookings.id}/space-bookings?crnOrName=CRN_CURRENT2_OFFLINE&sortBy=canonicalArrivalDate&sortDirection=asc")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -582,7 +583,7 @@ class Cas1SpaceBookingTest {
         .bodyAsListOfObjects<Cas1SpaceBookingSummary>()
 
       assertThat(response).hasSize(1)
-      assertThat(response[0].person.crn).isEqualTo("CRN_CURRENT2")
+      assertThat(response[0].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
       assertThat(response[0].person.personType).isEqualTo(PersonSummaryDiscriminator.fullPersonSummary)
     }
 
@@ -594,7 +595,7 @@ class Cas1SpaceBookingTest {
         caseAccess = CaseAccessFactory()
           .withUserExcluded(true)
           .withUserRestricted(true)
-          .withCrn("CRN_CURRENT2")
+          .withCrn("CRN_CURRENT2_OFFLINE")
           .produce(),
       )
 
@@ -663,7 +664,7 @@ class Cas1SpaceBookingTest {
       assertThat(response).hasSize(4)
       assertThat(response[0].person.crn).isEqualTo("CRN_CURRENT4")
       assertThat(response[1].person.crn).isEqualTo("CRN_CURRENT3")
-      assertThat(response[2].person.crn).isEqualTo("CRN_CURRENT2")
+      assertThat(response[2].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
       assertThat(response[3].person.crn).isEqualTo("CRN_CURRENT1")
     }
 
@@ -684,7 +685,7 @@ class Cas1SpaceBookingTest {
       assertThat(response[1].person.crn).isEqualTo("CRN_UPCOMING")
       assertThat(response[2].person.crn).isEqualTo("CRN_CURRENT4")
       assertThat(response[3].person.crn).isEqualTo("CRN_CURRENT3")
-      assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT2")
+      assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
       assertThat(response[5].person.crn).isEqualTo("CRN_CURRENT1")
       assertThat(response[6].person.crn).isEqualTo("CRN_DEPARTED")
       assertThat(response[7].person.crn).isEqualTo("CRN_LEGACY_NO_ARRIVAL")
@@ -708,7 +709,7 @@ class Cas1SpaceBookingTest {
       assertThat(response[1].person.crn).isEqualTo("CRN_LEGACY_NO_ARRIVAL")
       assertThat(response[2].person.crn).isEqualTo("CRN_DEPARTED")
       assertThat(response[3].person.crn).isEqualTo("CRN_CURRENT1")
-      assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT2")
+      assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
       assertThat(response[5].person.crn).isEqualTo("CRN_CURRENT3")
       assertThat(response[6].person.crn).isEqualTo("CRN_CURRENT4")
       assertThat(response[7].person.crn).isEqualTo("CRN_UPCOMING")
@@ -748,17 +749,17 @@ class Cas1SpaceBookingTest {
 
       assertThat(response).hasSize(9)
 
-      assertThat(response[0].tier).isEqualTo("Z")
-      assertThat(response[0].person.crn).isEqualTo("CRN_LEGACY_NO_DEPARTURE")
+      assertThat(response[0].tier).isNull()
+      assertThat(response[0].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
 
-      assertThat(response[1].tier).isEqualTo("U")
-      assertThat(response[1].person.crn).isEqualTo("CRN_UPCOMING")
+      assertThat(response[1].tier).isEqualTo("Z")
+      assertThat(response[1].person.crn).isEqualTo("CRN_LEGACY_NO_DEPARTURE")
 
-      assertThat(response[2].tier).isEqualTo("D")
-      assertThat(response[2].person.crn).isEqualTo("CRN_DEPARTED")
+      assertThat(response[2].tier).isEqualTo("U")
+      assertThat(response[2].person.crn).isEqualTo("CRN_UPCOMING")
 
-      assertThat(response[3].tier).isEqualTo("C")
-      assertThat(response[3].person.crn).isEqualTo("CRN_CURRENT2")
+      assertThat(response[3].tier).isEqualTo("D")
+      assertThat(response[3].person.crn).isEqualTo("CRN_DEPARTED")
 
       assertThat(response[4].tier).isEqualTo("B")
       assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT4")
@@ -1979,6 +1980,34 @@ abstract class SpaceBookingIntegrationTestBase : InitialiseDatabasePerClassTestB
       withPremises(premisesWithBookings)
       withPlacementRequest(placementRequest)
       withApplication(placementRequest.application)
+      withCreatedBy(user)
+
+      configuration.invoke(this)
+    }
+  }
+
+  protected fun createSpaceBookingWithOfflineApplication(
+    crn: String,
+    firstName: String,
+    lastName: String,
+    configuration: Cas1SpaceBookingEntityFactory.() -> Unit,
+  ): Cas1SpaceBookingEntity {
+    val (user) = givenAUser()
+    val (offender) = givenAnOffender(offenderDetailsConfigBlock = {
+      withCrn(crn)
+      withFirstName(firstName)
+      withLastName(lastName)
+    })
+    val offlineApplication = givenAnOfflineApplication(
+      crn = crn,
+      name = "$firstName $lastName",
+    )
+    return cas1SpaceBookingEntityFactory.produceAndPersist {
+      withCrn(offender.otherIds.crn)
+      withPremises(premisesWithBookings)
+      withPlacementRequest(null)
+      withApplication(null)
+      withOfflineApplication(offlineApplication)
       withCreatedBy(user)
 
       configuration.invoke(this)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOfflineApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOfflineApplication.kt
@@ -8,6 +8,7 @@ fun IntegrationTestBase.givenAnOfflineApplication(
   crn: String,
   eventNumber: String? = randomStringMultiCaseWithNumbers(6),
   eventNumberSet: Boolean = true,
+  name: String? = null,
 ) = offlineApplicationEntityFactory.produceAndPersist {
   withCrn(crn)
   withEventNumber(
@@ -17,4 +18,5 @@ fun IntegrationTestBase.givenAnOfflineApplication(
       null
     },
   )
+  withName(name)
 }


### PR DESCRIPTION
* Add `name` column to offline applications
* Update space booking search to return space bookings linked to offline applications, and consider the name on the offline application
* Auto seed a space booking linked to an offline application in local dev environments

This PR will be followed by a PR to backfill `offline_applications.name`