### PR TITLE
APS-1675 - Capture recordedBy on CAS1 arrival domain events

### DIFF
--- a/doc/how-to/modifying_domain_event_schemas.md
+++ b/doc/how-to/modifying_domain_event_schemas.md
@@ -19,13 +19,12 @@ Although if will differ on a case-by-case basis, it's only possible to make a ch
 
 ## Making a schema change that is backwards-compatible
 
-Unit and Integration tests will automatically pick up a new schema version defined in DomainEventEntity.kt and test serialization and de-serialization. To enable this when adding a new schema version:
-
 1. Add a new schema version entry to the corresponding DomainEventType (in DomainEventEntity.kt)
-2. Update Cas1DomainEventFactory.kt to ensure that JSON provided for prior schema versions reflect the legacy JSON (see createCas1DomainEventEnvelopeForSchemaVersion for an example of this)
+2. When creating the domain event, be sure to set the schema version to the latest value
 
 ## Managing a change that is not backwards-compatible
 
-In addition to the changes mentioned in the prior section:
-
-1. Update the CAS-specific DomainEventService to adapt domain event json created against the older schema version to the new schema. For an example of this, see Cas1DomainEventMigrationService
+1. Add a new schema version entry to the corresponding DomainEventType (in DomainEventEntity.kt)
+2. When creating the domain event, be sure to set the schema version to the latest value
+3. Update the CAS-specific DomainEventService to adapt domain event json created against the older schema via the Cas1DomainEventMigrationService
+4. Add a test for the older version in the Domain Event Integration Tests (DomainEventTest)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -213,6 +213,10 @@ enum class DomainEventType(
     Cas1EventType.personArrived.value,
     "Someone has arrived at an Approved Premises for their Booking",
     TimelineEventType.approvedPremisesPersonArrived,
+    schemaVersions = listOf(
+      DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
+      DomainEventSchemaVersion(2, "Added recordedBy field"),
+    ),
   ),
   APPROVED_PREMISES_PERSON_NOT_ARRIVED(
     DomainEventCas.CAS1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventService.kt
@@ -88,10 +88,11 @@ class DomainEventService(
     val dataJson = when {
       type == BookingCancelledEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED ->
         cas1DomainEventMigrationService.bookingCancelledJson(entity)
+      type == PersonArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED ->
+        cas1DomainEventMigrationService.personArrivedJson(entity)
       (type == ApplicationSubmittedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED) ||
         (type == ApplicationAssessedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED) ||
         (type == BookingMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_MADE) ||
-        (type == PersonArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED) ||
         (type == PersonNotArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED) ||
         (type == PersonDepartedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED) ||
         (type == BookingNotMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE) ||

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventMigrationService.kt
@@ -5,32 +5,78 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
+import com.fasterxml.jackson.module.kotlin.convertValue
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
 
 /**
 This is tested by the [DomainEventTest] integration test
  */
 @Service
-class Cas1DomainEventMigrationService(val objectMapper: ObjectMapper) {
+class Cas1DomainEventMigrationService(
+  val objectMapper: ObjectMapper,
+  val userService: UserService,
+) {
+
   fun bookingCancelledJson(entity: DomainEventEntity) =
     when (entity.schemaVersion) {
       2 -> entity.data
       else -> bookingCancelledV1JsonToV2Json(entity)
     }
 
-  fun bookingCancelledV1JsonToV2Json(domainEventEntity: DomainEventEntity): String {
+  fun personArrivedJson(entity: DomainEventEntity) =
+    when (entity.schemaVersion) {
+      2 -> entity.data
+      else -> personArrivedV1JsonToV2Json(entity)
+    }
+
+  private fun bookingCancelledV1JsonToV2Json(domainEventEntity: DomainEventEntity): String {
+    return modifyEventDetails(domainEventEntity) { eventDetailsNode ->
+      val cancellationRecordedAt = objectMapper.convertValue(domainEventEntity.occurredAt, TextNode::class.java)
+      eventDetailsNode.set<TextNode>("cancellationRecordedAt", cancellationRecordedAt)
+
+      val cancelledAt =
+        objectMapper.convertValue(eventDetailsNode["cancelledAt"], java.time.Instant::class.java)
+      val cancelledAtDate = objectMapper.convertValue(cancelledAt.toLocalDate(), TextNode::class.java)
+      eventDetailsNode.set<ArrayNode>("cancelledAtDate", cancelledAtDate)
+    }
+  }
+
+  private fun personArrivedV1JsonToV2Json(domainEventEntity: DomainEventEntity): String {
+    return modifyEventDetails(domainEventEntity) { eventDetailsNode ->
+      val triggeredByUser = domainEventEntity.triggeredByUserId?.let {
+        userService.findByIdOrNull(it)
+      }
+
+      /*
+      The primary purpose of this migration is to make v1 domain events schema valid.
+      `recordedBy` is not used to render the timeline, and these old domain events
+      will not be consumed externally, so the imperfect nature of the back fill is acceptable
+       */
+      eventDetailsNode.set<ObjectNode>(
+        "recordedBy",
+        objectMapper.convertValue(
+          StaffMember(
+            staffCode = triggeredByUser?.deliusStaffCode ?: "unknown",
+            forenames = triggeredByUser?.name ?: "unknown",
+            surname = "unknown",
+            username = triggeredByUser?.deliusUsername ?: "unknown",
+          ),
+        ),
+      )
+    }
+  }
+
+  private fun modifyEventDetails(
+    domainEventEntity: DomainEventEntity,
+    mutator: (eventDetailsNode: ObjectNode) -> Unit,
+  ): String {
     val dataModel: JsonNode = objectMapper.readTree(domainEventEntity.data)
     val eventDetails = dataModel["eventDetails"] as ObjectNode
-
-    val cancellationRecordedAt = objectMapper.convertValue(domainEventEntity.occurredAt, TextNode::class.java)
-    eventDetails.set<TextNode>("cancellationRecordedAt", cancellationRecordedAt)
-
-    val cancelledAt = objectMapper.convertValue(dataModel["eventDetails"]["cancelledAt"], java.time.Instant::class.java)
-    val cancelledAtDate = objectMapper.convertValue(cancelledAt.toLocalDate(), TextNode::class.java)
-    eventDetails.set<ArrayNode>("cancelledAtDate", cancelledAtDate)
-
+    mutator(eventDetails)
     return objectMapper.writeValueAsString(dataModel)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerEr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
@@ -58,6 +59,7 @@ class Cas1SpaceBookingService(
   private val cancellationReasonRepository: CancellationReasonRepository,
   private val nonArrivalReasonRepository: NonArrivalReasonRepository,
   private val lockablePlacementRequestRepository: LockablePlacementRequestRepository,
+  private val userService: UserService,
 ) {
   @Transactional
   fun createNewBooking(
@@ -199,6 +201,7 @@ class Cas1SpaceBookingService(
         existingCas1SpaceBooking,
         actualArrivalDate = arrivalDate,
         actualArrivalTime = arrivalTime,
+        recordedBy = userService.getUserForRequest(),
       ),
     )
 

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1523,6 +1523,8 @@ components:
           $ref: '#/components/schemas/Premises'
         keyWorker:
           $ref: '#/components/schemas/StaffMember'
+        recordedBy:
+          $ref: '#/components/schemas/StaffMember'
         arrivedAt:
           type: string
           example: '2022-11-30T14:51:30'
@@ -1548,6 +1550,7 @@ components:
         - premises
         - arrivedAt
         - expectedDepartureOn
+        - recordedBy
     PersonNotArrivedEnvelope:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonArrivedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonArrivedFactory.kt
@@ -24,6 +24,7 @@ class PersonArrivedFactory : Factory<PersonArrived> {
   private var arrivedAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(5) }
   private var expectedDepartureOn: Yielded<LocalDate> = { LocalDate.now().minusDays(5) }
   private var notes: Yielded<String?> = { null }
+  private var recordedBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
 
   fun withApplicationId(applicationId: UUID) = apply {
     this.applicationId = { applicationId }
@@ -81,5 +82,6 @@ class PersonArrivedFactory : Factory<PersonArrived> {
     arrivedAt = this.arrivedAt(),
     expectedDepartureOn = this.expectedDepartureOn(),
     notes = this.notes(),
+    recordedBy = this.recordedBy(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventServiceTest.kt
@@ -94,7 +94,7 @@ class DomainEventServiceTest {
     userService = userService,
     emitDomainEventsEnabled = emitDomainEventsEnabled,
     mockDomainEventUrlConfig,
-    Cas1DomainEventMigrationService(objectMapper),
+    Cas1DomainEventMigrationService(objectMapper, userService),
   )
 
   private val detailUrl = "http://example.com/1234"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/WebTestClientExtensions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/WebTestClientExtensions.kt
@@ -11,6 +11,10 @@ fun WebTestClient.BodyContentSpec.jsonForObject(value: Any): WebTestClient.BodyC
   return this.json(objectMapper.writeValueAsString(value))
 }
 
+inline fun <reified T> WebTestClient.ResponseSpec.bodyAsObject(): T {
+  return this.returnResult(T::class.java).responseBody.blockFirst()!!
+}
+
 inline fun <reified T> WebTestClient.ResponseSpec.bodyAsListOfObjects(): List<T> {
   val objectMapper =
     ApplicationContextProvider.get().getBean(ObjectMapper::class.java)


### PR DESCRIPTION
Domain event schema version control is used to identify older domain events that don’t have a ‘recordedBy’ element in the JSON and backfill the value with the domain event’s triggered by user, if available.

The primary purpose of this migration is to make v1 domain events schema valid. `recordedBy` is not used to render the timeline, and these old domain events will not be consumed externally, so the imperfect nature of the back fill is acceptable