### PR TITLE
APS-1730 capture previous values on booking amend domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -679,7 +679,7 @@ class PremisesController(
       newDepartureDate = body.newDepartureDate,
     )
 
-    val dateChange = extractResultEntityOrThrow(result)
+    val dateChange = extractEntityFromCasResult(result)
 
     return ResponseEntity.ok(dateChangeTransformer.transformJpaToApi(dateChange))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -255,6 +255,10 @@ enum class DomainEventType(
     Cas1EventType.bookingChanged.value,
     "An Approved Premises Booking has been changed",
     TimelineEventType.approvedPremisesBookingChanged,
+    schemaVersions = listOf(
+      DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
+      DomainEventSchemaVersion(2, "Captures previous set values, if changed."),
+    ),
   ),
   APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED(
     DomainEventCas.CAS1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.serviceScopeMatches
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
@@ -423,7 +424,7 @@ class BookingService(
     user: UserEntity,
     newArrivalDate: LocalDate?,
     newDepartureDate: LocalDate?,
-  ) = validated {
+  ) = validatedCasResult {
     val effectiveNewArrivalDate = newArrivalDate ?: booking.arrivalDate
     val effectiveNewDepartureDate = newDepartureDate ?: booking.departureDate
 
@@ -439,11 +440,11 @@ class BookingService(
         ?: throw InternalServerErrorProblem("No bed ID present on Booking: ${booking.id}")
 
       getBookingWithConflictingDates(effectiveNewArrivalDate, expectedLastUnavailableDate, booking.id, bedId)?.let {
-        return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.lastUnavailableDate} which overlaps with the desired dates"
+        return@validatedCasResult it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.lastUnavailableDate} which overlaps with the desired dates"
       }
 
       getLostBedWithConflictingDates(effectiveNewArrivalDate, expectedLastUnavailableDate, null, bedId)?.let {
-        return@validated it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
+        return@validatedCasResult it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -142,6 +142,8 @@ class Cas1BookingDomainEventService(
     booking: BookingEntity,
     changedBy: UserEntity,
     bookingChangedAt: OffsetDateTime,
+    previousArrivalDateIfChanged: LocalDate?,
+    previousDepartureDateIfChanged: LocalDate?,
   ) {
     val domainEventId = UUID.randomUUID()
     val applicationFacade = booking.cas1ApplicationFacade
@@ -169,6 +171,7 @@ class Cas1BookingDomainEventService(
         nomsNumber = offenderDetails?.otherIds?.nomsNumber,
         occurredAt = bookingChangedAt.toInstant(),
         bookingId = booking.id,
+        schemaVersion = 2,
         data = BookingChangedEnvelope(
           id = domainEventId,
           timestamp = bookingChangedAt.toInstant(),
@@ -193,6 +196,8 @@ class Cas1BookingDomainEventService(
             ),
             arrivalOn = booking.arrivalDate,
             departureOn = booking.departureDate,
+            previousArrivalOn = previousArrivalDateIfChanged,
+            previousDepartureOn = previousDepartureDateIfChanged,
           ),
         ),
       ),

--- a/src/main/resources/static/domain-events-api.yml
+++ b/src/main/resources/static/domain-events-api.yml
@@ -1241,6 +1241,16 @@ components:
           type: string
           example: '2023-04-30'
           format: date
+        previousArrivalOn:
+          type: string
+          description: Only set if the expected arrival on has changed
+          example: '2023-01-30'
+          format: date
+        previousDepartureOn:
+          type: string
+          description: Only set if the expected departure on has changed
+          example: '2023-01-30'
+          format: date
       required:
         - applicationId
         - applicationUrl

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -2244,7 +2244,7 @@ class BookingServiceTest {
     }
 
     @Test
-    fun `emits domain event when booking has associated application`() {
+    fun `emits domain event when booking has associated application, only arrival date changed`() {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(user)
         .withSubmittedAt(OffsetDateTime.now())
@@ -2264,10 +2264,10 @@ class BookingServiceTest {
       every { mockDateChangeRepository.save(any()) } answers { it.invocation.args[0] as DateChangeEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
 
-      every { mockCas1BookingDomainEventService.bookingChanged(any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingChanged(any(), any(), any(), any(), any()) } just Runs
 
-      val newArrivalDate = LocalDate.parse("2023-07-18")
-      val newDepartureDate = LocalDate.parse("2023-07-22")
+      val newArrivalDate = LocalDate.parse("2023-07-15")
+      val newDepartureDate = LocalDate.parse("2023-07-16")
 
       val result = bookingService.createDateChange(
         booking = booking,
@@ -2284,8 +2284,8 @@ class BookingServiceTest {
           match {
             it.booking.id == booking.id &&
               it.changedByUser == user &&
-              it.newArrivalDate == LocalDate.parse("2023-07-18") &&
-              it.newDepartureDate == LocalDate.parse("2023-07-22") &&
+              it.newArrivalDate == LocalDate.parse("2023-07-15") &&
+              it.newDepartureDate == LocalDate.parse("2023-07-16") &&
               it.previousArrivalDate == LocalDate.parse("2023-07-14") &&
               it.previousDepartureDate == LocalDate.parse("2023-07-16")
           },
@@ -2296,8 +2296,8 @@ class BookingServiceTest {
         mockBookingRepository.save(
           match {
             it.id == booking.id &&
-              it.arrivalDate == LocalDate.parse("2023-07-18") &&
-              it.departureDate == LocalDate.parse("2023-07-22")
+              it.arrivalDate == LocalDate.parse("2023-07-15") &&
+              it.departureDate == LocalDate.parse("2023-07-16")
           },
         )
       }
@@ -2307,12 +2307,14 @@ class BookingServiceTest {
           booking = booking,
           changedBy = user,
           bookingChangedAt = any(),
+          previousArrivalDateIfChanged = LocalDate.of(2023, 7, 14),
+          previousDepartureDateIfChanged = null,
         )
       }
     }
 
     @Test
-    fun `emits domain event when booking has associated offline application with an event number`() {
+    fun `emits domain event when booking has associated offline application with an event number, only departure date changed`() {
       val application = OfflineApplicationEntityFactory()
         .withEventNumber("123")
         .produce()
@@ -2331,9 +2333,9 @@ class BookingServiceTest {
       every { mockDateChangeRepository.save(any()) } answers { it.invocation.args[0] as DateChangeEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
 
-      every { mockCas1BookingDomainEventService.bookingChanged(any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingChanged(any(), any(), any(), any(), any()) } just Runs
 
-      val newArrivalDate = LocalDate.parse("2023-07-18")
+      val newArrivalDate = LocalDate.parse("2023-07-14")
       val newDepartureDate = LocalDate.parse("2023-07-22")
 
       val result = bookingService.createDateChange(
@@ -2351,6 +2353,8 @@ class BookingServiceTest {
           booking = booking,
           changedBy = user,
           bookingChangedAt = any(),
+          previousArrivalDateIfChanged = null,
+          previousDepartureDateIfChanged = LocalDate.of(2023, 7, 16),
         )
       }
     }
@@ -2375,7 +2379,7 @@ class BookingServiceTest {
       every { mockDateChangeRepository.save(any()) } answers { it.invocation.args[0] as DateChangeEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
 
-      every { mockCas1BookingDomainEventService.bookingChanged(any(), any(), any()) } just Runs
+      every { mockCas1BookingDomainEventService.bookingChanged(any(), any(), any(), any(), any()) } just Runs
 
       val newArrivalDate = LocalDate.parse("2023-07-18")
       val newDepartureDate = LocalDate.parse("2023-07-22")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -87,6 +87,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThat
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -2020,9 +2021,9 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-14"),
       )
 
-      assertThat(result is ValidatableActionResult.ConflictError).isTrue
-      result as ValidatableActionResult.ConflictError
-      assertThat(result.message).contains("A Booking already exists")
+      assertThat(result)
+        .isConflictError()
+        .hasMessageContaining("A Booking already exists")
     }
 
     @Test
@@ -2052,9 +2053,9 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-14"),
       )
 
-      assertThat(result is ValidatableActionResult.ConflictError).isTrue
-      result as ValidatableActionResult.ConflictError
-      assertThat(result.message).contains("A Lost Bed already exists")
+      assertThat(result)
+        .isConflictError()
+        .hasMessageContaining("A Lost Bed already exists")
     }
 
     @Test
@@ -2076,9 +2077,9 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-14"),
       )
 
-      assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
-      result as ValidatableActionResult.FieldValidationError
-      assertThat(result.validationMessages).containsEntry("$.newDepartureDate", "beforeBookingArrivalDate")
+      assertThat(result)
+        .isFieldValidationError()
+        .hasMessage("$.newDepartureDate", "beforeBookingArrivalDate")
     }
 
     @Test
@@ -2105,9 +2106,9 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-16"),
       )
 
-      assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
-      result as ValidatableActionResult.FieldValidationError
-      assertThat(result.validationMessages).containsEntry("$.newArrivalDate", "arrivalDateCannotBeChangedOnArrivedBooking")
+      assertThat(result)
+        .isFieldValidationError()
+        .hasMessage("$.newArrivalDate", "arrivalDateCannotBeChangedOnArrivedBooking")
     }
 
     @Test
@@ -2137,9 +2138,7 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-16"),
       )
 
-      assertThat(result is ValidatableActionResult.GeneralValidationError).isTrue
-      result as ValidatableActionResult.GeneralValidationError
-      assertThat(result.message).isEqualTo("This Booking is cancelled and as such cannot be modified")
+      assertThat(result).isGeneralValidationError("This Booking is cancelled and as such cannot be modified")
     }
 
     @Test
@@ -2168,8 +2167,8 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-15"),
       )
 
-      assertThat(result is ValidatableActionResult.Success).isTrue
-      result as ValidatableActionResult.Success
+      assertThat(result).isSuccess()
+      result as CasResult.Success
 
       verify {
         mockDateChangeRepository.save(
@@ -2216,8 +2215,8 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-22"),
       )
 
-      assertThat(result is ValidatableActionResult.Success).isTrue
-      result as ValidatableActionResult.Success
+      assertThat(result).isSuccess()
+      result as CasResult.Success
 
       verify {
         mockDateChangeRepository.save(
@@ -2276,8 +2275,8 @@ class BookingServiceTest {
         newDepartureDate = newDepartureDate,
       )
 
-      assertThat(result is ValidatableActionResult.Success).isTrue
-      result as ValidatableActionResult.Success
+      assertThat(result).isSuccess()
+      result as CasResult.Success
 
       verify {
         mockDateChangeRepository.save(
@@ -2345,8 +2344,8 @@ class BookingServiceTest {
         newDepartureDate = newDepartureDate,
       )
 
-      assertThat(result is ValidatableActionResult.Success).isTrue
-      result as ValidatableActionResult.Success
+      assertThat(result).isSuccess()
+      result as CasResult.Success
 
       verify(exactly = 1) {
         mockCas1BookingDomainEventService.bookingChanged(
@@ -2391,8 +2390,8 @@ class BookingServiceTest {
         newDepartureDate = newDepartureDate,
       )
 
-      assertThat(result is ValidatableActionResult.Success).isTrue
-      result as ValidatableActionResult.Success
+      assertThat(result).isSuccess()
+      result as CasResult.Success
 
       verify {
         mockDateChangeRepository.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
@@ -290,7 +290,7 @@ class Cas1BookingCas1DomainEventServiceTest {
   }
 
   @Nested
-  inner class BookingAmended {
+  inner class BookingChanged {
 
     private val changedBy = UserEntityFactory()
       .withDefaults()
@@ -306,7 +306,7 @@ class Cas1BookingCas1DomainEventServiceTest {
       .produce()
 
     @Test
-    fun `success for application`() {
+    fun `success for application, no date changes`() {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(changedBy)
         .withSubmittedAt(OffsetDateTime.now())
@@ -343,6 +343,8 @@ class Cas1BookingCas1DomainEventServiceTest {
         booking,
         changedBy,
         bookingChangedAt = createdAt,
+        previousArrivalDateIfChanged = null,
+        previousDepartureDateIfChanged = null,
       )
 
       val domainEventArgument = slot<DomainEvent<BookingChangedEnvelope>>()
@@ -384,10 +386,12 @@ class Cas1BookingCas1DomainEventServiceTest {
 
       assertThat(data.arrivalOn).isEqualTo(LocalDate.of(2012, 12, 12))
       assertThat(data.departureOn).isEqualTo(LocalDate.of(2099, 11, 11))
+      assertThat(data.previousArrivalOn).isNull()
+      assertThat(data.previousDepartureOn).isNull()
     }
 
     @Test
-    fun `success for offline application`() {
+    fun `success for offline application, date changes`() {
       val offlineApplication = OfflineApplicationEntityFactory()
         .withEventNumber("offline app event number")
         .produce()
@@ -422,6 +426,8 @@ class Cas1BookingCas1DomainEventServiceTest {
         booking,
         changedBy,
         bookingChangedAt = createdAt,
+        previousArrivalDateIfChanged = LocalDate.of(2012, 12, 11),
+        previousDepartureDateIfChanged = LocalDate.of(2099, 11, 10),
       )
 
       val domainEventArgument = slot<DomainEvent<BookingChangedEnvelope>>()
@@ -463,6 +469,8 @@ class Cas1BookingCas1DomainEventServiceTest {
 
       assertThat(data.arrivalOn).isEqualTo(LocalDate.of(2012, 12, 12))
       assertThat(data.departureOn).isEqualTo(LocalDate.of(2099, 11, 11))
+      assertThat(data.previousArrivalOn).isEqualTo(LocalDate.of(2012, 12, 11))
+      assertThat(data.previousDepartureOn).isEqualTo(LocalDate.of(2099, 11, 10))
     }
   }
 


### PR DESCRIPTION
This PR updates the CAS1 booking changed domain event to capture the previous date values, if changed. It populates these values for booking changes.
