### PR TITLE
APS-1676: Day Summary Endpoint 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -52,9 +52,9 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
     WHERE
       (CAST(:premisesId AS UUID) IS NULL OR oosb.premises_id = :premisesId) AND
       (CAST(:apAreaId AS UUID) IS NULL OR apa.id = :apAreaId) AND 
-      (FALSE = :excludePast OR dd.end_date >= CURRENT_DATE) AND
-      (FALSE = :excludeCurrent OR CURRENT_DATE NOT BETWEEN dd.start_date AND dd.end_date) AND
-      (FALSE = :excludeFuture OR dd.start_date <= CURRENT_DATE) AND 
+      (FALSE = :excludePast OR dd.end_date >= :date) AND
+      (FALSE = :excludeCurrent OR :date NOT BETWEEN dd.start_date AND dd.end_date) AND
+      (FALSE = :excludeFuture OR dd.start_date <= :date) AND 
       (oosb_cancellations IS NULL)
     """
   }
@@ -70,12 +70,13 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
     """,
     nativeQuery = true,
   )
-  fun findOutOfServiceBedIds(
+  fun findOutOfServiceBedIdsForDate(
     premisesId: UUID?,
     apAreaId: UUID?,
     excludePast: Boolean,
     excludeCurrent: Boolean,
     excludeFuture: Boolean,
+    date: LocalDate? = LocalDate.now(),
     pageable: Pageable?,
   ): Page<String>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedSummaryService.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Temporality
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class Cas1OutOfServiceBedSummaryService(
+  private val cas1PremisesService: Cas1PremisesService,
+  private val cas1OutOfServiceBedService: Cas1OutOfServiceBedService,
+) {
+
+  fun getOutOfServiceBedSummaries(
+    premisesId: UUID,
+    apAreaId: UUID,
+    date: LocalDate,
+  ): CasResult<List<Cas1OutOfServiceBedEntity>> {
+    if (cas1PremisesService.findPremiseById(premisesId) == null) return CasResult.NotFound("premises", premisesId.toString())
+
+    val (outOfServiceBeds) = cas1OutOfServiceBedService.getOutOfServiceBedsForDate(
+      temporality = setOf(Temporality.current),
+      premisesId = premisesId,
+      date = date,
+      apAreaId = apAreaId,
+      pageCriteria = PageCriteria(
+        sortBy = Cas1OutOfServiceBedSortField.startDate,
+        sortDirection = SortDirection.asc,
+        page = 1,
+        perPage = 1000,
+      ),
+    )
+
+    return CasResult.Success(
+      outOfServiceBeds,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingDaySummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingDaySummaryService.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummarySortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingDaySummarySearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.forCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LimitedAccessStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingDaySummaryTransformer
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class Cas1SpaceBookingDaySummaryService(
+  val userAccessService: UserAccessService,
+  private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
+  private val characteristicService: CharacteristicService,
+  private val cas1SpaceBookingDaySummaryTransformer: Cas1SpaceBookingDaySummaryTransformer,
+  private val offenderService: OffenderService,
+  private val userService: UserService,
+  private val cas1PremisesService: Cas1PremisesService,
+) {
+
+  fun getBookingDaySummaries(
+    premisesId: UUID,
+    date: LocalDate,
+    bookingsCriteriaFilter: List<Cas1SpaceBookingCharacteristic>?,
+    bookingsSortBy: Cas1SpaceBookingDaySummarySortField,
+    bookingsSortDirection: SortDirection,
+  ): CasResult<List<Cas1SpaceBookingDaySummary>> {
+    if (cas1PremisesService.findPremiseById(premisesId) == null) return CasResult.NotFound("premises", premisesId.toString())
+
+    val sort = Sort.by(
+      when (bookingsSortDirection) {
+        SortDirection.desc -> Sort.Direction.DESC
+        SortDirection.asc -> Sort.Direction.ASC
+      },
+      bookingsSortBy.value,
+    )
+
+    val spaceBookingsForDate = cas1SpaceBookingRepository.findAllPremisesBookingsForDate(
+      premisesId = premisesId,
+      daySummaryDate = date,
+      bookingsCriteriaFilter = getBookingCharacteristicIds(bookingsCriteriaFilter),
+      sort = sort,
+    )
+
+    val offenderSummaries = getOffenderSummariesForBookings(spaceBookingsForDate)
+
+    val spaceBookingDaySummaries =
+      spaceBookingsForDate.map { bookingSummary ->
+        cas1SpaceBookingDaySummaryTransformer.toCas1SpaceBookingDaySummary(
+          bookingSummary,
+          PersonTransformer()
+            .personSummaryInfoToPersonSummary(
+              offenderSummaries.forCrn(bookingSummary.crn),
+            ),
+        )
+      }
+    return CasResult.Success(
+      spaceBookingDaySummaries,
+    )
+  }
+
+  private fun getBookingCharacteristicIds(bookingsCriteriaFilter: List<Cas1SpaceBookingCharacteristic>?) =
+    bookingsCriteriaFilter?.let { bookingCriteria ->
+      val characteristics = bookingCriteria.map { it.value }
+      characteristicService.getCharacteristicsByPropertyNames(characteristics, ServiceName.approvedPremises)
+        .map { characteristic -> characteristic.id }
+    }
+
+  private fun getOffenderSummariesForBookings(spaceBookings: List<Cas1SpaceBookingDaySummarySearchResult>): List<PersonSummaryInfoResult> {
+    val user = userService.getUserForRequest()
+    return offenderService.getPersonSummaryInfoResults(
+      crns = spaceBookings.map { it.crn }.toSet(),
+      limitedAccessStrategy = user.cas1LimitedAccessStrategy(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedSummaryTransformer.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+
+@Component
+class Cas1OutOfServiceBedSummaryTransformer(
+  private val cas1OutOfServiceBedReasonTransformer: Cas1OutOfServiceBedReasonTransformer,
+) {
+
+  fun toCas1OutOfServiceBedSummary(jpa: Cas1OutOfServiceBedEntity) = Cas1OutOfServiceBedSummary(
+    id = jpa.id,
+    roomName = jpa.bed.room.name,
+    startDate = jpa.startDate,
+    endDate = jpa.endDate,
+    reason = cas1OutOfServiceBedReasonTransformer.transformJpaToApi(jpa.reason),
+    characteristics = jpa.bed.room.characteristics.map { it.asCas1SpaceCharacteristic() },
+  )
+
+  private fun CharacteristicEntity.asCas1SpaceCharacteristic() =
+    Cas1SpaceCharacteristic.entries.first { it.value == this.propertyName }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesDayTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesDayTransformer.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesDaySummary
+import java.time.LocalDate
+
+@Component
+class Cas1PremisesDayTransformer {
+
+  fun toCas1PremisesDaySummary(
+    date: LocalDate,
+    premisesCapacity: Cas1PremiseCapacity,
+  ) =
+    Cas1PremisesDaySummary(
+      forDate = date,
+      previousDate = date.minusDays(1),
+      nextDate = date.plusDays(1),
+      capacity = premisesCapacity.capacity.first(),
+      spaceBookings = emptyList(),
+      outOfServiceBeds = emptyList(),
+    )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesDayTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesDayTransformer.kt
@@ -1,7 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacityForDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesDaySummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
 import java.time.LocalDate
@@ -11,15 +12,16 @@ class Cas1PremisesDayTransformer {
 
   fun toCas1PremisesDaySummary(
     date: LocalDate,
-    premisesCapacity: Cas1PremiseCapacity,
+    premisesCapacity: Cas1PremiseCapacityForDay,
     spaceBookings: List<Cas1SpaceBookingDaySummary>,
+    outOfServiceBeds: List<Cas1OutOfServiceBedSummary>,
   ) =
     Cas1PremisesDaySummary(
       forDate = date,
       previousDate = date.minusDays(1),
       nextDate = date.plusDays(1),
-      capacity = premisesCapacity.capacity.first(),
+      capacity = premisesCapacity,
       spaceBookings = spaceBookings,
-      outOfServiceBeds = emptyList(),
+      outOfServiceBeds = outOfServiceBeds,
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesDayTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesDayTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesDaySummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
 import java.time.LocalDate
 
 @Component
@@ -11,13 +12,14 @@ class Cas1PremisesDayTransformer {
   fun toCas1PremisesDaySummary(
     date: LocalDate,
     premisesCapacity: Cas1PremiseCapacity,
+    spaceBookings: List<Cas1SpaceBookingDaySummary>,
   ) =
     Cas1PremisesDaySummary(
       forDate = date,
       previousDate = date.minusDays(1),
       nextDate = date.plusDays(1),
       capacity = premisesCapacity.capacity.first(),
-      spaceBookings = emptyList(),
+      spaceBookings = spaceBookings,
       outOfServiceBeds = emptyList(),
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingDaySummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingDaySummaryTransformer.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingDaySummarySearchResult
+
+@Component
+class Cas1SpaceBookingDaySummaryTransformer {
+
+  private val releaseTypeToBeDetermined = "TBD"
+
+  fun toCas1SpaceBookingDaySummary(
+    jpa: Cas1SpaceBookingDaySummarySearchResult,
+    personSummary: PersonSummary,
+  ) = Cas1SpaceBookingDaySummary(
+    id = jpa.id,
+    canonicalArrivalDate = jpa.canonicalArrivalDate,
+    canonicalDepartureDate = jpa.canonicalDepartureDate,
+    tier = jpa.tier,
+    releaseType = releaseTypeToBeDetermined,
+    essentialCharacteristics = characteristicEntityToCharacteristic(jpa.characteristicsPropertyNames),
+    person = personSummary,
+  )
+
+  private fun characteristicEntityToCharacteristic(characteristics: String?): List<Cas1SpaceBookingCharacteristic> =
+    characteristics?.let { characteristicList ->
+      characteristicList.split(",").map { characteristic ->
+        Cas1SpaceBookingCharacteristic.entries.first { it.value == characteristic }
+      }
+    } ?: emptyList()
+}

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -925,7 +925,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremiseDaySummary'
+                $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremisesDaySummary'
           headers:
             X-Pagination-CurrentPage:
               $ref: '_shared.yml#/components/headers/X-Pagination-CurrentPage'

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -538,7 +538,7 @@ components:
         - CANONICAL_DEPARTURE_DATE
         - RELEASE_TYPE
         - SPACE_TYPE
-    Cas1PremiseDaySummary:
+    Cas1PremisesDaySummary:
       type: object
       properties:
         forDate:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -837,6 +837,8 @@ components:
         id:
           type: string
           format: uuid
+        roomName:
+          type: string
         startDate:
           type: string
           format: date

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -530,7 +530,6 @@ components:
         - canonicalArrivalDate
         - canonicalDepartureDate
         - releaseType
-        - spaceType
       x-enum-varnames:
         - PERSON_NAME
         - TIER
@@ -597,9 +596,7 @@ components:
         - person
         - canonicalArrivalDate
         - canonicalDepartureDate
-        - tier
         - spaceType
-        - releaseType
         - essentialCharacteristics
     Cas1SpaceBookingSummaryStatus:
       type: string

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6580,7 +6580,6 @@ components:
         - canonicalArrivalDate
         - canonicalDepartureDate
         - releaseType
-        - spaceType
       x-enum-varnames:
         - PERSON_NAME
         - TIER
@@ -6647,9 +6646,7 @@ components:
         - person
         - canonicalArrivalDate
         - canonicalDepartureDate
-        - tier
         - spaceType
-        - releaseType
         - essentialCharacteristics
     Cas1SpaceBookingSummaryStatus:
       type: string

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -927,7 +927,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/Cas1PremiseDaySummary'
+                $ref: '#/components/schemas/Cas1PremisesDaySummary'
           headers:
             X-Pagination-CurrentPage:
               $ref: '#/components/headers/X-Pagination-CurrentPage'
@@ -6588,7 +6588,7 @@ components:
         - CANONICAL_DEPARTURE_DATE
         - RELEASE_TYPE
         - SPACE_TYPE
-    Cas1PremiseDaySummary:
+    Cas1PremisesDaySummary:
       type: object
       properties:
         forDate:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6887,6 +6887,8 @@ components:
         id:
           type: string
           format: uuid
+        roomName:
+          type: string
         startDate:
           type: string
           format: date

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -8,18 +8,34 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesBasicSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesDaySummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPersonSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummaryDiscriminator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOutOfServiceBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesGender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_ASSESSOR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_CRU_MEMBER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_FUTURE_MANAGER
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsListOfObjects
 import java.time.LocalDate
 import java.util.UUID
@@ -441,16 +457,32 @@ class Cas1PremisesTest : IntegrationTestBase() {
   inner class GetDaySummary : InitialiseDatabasePerClassTestBase() {
 
     lateinit var premises: ApprovedPremisesEntity
+    lateinit var spaceBookingEarly: Cas1SpaceBookingEntity
+    lateinit var spaceBookingLate: Cas1SpaceBookingEntity
+    lateinit var spaceBookingOfflineApplication: Cas1SpaceBookingEntity
+    lateinit var applicationA: ApprovedPremisesApplicationEntity
+    lateinit var placementRequestA: PlacementRequestEntity
+    lateinit var applicationB: ApprovedPremisesApplicationEntity
+    lateinit var placementRequestB: PlacementRequestEntity
+    lateinit var offenderA: CaseSummary
+    lateinit var offenderB: CaseSummary
+    lateinit var offenderOffline: CaseSummary
 
     val summaryDate = LocalDate.now()
+    val tierA = "A2"
+    val tierB = "B3"
+    val releaseTypeToBeDetermined = "TBD"
 
+    @SuppressWarnings("UnusedPrivateProperty")
     @BeforeAll
     fun setupTestData() {
       val region = givenAProbationRegion(
         apArea = givenAnApArea(name = "The ap area name"),
       )
 
+      val premisesId = UUID.randomUUID()
       premises = approvedPremisesEntityFactory.produceAndPersist {
+        withId(premisesId)
         withName("the premises name")
         withApCode("the ap code")
         withPostcode("the postcode")
@@ -458,10 +490,131 @@ class Cas1PremisesTest : IntegrationTestBase() {
         withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
         withManagerDetails("manager details")
       }
+
+      bedEntityFactory.produceAndPersistMultiple(5) {
+        withYieldedRoom {
+          roomEntityFactory.produceAndPersist {
+            withYieldedPremises { premises }
+          }
+        }
+      }
+
+      val (user) = givenAUser()
+      val (offenderAAA) = givenAnOffender(offenderDetailsConfigBlock = {
+        withCrn("crn1")
+        withFirstName("firstNameAAA")
+        withLastName("lastNameAAA")
+        withCurrentRestriction(false)
+      })
+      offenderA = offenderAAA.asCaseSummary()
+
+      val (offenderBBB) = givenAnOffender(offenderDetailsConfigBlock = {
+        withCrn("crn2")
+        withFirstName("firstNameBBB")
+        withLastName("lastNameBBB")
+        withCurrentRestriction(false)
+      })
+      offenderB = offenderBBB.asCaseSummary()
+      val (offenderOfflineApplication) = givenAnOffender(offenderDetailsConfigBlock = {
+        withCrn("offline_crn")
+        withFirstName("mister")
+        withLastName("offline")
+        withCurrentRestriction(false)
+      })
+      offenderOffline = offenderOfflineApplication.asCaseSummary()
+
+      val pRequestA = givenAPlacementRequest(
+        placementRequestAllocatedTo = user,
+        assessmentAllocatedTo = user,
+        createdByUser = user,
+        crn = offenderA.crn,
+        name = "$offenderA.firstName $offenderA.lastName",
+        tier = tierA,
+      )
+      placementRequestA = pRequestA.first
+      applicationA = pRequestA.second
+
+      val pRequestB = givenAPlacementRequest(
+        placementRequestAllocatedTo = user,
+        assessmentAllocatedTo = user,
+        createdByUser = user,
+        crn = offenderB.crn,
+        name = "$offenderB.firstName $offenderB.lastName",
+        tier = tierB,
+      )
+      placementRequestB = pRequestB.first
+      applicationB = pRequestB.second
+
+      spaceBookingEarly = createSpaceBooking(
+        crn = offenderA.crn,
+        placementRequest = this.placementRequestA,
+        application = applicationA,
+      ) {
+        withCrn(offenderA.crn)
+        withPremises(premises)
+        withCanonicalArrivalDate(LocalDate.now().minusDays(3))
+        withCanonicalDepartureDate(LocalDate.now().plusDays(3))
+        withCreatedBy(user)
+        withCriteria(
+          findCharacteristic(CAS1_PROPERTY_NAME_ARSON_SUITABLE),
+        )
+      }
+
+      spaceBookingLate = createSpaceBooking(
+        crn = offenderA.crn,
+        placementRequest = this.placementRequestA,
+        application = applicationB,
+      ) {
+        withCrn(offenderB.crn)
+        withPremises(premises)
+        withCanonicalArrivalDate(LocalDate.now().minusDays(6))
+        withCanonicalDepartureDate(LocalDate.now().plusDays(6))
+        withCreatedBy(user)
+        withCriteria(
+          findCharacteristic(CAS1_PROPERTY_NAME_ARSON_SUITABLE),
+          findCharacteristic(CAS1_PROPERTY_NAME_ENSUITE),
+          findCharacteristic(CAS1_PROPERTY_NAME_SINGLE_ROOM),
+        )
+      }
+
+      val spaceBookingCancelled = createSpaceBooking(
+        crn = offenderA.crn,
+        placementRequest = this.placementRequestA,
+        application = applicationB,
+      ) {
+        withCrn(offenderB.crn)
+        withPremises(premises)
+        withCanonicalArrivalDate(LocalDate.now().minusDays(2))
+        withCanonicalDepartureDate(LocalDate.now().plusDays(2))
+        withCreatedBy(user)
+        withCriteria(
+          findCharacteristic(CAS1_PROPERTY_NAME_ARSON_SUITABLE),
+          findCharacteristic(CAS1_PROPERTY_NAME_ENSUITE),
+          findCharacteristic(CAS1_PROPERTY_NAME_SINGLE_ROOM),
+        )
+        withCancellationOccurredAt(LocalDate.now())
+      }
+
+      spaceBookingOfflineApplication = createSpaceBookingWithOfflineApplication(
+        crn = offenderOffline.crn,
+        firstName = offenderOffline.name.forename,
+        lastName = offenderOffline.name.surname,
+        premises = premises,
+      ) {
+        withPremises(premises)
+        withCanonicalArrivalDate(LocalDate.now().minusDays(2))
+        withCanonicalDepartureDate(LocalDate.now().plusDays(2))
+        withActualDepartureDate(null)
+        withCriteria(
+          findCharacteristic(CAS1_PROPERTY_NAME_SINGLE_ROOM),
+        )
+      }
+
+      apDeliusContextAddListCaseSummaryToBulkResponse(listOf(offenderA, offenderB, offenderOffline))
     }
 
     @Test
-    fun `Returns 403 Forbidden if user does not have correct role`() {
+    fun `returns 403 Forbidden if user does not have correct role`() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_ASSESSOR))
 
       webTestClient.get()
@@ -473,7 +626,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Returns 404 if premise doesn't exist`() {
+    fun `returns 404 if premise doesn't exist`() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
 
       webTestClient.get()
@@ -485,19 +638,104 @@ class Cas1PremisesTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Returns premises day summary`() {
+    fun `returns premises day summary with no filters applied`() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
 
-      bedEntityFactory.produceAndPersistMultiple(5) {
-        withYieldedRoom {
-          roomEntityFactory.produceAndPersist {
-            withYieldedPremises { premises }
-          }
-        }
-      }
+      val summaries = webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/day-summary/$summaryDate")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1PremisesDaySummary::class.java).responseBody.blockFirst()!!
+
+      assertThat(summaries.forDate).isEqualTo(summaryDate)
+      assertThat(summaries.nextDate).isEqualTo(summaryDate.plusDays(1))
+      assertThat(summaries.previousDate).isEqualTo(summaryDate.minusDays(1))
+      assertThat(summaries.spaceBookings.size).isEqualTo(3)
+      assertThat(summaries.outOfServiceBeds).isEmpty()
+
+      val summaryBookingOffline = summaries.spaceBookings[0]
+      assertThat(summaryBookingOffline.id).isEqualTo(spaceBookingOfflineApplication.id)
+      assertThat(summaryBookingOffline.tier).isEqualTo(null)
+      assertThat(summaryBookingOffline.releaseType).isEqualTo(releaseTypeToBeDetermined)
+      assertThat(summaryBookingOffline.canonicalArrivalDate).isEqualTo(summaryBookingOffline.canonicalArrivalDate)
+      assertThat(summaryBookingOffline.canonicalDepartureDate).isEqualTo(summaryBookingOffline.canonicalDepartureDate)
+      assertThat(summaryBookingOffline.essentialCharacteristics.size).isEqualTo(1)
+      assertThat(summaryBookingOffline.essentialCharacteristics[0].value).isEqualTo(CAS1_PROPERTY_NAME_SINGLE_ROOM)
+
+      val summaryBooking1 = summaries.spaceBookings[1]
+      assertThat(summaryBooking1.id).isEqualTo(spaceBookingLate.id)
+      assertThat(summaryBooking1.tier).isEqualTo(tierB)
+      assertThat(summaryBooking1.canonicalArrivalDate).isEqualTo(spaceBookingLate.canonicalArrivalDate)
+      assertThat(summaryBooking1.canonicalDepartureDate).isEqualTo(spaceBookingLate.canonicalDepartureDate)
+      assertThat(summaryBooking1.essentialCharacteristics.size).isEqualTo(3)
+      assertThat(summaryBooking1.essentialCharacteristics[0].value).isEqualTo(CAS1_PROPERTY_NAME_ARSON_SUITABLE)
+      assertThat(summaryBooking1.essentialCharacteristics[1].value).isEqualTo(CAS1_PROPERTY_NAME_ENSUITE)
+      assertThat(summaryBooking1.essentialCharacteristics[2].value).isEqualTo(CAS1_PROPERTY_NAME_SINGLE_ROOM)
+      assertThat(summaryBooking1.releaseType).isEqualTo(releaseTypeToBeDetermined)
+
+      val summaryBooking2 = summaries.spaceBookings[2]
+      assertThat(summaryBooking2.id).isEqualTo(spaceBookingEarly.id)
+      assertThat(summaryBooking2.tier).isEqualTo(tierA)
+      assertThat(summaryBooking2.canonicalArrivalDate).isEqualTo(spaceBookingEarly.canonicalArrivalDate)
+      assertThat(summaryBooking2.canonicalDepartureDate).isEqualTo(spaceBookingEarly.canonicalDepartureDate)
+      assertThat(summaryBooking2.essentialCharacteristics.size).isEqualTo(1)
+      assertThat(summaryBooking2.essentialCharacteristics[0].value).isEqualTo(CAS1_PROPERTY_NAME_ARSON_SUITABLE)
+      assertThat(summaryBooking2.releaseType).isEqualTo(releaseTypeToBeDetermined)
+
+      val offender1 = summaryBookingOffline.person
+      assertThat(offender1.crn).isEqualTo(offenderOffline.crn)
+      assertThat(offender1.personType).isEqualTo(PersonSummaryDiscriminator.fullPersonSummary)
+      assertThat(offender1).isInstanceOf(FullPersonSummary::class.java)
+      assertThat((offender1 as FullPersonSummary).name).isEqualTo("${offenderOffline.name.forename} ${offenderOffline.name.surname}")
+
+      val offender2 = summaryBooking1.person
+      assertThat(offender2.crn).isEqualTo(offenderB.crn)
+      assertThat(offender2.personType).isEqualTo(PersonSummaryDiscriminator.fullPersonSummary)
+      assertThat(offender2).isInstanceOf(FullPersonSummary::class.java)
+      assertThat((offender2 as FullPersonSummary).name).isEqualTo("${offenderB.name.forename} ${offenderB.name.surname}")
+
+      val offender3 = summaryBooking2.person
+      assertThat(offender3.crn).isEqualTo(offenderA.crn)
+      assertThat(offender3.personType).isEqualTo(PersonSummaryDiscriminator.fullPersonSummary)
+      assertThat(offender3).isInstanceOf(FullPersonSummary::class.java)
+      assertThat((offender3 as FullPersonSummary).name).isEqualTo("${offenderA.name.forename} ${offenderA.name.surname}")
+
+      val capacity = summaries.capacity
+      assertThat(capacity.date).isEqualTo(summaryDate)
+      assertThat(capacity.totalBedCount).isEqualTo(5)
+      assertThat(capacity.availableBedCount).isEqualTo(5)
+      assertThat(capacity.bookingCount).isEqualTo(3)
+      assertThat(capacity.characteristicAvailability.count()).isEqualTo(6)
+    }
+
+    @Test
+    fun `returns premises day summaries when filters applied with matching bookings`() {
+      val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
 
       val summary = webTestClient.get()
-        .uri("/cas1/premises/${premises.id}/day-summary/$summaryDate")
+        .uri("/cas1/premises/${premises.id}/day-summary/$summaryDate?bookingsCriteriaFilter=hasEnSuite")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1PremisesDaySummary::class.java).responseBody.blockFirst()!!
+
+      assertThat(summary.forDate).isEqualTo(summaryDate)
+      assertThat(summary.nextDate).isEqualTo(summaryDate.plusDays(1))
+      assertThat(summary.previousDate).isEqualTo(summaryDate.minusDays(1))
+      assertThat(summary.spaceBookings.size).isEqualTo(1)
+      val summaryBooking = summary.spaceBookings[0]
+      assertThat(summaryBooking.essentialCharacteristics[1].value).isEqualTo(CAS1_PROPERTY_NAME_ENSUITE)
+    }
+
+    @Test
+    fun `returns no space booking summaries when filters applied with no matching bookings`() {
+      val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
+
+      val summary = webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/day-summary/$summaryDate?bookingsCriteriaFilter=isStepFreeDesignated")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -509,12 +747,111 @@ class Cas1PremisesTest : IntegrationTestBase() {
       assertThat(summary.previousDate).isEqualTo(summaryDate.minusDays(1))
       assertThat(summary.spaceBookings).isEmpty()
       assertThat(summary.outOfServiceBeds).isEmpty()
-      val capacity = summary.capacity
-      assertThat(capacity.date).isEqualTo(summaryDate)
-      assertThat(capacity.totalBedCount).isEqualTo(5)
-      assertThat(capacity.availableBedCount).isEqualTo(5)
-      assertThat(capacity.bookingCount).isEqualTo(0)
-      assertThat(capacity.characteristicAvailability.count()).isEqualTo(6)
+    }
+
+    @Test
+    fun `returns ordered space booking summaries when order by person name ascending`() {
+      val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
+
+      val summaries = webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/day-summary/$summaryDate?bookingsSortDirection=asc&bookingsSortBy=personName")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1PremisesDaySummary::class.java).responseBody.blockFirst()!!
+
+      assertThat(summaries.spaceBookings.size).isEqualTo(3)
+
+      val offender1 = summaries.spaceBookings[0].person
+      assertThat((offender1 as FullPersonSummary).name).isEqualTo("firstNameAAA lastNameAAA")
+      val offender2 = summaries.spaceBookings[1].person
+      assertThat((offender2 as FullPersonSummary).name).isEqualTo("firstNameBBB lastNameBBB")
+      val offender3 = summaries.spaceBookings[2].person
+      assertThat((offender3 as FullPersonSummary).name).isEqualTo("mister offline")
+    }
+
+    @Test
+    fun `returns ordered space booking summaries when order by tier ascending`() {
+      val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
+
+      val summaries = webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/day-summary/$summaryDate?bookingsSortDirection=asc&bookingsSortBy=tier")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1PremisesDaySummary::class.java).responseBody.blockFirst()!!
+
+      assertThat(summaries.spaceBookings.size).isEqualTo(3)
+
+      assertThat(summaries.spaceBookings[0].tier).isEqualTo(tierA)
+      assertThat(summaries.spaceBookings[1].tier).isEqualTo(tierB)
+      assertThat(summaries.spaceBookings[2].tier).isNull()
+    }
+
+    @Test
+    fun `returns ordered space booking summaries when order by tier descending`() {
+      val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
+
+      val summaries = webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/day-summary/$summaryDate?bookingsSortDirection=desc&bookingsSortBy=tier")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1PremisesDaySummary::class.java).responseBody.blockFirst()!!
+
+      assertThat(summaries.spaceBookings.size).isEqualTo(3)
+
+      assertThat(summaries.spaceBookings[0].tier).isNull()
+      assertThat(summaries.spaceBookings[1].tier).isEqualTo(tierB)
+      assertThat(summaries.spaceBookings[2].tier).isEqualTo(tierA)
+    }
+
+    private fun findCharacteristic(propertyName: String) =
+      characteristicRepository.findByPropertyName(propertyName, ServiceName.approvedPremises.value)!!
+
+    private fun createSpaceBooking(
+      crn: String,
+      placementRequest: PlacementRequestEntity,
+      application: ApprovedPremisesApplicationEntity,
+      configuration: Cas1SpaceBookingEntityFactory.() -> Unit,
+    ): Cas1SpaceBookingEntity {
+      val (user) = givenAUser()
+
+      return cas1SpaceBookingEntityFactory.produceAndPersist {
+        withCrn(crn)
+        withPlacementRequest(placementRequest)
+        withApplication(application)
+        withCreatedBy(user)
+
+        configuration.invoke(this)
+      }
+    }
+
+    private fun createSpaceBookingWithOfflineApplication(
+      crn: String,
+      firstName: String,
+      lastName: String,
+      premises: ApprovedPremisesEntity,
+      configuration: Cas1SpaceBookingEntityFactory.() -> Unit,
+    ): Cas1SpaceBookingEntity {
+      val (user) = givenAUser()
+      val offlineApplication = givenAnOfflineApplication(
+        crn = crn,
+        name = "$firstName $lastName",
+      )
+      return cas1SpaceBookingEntityFactory.produceAndPersist {
+        withCrn(crn)
+        withPremises(premises)
+        withPlacementRequest(null)
+        withApplication(null)
+        withOfflineApplication(offlineApplication)
+        withCreatedBy(user)
+
+        configuration.invoke(this)
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
@@ -575,7 +575,7 @@ class Cas1OutOfServiceBedServiceTest {
       val expectedPageable = getPageableOrAllPages(expectedSortFieldString, sortDirection, page = null, pageSize = null, unsafe = true)
 
       every {
-        outOfServiceBedRepository.findOutOfServiceBedIds(
+        outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
           premisesId = any(),
           apAreaId = any(),
           excludePast = any(),
@@ -595,7 +595,7 @@ class Cas1OutOfServiceBedServiceTest {
       )
 
       verify(exactly = 1) {
-        outOfServiceBedRepository.findOutOfServiceBedIds(
+        outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
           premisesId = null,
           apAreaId = null,
           excludePast = false,
@@ -610,7 +610,7 @@ class Cas1OutOfServiceBedServiceTest {
     @ParameterizedTest
     fun `Filters correctly according to the temporality`(temporality: List<Temporality>) {
       every {
-        outOfServiceBedRepository.findOutOfServiceBedIds(
+        outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
           premisesId = any(),
           apAreaId = any(),
           excludePast = any(),
@@ -630,7 +630,7 @@ class Cas1OutOfServiceBedServiceTest {
       )
 
       verify(exactly = 1) {
-        outOfServiceBedRepository.findOutOfServiceBedIds(
+        outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
           premisesId = null,
           apAreaId = null,
           excludePast = !temporality.contains(Temporality.past),
@@ -644,7 +644,7 @@ class Cas1OutOfServiceBedServiceTest {
     @Test
     fun `Filters correctly according to the premises ID`() {
       every {
-        outOfServiceBedRepository.findOutOfServiceBedIds(
+        outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
           premisesId = any(),
           apAreaId = any(),
           excludePast = any(),
@@ -666,7 +666,7 @@ class Cas1OutOfServiceBedServiceTest {
       )
 
       verify(exactly = 1) {
-        outOfServiceBedRepository.findOutOfServiceBedIds(
+        outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
           premisesId = expectedId,
           apAreaId = null,
           excludePast = false,
@@ -680,7 +680,7 @@ class Cas1OutOfServiceBedServiceTest {
     @Test
     fun `Filters correctly according to the AP area ID`() {
       every {
-        outOfServiceBedRepository.findOutOfServiceBedIds(
+        outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
           premisesId = any(),
           apAreaId = any(),
           excludePast = any(),
@@ -702,7 +702,7 @@ class Cas1OutOfServiceBedServiceTest {
       )
 
       verify(exactly = 1) {
-        outOfServiceBedRepository.findOutOfServiceBedIds(
+        outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
           premisesId = null,
           apAreaId = expectedId,
           excludePast = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedSummaryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedSummaryServiceTest.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedSummaryService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1OutOfServiceBedSummaryServiceTest {
+
+  private val cas1PremisesService = mockk<Cas1PremisesService>()
+  private val cas1OutOfServiceBedService = mockk<Cas1OutOfServiceBedService>()
+
+  private val service = Cas1OutOfServiceBedSummaryService(
+    cas1PremisesService,
+    cas1OutOfServiceBedService,
+  )
+
+  @Nested
+  inner class GetOutOfServiceBedSummaries {
+
+    @Test
+    fun `returns not found error if premises with the given Id does not exist`() {
+      every { cas1PremisesService.findPremiseById(any()) } returns null
+
+      val result = service.getOutOfServiceBedSummaries(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        LocalDate.now(),
+      )
+
+      assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
+      assertThat((result as CasResult.NotFound).entityType).isEqualTo("premises")
+    }
+  }
+
+  @Test
+  fun `returns out of service bed summaries when out of service beds exist`() {
+    val apArea = ApAreaEntityFactory()
+      .produce()
+    val probationRegion = ProbationRegionEntityFactory()
+      .withApArea(apArea)
+      .produce()
+    val premises = ApprovedPremisesEntityFactory()
+      .withLocalAuthorityArea(LocalAuthorityAreaEntityFactory().produce())
+      .withProbationRegion(probationRegion)
+      .produce()
+    val date = LocalDate.now()
+
+    val outOfServiceBed1 = Cas1OutOfServiceBedEntityFactory()
+      .withBed {
+        withRoom {
+          withPremises(
+            ApprovedPremisesEntityFactory()
+              .withDefaults()
+              .produce(),
+          )
+        }
+      }
+      .produce()
+
+    every { cas1PremisesService.findPremiseById(premises.id) } returns premises
+    every { cas1OutOfServiceBedService.getOutOfServiceBedsForDate(any(), premises.id, apArea.id, date, any()) } returns
+      Pair(listOf(outOfServiceBed1), PaginationMetadata(0, 0, 0, 0))
+
+    val result = service.getOutOfServiceBedSummaries(
+      premisesId = premises.id,
+      apAreaId = apArea.id,
+      date = LocalDate.now(),
+    )
+
+    assertThat(result).isInstanceOf(CasResult.Success::class.java)
+    result as CasResult.Success
+    val outOfServiceBedSummaries = result.value
+    assertThat(outOfServiceBedSummaries.size).isEqualTo(1)
+    assertThat(result.value[0]).isInstanceOf(Cas1OutOfServiceBedEntity::class.java)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingDaySummaryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingDaySummaryServiceTest.kt
@@ -1,0 +1,168 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.domain.Sort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummarySortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingDaySummaryService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingDaySummaryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1.Cas1SpaceBookingDaySummarySearchResultImpl
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1SpaceBookingDaySummaryServiceTest {
+
+  private val userAccessService = mockk<UserAccessService>()
+  private val cas1SpaceBookingRepository = mockk<Cas1SpaceBookingRepository>()
+  private val characteristicService = mockk<CharacteristicService>()
+  private val cas1SpaceBookingDaySummaryTransformer = mockk<Cas1SpaceBookingDaySummaryTransformer>()
+  private val offenderService = mockk<OffenderService>()
+  private val userService = mockk<UserService>()
+  private val cas1PremisesService = mockk<Cas1PremisesService>()
+
+  private val service = Cas1SpaceBookingDaySummaryService(
+    userAccessService,
+    cas1SpaceBookingRepository,
+    characteristicService,
+    cas1SpaceBookingDaySummaryTransformer,
+    offenderService,
+    userService,
+    cas1PremisesService,
+  )
+
+  @Nested
+  inner class GetBookingDaySummaries {
+
+    @Test
+    fun `returns not found error if premises with the given Id does not exist`() {
+      every { cas1PremisesService.findPremiseById(any()) } returns null
+
+      val result = service.getBookingDaySummaries(
+        UUID.randomUUID(),
+        LocalDate.now(),
+        emptyList(),
+        Cas1SpaceBookingDaySummarySortField.PERSON_NAME,
+        SortDirection.desc,
+      )
+
+      assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
+      assertThat((result as CasResult.NotFound).entityType).isEqualTo("premises")
+    }
+  }
+
+  @Test
+  fun `returns booking day summaries when bookings exist`() {
+    val premisesId = UUID.randomUUID()
+    val date = LocalDate.now()
+    val sort = Sort.by(Sort.Direction.DESC, Cas1SpaceBookingDaySummarySortField.PERSON_NAME.value)
+
+    val spaceBooking1Summary = Cas1SpaceBookingDaySummarySearchResultImpl(
+      UUID.randomUUID(),
+      "crn1",
+      LocalDate.now().minusDays(3),
+      LocalDate.now().plusDays(3),
+      tier = "A1",
+      releaseType = "rotl",
+      characteristicsPropertyNames = "isArsonSuitable,hasEnSuite",
+    )
+    val spaceBooking2Summary = Cas1SpaceBookingDaySummarySearchResultImpl(
+      UUID.randomUUID(),
+      "crn2",
+      LocalDate.now().minusDays(2),
+      LocalDate.now().plusDays(2),
+      tier = "A2",
+      releaseType = "licence",
+      characteristicsPropertyNames = "isSingle",
+    )
+    val spaceBookingSummaries = listOf(spaceBooking1Summary, spaceBooking2Summary)
+
+    val person1CaseSummary = CaseSummaryFactory().produce()
+    val person2CaseSummary = CaseSummaryFactory().produce()
+    val personSummaries = listOf(
+      PersonSummaryInfoResult.Success.Full("crn1", person1CaseSummary),
+      PersonSummaryInfoResult.Success.Full("crn2", person2CaseSummary),
+    )
+    val person1Summary = PersonTransformer()
+      .personSummaryInfoToPersonSummary(
+        PersonSummaryInfoResult.Success.Full("crn1", person1CaseSummary),
+      )
+    val person2Summary = PersonTransformer()
+      .personSummaryInfoToPersonSummary(
+        PersonSummaryInfoResult.Success.Full("crn2", person2CaseSummary),
+      )
+
+    val booking1DaySummary = Cas1SpaceBookingDaySummary(
+      id = UUID.randomUUID(),
+      person = person1Summary,
+      canonicalArrivalDate = LocalDate.now().minusDays(6),
+      canonicalDepartureDate = LocalDate.now().plusDays(6),
+      tier = "A2",
+      releaseType = "rotl",
+      essentialCharacteristics = listOf(Cas1SpaceBookingCharacteristic.IS_SINGLE, Cas1SpaceBookingCharacteristic.HAS_EN_SUITE),
+    )
+
+    val booking2DaySummary = Cas1SpaceBookingDaySummary(
+      id = UUID.randomUUID(),
+      person = person2Summary,
+      canonicalArrivalDate = LocalDate.now().minusDays(3),
+      canonicalDepartureDate = LocalDate.now().plusDays(36),
+      tier = "B3",
+      releaseType = "licence",
+      essentialCharacteristics = listOf(Cas1SpaceBookingCharacteristic.IS_SINGLE),
+    )
+
+    val roomCharacteristic = CharacteristicEntityFactory()
+      .withPropertyName("isArsonSuitable")
+      .withModelScope("room")
+      .withServiceScope("approved-premises")
+      .produce()
+
+    val user = UserEntityFactory()
+      .withDefaults()
+      .produce()
+
+    every { cas1PremisesService.findPremiseById(premisesId) } returns ApprovedPremisesEntityFactory().withDefaults().produce()
+    every { cas1SpaceBookingRepository.findAllPremisesBookingsForDate(premisesId, date, any(), sort, any()) } returns spaceBookingSummaries
+    every { characteristicService.getCharacteristicsByPropertyNames(any(), ServiceName.approvedPremises) } returns listOf(roomCharacteristic)
+    every { userService.getUserForRequest() } returns user
+    every { offenderService.getPersonSummaryInfoResults(any(), any()) } returns personSummaries
+    every { cas1SpaceBookingDaySummaryTransformer.toCas1SpaceBookingDaySummary(spaceBookingSummaries[0], any()) } returns booking1DaySummary
+    every { cas1SpaceBookingDaySummaryTransformer.toCas1SpaceBookingDaySummary(spaceBookingSummaries[1], any()) } returns booking2DaySummary
+
+    val result = service.getBookingDaySummaries(
+      premisesId,
+      LocalDate.now(),
+      listOf(Cas1SpaceBookingCharacteristic.IS_SINGLE),
+      Cas1SpaceBookingDaySummarySortField.PERSON_NAME,
+      SortDirection.desc,
+    )
+
+    assertThat(result).isInstanceOf(CasResult.Success::class.java)
+    result as CasResult.Success
+    val daySummaries = result.value
+    assertThat(daySummaries.size).isEqualTo(2)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedSummaryTransformerTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedSummaryTransformer
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1OutOfServiceBedSummaryTransformerTest {
+
+  private val cas1OutOfServiceBedReasonTransformer = mockk<Cas1OutOfServiceBedReasonTransformer>()
+
+  private val transformer = Cas1OutOfServiceBedSummaryTransformer(
+    cas1OutOfServiceBedReasonTransformer,
+  )
+
+  @Test
+  fun toCas1OutOfServiceBedSummary() {
+    val roomCharacteristic = CharacteristicEntity(
+      id = UUID.randomUUID(),
+      propertyName = "hasLift",
+      name = "hasLift",
+      serviceScope = "approved-premises",
+      modelScope = "room",
+      isActive = true,
+    )
+    val room = RoomEntityFactory()
+      .withName("BedRoom 1")
+      .withCharacteristics(mutableListOf(roomCharacteristic))
+      .withDefaults()
+      .produce()
+    val startDate = LocalDate.now().plusDays(1)
+    val endDate = startDate.plusDays(10)
+    val bed = BedEntityFactory()
+      .withDefaults()
+      .withRoom(room)
+      .produce()
+    val outOfServiceReason = Cas1OutOfServiceBedReasonEntityFactory()
+      .produce()
+
+    val expectedReason = Cas1OutOfServiceBedReason(
+      id = outOfServiceReason.id,
+      name = outOfServiceReason.name,
+      isActive = true,
+    )
+
+    val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()
+      .withBed(bed)
+      .produce()
+      .apply {
+        this.revisionHistory += Cas1OutOfServiceBedRevisionEntityFactory()
+          .withOutOfServiceBed(this)
+          .withStartDate(startDate)
+          .withEndDate(endDate)
+          .withReason(outOfServiceReason)
+          .produce()
+      }
+
+    every { cas1OutOfServiceBedReasonTransformer.transformJpaToApi(any()) } returns expectedReason
+
+    val result = transformer.toCas1OutOfServiceBedSummary(outOfServiceBed)
+
+    assertThat(result.id).isEqualTo(outOfServiceBed.id)
+    assertThat(result.roomName).isEqualTo(bed.room.name)
+    assertThat(result.startDate).isEqualTo(outOfServiceBed.startDate)
+    assertThat(result.endDate).isEqualTo(outOfServiceBed.endDate)
+    assertThat(result.characteristics.size).isEqualTo(1)
+    assertThat(result.characteristics[0].name).isEqualTo(roomCharacteristic.name)
+    val reason = result.reason
+    assertThat(reason.id).isEqualTo(expectedReason.id)
+    assertThat(reason.name).isEqualTo(expectedReason.name)
+    assertThat(reason.isActive).isEqualTo(expectedReason.isActive)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacityForDay
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCharacteristicAvailability
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremisesDayTransformer
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1PremisesDayTransformerTest {
+
+  @InjectMockKs
+  lateinit var transformer: Cas1PremisesDayTransformer
+
+  @Test
+  fun toCas1PremisesDaySummary() {
+    val premise = ApprovedPremisesEntityFactory().withDefaults().produce()
+    val cas1PremisesSummary = Cas1PremisesSummary(
+      id = premise.id,
+      name = premise.name,
+      apCode = premise.apCode,
+      postcode = premise.postcode,
+      apArea = ApArea(UUID.randomUUID(), "identifier", "name"),
+      bedCount = 5,
+      availableBeds = 4,
+      outOfServiceBeds = 1,
+      supportsSpaceBookings = true,
+      overbookingSummary = emptyList(),
+      managerDetails = "manager details",
+    )
+
+    val currentSearchDay = LocalDate.now()
+
+    val capacity = listOf(
+      Cas1PremiseCapacityForDay(
+        date = currentSearchDay,
+        totalBedCount = 5,
+        availableBedCount = 3,
+        bookingCount = 4,
+        characteristicAvailability = listOf(
+          Cas1PremiseCharacteristicAvailability(Cas1SpaceCharacteristic.isSingle, 10, 4),
+          Cas1PremiseCharacteristicAvailability(Cas1SpaceCharacteristic.isWheelchairAccessible, 20, 8),
+        ),
+      ),
+    )
+
+    val premiseCapacity = Cas1PremiseCapacity(
+      premise = cas1PremisesSummary,
+      startDate = currentSearchDay,
+      endDate = currentSearchDay,
+      capacity = capacity,
+    )
+
+    val result = transformer.toCas1PremisesDaySummary(
+      currentSearchDay,
+      premiseCapacity,
+    )
+
+    assertThat(result.forDate).isEqualTo(currentSearchDay)
+    assertThat(result.previousDate).isEqualTo(currentSearchDay.minusDays(1))
+    assertThat(result.nextDate).isEqualTo(currentSearchDay.plusDays(1))
+    assertThat(result.capacity).isEqualTo(capacity[0])
+    assertThat(result.spaceBookings).isEmpty()
+    assertThat(result.outOfServiceBeds).isEmpty()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
@@ -5,16 +5,15 @@ import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacityForDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCharacteristicAvailability
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummaryDiscriminator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPersonSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremisesDayTransformer
 import java.time.LocalDate
 import java.util.UUID
@@ -27,24 +26,9 @@ class Cas1PremisesDayTransformerTest {
 
   @Test
   fun toCas1PremisesDaySummary() {
-    val premise = ApprovedPremisesEntityFactory().withDefaults().produce()
-    val cas1PremisesSummary = Cas1PremisesSummary(
-      id = premise.id,
-      name = premise.name,
-      apCode = premise.apCode,
-      postcode = premise.postcode,
-      apArea = ApArea(UUID.randomUUID(), "identifier", "name"),
-      bedCount = 5,
-      availableBeds = 4,
-      outOfServiceBeds = 1,
-      supportsSpaceBookings = true,
-      overbookingSummary = emptyList(),
-      managerDetails = "manager details",
-    )
-
     val currentSearchDay = LocalDate.now()
 
-    val capacity = listOf(
+    val capacity =
       Cas1PremiseCapacityForDay(
         date = currentSearchDay,
         totalBedCount = 5,
@@ -54,8 +38,7 @@ class Cas1PremisesDayTransformerTest {
           Cas1PremiseCharacteristicAvailability(Cas1SpaceBookingCharacteristic.IS_SINGLE, 10, 4),
           Cas1PremiseCharacteristicAvailability(Cas1SpaceBookingCharacteristic.IS_WHEELCHAIR_DESIGNATED, 20, 8),
         ),
-      ),
-    )
+      )
 
     val spaceBookings = listOf(
       Cas1SpaceBookingDaySummary(
@@ -72,24 +55,28 @@ class Cas1PremisesDayTransformerTest {
       ),
     )
 
-    val premiseCapacity = Cas1PremiseCapacity(
-      premise = cas1PremisesSummary,
-      startDate = currentSearchDay,
-      endDate = currentSearchDay,
-      capacity = capacity,
+    val outOfServiceBeds = listOf(
+      Cas1OutOfServiceBedSummary(
+        id = UUID.randomUUID(),
+        startDate = LocalDate.now().minusDays(5),
+        endDate = LocalDate.now().plusDays(5),
+        reason = Cas1OutOfServiceBedReason(UUID.randomUUID(), "reason", true),
+        characteristics = listOf(Cas1SpaceCharacteristic.isSingle),
+      ),
     )
 
     val result = transformer.toCas1PremisesDaySummary(
       currentSearchDay,
-      premiseCapacity,
+      capacity,
       spaceBookings,
+      outOfServiceBeds,
     )
 
     assertThat(result.forDate).isEqualTo(currentSearchDay)
     assertThat(result.previousDate).isEqualTo(currentSearchDay.minusDays(1))
     assertThat(result.nextDate).isEqualTo(currentSearchDay.plusDays(1))
-    assertThat(result.capacity).isEqualTo(capacity[0])
+    assertThat(result.capacity).isEqualTo(capacity)
     assertThat(result.spaceBookings).isEqualTo(spaceBookings)
-    assertThat(result.outOfServiceBeds).isEmpty()
+    assertThat(result.outOfServiceBeds).isEqualTo(outOfServiceBeds)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
@@ -10,7 +10,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacityForDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCharacteristicAvailability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummaryDiscriminator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPersonSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremisesDayTransformer
 import java.time.LocalDate
@@ -48,9 +51,24 @@ class Cas1PremisesDayTransformerTest {
         availableBedCount = 3,
         bookingCount = 4,
         characteristicAvailability = listOf(
-          Cas1PremiseCharacteristicAvailability(Cas1SpaceCharacteristic.isSingle, 10, 4),
-          Cas1PremiseCharacteristicAvailability(Cas1SpaceCharacteristic.isWheelchairAccessible, 20, 8),
+          Cas1PremiseCharacteristicAvailability(Cas1SpaceBookingCharacteristic.IS_SINGLE, 10, 4),
+          Cas1PremiseCharacteristicAvailability(Cas1SpaceBookingCharacteristic.IS_WHEELCHAIR_DESIGNATED, 20, 8),
         ),
+      ),
+    )
+
+    val spaceBookings = listOf(
+      Cas1SpaceBookingDaySummary(
+        id = UUID.randomUUID(),
+        person = RestrictedPersonSummary(
+          crn = "crn",
+          personType = PersonSummaryDiscriminator.restrictedPersonSummary,
+        ),
+        canonicalArrivalDate = currentSearchDay.minusDays(1),
+        canonicalDepartureDate = currentSearchDay.plusDays(1),
+        tier = "Tier 1",
+        releaseType = "rotl",
+        essentialCharacteristics = listOf(Cas1SpaceBookingCharacteristic.IS_SINGLE, Cas1SpaceBookingCharacteristic.HAS_EN_SUITE),
       ),
     )
 
@@ -64,13 +82,14 @@ class Cas1PremisesDayTransformerTest {
     val result = transformer.toCas1PremisesDaySummary(
       currentSearchDay,
       premiseCapacity,
+      spaceBookings,
     )
 
     assertThat(result.forDate).isEqualTo(currentSearchDay)
     assertThat(result.previousDate).isEqualTo(currentSearchDay.minusDays(1))
     assertThat(result.nextDate).isEqualTo(currentSearchDay.plusDays(1))
     assertThat(result.capacity).isEqualTo(capacity[0])
-    assertThat(result.spaceBookings).isEmpty()
+    assertThat(result.spaceBookings).isEqualTo(spaceBookings)
     assertThat(result.outOfServiceBeds).isEmpty()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingDaySummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingDaySummaryTransformerTest.kt
@@ -1,0 +1,100 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPersonSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingDaySummarySearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingDaySummaryTransformer
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1SpaceBookingDaySummaryTransformerTest {
+
+  private val releaseTypeToBeDetermined = "TBD"
+  private val transformer = Cas1SpaceBookingDaySummaryTransformer()
+
+  @ParameterizedTest
+  @EnumSource(value = Cas1SpaceBookingCharacteristic::class)
+  fun `toCas1SpaceBookingDaySummary`(characteristic: Cas1SpaceBookingCharacteristic) {
+    val spaceBookingSummary =
+      Cas1SpaceBookingDaySummarySearchResultImpl(
+        UUID.randomUUID(),
+        "crn1",
+        LocalDate.now().minusDays(3),
+        LocalDate.now().plusDays(3),
+        tier = "A1",
+        releaseType = "rotl",
+        characteristicsPropertyNames = characteristic.value,
+      )
+    val personSummary = PersonTransformer()
+      .personSummaryInfoToPersonSummary(
+        PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
+      )
+
+    val result = transformer.toCas1SpaceBookingDaySummary(
+      spaceBookingSummary,
+      personSummary,
+    )
+
+    assertThat(result.id).isEqualTo(spaceBookingSummary.id)
+    assertThat(result.canonicalArrivalDate).isEqualTo(spaceBookingSummary.canonicalArrivalDate)
+    assertThat(result.canonicalDepartureDate).isEqualTo(spaceBookingSummary.canonicalDepartureDate)
+    assertThat(result.tier).isEqualTo(spaceBookingSummary.tier)
+    assertThat(result.releaseType).isEqualTo(releaseTypeToBeDetermined)
+    assertThat(result.essentialCharacteristics.size).isEqualTo(1)
+    assertThat(result.essentialCharacteristics[0]).isEqualTo(characteristic)
+    val offender = result.person as FullPersonSummary
+    assertThat(offender.crn).isEqualTo(personSummary.crn)
+    assertThat(offender.name).isEqualTo((personSummary as FullPersonSummary).name)
+  }
+
+  @Test
+  fun `toCas1SpaceBookingDaySummary with multiple characteristics`() {
+    val spaceBookingSummary =
+      Cas1SpaceBookingDaySummarySearchResultImpl(
+        UUID.randomUUID(),
+        "crn1",
+        LocalDate.now().minusDays(3),
+        LocalDate.now().plusDays(3),
+        tier = "A1",
+        releaseType = "rotl",
+        characteristicsPropertyNames = "isArsonSuitable,hasEnSuite,isSingle,isStepFreeDesignated,isSuitedForSexOffenders,isWheelchairDesignated",
+      )
+    val personSummary = PersonTransformer()
+      .personSummaryInfoToPersonSummary(
+        PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
+      )
+
+    val result = transformer.toCas1SpaceBookingDaySummary(
+      spaceBookingSummary,
+      personSummary,
+    )
+
+    assertThat(result.essentialCharacteristics.size).isEqualTo(6)
+    assertThat(result.essentialCharacteristics[0]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_ARSON_SUITABLE)
+    assertThat(result.essentialCharacteristics[1]).isEqualTo(Cas1SpaceBookingCharacteristic.HAS_EN_SUITE)
+    assertThat(result.essentialCharacteristics[2]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_SINGLE)
+    assertThat(result.essentialCharacteristics[3]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_STEP_FREE_DESIGNATED)
+    assertThat(result.essentialCharacteristics[4]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_SUITED_FOR_SEX_OFFENDERS)
+    assertThat(result.essentialCharacteristics[5]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_WHEELCHAIR_DESIGNATED)
+  }
+}
+
+data class Cas1SpaceBookingDaySummarySearchResultImpl(
+  override val id: UUID,
+  override val crn: String,
+  override val canonicalArrivalDate: LocalDate,
+  override val canonicalDepartureDate: LocalDate,
+  override val tier: String,
+  override val releaseType: String,
+  override val characteristicsPropertyNames: String,
+) : Cas1SpaceBookingDaySummarySearchResult


### PR DESCRIPTION
Implement Day Summary Endpoint. 

GET /cas1/premises/{premiseId}/day-summary/{date}
Given a premises id and a specific date, the endpoint returns information on capacity, bookings and out of service beds for the given date. 

3 Separate commits covering 3 parts of functionality : 

- Populate capacity information (and date fields)
- Populate booking information with filtering and sorting implemented
- Populate out of service bed information

Release Type still to be determined
