### PR TITLE
Remove unused availability info from space search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1SpaceSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1SpaceSearchRepository.kt
@@ -4,7 +4,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import java.sql.ResultSet
-import java.time.LocalDate
 import java.util.UUID
 
 private const val AP_TYPE_FILTER = """
@@ -117,13 +116,6 @@ WHERE
 ORDER BY result.distance_in_miles
 """
 
-private const val SPACE_AVAILABILITY_QUERY = """
-SELECT
-  p.id AS premises_id
-FROM premises p
-WHERE id IN (:premisesIds)
-"""
-
 @Repository
 class Cas1SpaceSearchRepository(
   private val jdbcTemplate: NamedParameterJdbcTemplate,
@@ -223,23 +215,6 @@ class Cas1SpaceSearchRepository(
     }
 
     return query to params
-  }
-
-  fun getSpaceAvailabilityForCandidatePremises(
-    premisesIds: List<UUID>,
-    startDate: LocalDate,
-    durationInDays: Int,
-  ): List<SpaceAvailability> = jdbcTemplate.query(
-    SPACE_AVAILABILITY_QUERY,
-    mapOf<String, Any>(
-      "premisesIds" to premisesIds,
-      "startDate" to startDate,
-      "duration" to durationInDays,
-    ),
-  ) { rs, _ ->
-    SpaceAvailability(
-      rs.getUUID("premises_id"),
-    )
   }
 
   private fun ResultSet.getUUID(columnLabel: String) = UUID.fromString(this.getString(columnLabel))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
-import kotlinx.datetime.toKotlinDatePeriod
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -25,7 +24,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.serviceScopeMatches
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
@@ -48,7 +46,6 @@ class Cas1SpaceBookingService(
   private val cas1PremisesService: Cas1PremisesService,
   private val placementRequestService: PlacementRequestService,
   private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
-  private val cas1SpaceSearchRepository: Cas1SpaceSearchRepository,
   private val cas1BookingDomainEventService: Cas1BookingDomainEventService,
   private val cas1BookingEmailService: Cas1BookingEmailService,
   private val cas1SpaceBookingManagementDomainEventService: Cas1SpaceBookingManagementDomainEventService,
@@ -103,9 +100,6 @@ class Cas1SpaceBookingService(
     if (cas1SpaceBookingRepository.findByPlacementRequestId(placementRequestId).any { it.isActive() }) {
       return placementRequestId hasConflictError "A Space Booking already exists for this placement request"
     }
-
-    val durationInDays = arrivalDate.until(departureDate).toKotlinDatePeriod().days
-    cas1SpaceSearchRepository.getSpaceAvailabilityForCandidatePremises(listOf(premisesId), arrivalDate, durationInDays)
 
     val application = placementRequest.application
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceSearchResultsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceSearchResultsTransformer.kt
@@ -5,36 +5,36 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult as ApiSpaceSearchResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchResult as DomainSpaceSearchResult
 
 @Component
 class Cas1SpaceSearchResultsTransformer {
-  fun transformDomainToApi(searchParameters: Cas1SpaceSearchParameters, results: List<DomainSpaceSearchResult>) =
+  fun transformDomainToApi(searchParameters: Cas1SpaceSearchParameters, results: List<CandidatePremises>) =
     Cas1SpaceSearchResults(
       resultsCount = results.size,
       searchCriteria = searchParameters,
-      results = results.map {
+      results = results.map { candidatePremises ->
         ApiSpaceSearchResult(
           premises = Cas1PremisesSearchResultSummary(
-            id = it.candidatePremises.premisesId,
-            apCode = it.candidatePremises.apCode,
-            deliusQCode = it.candidatePremises.deliusQCode,
-            apType = it.candidatePremises.apType.asApiType(),
-            name = it.candidatePremises.name,
-            addressLine1 = it.candidatePremises.addressLine1,
-            addressLine2 = it.candidatePremises.addressLine2,
-            town = it.candidatePremises.town,
-            postcode = it.candidatePremises.postcode,
+            id = candidatePremises.premisesId,
+            apCode = candidatePremises.apCode,
+            deliusQCode = candidatePremises.deliusQCode,
+            apType = candidatePremises.apType.asApiType(),
+            name = candidatePremises.name,
+            addressLine1 = candidatePremises.addressLine1,
+            addressLine2 = candidatePremises.addressLine2,
+            town = candidatePremises.town,
+            postcode = candidatePremises.postcode,
             apArea = NamedId(
-              id = it.candidatePremises.apAreaId,
-              name = it.candidatePremises.apAreaName,
+              id = candidatePremises.apAreaId,
+              name = candidatePremises.apAreaName,
             ),
-            totalSpaceCount = it.candidatePremises.totalSpaceCount,
+            totalSpaceCount = candidatePremises.totalSpaceCount,
             premisesCharacteristics = listOf(),
           ),
-          distanceInMiles = it.candidatePremises.distanceInMiles.toBigDecimal(),
+          distanceInMiles = candidatePremises.distanceInMiles.toBigDecimal(),
           spacesAvailable = listOf(),
         )
       },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/CollectionUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/CollectionUtils.kt
@@ -1,17 +1,3 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 fun <T> Collection<T>.containsAny(vararg values: T): Boolean = values.toSet().intersect(this.toSet()).isNotEmpty()
-
-fun <T, U, ID> Iterable<T>.zipBy(
-  other: Iterable<U>,
-  keySelector1: T.() -> ID,
-  keySelector2: U.() -> ID,
-): Iterable<Pair<T, U>> {
-  val otherMap = other.associateBy(keySelector2)
-
-  return this.map {
-    val key = it.keySelector1()
-
-    Pair(it, otherMap[key]!!)
-  }
-}

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -304,10 +304,13 @@ components:
           example: 2.1
         spacesAvailable:
           type: array
+          deprecated: true
+          description: "This is not populated and will be removed in the future"
           items:
             $ref: '#/components/schemas/Cas1SpaceAvailability'
     Cas1SpaceAvailability:
       type: object
+      deprecated: true
       properties:
         spaceCharacteristics:
           type: array

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6353,10 +6353,13 @@ components:
           example: 2.1
         spacesAvailable:
           type: array
+          deprecated: true
+          description: "This is not populated and will be removed in the future"
           items:
             $ref: '#/components/schemas/Cas1SpaceAvailability'
     Cas1SpaceAvailability:
       type: object
+      deprecated: true
       properties:
         spaceCharacteristics:
           type: array

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1SpaceBookingServiceTest.kt
@@ -54,8 +54,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository.Constants.NOT_APPLICABLE_MOVE_ON_CATEGORY_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.SpaceAvailability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
@@ -90,9 +88,6 @@ class Cas1SpaceBookingServiceTest {
 
   @MockK
   private lateinit var spaceBookingRepository: Cas1SpaceBookingRepository
-
-  @MockK
-  private lateinit var spaceSearchRepository: Cas1SpaceSearchRepository
 
   @MockK
   private lateinit var cas1BookingDomainEventService: Cas1BookingDomainEventService
@@ -334,19 +329,11 @@ class Cas1SpaceBookingServiceTest {
       val durationInDays = 1
       val departureDate = arrivalDate.plusDays(durationInDays.toLong())
 
-      val spaceAvailability = SpaceAvailability(
-        premisesId = premises.id,
-      )
-
       every { cas1PremisesService.findPremiseById(premises.id) } returns premises
       every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
       every { spaceBookingRepository.findByPlacementRequestId(placementRequest.id) } returns emptyList()
       every { lockablePlacementRequestRepository.acquirePessimisticLock(placementRequest.id) } returns
         LockablePlacementRequestEntity(placementRequest.id)
-
-      every {
-        spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(listOf(premises.id), arrivalDate, durationInDays)
-      } returns listOf(spaceAvailability)
 
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
 
@@ -443,19 +430,11 @@ class Cas1SpaceBookingServiceTest {
       val durationInDays = 1
       val departureDate = arrivalDate.plusDays(durationInDays.toLong())
 
-      val spaceAvailability = SpaceAvailability(
-        premisesId = premises.id,
-      )
-
       every { cas1PremisesService.findPremiseById(premises.id) } returns premises
       every { placementRequestService.getPlacementRequestOrNull(placementRequest.id) } returns placementRequest
       every { spaceBookingRepository.findByPlacementRequestId(placementRequest.id) } returns emptyList()
       every { lockablePlacementRequestRepository.acquirePessimisticLock(placementRequest.id) } returns
         LockablePlacementRequestEntity(placementRequest.id)
-
-      every {
-        spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(listOf(premises.id), arrivalDate, durationInDays)
-      } returns listOf(spaceAvailability)
 
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
@@ -27,11 +27,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremiseApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.SpaceAvailability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchService
 import java.time.LocalDate
 import java.util.UUID
@@ -151,18 +149,6 @@ class Cas1SpaceSearchServiceTest {
 
     every { applicationRepository.findByIdOrNull(application.id) } returns application
 
-    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
-    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
-    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
-
-    every {
-      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
-        any(),
-        any(),
-        any(),
-      )
-    } returns listOf(spaceAvailability3, spaceAvailability1, spaceAvailability2)
-
     val result = service.findSpaces(
       Cas1SpaceSearchParameters(
         applicationId = application.id,
@@ -178,9 +164,9 @@ class Cas1SpaceSearchServiceTest {
 
     assertThat(result).hasSize(3)
     assertThat(result).containsExactly(
-      Cas1SpaceSearchResult(candidatePremises1, spaceAvailability1),
-      Cas1SpaceSearchResult(candidatePremises2, spaceAvailability2),
-      Cas1SpaceSearchResult(candidatePremises3, spaceAvailability3),
+      candidatePremises1,
+      candidatePremises2,
+      candidatePremises3,
     )
 
     verify(exactly = 1) {
@@ -197,12 +183,6 @@ class Cas1SpaceSearchServiceTest {
         isWomensPremises = false,
         spaceCharacteristics.filter { it.modelMatches("premises") }.map { it.id },
         spaceCharacteristics.filter { it.modelMatches("room") }.map { it.id },
-      )
-
-      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
-        listOf(candidatePremises1.premisesId, candidatePremises2.premisesId, candidatePremises3.premisesId),
-        LocalDate.parse("2024-08-01"),
-        14,
       )
     }
 
@@ -285,18 +265,6 @@ class Cas1SpaceSearchServiceTest {
       )
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
-    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
-    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
-    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
-
-    every {
-      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
-        any(),
-        any(),
-        any(),
-      )
-    } returns listOf(spaceAvailability3, spaceAvailability1, spaceAvailability2)
-
     service.findSpaces(
       Cas1SpaceSearchParameters(
         applicationId = application.id,
@@ -324,12 +292,6 @@ class Cas1SpaceSearchServiceTest {
 
     verify {
       characteristicService.getCharacteristicsByPropertyNames(any(), ServiceName.approvedPremises)
-
-      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
-        any(),
-        any(),
-        any(),
-      )
     }
 
     confirmVerified()
@@ -411,18 +373,6 @@ class Cas1SpaceSearchServiceTest {
       )
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
-    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
-    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
-    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
-
-    every {
-      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
-        any(),
-        any(),
-        any(),
-      )
-    } returns listOf(spaceAvailability3, spaceAvailability1, spaceAvailability2)
-
     service.findSpaces(
       Cas1SpaceSearchParameters(
         applicationId = application.id,
@@ -450,12 +400,6 @@ class Cas1SpaceSearchServiceTest {
 
     verify {
       characteristicService.getCharacteristicsByPropertyNames(any(), ServiceName.approvedPremises)
-
-      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
-        any(),
-        any(),
-        any(),
-      )
     }
     confirmVerified()
   }
@@ -536,18 +480,6 @@ class Cas1SpaceSearchServiceTest {
       )
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
-    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
-    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
-    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
-
-    every {
-      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
-        any(),
-        any(),
-        any(),
-      )
-    } returns listOf(spaceAvailability3, spaceAvailability1, spaceAvailability2)
-
     service.findSpaces(
       Cas1SpaceSearchParameters(
         applicationId = application.id,
@@ -580,12 +512,6 @@ class Cas1SpaceSearchServiceTest {
 
     verify {
       characteristicService.getCharacteristicsByPropertyNames(any(), ServiceName.approvedPremises)
-
-      spaceSearchRepository.getSpaceAvailabilityForCandidatePremises(
-        any(),
-        any(),
-        any(),
-      )
     }
 
     confirmVerified()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceSearchResultsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceSearchResultsTransformerTest.kt
@@ -8,14 +8,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.SpaceAvailability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
 import java.time.LocalDate
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult as ApiSpaceSearchResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchResult as DomainSpaceSearchResult
 
 class Cas1SpaceSearchResultsTransformerTest {
   private val transformer = Cas1SpaceSearchResultsTransformer()
@@ -82,23 +80,10 @@ class Cas1SpaceSearchResultsTransformerTest {
       9,
     )
 
-    val spaceAvailability1 = SpaceAvailability(candidatePremises1.premisesId)
-    val spaceAvailability2 = SpaceAvailability(candidatePremises2.premisesId)
-    val spaceAvailability3 = SpaceAvailability(candidatePremises3.premisesId)
-
     val searchResults = listOf(
-      DomainSpaceSearchResult(
-        candidatePremises = candidatePremises1,
-        spaceAvailability = spaceAvailability1,
-      ),
-      DomainSpaceSearchResult(
-        candidatePremises = candidatePremises2,
-        spaceAvailability = spaceAvailability2,
-      ),
-      DomainSpaceSearchResult(
-        candidatePremises = candidatePremises3,
-        spaceAvailability = spaceAvailability3,
-      ),
+      candidatePremises1,
+      candidatePremises2,
+      candidatePremises3,
     )
 
     val actual = transformer.transformDomainToApi(searchParameters, searchResults)


### PR DESCRIPTION
When the Space Search Service was originally written, it was expected that the results would include availability for each returned premise. This is no longer the case and is managed by a separate API.

This commit removes the ‘placeholder’ code added to provide capacity, simplifying the response from the space search service.

It doesn’t make any functional changes to the code