### PR TITLE
APS-1675 - Simplify CAS1 Domain Event Migration Testing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventMigrationService.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
 
 /**
-This is tested by unit tests for [uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventService]
+This is tested by the [DomainEventTest] integration test
  */
 @Service
 class Cas1DomainEventMigrationService(val objectMapper: ObjectMapper) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.domainevents.DomainEventSummaryImpl
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeWithLatestJson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Cas1DomainEventsFactory
 
 class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
@@ -163,9 +163,9 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
         withCreatedBy(userEntity)
       }
 
-      createCas1DomainEventEnvelopeWithLatestJson(type, clarificationNote.id)
+      Cas1DomainEventsFactory.createEnvelopeForLatestSchemaVersion(type, clarificationNote.id)
     } else {
-      createCas1DomainEventEnvelopeWithLatestJson(type)
+      Cas1DomainEventsFactory.createEnvelopeForLatestSchemaVersion(type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -157,15 +157,17 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
     assessmentEntity: ApprovedPremisesAssessmentEntity,
     userEntity: UserEntity,
   ): DomainEventEntity {
+    val domainEventsFactory = Cas1DomainEventsFactory(objectMapper)
+
     val data = if (type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED) {
       val clarificationNote = assessmentClarificationNoteEntityFactory.produceAndPersist {
         withAssessment(assessmentEntity)
         withCreatedBy(userEntity)
       }
 
-      Cas1DomainEventsFactory.createEnvelopeForLatestSchemaVersion(type, clarificationNote.id)
+      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type, clarificationNote.id)
     } else {
-      Cas1DomainEventsFactory.createEnvelopeForLatestSchemaVersion(type)
+      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlCon
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventCas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventSchemaVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeForSchemaVersion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Cas1DomainEventsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -77,7 +77,7 @@ class DomainEventTest : InitialiseDatabasePerClassTestBase() {
     val now = LocalDateTime.now()
     clock.setNow(now.roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
 
-    val domainEventAndJson = createCas1DomainEventEnvelopeForSchemaVersion(
+    val domainEventAndJson = Cas1DomainEventsFactory.createEnvelopeForSchemaVersion(
       type = domainEventType,
       objectMapper = objectMapper,
       occurredAt = clock.instant(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DomainEventTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.MethodSource
@@ -10,8 +12,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventCa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventSchemaVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Cas1DomainEventsFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
-import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
@@ -19,8 +19,17 @@ class DomainEventTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var domainEventUrlConfig: DomainEventUrlConfig
 
+  lateinit var domainEventsFactory: Cas1DomainEventsFactory
+
   private fun generateUrlForDomainEventType(domainEventType: DomainEventType, uuid: UUID) = domainEventUrlConfig.getUrlForDomainEventId(domainEventType, uuid)
     .replace("http://api", "")
+
+  @BeforeEach
+  fun setup() {
+    clock.setToNowWithoutMillis()
+
+    domainEventsFactory = Cas1DomainEventsFactory(objectMapper)
+  }
 
   @ParameterizedTest
   @EnumSource(DomainEventType::class, names = ["APPROVED_PREMISES_.+"], mode = EnumSource.Mode.MATCH_ANY)
@@ -53,45 +62,69 @@ class DomainEventTest : InitialiseDatabasePerClassTestBase() {
   private companion object {
     @JvmStatic
     fun allCas1DomainEventTypes() = DomainEventType.values().filter { it.cas == DomainEventCas.CAS1 }
-
-    @JvmStatic
-    fun allDomainEventTypesAndVersions() = DomainEventType
-      .entries
-      .filter { it.cas == DomainEventCas.CAS1 }
-      .flatMap { type -> type.schemaVersions.map { DomainEventTypeAndVersion(type, it) } }
   }
 
   data class DomainEventTypeAndVersion(val type: DomainEventType, val version: DomainEventSchemaVersion)
 
   @ParameterizedTest
-  @MethodSource("allDomainEventTypesAndVersions")
-  fun `Get event returns 200 with correct body`(domainEventTypeAndVersion: DomainEventTypeAndVersion) {
-    val domainEventType = domainEventTypeAndVersion.type
-    val version = domainEventTypeAndVersion.version
-
+  @MethodSource("allCas1DomainEventTypes")
+  fun `Get event returns 200 with correct body for all types and latest schema versions`(type: DomainEventType) {
     val jwt = jwtAuthHelper.createClientCredentialsJwt(
       username = "username",
       roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
     )
 
-    val now = LocalDateTime.now()
-    clock.setNow(now.roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
-
-    val domainEventAndJson = Cas1DomainEventsFactory.createEnvelopeForSchemaVersion(
-      type = domainEventType,
-      objectMapper = objectMapper,
+    val domainEventAndJson = domainEventsFactory.createEnvelopeLatestVersion(
+      type = type,
       occurredAt = clock.instant(),
-      schemaVersion = version,
     )
 
     val event = domainEventFactory.produceAndPersist {
-      withType(domainEventType)
+      withType(type)
       withData(domainEventAndJson.persistedJson)
       withOccurredAt(clock.instant().atOffset(ZoneOffset.UTC))
-      withSchemaVersion(version.versionNo)
+      withSchemaVersion(domainEventAndJson.schemaVersion.versionNo)
     }
 
-    val url = generateUrlForDomainEventType(domainEventType, event.id)
+    val url = generateUrlForDomainEventType(type, event.id)
+
+    val response = webTestClient.get()
+      .uri(url)
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(domainEventAndJson.envelope::class.java)
+      .returnResult()
+
+    assertThat(response.responseBody).isEqualTo(domainEventAndJson.envelope)
+  }
+
+  @Test
+  fun `Get APPROVED_PREMISES_BOOKING_CANCELLED v1 is correctly migrated to v2 by deriving cancelled at date fields`() {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      roles = listOf("ROLE_APPROVED_PREMISES_EVENTS"),
+    )
+
+    val domainEventAndJson = domainEventsFactory.createEnvelopeLatestVersion(
+      type = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
+      occurredAt = clock.instant(),
+    )
+
+    val persistedJson = domainEventsFactory.removeEventDetails(
+      objectMapper.writeValueAsString(domainEventAndJson.envelope),
+      listOf("cancelledAtDate", "cancellationRecordedAt"),
+    )
+
+    val event = domainEventFactory.produceAndPersist {
+      withType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
+      withData(persistedJson)
+      withOccurredAt(clock.instant().atOffset(ZoneOffset.UTC))
+      withSchemaVersion(1)
+    }
+
+    val url = generateUrlForDomainEventType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED, event.id)
 
     val response = webTestClient.get()
       .uri(url)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTimelineTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.domainevents.DomainEventSummaryImpl
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeWithLatestJson
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Cas1DomainEventsFactory
 import java.time.LocalDate
 
 class Cas1SpaceBookingTimelineTest : InitialiseDatabasePerClassTestBase() {
@@ -191,9 +191,9 @@ class Cas1SpaceBookingTimelineTest : InitialiseDatabasePerClassTestBase() {
         withAssessment(assessmentEntity)
         withCreatedBy(userEntity)
       }
-      createCas1DomainEventEnvelopeWithLatestJson(type, clarificationNote.id)
+      Cas1DomainEventsFactory.createEnvelopeForLatestSchemaVersion(type, clarificationNote.id)
     } else {
-      createCas1DomainEventEnvelopeWithLatestJson(type)
+      Cas1DomainEventsFactory.createEnvelopeForLatestSchemaVersion(type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTimelineTest.kt
@@ -186,14 +186,16 @@ class Cas1SpaceBookingTimelineTest : InitialiseDatabasePerClassTestBase() {
     assessmentEntity: ApprovedPremisesAssessmentEntity,
     userEntity: UserEntity,
   ): DomainEventEntity {
+    val domainEventsFactory = Cas1DomainEventsFactory(objectMapper)
+
     val data = if (type == DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED) {
       val clarificationNote = assessmentClarificationNoteEntityFactory.produceAndPersist {
         withAssessment(assessmentEntity)
         withCreatedBy(userEntity)
       }
-      Cas1DomainEventsFactory.createEnvelopeForLatestSchemaVersion(type, clarificationNote.id)
+      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type, clarificationNote.id)
     } else {
-      Cas1DomainEventsFactory.createEnvelopeForLatestSchemaVersion(type)
+      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/MutableClockConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/MutableClockConfiguration.kt
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.test.context.event.annotation.BeforeTestMethod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
@@ -30,6 +31,10 @@ class MutableClockConfiguration {
 
     fun setNow(now: LocalDateTime) {
       fixedTime = now.toInstant(ZoneOffset.UTC)
+    }
+
+    fun setToNowWithoutMillis() {
+      setNow(LocalDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
     }
 
     fun advanceOneMinute() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -70,7 +70,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DomainEventServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventMigrationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.createCas1DomainEventEnvelopeForSchemaVersion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Cas1DomainEventsFactory
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -149,7 +149,7 @@ class DomainEventServiceTest {
       val nomsNumber = "theNomsNumber"
 
       val method = fetchGetterForType(type)
-      val domainEventAndJson = createCas1DomainEventEnvelopeForSchemaVersion(
+      val domainEventAndJson = Cas1DomainEventsFactory.createEnvelopeForSchemaVersion(
         type = type,
         objectMapper = objectMapper,
         schemaVersion = version,
@@ -222,7 +222,7 @@ class DomainEventServiceTest {
       val crn = "CRN"
       val nomsNumber = "theNomsNumber"
       val occurredAt = Instant.now()
-      val domainEventAndJson = createCas1DomainEventEnvelopeForSchemaVersion(type, objectMapper, version)
+      val domainEventAndJson = Cas1DomainEventsFactory.createEnvelopeForSchemaVersion(type, objectMapper, version)
       val metadata = mapOf(MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER to "value1")
 
       every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
@@ -292,7 +292,7 @@ class DomainEventServiceTest {
       val crn = "CRN"
       val nomsNumber = "123"
       val occurredAt = Instant.now()
-      val domainEventAndJson = createCas1DomainEventEnvelopeForSchemaVersion(type, objectMapper, version)
+      val domainEventAndJson = Cas1DomainEventsFactory.createEnvelopeForSchemaVersion(type, objectMapper, version)
 
       every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
@@ -341,7 +341,7 @@ class DomainEventServiceTest {
       val crn = "CRN"
       val nomsNumber = "123"
       val occurredAt = Instant.now()
-      val domainEventAndJson = createCas1DomainEventEnvelopeForSchemaVersion(domainEventType, objectMapper, version)
+      val domainEventAndJson = Cas1DomainEventsFactory.createEnvelopeForSchemaVersion(domainEventType, objectMapper, version)
 
       every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
@@ -49,184 +49,187 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventTy
 import java.time.Instant
 import java.util.UUID
 
-fun createCas1DomainEventEnvelopeForSchemaVersion(
-  type: DomainEventType,
-  objectMapper: ObjectMapper,
-  schemaVersion: DomainEventSchemaVersion,
-  requestId: UUID = UUID.randomUUID(),
-  occurredAt: Instant = Instant.now(),
-): DomainEventEnvelopeAndPersistedJson {
-  val envelope = createCas1DomainEventEnvelopeWithLatestJson(
-    type,
-    requestId,
-    occurredAt = occurredAt,
-  )
+object Cas1DomainEventsFactory {
 
-  val persistedJson = if (type == DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED && schemaVersion.versionNo == null) {
-    removeEventDetails(
-      objectMapper,
-      objectMapper.writeValueAsString(envelope),
-      listOf("cancelledAtDate", "cancellationRecordedAt"),
+  fun createEnvelopeForSchemaVersion(
+    type: DomainEventType,
+    objectMapper: ObjectMapper,
+    schemaVersion: DomainEventSchemaVersion,
+    requestId: UUID = UUID.randomUUID(),
+    occurredAt: Instant = Instant.now(),
+  ): DomainEventEnvelopeAndPersistedJson {
+    val envelope = createEnvelopeForLatestSchemaVersion(
+      type,
+      requestId,
+      occurredAt = occurredAt,
     )
-  } else {
-    objectMapper.writeValueAsString(envelope)
+
+    val persistedJson = if (type == DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED && schemaVersion.versionNo == null) {
+      removeEventDetails(
+        objectMapper,
+        objectMapper.writeValueAsString(envelope),
+        listOf("cancelledAtDate", "cancellationRecordedAt"),
+      )
+    } else {
+      objectMapper.writeValueAsString(envelope)
+    }
+
+    return DomainEventEnvelopeAndPersistedJson(
+      envelope = envelope,
+      persistedJson = persistedJson,
+    )
   }
 
-  return DomainEventEnvelopeAndPersistedJson(
-    envelope = envelope,
-    persistedJson = persistedJson,
-  )
+  @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
+  fun createEnvelopeForLatestSchemaVersion(
+    type: DomainEventType,
+    requestId: UUID = UUID.randomUUID(),
+    occurredAt: Instant = Instant.now(),
+  ): Any {
+    val id = UUID.randomUUID()
+    val eventType = EventType.entries.find { it.value == type.typeName } ?: throw RuntimeException("Cannot find EventType for $type")
+
+    return when (type) {
+      DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> ApplicationSubmittedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = ApplicationSubmittedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> ApplicationAssessedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = ApplicationAssessedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> BookingMadeEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = BookingMadeFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> PersonArrivedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = PersonArrivedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> PersonNotArrivedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = PersonNotArrivedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> PersonDepartedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = PersonDepartedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> BookingNotMadeEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = BookingNotMadeFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> {
+        return BookingCancelledEnvelope(
+          id = id,
+          timestamp = occurredAt,
+          eventType = eventType,
+          eventDetails = BookingCancelledFactory()
+            .withCancellationRecordedAt(occurredAt)
+            .produce(),
+        )
+      }
+      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> BookingChangedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = BookingChangedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED -> BookingKeyWorkerAssignedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = BookingKeyWorkerAssignedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> ApplicationWithdrawnEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = ApplicationWithdrawnFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> AssessmentAppealedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = AssessmentAppealedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> AssessmentAllocatedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = AssessmentAllocatedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> PlacementApplicationWithdrawnEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = PlacementApplicationWithdrawnFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED -> PlacementApplicationAllocatedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = PlacementApplicationAllocatedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN -> MatchRequestWithdrawnEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = MatchRequestWithdrawnFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED -> RequestForPlacementCreatedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = RequestForPlacementCreatedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED -> RequestForPlacementAssessedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = RequestForPlacementAssessedFactory().produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED -> FurtherInformationRequestedEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = FurtherInformationRequestedFactory()
+          .withRequestId(requestId)
+          .produce(),
+      )
+      DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED -> ApplicationExpiredEnvelope(
+        id = id,
+        timestamp = occurredAt,
+        eventType = eventType,
+        eventDetails = ApplicationExpiredFactory().produce(),
+      )
+      else -> throw RuntimeException("Domain event type $type not supported")
+    }
+  }
+
+  fun removeEventDetails(objectMapper: ObjectMapper, json: String, fields: List<String>): String {
+    val dataModel: JsonNode = objectMapper.readTree(json)
+    fields.forEach {
+      (dataModel["eventDetails"] as ObjectNode).remove(it)
+    }
+    return objectMapper.writeValueAsString(dataModel)
+  }
 }
 
 data class DomainEventEnvelopeAndPersistedJson(
   val envelope: Any,
   val persistedJson: String,
 )
-
-private fun removeEventDetails(objectMapper: ObjectMapper, json: String, fields: List<String>): String {
-  val dataModel: JsonNode = objectMapper.readTree(json)
-  fields.forEach {
-    (dataModel["eventDetails"] as ObjectNode).remove(it)
-  }
-  return objectMapper.writeValueAsString(dataModel)
-}
-
-@SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
-fun createCas1DomainEventEnvelopeWithLatestJson(
-  type: DomainEventType,
-  requestId: UUID = UUID.randomUUID(),
-  occurredAt: Instant = Instant.now(),
-): Any {
-  val id = UUID.randomUUID()
-  val eventType = EventType.entries.find { it.value == type.typeName } ?: throw RuntimeException("Cannot find EventType for $type")
-
-  return when (type) {
-    DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> ApplicationSubmittedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = ApplicationSubmittedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> ApplicationAssessedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = ApplicationAssessedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> BookingMadeEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = BookingMadeFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> PersonArrivedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = PersonArrivedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> PersonNotArrivedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = PersonNotArrivedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> PersonDepartedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = PersonDepartedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> BookingNotMadeEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = BookingNotMadeFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> {
-      return BookingCancelledEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = BookingCancelledFactory()
-          .withCancellationRecordedAt(occurredAt)
-          .produce(),
-      )
-    }
-    DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> BookingChangedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = BookingChangedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED -> BookingKeyWorkerAssignedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = BookingKeyWorkerAssignedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> ApplicationWithdrawnEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = ApplicationWithdrawnFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> AssessmentAppealedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = AssessmentAppealedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> AssessmentAllocatedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = AssessmentAllocatedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> PlacementApplicationWithdrawnEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = PlacementApplicationWithdrawnFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED -> PlacementApplicationAllocatedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = PlacementApplicationAllocatedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN -> MatchRequestWithdrawnEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = MatchRequestWithdrawnFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED -> RequestForPlacementCreatedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = RequestForPlacementCreatedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED -> RequestForPlacementAssessedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = RequestForPlacementAssessedFactory().produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED -> FurtherInformationRequestedEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = FurtherInformationRequestedFactory()
-        .withRequestId(requestId)
-        .produce(),
-    )
-    DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED -> ApplicationExpiredEnvelope(
-      id = id,
-      timestamp = occurredAt,
-      eventType = eventType,
-      eventDetails = ApplicationExpiredFactory().produce(),
-    )
-    else -> throw RuntimeException("Domain event type $type not supported")
-  }
-}


### PR DESCRIPTION
Before this commit we tested domain event migrations by having the Cas1DomainEventFactory return JSON matching all potential schema versions. Currently only `DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED` supports two different schema versions.

This code was difficult to understand, and only worked if the fields added to the latest schema version could be derived from fields already in the domain event.

This commit sacrifices cleverness in favour of readability, instead adding an explicit test in DomainEventTest for every domain event version migration (currently there’s only one for `DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED`) and updating the factory to only every return domain events for the latest schema version