### PR TITLE
APS-1727 - Optionally exclude booking from capacity calculations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -65,11 +65,17 @@ class Cas1PremisesController(
     premisesId: UUID,
     startDate: LocalDate,
     endDate: LocalDate,
+    excludeSpaceBookingId: UUID?,
   ): ResponseEntity<Cas1PremiseCapacity> {
     userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PREMISES_VIEW)
 
     val premiseSummaryInfo = cas1PremisesService.getPremisesSummary(premisesId)
-    val premiseCapacity = cas1PremisesService.getPremiseCapacity(premisesId, startDate, endDate)
+    val premiseCapacity = cas1PremisesService.getPremiseCapacity(
+      premisesId = premisesId,
+      startDate = startDate,
+      endDate = endDate,
+      excludeSpaceBookingId = excludeSpaceBookingId,
+    )
 
     return ResponseEntity.ok().body(
       cas1PremiseCapacityTransformer.toCas1PremiseCapacitySummary(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -44,6 +44,7 @@ class Cas1PremisesService(
     premisesId: UUID,
     startDate: LocalDate,
     endDate: LocalDate,
+    excludeSpaceBookingId: UUID?,
   ): CasResult<SpacePlanningService.PremiseCapacitySummary> {
     val premises = premisesRepository.findByIdOrNull(premisesId)
       ?: return CasResult.NotFound("premises", premisesId.toString())
@@ -56,6 +57,7 @@ class Cas1PremisesService(
       spacePlanningService.capacity(
         premises = premises,
         range = DateRange(startDate, endDate),
+        excludeSpaceBookingId = excludeSpaceBookingId,
       ),
     )
   }

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -409,6 +409,13 @@ paths:
           schema:
             type: string
             format: date
+        - name: excludeSpaceBookingId
+          in: query
+          description: ID of a booking to exclude from capacity calculations
+          required: false
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -411,6 +411,13 @@ paths:
           schema:
             type: string
             format: date
+        - name: excludeSpaceBookingId
+          in: query
+          description: ID of a booking to exclude from capacity calculations
+          required: false
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: successful operation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
@@ -96,6 +96,7 @@ class Cas1PremisesServiceTest {
         premisesId = PREMISES_ID,
         startDate = LocalDate.of(2020, 1, 2),
         endDate = LocalDate.of(2020, 1, 3),
+        excludeSpaceBookingId = null,
       )
 
       assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
@@ -111,6 +112,7 @@ class Cas1PremisesServiceTest {
         premisesId = PREMISES_ID,
         startDate = LocalDate.of(2020, 1, 4),
         endDate = LocalDate.of(2020, 1, 3),
+        excludeSpaceBookingId = null,
       )
 
       assertThat(result).isInstanceOf(CasResult.GeneralValidationError::class.java)
@@ -118,8 +120,9 @@ class Cas1PremisesServiceTest {
     }
 
     @Test
-    fun `success`() {
+    fun success() {
       val premise = ApprovedPremisesEntityFactory().withDefaults().withId(PREMISES_ID).produce()
+      val excludeSpaceBookingId = UUID.randomUUID()
 
       every { approvedPremisesRepository.findByIdOrNull(PREMISES_ID) } returns premise
 
@@ -132,6 +135,7 @@ class Cas1PremisesServiceTest {
             LocalDate.of(2020, 1, 2),
             LocalDate.of(2020, 1, 3),
           ),
+          excludeSpaceBookingId = excludeSpaceBookingId,
         )
       } returns capacityResponse
 
@@ -139,6 +143,7 @@ class Cas1PremisesServiceTest {
         premisesId = PREMISES_ID,
         startDate = LocalDate.of(2020, 1, 2),
         endDate = LocalDate.of(2020, 1, 3),
+        excludeSpaceBookingId = excludeSpaceBookingId,
       )
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)


### PR DESCRIPTION
This commit adds the option to exclude a given space booking id when calculating a premises occupancy. This will be used when retrieving capacity as part of amending the referenced booking.