### PR TITLE
APS-1768 - Allow Space Booking creation for LAOs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PlacementRequestsController.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementRequestService.PlacementRequestAndCancellations
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingNotMadeTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NewPlacementRequestBookingConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestDetailTransformer
@@ -207,8 +208,7 @@ class PlacementRequestsController(
   ): PlacementRequestDetail {
     val personInfo = offenderService.getPersonInfoResult(
       placementRequestAndCancellations.placementRequest.application.crn,
-      forUser.deliusUsername,
-      ignoreLaoRestrictions = false,
+      forUser.cas1LimitedAccessStrategy(),
     )
 
     return placementRequestDetailTransformer.transformJpaToApi(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -150,7 +150,7 @@ class OffenderService(
     }
   }
 
-  fun toPersonSummaryInfo(
+  private fun toPersonSummaryInfo(
     crn: String,
     caseSummary: CaseSummary?,
     caseAccess: CaseAccess?,
@@ -659,7 +659,25 @@ class OffenderService(
     outputStream: OutputStream,
   ) = apDeliusContextApiClient.getDocument(crn, documentId, outputStream)
 
-  @SuppressWarnings("CyclomaticComplexMethod", "NestedBlockDepth", "ReturnCount")
+  fun getPersonInfoResult(
+    crn: String,
+    limitedAccessStrategy: LimitedAccessStrategy,
+  ) = getPersonInfoResults(
+    crns = setOf(crn),
+    deliusUsername = when (limitedAccessStrategy) {
+      is LimitedAccessStrategy.IgnoreLimitedAccess -> null
+      is LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess -> limitedAccessStrategy.deliusUsername
+    },
+    ignoreLaoRestrictions = when (limitedAccessStrategy) {
+      is LimitedAccessStrategy.IgnoreLimitedAccess -> true
+      is LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess -> false
+    },
+  ).first()
+
+  @Deprecated(
+    """Use version that takes limitedAccessStrategy, derive from [UserEntity.cas1LimitedAccessStrategy()] 
+    |or [UserEntity.cas3LimitedAccessStrategy()]""",
+  )
   fun getPersonInfoResult(
     crn: String,
     deliusUsername: String?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -1259,7 +1259,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Allocated to calling User, offender is LAO, user has LAO access, returns 200`() {
+    fun `Allocated to calling User, offender is LAO, user has LAO access, returns 200 and FullPerson`() {
       givenAUser { user, jwt ->
         givenAUser { otherUser, _ ->
           givenAnOffender(
@@ -1305,7 +1305,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Allocated to calling User, offender is LAO, user doesn't have LAO access but has LAO qualification, returns 200`() {
+    fun `Allocated to calling User, offender is LAO, user doesn't have LAO access but has LAO qualification, returns 200 and FullPerson`() {
       givenAUser(qualifications = listOf(UserQualification.LAO)) { user, jwt ->
         givenAUser { otherUser, _ ->
           givenAnOffender(
@@ -1330,10 +1330,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                   objectMapper.writeValueAsString(
                     placementRequestDetailTransformer.transformJpaToApi(
                       placementRequest,
-                      PersonInfoResult.Success.Restricted(
-                        offenderDetails.otherIds.crn,
-                        offenderDetails.otherIds.nomsNumber,
-                      ),
+                      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                       listOf(),
                     ),
                   ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -917,6 +917,357 @@ class OffenderServiceTest {
   }
 
   @Nested
+  inner class GetPersonInfoResultWithQualification {
+    @Test
+    fun `returns NotFound if ap-and-delius API responds with a 404`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf(crn)) } returns mapOf(
+        crn to
+          StatusCode(
+            HttpMethod.GET,
+            "/secure/offenders/crn/ABC123",
+            HttpStatus.NOT_FOUND,
+            null,
+            true,
+          ),
+      )
+
+      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, listOf(crn)) } returns mapOf(
+        crn to
+          StatusCode(
+            HttpMethod.GET,
+            "/secure/offenders/crn/$crn/user/$deliusUsername/userAccess",
+            HttpStatus.NOT_FOUND,
+            null,
+            true,
+          ),
+      )
+
+      every { mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(PersonSummaryInfoResult.NotFound(crn), null) } returns PersonInfoResult.NotFound(crn)
+
+      val result = offenderService.getPersonInfoResult(
+        crn = crn,
+        limitedAccessStrategy = ReturnRestrictedIfLimitedAccess(deliusUsername),
+      )
+      assertThat(result is PersonInfoResult.NotFound).isTrue
+    }
+
+    @Test
+    fun `throws Exception when ap-and-delius API responds with a 500`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf(crn)) } returns mapOf(
+        crn to
+          StatusCode(
+            HttpMethod.GET,
+            "/secure/offenders/crn/ABC123",
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            null,
+            true,
+          ),
+      )
+
+      every {
+        mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, listOf(crn))
+      } returns mapOf(
+        crn to
+          StatusCode(
+            HttpMethod.GET,
+            "/secure/offenders/crn/$crn/user/$deliusUsername/userAccess",
+            HttpStatus.NOT_FOUND,
+            null,
+            false,
+          ),
+      )
+
+      val exception = assertThrows<RuntimeException> {
+        offenderService.getPersonInfoResult(
+          crn = crn,
+          limitedAccessStrategy = ReturnRestrictedIfLimitedAccess(deliusUsername),
+        )
+      }
+      assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/ABC123: 500 INTERNAL_SERVER_ERROR")
+    }
+
+    @Test
+    fun `throws Exception when LAO respond is Forbidden`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCrn(crn)
+        .withCurrentRestriction(true)
+        .withoutNomsNumber()
+        .produce()
+
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf(crn)) } returns mapOf(
+        crn to ClientResult.Success(
+          status = HttpStatus.OK,
+          body = offenderDetails,
+        ),
+      )
+
+      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, listOf(crn)) } returns mapOf(
+        crn to
+          StatusCode(
+            HttpMethod.GET,
+            "/secure/offenders/crn/$crn/user/$deliusUsername/userAccess",
+            HttpStatus.FORBIDDEN,
+            null,
+          ),
+      )
+
+      val exception = assertThrows<RuntimeException> {
+        offenderService.getPersonInfoResult(
+          crn = crn,
+          limitedAccessStrategy = ReturnRestrictedIfLimitedAccess(deliusUsername),
+        )
+      }
+      assertThat(exception.message).isEqualTo("Unable to complete GET request to /secure/offenders/crn/ABC123/user/USER/userAccess: 403 FORBIDDEN")
+    }
+
+    @Test
+    fun `throws Exception when LAO calls fail with BadRequest exception`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCrn(crn)
+        .withCurrentRestriction(true)
+        .withoutNomsNumber()
+        .produce()
+
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummary(crn) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = offenderDetails,
+      )
+
+      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrn(deliusUsername, crn) } returns StatusCode(
+        HttpMethod.GET,
+        "/secure/offenders/crn/$crn/user/$deliusUsername/userAccess",
+        HttpStatus.BAD_REQUEST,
+        null,
+      )
+
+      assertThrows<RuntimeException> {
+        offenderService.getPersonInfoResult(
+          crn = crn,
+          limitedAccessStrategy = ReturnRestrictedIfLimitedAccess(deliusUsername),
+        )
+      }
+    }
+
+    @Test
+    fun `returns Restricted for LAO Offender where user does not have access and strategy is ReturnRestrictedIfLimitedAccess`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+      val nomsNumber = randomStringMultiCaseWithNumbers(10)
+
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf(crn)) } returns mapOf(
+        crn to ClientResult.Success(
+          status = HttpStatus.OK,
+          body = OffenderDetailsSummaryFactory()
+            .withCrn(crn)
+            .withNomsNumber(nomsNumber)
+            .withCurrentRestriction(true)
+            .produce(),
+        ),
+      )
+
+      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, listOf(crn)) } returns mapOf(
+        crn to
+          StatusCode(
+            status = HttpStatus.FORBIDDEN,
+            method = HttpMethod.GET,
+            path = "/secure/offenders/crn/$crn/user/$deliusUsername/userAccess",
+            body = objectMapper.writeValueAsString(
+              UserOffenderAccess(
+                userRestricted = true,
+                userExcluded = false,
+                restrictionMessage = null,
+              ),
+            ),
+          ),
+      )
+
+      every {
+        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+          PersonSummaryInfoResult.Success.Restricted(crn, nomsNumber),
+          null,
+        )
+      } returns PersonInfoResult.Success.Restricted(crn, nomsNumber)
+
+      val result = offenderService.getPersonInfoResult(
+        crn = crn,
+        limitedAccessStrategy = ReturnRestrictedIfLimitedAccess(deliusUsername),
+      )
+
+      assertThat(result is PersonInfoResult.Success.Restricted).isTrue
+      result as PersonInfoResult.Success.Restricted
+      assertThat(result.crn).isEqualTo(crn)
+    }
+
+    @Test
+    fun `returns Full for LAO Offender where user has access and strategy is ReturnRestrictedIfLimitedAccess`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCrn(crn)
+        .withCurrentRestriction(true)
+        .withoutNomsNumber()
+        .produce()
+
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf(crn)) } returns mapOf(
+        crn to ClientResult.Success(
+          status = HttpStatus.OK,
+          body = offenderDetails,
+        ),
+      )
+
+      every {
+        mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, listOf(crn))
+      } returns mapOf(
+        crn to clientResultSuccess(false, false),
+      )
+
+      every {
+        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+          PersonSummaryInfoResult.Success.Full(
+            crn,
+            offenderDetails.asCaseSummary(),
+          ),
+          null,
+        )
+      } returns PersonInfoResult.Success.Full(crn, offenderDetails, null)
+
+      val result = offenderService.getPersonInfoResult(
+        crn = crn,
+        limitedAccessStrategy = ReturnRestrictedIfLimitedAccess(deliusUsername),
+      )
+
+      assertThat(result is PersonInfoResult.Success.Full).isTrue
+      result as PersonInfoResult.Success.Full
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.offenderDetailSummary).isEqualTo(offenderDetails)
+      assertThat(result.inmateDetail).isEqualTo(null)
+    }
+
+    @Test
+    fun `returns Full for LAO Offender where user does not have access and strategy is IgnoreLimitedAccess`() {
+      val crn = "ABC123"
+      val deliusUsername = "USER"
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCrn(crn)
+        .withCurrentRestriction(true)
+        .withoutNomsNumber()
+        .produce()
+
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf(crn)) } returns mapOf(
+        crn to ClientResult.Success(
+          status = HttpStatus.OK,
+          body = offenderDetails,
+        ),
+      )
+
+      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, listOf(crn)) } returns mapOf(
+        crn to
+          StatusCode(
+            HttpMethod.GET,
+            "/secure/offenders/crn/$crn/user/$deliusUsername/userAccess",
+            HttpStatus.FORBIDDEN,
+            objectMapper.writeValueAsString(
+              UserOffenderAccess(
+                userRestricted = true,
+                userExcluded = false,
+                restrictionMessage = null,
+              ),
+            ),
+            true,
+          ),
+      )
+
+      every {
+        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+          PersonSummaryInfoResult.Success.Full(
+            crn,
+            offenderDetails.asCaseSummary(),
+          ),
+          null,
+        )
+      } returns PersonInfoResult.Success.Full(crn, offenderDetails, null)
+
+      val result = offenderService.getPersonInfoResult(
+        crn = crn,
+        limitedAccessStrategy = LimitedAccessStrategy.IgnoreLimitedAccess,
+      )
+
+      assertThat(result is PersonInfoResult.Success.Full).isTrue
+      result as PersonInfoResult.Success.Full
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.offenderDetailSummary).isEqualTo(offenderDetails)
+      assertThat(result.inmateDetail).isEqualTo(null)
+    }
+
+    @Test
+    fun `returns Full for Non LAO Offender`() {
+      val crn = "ABC123"
+      val nomsNumber = "NOMSABC"
+      val deliusUsername = "USER"
+
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCrn(crn)
+        .withNomsNumber(nomsNumber)
+        .produce()
+
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummaries(listOf(crn)) } returns mapOf(
+        crn to ClientResult.Success(
+          status = HttpStatus.OK,
+          body = offenderDetails,
+        ),
+      )
+
+      every { mockOffenderDetailsDataSource.getUserAccessForOffenderCrns(deliusUsername, listOf(crn)) } returns mapOf(
+        crn to clientResultSuccess(false, false),
+      )
+
+      val inmateDetail = InmateDetailFactory()
+        .withOffenderNo(nomsNumber)
+        .produce()
+
+      every { mockPrisonsApiClient.getInmateDetailsWithWait(nomsNumber) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = inmateDetail,
+      )
+
+      every {
+        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+          PersonSummaryInfoResult.Success.Full(
+            crn,
+            offenderDetails.asCaseSummary(),
+          ),
+          inmateDetail,
+        )
+      } returns PersonInfoResult.Success.Full(crn, offenderDetails, inmateDetail)
+
+      val result = offenderService.getPersonInfoResult(
+        crn = crn,
+        limitedAccessStrategy = LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess(deliusUsername),
+      )
+
+      assertThat(result is PersonInfoResult.Success.Full).isTrue
+      result as PersonInfoResult.Success.Full
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.offenderDetailSummary).isEqualTo(offenderDetails)
+      assertThat(result.inmateDetail).isEqualTo(inmateDetail)
+    }
+  }
+
+  @Nested
   inner class GetPersonInfoResult {
     @Test
     fun `returns NotFound if ap-and-delius API responds with a 404`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -917,9 +917,9 @@ class OffenderServiceTest {
   }
 
   @Nested
-  inner class GetInfoForPerson {
+  inner class GetPersonInfoResult {
     @Test
-    fun `returns NotFound if Community API responds with a 404`() {
+    fun `returns NotFound if ap-and-delius API responds with a 404`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -952,7 +952,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `getInfoForPerson throws runtime exception when Community API responds with a 500`() {
+    fun `throws Exception when ap-and-delius API responds with a 500`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -985,7 +985,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `getInfoForPerson throws runtime exception when LAO respond is Forbidden`() {
+    fun `throws Exception when LAO respond is Forbidden`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -1017,7 +1017,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `throws runtime exception when LAO calls fail with BadRequest exception`() {
+    fun `throws Exception when LAO calls fail with BadRequest exception`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -1043,7 +1043,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `returns Restricted for LAO Offender where user does not pass check and ignoreLaoRestrictions is false`() {
+    fun `returns Restricted for LAO Offender where user does not have access and ignoreLaoRestrictions is false`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
       val nomsNumber = randomStringMultiCaseWithNumbers(10)
@@ -1090,7 +1090,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `returns Full for LAO Offender where user does pass check and ignoreLaoRestrictions is false`() {
+    fun `returns Full for LAO Offender where user has access and ignoreLaoRestrictions is false`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -1133,7 +1133,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `returns Full for LAO Offender where user does not pass check but ignoreLaoRestrictions is true`() {
+    fun `returns Full for LAO Offender where user does not have acess and ignoreLaoRestrictions is true`() {
       val crn = "ABC123"
       val deliusUsername = "USER"
 
@@ -1187,7 +1187,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `returns Full for CRN with both Community API and Prison API data where Community API links to Prison API`() {
+    fun `returns Full for Non LAO Offender`() {
       val crn = "ABC123"
       val nomsNumber = "NOMSABC"
       val deliusUsername = "USER"


### PR DESCRIPTION
Before this commit a RestrictedPerson would be returned when retreiving a placement request, even if the calling user has the ‘Limited Access’ qualification.

This commit changes the PlacementRequest qualification to consider this qualification. This subsequently allows space bookings to be created for LAOs where the user has the ‘limited access’ qualification

To support this a new version of `OffenderService. getPersonInfoResult` is added that accepts the LimitedAccessStrategy, with the existing functions being deprecated.