### PR TITLE
Remove 'AnyValue' component.

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1671,9 +1671,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
             assessmentId:
@@ -1721,9 +1721,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             submittedAt:
@@ -1761,7 +1761,7 @@ components:
         outdatedSchema:
           type: boolean
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         submittedAt:
           type: string
           format: date-time
@@ -1798,9 +1798,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
@@ -2150,9 +2150,6 @@ components:
         - requestedFurtherInformation
         - pendingPlacementRequest
         - expired
-    AnyValue:
-      description: Any object that conforms to the current JSON schema for an application
-      type: object
     Unit:
       description: Any object
       type: object
@@ -2216,7 +2213,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -2270,7 +2267,7 @@ components:
         type:
           type: string
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -2342,7 +2339,7 @@ components:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         applicationId:
           type: string
           format: uuid
@@ -2414,7 +2411,7 @@ components:
                 type: string
                 example: 'PSS'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
           required:
             - arrivalDate
             - summaryData
@@ -2535,7 +2532,7 @@ components:
         rejectionRationale:
           type: string
         data:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         clarificationNotes:
           type: array
           items:
@@ -2625,7 +2622,7 @@ components:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             releaseDate:
               type: string
               format: date
@@ -2790,7 +2787,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
         releaseDate:
           type: string
           format: date
@@ -2803,7 +2800,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         requirements:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
@@ -2818,7 +2815,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         rejectionRationale:
           type: string
         referralRejectionReasonId:
@@ -2912,7 +2909,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:
@@ -3834,9 +3831,9 @@ components:
               type: string
               format: date-time
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             canBeWithdrawn:
               type: boolean
             isWithdrawn:
@@ -3876,14 +3873,14 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       required:
         - data
     SubmitPlacementApplication:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         placementType:
           $ref: '#/components/schemas/PlacementType'
         placementDates:
@@ -3952,7 +3949,7 @@ components:
             If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
           format: date-time
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         canBeDirectlyWithdrawn:
           description: |
             If true, the user making this request can withdraw this request for placement. 

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5972,9 +5972,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
             assessmentId:
@@ -6022,9 +6022,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             submittedAt:
@@ -6062,7 +6062,7 @@ components:
         outdatedSchema:
           type: boolean
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         submittedAt:
           type: string
           format: date-time
@@ -6099,9 +6099,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
@@ -6451,9 +6451,6 @@ components:
         - requestedFurtherInformation
         - pendingPlacementRequest
         - expired
-    AnyValue:
-      description: Any object that conforms to the current JSON schema for an application
-      type: object
     Unit:
       description: Any object
       type: object
@@ -6517,7 +6514,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -6571,7 +6568,7 @@ components:
         type:
           type: string
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -6643,7 +6640,7 @@ components:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         applicationId:
           type: string
           format: uuid
@@ -6715,7 +6712,7 @@ components:
                 type: string
                 example: 'PSS'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
           required:
             - arrivalDate
             - summaryData
@@ -6836,7 +6833,7 @@ components:
         rejectionRationale:
           type: string
         data:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         clarificationNotes:
           type: array
           items:
@@ -6926,7 +6923,7 @@ components:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             releaseDate:
               type: string
               format: date
@@ -7091,7 +7088,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
         releaseDate:
           type: string
           format: date
@@ -7104,7 +7101,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         requirements:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
@@ -7119,7 +7116,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         rejectionRationale:
           type: string
         referralRejectionReasonId:
@@ -7213,7 +7210,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:
@@ -8135,9 +8132,9 @@ components:
               type: string
               format: date-time
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             canBeWithdrawn:
               type: boolean
             isWithdrawn:
@@ -8177,14 +8174,14 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       required:
         - data
     SubmitPlacementApplication:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         placementType:
           $ref: '#/components/schemas/PlacementType'
         placementDates:
@@ -8253,7 +8250,7 @@ components:
             If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
           format: date-time
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         canBeDirectlyWithdrawn:
           description: |
             If true, the user making this request can withdraw this request for placement. 

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2893,9 +2893,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
             assessmentId:
@@ -2943,9 +2943,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             submittedAt:
@@ -2983,7 +2983,7 @@ components:
         outdatedSchema:
           type: boolean
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         submittedAt:
           type: string
           format: date-time
@@ -3020,9 +3020,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
@@ -3372,9 +3372,6 @@ components:
         - requestedFurtherInformation
         - pendingPlacementRequest
         - expired
-    AnyValue:
-      description: Any object that conforms to the current JSON schema for an application
-      type: object
     Unit:
       description: Any object
       type: object
@@ -3438,7 +3435,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -3492,7 +3489,7 @@ components:
         type:
           type: string
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -3564,7 +3561,7 @@ components:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         applicationId:
           type: string
           format: uuid
@@ -3636,7 +3633,7 @@ components:
                 type: string
                 example: 'PSS'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
           required:
             - arrivalDate
             - summaryData
@@ -3757,7 +3754,7 @@ components:
         rejectionRationale:
           type: string
         data:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         clarificationNotes:
           type: array
           items:
@@ -3847,7 +3844,7 @@ components:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             releaseDate:
               type: string
               format: date
@@ -4012,7 +4009,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
         releaseDate:
           type: string
           format: date
@@ -4025,7 +4022,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         requirements:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
@@ -4040,7 +4037,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         rejectionRationale:
           type: string
         referralRejectionReasonId:
@@ -4134,7 +4131,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:
@@ -5056,9 +5053,9 @@ components:
               type: string
               format: date-time
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             canBeWithdrawn:
               type: boolean
             isWithdrawn:
@@ -5098,14 +5095,14 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       required:
         - data
     SubmitPlacementApplication:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         placementType:
           $ref: '#/components/schemas/PlacementType'
         placementDates:
@@ -5174,7 +5171,7 @@ components:
             If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
           format: date-time
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         canBeDirectlyWithdrawn:
           description: |
             If true, the user making this request can withdraw this request for placement. 

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2262,9 +2262,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
             assessmentId:
@@ -2312,9 +2312,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             submittedAt:
@@ -2352,7 +2352,7 @@ components:
         outdatedSchema:
           type: boolean
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         submittedAt:
           type: string
           format: date-time
@@ -2389,9 +2389,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
@@ -2741,9 +2741,6 @@ components:
         - requestedFurtherInformation
         - pendingPlacementRequest
         - expired
-    AnyValue:
-      description: Any object that conforms to the current JSON schema for an application
-      type: object
     Unit:
       description: Any object
       type: object
@@ -2807,7 +2804,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -2861,7 +2858,7 @@ components:
         type:
           type: string
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -2933,7 +2930,7 @@ components:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         applicationId:
           type: string
           format: uuid
@@ -3005,7 +3002,7 @@ components:
                 type: string
                 example: 'PSS'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
           required:
             - arrivalDate
             - summaryData
@@ -3126,7 +3123,7 @@ components:
         rejectionRationale:
           type: string
         data:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         clarificationNotes:
           type: array
           items:
@@ -3216,7 +3213,7 @@ components:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             releaseDate:
               type: string
               format: date
@@ -3381,7 +3378,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
         releaseDate:
           type: string
           format: date
@@ -3394,7 +3391,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         requirements:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
@@ -3409,7 +3406,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         rejectionRationale:
           type: string
         referralRejectionReasonId:
@@ -3503,7 +3500,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:
@@ -4425,9 +4422,9 @@ components:
               type: string
               format: date-time
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             canBeWithdrawn:
               type: boolean
             isWithdrawn:
@@ -4467,14 +4464,14 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       required:
         - data
     SubmitPlacementApplication:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         placementType:
           $ref: '#/components/schemas/PlacementType'
         placementDates:
@@ -4543,7 +4540,7 @@ components:
             If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
           format: date-time
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         canBeDirectlyWithdrawn:
           description: |
             If true, the user making this request can withdraw this request for placement. 

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1770,9 +1770,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
             assessmentId:
@@ -1820,9 +1820,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             submittedAt:
@@ -1860,7 +1860,7 @@ components:
         outdatedSchema:
           type: boolean
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         submittedAt:
           type: string
           format: date-time
@@ -1897,9 +1897,9 @@ components:
             outdatedSchema:
               type: boolean
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             status:
               $ref: '#/components/schemas/ApplicationStatus'
             risks:
@@ -2249,9 +2249,6 @@ components:
         - requestedFurtherInformation
         - pendingPlacementRequest
         - expired
-    AnyValue:
-      description: Any object that conforms to the current JSON schema for an application
-      type: object
     Unit:
       description: Any object
       type: object
@@ -2315,7 +2312,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -2369,7 +2366,7 @@ components:
         type:
           type: string
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
       discriminator:
         propertyName: type
         mapping:
@@ -2441,7 +2438,7 @@ components:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         applicationId:
           type: string
           format: uuid
@@ -2513,7 +2510,7 @@ components:
                 type: string
                 example: 'PSS'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
           required:
             - arrivalDate
             - summaryData
@@ -2634,7 +2631,7 @@ components:
         rejectionRationale:
           type: string
         data:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         clarificationNotes:
           type: array
           items:
@@ -2724,7 +2721,7 @@ components:
             status:
               $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
             summaryData:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             releaseDate:
               type: string
               format: date
@@ -2889,7 +2886,7 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
         releaseDate:
           type: string
           format: date
@@ -2902,7 +2899,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         requirements:
           $ref: '#/components/schemas/PlacementRequirements'
         placementDates:
@@ -2917,7 +2914,7 @@ components:
       type: object
       properties:
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         rejectionRationale:
           type: string
         referralRejectionReasonId:
@@ -3011,7 +3008,7 @@ components:
         isWithdrawn:
           type: boolean
         domainEvent:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
     ReferralHistoryDomainEventNote:
       type: object
       allOf:
@@ -3933,9 +3930,9 @@ components:
               type: string
               format: date-time
             data:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             document:
-              $ref: '#/components/schemas/AnyValue'
+              $ref: '#/components/schemas/Unit'
             canBeWithdrawn:
               type: boolean
             isWithdrawn:
@@ -3975,14 +3972,14 @@ components:
         data:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AnyValue'
+            $ref: '#/components/schemas/Unit'
       required:
         - data
     SubmitPlacementApplication:
       type: object
       properties:
         translatedDocument:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         placementType:
           $ref: '#/components/schemas/PlacementType'
         placementDates:
@@ -4051,7 +4048,7 @@ components:
             If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
           format: date-time
         document:
-          $ref: '#/components/schemas/AnyValue'
+          $ref: '#/components/schemas/Unit'
         canBeDirectlyWithdrawn:
           description: |
             If true, the user making this request can withdraw this request for placement. 


### PR DESCRIPTION
This generates in kotlin as 'Any', which is then generated in documentation as 'Unit' by springdoc. The UI has been changed to reflect this, for when we switch over to autogenerated documentation