### PR TITLE
Tighten up characteristics returned for capacty

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremiseCapacitySummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremiseCapacitySummaryTransformer.kt
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacityForDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCharacteristicAvailability
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningService.PremiseCapacitySummary
@@ -34,7 +34,7 @@ class Cas1PremiseCapacitySummaryTransformer(
 
   private fun SpacePlanningService.PremiseCharacteristicAvailability.toApiType() =
     Cas1PremiseCharacteristicAvailability(
-      characteristic = Cas1SpaceCharacteristic.entries.first { it.value == this.characteristicPropertyName },
+      characteristic = Cas1SpaceBookingCharacteristic.entries.first { it.value == this.characteristicPropertyName },
       availableBedsCount = availableBedsCount,
       bookingsCount = bookingsCount,
     )

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -751,10 +751,9 @@ components:
         - characteristicAvailability
     Cas1PremiseCharacteristicAvailability:
       type: object
-      description:  "Will only ever be returned for the following characteristics: 'isArsonSuitable', 'hasEnSuite', 'isSingle', 'isStepFreeDesignated', 'isSuitedForSexOffenders' or 'isWheelchairDesignated'"
       properties:
         characteristic:
-          $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+          $ref: '#/components/schemas/Cas1SpaceBookingCharacteristic'
         availableBedsCount:
           description: the number of available beds with this characteristic
           type: integer

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6865,10 +6865,9 @@ components:
         - characteristicAvailability
     Cas1PremiseCharacteristicAvailability:
       type: object
-      description:  "Will only ever be returned for the following characteristics: 'isArsonSuitable', 'hasEnSuite', 'isSingle', 'isStepFreeDesignated', 'isSuitedForSexOffenders' or 'isWheelchairDesignated'"
       properties:
         characteristic:
-          $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+          $ref: '#/components/schemas/Cas1SpaceBookingCharacteristic'
         availableBedsCount:
           description: the number of available beds with this characteristic
           type: integer

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremiseCapacitySummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremiseCapacitySummaryTransformerTest.kt
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningService.PremiseCapacityForDay
@@ -53,7 +53,7 @@ class Cas1PremiseCapacitySummaryTransformerTest {
               bookingsCount = 4,
             ),
             PremiseCharacteristicAvailability(
-              characteristicPropertyName = "isWheelchairAccessible",
+              characteristicPropertyName = "isWheelchairDesignated",
               availableBedsCount = 20,
               bookingsCount = 8,
             ),
@@ -88,12 +88,12 @@ class Cas1PremiseCapacitySummaryTransformerTest {
     assertThat(capacityForDay.characteristicAvailability).hasSize(2)
 
     val characteristicAvailability1 = capacityForDay.characteristicAvailability[0]
-    assertThat(characteristicAvailability1.characteristic).isEqualTo(Cas1SpaceCharacteristic.isSingle)
+    assertThat(characteristicAvailability1.characteristic).isEqualTo(Cas1SpaceBookingCharacteristic.IS_SINGLE)
     assertThat(characteristicAvailability1.availableBedsCount).isEqualTo(10)
     assertThat(characteristicAvailability1.bookingsCount).isEqualTo(4)
 
     val characteristicAvailability2 = capacityForDay.characteristicAvailability[1]
-    assertThat(characteristicAvailability2.characteristic).isEqualTo(Cas1SpaceCharacteristic.isWheelchairAccessible)
+    assertThat(characteristicAvailability2.characteristic).isEqualTo(Cas1SpaceBookingCharacteristic.IS_WHEELCHAIR_DESIGNATED)
     assertThat(characteristicAvailability2.availableBedsCount).isEqualTo(20)
     assertThat(characteristicAvailability2.bookingsCount).isEqualTo(8)
   }


### PR DESCRIPTION
This commit changes the /capacity endpoint to return characteristics of type `Cas1SpaceBookingCharacteristic` instead of `Cas1SpaceCharacteristic`, making the constraint previously described in the API description concrete.