### PR TITLE
APS-1718 Capture recordedBy on CAS1 departure domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -229,6 +229,10 @@ enum class DomainEventType(
     Cas1EventType.personDeparted.value,
     "Someone has left an Approved Premises",
     TimelineEventType.approvedPremisesPersonDeparted,
+    schemaVersions = listOf(
+      DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
+      DomainEventSchemaVersion(2, "Added recordedBy field"),
+    ),
   ),
   APPROVED_PREMISES_BOOKING_NOT_MADE(
     DomainEventCas.CAS1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementDomainEventService.kt
@@ -161,15 +161,16 @@ class Cas1SpaceBookingManagementDomainEventService(
   }
 
   data class DepartureInfo(
-    val departedCas1SpaceBooking: Cas1SpaceBookingEntity,
+    val spaceBooking: Cas1SpaceBookingEntity,
     val departureReason: DepartureReasonEntity,
     val moveOnCategory: MoveOnCategoryEntity,
     val actualDepartureDate: LocalDate,
     val actualDepartureTime: LocalTime,
+    val recordedBy: UserEntity,
   )
 
   fun departureRecorded(departureInfo: DepartureInfo) {
-    val departedCas1SpaceBooking = departureInfo.departedCas1SpaceBooking
+    val departedCas1SpaceBooking = departureInfo.spaceBooking
     val departureReason = departureInfo.departureReason
     val moveOnCategory = departureInfo.moveOnCategory
 
@@ -178,6 +179,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val applicationId = departedCas1SpaceBooking.applicationFacade.id
     val premises = mapApprovedPremisesEntityToPremises(departedCas1SpaceBooking.premises)
     val offenderDetails = getOffenderForCrn(departedCas1SpaceBooking.crn)
+    val recordedByStaffDetails = getStaffDetailsByUsername(departureInfo.recordedBy.deliusUsername)
     val keyWorker = getStaffDetailsByStaffCode(departedCas1SpaceBooking.keyWorkerStaffCode)
     val eventNumber = departedCas1SpaceBooking.deliusEventNumber!!
 
@@ -192,6 +194,7 @@ class Cas1SpaceBookingManagementDomainEventService(
         occurredAt = OffsetDateTime.now().toInstant(),
         cas1SpaceBookingId = departedCas1SpaceBooking.id,
         bookingId = null,
+        schemaVersion = 2,
         data = PersonDepartedEnvelope(
           id = domainEventId,
           timestamp = OffsetDateTime.now().toInstant(),
@@ -207,6 +210,7 @@ class Cas1SpaceBookingManagementDomainEventService(
             deliusEventNumber = eventNumber,
             premises = premises,
             keyWorker = keyWorker!!,
+            recordedBy = recordedByStaffDetails.toStaffMember(),
             departedAt = actualDepartureDateTime,
             reason = departureReason.name,
             legacyReasonCode = departureReason.legacyDeliusReasonCode!!,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -92,11 +92,12 @@ class Cas1DomainEventService(
         cas1DomainEventMigrationService.bookingCancelledJson(entity)
       type == PersonArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED ->
         cas1DomainEventMigrationService.personArrivedJson(entity)
+      type == PersonDepartedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED ->
+        cas1DomainEventMigrationService.personDepartedJson(entity)
       (type == ApplicationSubmittedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED) ||
         (type == ApplicationAssessedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED) ||
         (type == BookingMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_MADE) ||
         (type == PersonNotArrivedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED) ||
-        (type == PersonDepartedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED) ||
         (type == BookingNotMadeEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE) ||
         (type == BookingChangedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED) ||
         (type == BookingKeyWorkerAssignedEnvelope::class && entity.type == DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED) ||

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -395,6 +395,7 @@ class Cas1SpaceBookingService(
         moveOnCategory!!,
         departureInfo.departureDate,
         departureInfo.departureTime,
+        recordedBy = userService.getUserForRequest(),
       ),
     )
 

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1643,6 +1643,8 @@ components:
           $ref: '#/components/schemas/BookingId'
         keyWorker:
           $ref: '#/components/schemas/StaffMember'
+        recordedBy:
+          $ref: '#/components/schemas/StaffMember'
         premises:
           $ref: '#/components/schemas/Premises'
         departedAt:
@@ -1673,6 +1675,7 @@ components:
         - applicationUrl
         - bookingId
         - keyWorker
+        - recordedBy
         - premises
         - departedAt
         - reason

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonDepartedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PersonDepartedFactory.kt
@@ -21,6 +21,7 @@ class PersonDepartedFactory : Factory<PersonDeparted> {
   private var bookingId: Yielded<UUID> = { UUID.randomUUID() }
   private var premises: Yielded<Premises> = { EventPremisesFactory().produce() }
   private var keyWorker: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var recordedBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
   private var departedAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(5) }
   private var reason: Yielded<String> = { randomOf(listOf("Bed Withdrawn", "Died", "Other", "Planned move-on")) }
   private var legacyReasonCode: Yielded<String> = { randomOf(listOf("A", "B", "C", "D")) }
@@ -71,6 +72,7 @@ class PersonDepartedFactory : Factory<PersonDeparted> {
     bookingId = this.bookingId(),
     premises = this.premises(),
     keyWorker = this.keyWorker(),
+    recordedBy = this.recordedBy(),
     departedAt = this.departedAt(),
     reason = this.reason(),
     legacyReasonCode = this.legacyReasonCode(),


### PR DESCRIPTION
Domain event schema version control is used to identify older domain events that don’t have a ‘recordedBy’ element in the JSON and backfill the value with the domain event’s triggered by user, if available.

The primary purpose of this migration is to make v1 domain events schema valid. `recordedBy` is not used to render the timeline, and these old domain events will not be consumed externally, so the imperfect nature of the back fill is acceptable.