### PR TITLE
Add Unit model for UI

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2153,6 +2153,9 @@ components:
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
       type: object
+    Unit:
+      description: Any object
+      type: object
     ApplicationTimelineNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6436,6 +6436,9 @@ components:
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
       type: object
+    Unit:
+      description: Any object
+      type: object
     ApplicationTimelineNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3334,6 +3334,9 @@ components:
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
       type: object
+    Unit:
+      description: Any object
+      type: object
     ApplicationTimelineNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2744,6 +2744,9 @@ components:
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
       type: object
+    Unit:
+      description: Any object
+      type: object
     ApplicationTimelineNote:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2252,6 +2252,9 @@ components:
     AnyValue:
       description: Any object that conforms to the current JSON schema for an application
       type: object
+    Unit:
+      description: Any object
+      type: object
     ApplicationTimelineNote:
       type: object
       properties:


### PR DESCRIPTION
This is to replicate the AnyValue model that is defined - as it is generated as 'Unit'. This will take out one set of changes for before the switchover.