### PR TITLE
APS-1733 - Simplify XLSX Seeding API Calls

### DIFF
--- a/script/run_seed_from_excel_job
+++ b/script/run_seed_from_excel_job
@@ -6,12 +6,20 @@
 
 set -e
 
+SEED_JOB_ID=$1
+FILE_NAME=$2
+
+if [ -z "$SEED_JOB_ID" ] || [ -z "$FILE_NAME" ]
+then
+  echo "Usage: run_seed_from_excel_job seed_job_id file_name"
+  exit 1
+fi
+
 curl --location --request POST 'http://127.0.0.1:8080/seedFromExcel' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-    "seedType": "'$1'",
-    "premisesId": "'$2'",
-    "fileName": "'"$3"'"
+    "seedType": "'"$SEED_JOB_ID"'",
+    "fileName": "'"$FILE_NAME"'"
 }'
 
 echo "Requested job - check the application logs for processing status"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedFromExcelController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/SeedFromExcelController.kt
@@ -12,7 +12,7 @@ class SeedFromExcelController(private val seedXslxService: SeedXlsxService) : Se
   override fun seedFromExcelPost(seedFromExcelRequest: SeedFromExcelRequest): ResponseEntity<Unit> {
     throwIfNotLoopbackRequest()
 
-    seedXslxService.seedExcelData(seedFromExcelRequest.seedType, seedFromExcelRequest.premisesId, seedFromExcelRequest.fileName)
+    seedXslxService.seedExcelData(seedFromExcelRequest.seedType, seedFromExcelRequest.fileName)
 
     return ResponseEntity(HttpStatus.ACCEPTED)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
 
 import java.io.File
-import java.util.UUID
 
 abstract class SeedJob<RowType>(
   val requiredHeaders: Set<String>? = null,
@@ -29,7 +28,7 @@ abstract class SeedJob<RowType>(
 
 @Suppress("TooGenericExceptionThrown")
 interface ExcelSeedJob {
-  fun processXlsx(file: File, premisesId: UUID)
+  fun processXlsx(file: File)
 }
 
 class SeedException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedXlsxService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedXlsxService.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1SeedRoomsF
 import java.io.File
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
-import java.util.UUID
 import kotlin.reflect.KClass
 
 @Service
@@ -21,7 +20,7 @@ class SeedXlsxService(
   private val seedLogger: SeedLogger,
 ) {
   @SuppressWarnings("TooGenericExceptionThrown", "TooGenericExceptionCaught")
-  fun seedExcelData(excelSeedFileType: SeedFromExcelFileType, premisesId: UUID, filename: String) {
+  fun seedExcelData(excelSeedFileType: SeedFromExcelFileType, filename: String) {
     seedLogger.info("Starting seed request: $excelSeedFileType - $filename")
 
     try {
@@ -38,7 +37,7 @@ class SeedXlsxService(
 
       val seedStarted = LocalDateTime.now()
 
-      transactionTemplate.executeWithoutResult { processExcelJob(job, premisesId, file) }
+      transactionTemplate.executeWithoutResult { processExcelJob(job, file) }
 
       val timeTaken = ChronoUnit.MILLIS.between(seedStarted, LocalDateTime.now())
       seedLogger.info("Excel seed request complete. Took $timeTaken millis")
@@ -50,10 +49,10 @@ class SeedXlsxService(
   private fun <T : Any> getBean(clazz: KClass<T>) = applicationContext.getBean(clazz.java)
 
   @Suppress("TooGenericExceptionThrown", "TooGenericExceptionCaught")
-  private fun processExcelJob(job: ExcelSeedJob, premisesId: UUID, file: File) {
+  private fun processExcelJob(job: ExcelSeedJob, file: File) {
     seedLogger.info("Processing XLSX file ${file.absolutePath}")
     try {
-      job.processXlsx(file, premisesId)
+      job.processXlsx(file)
     } catch (exception: Exception) {
       throw RuntimeException("Unable to process XLSX file", exception)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedPremisesFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedPremisesFromSiteSurveyXlsxJob.kt
@@ -4,8 +4,6 @@ import jakarta.persistence.EntityManager
 import org.javers.core.Javers
 import org.javers.core.JaversBuilder
 import org.javers.core.diff.ListCompareAlgorithm
-import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.locationtech.jts.geom.Point
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -41,9 +39,8 @@ class Cas1SeedPremisesFromSiteSurveyXlsxJob(
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun processXlsx(file: File, premisesId: UUID) {
-    val dataFrame = DataFrame.readExcel(file, "Sheet2")
-    val siteSurveyPremise = Cas1SiteSurveyPremiseFactory().load(dataFrame)
+  override fun processXlsx(file: File) {
+    val siteSurveyPremise = Cas1SiteSurveyPremiseFactory().load(file)
     val premiseInfo = resolvePremiseInfo(siteSurveyPremise)
     val existingPremises = premisesRepository.findByQCode(siteSurveyPremise.qCode)
     if (existingPremises == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SiteSurveyPremiseFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SiteSurveyPremiseFactory.kt
@@ -3,17 +3,26 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.getColumn
+import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.jetbrains.kotlinx.dataframe.name
+import java.io.File
 
 class Cas1SiteSurveyPremiseFactory {
 
-  fun load(dataFrame: DataFrame<*>) = dataFrame.toInternalModel()
+  fun load(file: File) = toDataFame(file).toInternalModel()
+
+  fun getQCode(file: File) = toDataFame(file).getQCode()
+
+  private fun toDataFame(file: File) = DataFrame.readExcel(file, "Sheet2")
+
+  private fun DataFrame<*>.getQCode(): String {
+    ensureCorrectColumnCount()
+
+    return resolveAnswer("AP Identifier (Q No.)")
+  }
 
   private fun DataFrame<*>.toInternalModel(): Cas1SiteSurveyPremise {
-    val columnsCount = columnsCount()
-    if (columnsCount < 2) {
-      error("Inadequate number of columns. Expected at least 2 columns, got $columnsCount")
-    }
+    ensureCorrectColumnCount()
 
     return Cas1SiteSurveyPremise(
       name = resolveAnswer("Name of AP"),
@@ -51,6 +60,13 @@ class Cas1SiteSurveyPremiseFactory {
       hasAHearingLoop = resolveAnswer("Does this AP have or has access to a hearing loop?").dropDownYesNoToBoolean(),
       additionalRestrictions = resolveAnswer("Are there any additional restrictions on people that this AP can accommodate?"),
     )
+  }
+
+  private fun DataFrame<*>.ensureCorrectColumnCount() {
+    val columnsCount = columnsCount()
+    if (columnsCount < 2) {
+      error("Inadequate number of columns. Expected at least 2 columns, got $columnsCount")
+    }
   }
 
   /**

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3689,9 +3689,6 @@ components:
       properties:
         seedType:
           $ref: '#/components/schemas/SeedFromExcelFileType'
-        premisesId:
-          type: string
-          format: uuid
         fileName:
           type: string
       required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7990,9 +7990,6 @@ components:
       properties:
         seedType:
           $ref: '#/components/schemas/SeedFromExcelFileType'
-        premisesId:
-          type: string
-          format: uuid
         fileName:
           type: string
       required:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4911,9 +4911,6 @@ components:
       properties:
         seedType:
           $ref: '#/components/schemas/SeedFromExcelFileType'
-        premisesId:
-          type: string
-          format: uuid
         fileName:
           type: string
       required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4280,9 +4280,6 @@ components:
       properties:
         seedType:
           $ref: '#/components/schemas/SeedFromExcelFileType'
-        premisesId:
-          type: string
-          format: uuid
         fileName:
           type: string
       required:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3788,9 +3788,6 @@ components:
       properties:
         seedType:
           $ref: '#/components/schemas/SeedFromExcelFileType'
-        premisesId:
-          type: string
-          format: uuid
         fileName:
           type: string
       required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromSiteSurveyXlsxTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
@@ -13,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistrictEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DataFrameUtils.createNameValueDataFrame
 import java.util.UUID
 
 class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
@@ -28,8 +28,8 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `create new premise - all characteristics`() {
-    val header = listOf("Name of AP", "The Premise Name")
-    val rows = mutableListOf(
+    val dataFrame = createNameValueDataFrame(
+      "Name of AP", "The Premise Name",
       "AP Identifier (Q No.)", "Q123",
       "AP Area", "Irrelevant",
       "Probation Delivery Unit", "Irrelevant",
@@ -61,8 +61,6 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
       "Does this AP have or has access to a hearing loop?", "Yes",
       "Are there any additional restrictions on people that this AP can accommodate?", "Some useful notes here",
     )
-
-    val dataFrame = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "site_survey.xlsx",
@@ -126,8 +124,8 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `create new premise - no characteristics`() {
-    val header = listOf("Name of AP", "The Premise Name 2")
-    val rows = mutableListOf(
+    val dataFrame = createNameValueDataFrame(
+      "Name of AP", "The Premise Name 2",
       "AP Identifier (Q No.)", "Q123",
       "AP Area", "Irrelevant",
       "Probation Delivery Unit", "Irrelevant",
@@ -159,8 +157,6 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
       "Does this AP have or has access to a hearing loop?", "No",
       "Are there any additional restrictions on people that this AP can accommodate?", "Some useful notes here",
     )
-
-    val dataFrame = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "site_survey.xlsx",
@@ -239,8 +235,8 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
       ),
     )
 
-    val header = listOf("Name of AP", "The Premise Name")
-    val rows = mutableListOf(
+    val dataFrame = createNameValueDataFrame(
+      "Name of AP", "The Premise Name",
       "AP Identifier (Q No.)", "QExisting",
       "AP Area", "Irrelevant",
       "Probation Delivery Unit", "Irrelevant",
@@ -272,8 +268,6 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
       "Does this AP have or has access to a hearing loop?", "No",
       "Are there any additional restrictions on people that this AP can accommodate?", "Some useful notes here",
     )
-
-    val dataFrame = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "site_survey.xlsx",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromSiteSurveyXlsxTest.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistrictEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DataFrameUtils.createNameValueDataFrame
-import java.util.UUID
 
 class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
@@ -69,7 +68,6 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_PREMISES,
-      UUID.randomUUID(),
       "site_survey.xlsx",
     )
 
@@ -165,7 +163,6 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_PREMISES,
-      UUID.randomUUID(),
       "site_survey.xlsx",
     )
 
@@ -276,7 +273,6 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_PREMISES,
-      UUID.randomUUID(),
       "site_survey.xlsx",
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromSiteSurveyXlsxTest.kt
@@ -64,12 +64,15 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet2", dataFrame)
+    createXlsxForSeeding(
+      fileName = "site_survey.xlsx",
+      sheets = mapOf("Sheet2" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_PREMISES,
       UUID.randomUUID(),
-      "example.xlsx",
+      "site_survey.xlsx",
     )
 
     val createdPremise = approvedPremisesRepository.findByQCode("Q123")!!
@@ -159,12 +162,15 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet2", dataFrame)
+    createXlsxForSeeding(
+      fileName = "site_survey.xlsx",
+      sheets = mapOf("Sheet2" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_PREMISES,
       UUID.randomUUID(),
-      "example.xlsx",
+      "site_survey.xlsx",
     )
 
     val createdPremise = approvedPremisesRepository.findByQCode("Q123")!!
@@ -269,12 +275,15 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet2", dataFrame)
+    createXlsxForSeeding(
+      fileName = "site_survey.xlsx",
+      sheets = mapOf("Sheet2" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_PREMISES,
       UUID.randomUUID(),
-      "example.xlsx",
+      "site_survey.xlsx",
     )
 
     val createdPremise = approvedPremisesRepository.findByQCode("QExisting")!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFromExcelF
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.QuestionCriteriaMapping
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.SiteSurveyImportException
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DataFrameUtils.createNameValueDataFrame
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
@@ -37,12 +37,11 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
     val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
+    approvedPremisesEntityFactory.produceAndPersist {
       withLocalAuthorityArea(localAuthorityArea)
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val premisesId = premises.id
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
     val rows = mutableListOf(
@@ -53,20 +52,23 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     )
     rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf(0)))
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
-    createXlsxForSeeding(
-      fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+    withXlsx(
+      xlsxName = "example",
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
     val newRoom = roomRepository.findByCode("Q999 - 1")
+    assertThat(newRoom).isNotNull
     assertThat(newRoom!!.characteristics).anyMatch {
       it.name == "Is this room located on the ground floor?" &&
         it.propertyName == "isGroundFloor"
@@ -85,12 +87,11 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
     val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
+    approvedPremisesEntityFactory.produceAndPersist {
       withLocalAuthorityArea(localAuthorityArea)
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val premisesId = premises.id
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW", "SWABI02NEW", "SWABI03NEW")
     val rows = mutableListOf(
@@ -105,16 +106,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     )
     rows.addCharacteristics(3, mapOf("Is this room located on the ground floor?" to listOf(1)))
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
@@ -157,13 +160,11 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
     val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
+    approvedPremisesEntityFactory.produceAndPersist {
       withLocalAuthorityArea(localAuthorityArea)
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val premisesId = premises.id
-
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW", "SWABI02NEW", "SWABI03NEW")
     val rows = mutableListOf(
       "Room Number / Name",
@@ -177,16 +178,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     )
     rows.addCharacteristics(3, mapOf("Is this room located on the ground floor?" to listOf(1, 2)))
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
@@ -226,12 +229,11 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
     val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
+    approvedPremisesEntityFactory.produceAndPersist {
       withLocalAuthorityArea(localAuthorityArea)
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val premisesId = premises.id
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
     val rows = mutableListOf(
@@ -242,16 +244,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     )
     rows.addCharacteristics(1)
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
@@ -276,7 +280,6 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val premisesId = premises.id
     val roomCode = "$qCode - 1"
     roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -292,16 +295,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     )
     rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf(0)))
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
@@ -329,7 +334,6 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val premisesId = premises.id
     val roomCode = "$qCode - 1"
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -350,16 +354,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     )
     rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf(0)))
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
@@ -387,7 +393,6 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val premisesId = premises.id
     val roomCode = "$qCode - 1"
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -408,16 +413,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     )
     rows.addCharacteristics(1)
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
@@ -434,11 +441,12 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
   fun `Invalid questions throws exception, fails to process xlsx, rolls back transaction and logs an error`() {
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
     val probationRegion = probationRegionEntityFactory.produceAndPersist()
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
+    val qCode = "Q999"
+    approvedPremisesEntityFactory.produceAndPersist {
       withLocalAuthorityArea(localAuthorityArea)
       withProbationRegion(probationRegion)
+      withQCode("Q999")
     }
-    val premisesId = premises.id
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
     val rows = mutableListOf(
@@ -450,16 +458,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     rows.addCharacteristics(1)
     rows.replaceAll { if (it == "Is this room located on the ground floor?") "Bad question" else it }
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
@@ -478,11 +488,12 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
   fun `Invalid answer throws exception, fails to process xlsx, rolls back transaction and logs an error`() {
     val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
     val probationRegion = probationRegionEntityFactory.produceAndPersist()
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
+    val qCode = "Q999"
+    approvedPremisesEntityFactory.produceAndPersist {
       withLocalAuthorityArea(localAuthorityArea)
       withProbationRegion(probationRegion)
+      withQCode("Q999")
     }
-    val premisesId = premises.id
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
     val rows = mutableListOf(
@@ -494,16 +505,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf(0)))
     rows.replaceAll { if (it == "Yes") "Bad answer" else it }
 
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      premisesId,
       "example.xlsx",
     )
 
@@ -522,16 +535,18 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
   fun `Creating a new room for a premise that doesn't exist throws error`() {
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
     val rows = listOf("", "")
-    val dataFrame = dataFrameOf(header, rows)
+    val roomsSheet = dataFrameOf(header, rows)
 
     createXlsxForSeeding(
       fileName = "example.xlsx",
-      sheets = mapOf("Sheet3" to dataFrame),
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", "INVALIDQCODE"),
+        "Sheet3" to roomsSheet,
+      ),
     )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-      UUID.fromString("97d6b3f1-3121-4afb-a4a6-e4a84b533c18"),
       "example.xlsx",
     )
 
@@ -542,7 +557,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
           it.throwable != null &&
           it.throwable.message == "Unable to process XLSX file" &&
           it.throwable.cause is SiteSurveyImportException &&
-          it.throwable.cause!!.message == "No premises with id '97d6b3f1-3121-4afb-a4a6-e4a84b533c18' found."
+          it.throwable.cause!!.message == "No premises with qcode 'INVALIDQCODE' found."
       }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
@@ -55,7 +55,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -104,7 +107,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -173,7 +179,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -235,7 +244,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -282,7 +294,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -337,7 +352,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -392,7 +410,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -431,7 +452,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -472,7 +496,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
@@ -497,7 +524,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     val rows = listOf("", "")
     val dataFrame = dataFrameOf(header, rows)
 
-    withXlsx("example", "Sheet3", dataFrame)
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf("Sheet3" to dataFrame),
+    )
 
     seedXlsxService.seedExcelData(
       SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.LogEntry
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption
 import kotlin.io.path.Path
+import kotlin.io.path.pathString
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 abstract class SeedTestBase : IntegrationTestBase() {
@@ -67,13 +68,26 @@ abstract class SeedTestBase : IntegrationTestBase() {
     )
   }
 
-  protected fun withXlsx(xlsxName: String, sheetName: String, dataFrame: DataFrame<*>) {
-    if (!Files.isDirectory(Path(seedFilePrefix))) {
-      Files.createDirectory(Path(seedFilePrefix))
+  protected fun createXlsxForSeeding(fileName: String, sheets: Map<String, DataFrame<*>>) {
+    val dir = Path(seedFilePrefix)
+
+    if (!Files.isDirectory(dir)) {
+      Files.createDirectory(dir)
     }
-    dataFrame.writeExcel(
-      "$seedFilePrefix/$xlsxName.xlsx",
-      sheetName = sheetName,
-    )
+
+    val file = dir.resolve(fileName)
+    if (Files.exists(file)) {
+      Files.delete(file)
+    }
+
+    var fileExists = false
+    sheets.forEach { (name, dataFrame) ->
+      dataFrame.writeExcel(
+        path = file.pathString,
+        sheetName = name,
+        keepFile = fileExists,
+      )
+      fileExists = true
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedXlsxService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.LogEntry
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption
 import kotlin.io.path.Path
@@ -84,6 +85,26 @@ abstract class SeedTestBase : IntegrationTestBase() {
     sheets.forEach { (name, dataFrame) ->
       dataFrame.writeExcel(
         path = file.pathString,
+        sheetName = name,
+        keepFile = fileExists,
+      )
+      fileExists = true
+    }
+  }
+
+  protected fun withXlsx(xlsxName: String, sheets: Map<String, DataFrame<*>>) {
+    if (!Files.isDirectory(Path(seedFilePrefix))) {
+      Files.createDirectory(Path(seedFilePrefix))
+    }
+    val path = "$seedFilePrefix/$xlsxName.xlsx"
+    if (File(path).exists()) {
+      File(path).delete()
+    }
+
+    var fileExists = false
+    sheets.forEach { (name, dataFrame) ->
+      dataFrame.writeExcel(
+        "$seedFilePrefix/$xlsxName.xlsx",
         sheetName = name,
         keepFile = fileExists,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedXlsxScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedXlsxScaffoldingTest.kt
@@ -5,7 +5,6 @@ import org.jetbrains.kotlinx.dataframe.api.emptyDataFrame
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFromExcelFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFromExcelRequest
-import java.util.UUID
 
 class SeedXlsxScaffoldingTest : SeedTestBase() {
 
@@ -16,7 +15,6 @@ class SeedXlsxScaffoldingTest : SeedTestBase() {
       .bodyValue(
         SeedFromExcelRequest(
           seedType = SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
-          premisesId = UUID.randomUUID(),
           fileName = "file.xlsx",
         ),
       )
@@ -27,7 +25,7 @@ class SeedXlsxScaffoldingTest : SeedTestBase() {
 
   @Test
   fun `Attempting to process an xlsx file containing forward slashes logs an error`() {
-    seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS, UUID.randomUUID(), "/afile")
+    seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS, "/afile")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -41,7 +39,7 @@ class SeedXlsxScaffoldingTest : SeedTestBase() {
 
   @Test
   fun `Attempting to process an xlsx file containing backward slashes logs an error`() {
-    seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS, UUID.randomUUID(), "\\afile")
+    seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS, "\\afile")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -55,7 +53,7 @@ class SeedXlsxScaffoldingTest : SeedTestBase() {
 
   @Test
   fun `Attempting to process a non-existent xlsx file logs an error`() {
-    seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS, UUID.randomUUID(), "non-existent")
+    seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS, "non-existent")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -74,13 +72,13 @@ class SeedXlsxScaffoldingTest : SeedTestBase() {
       sheets = mapOf("wrongSheetName" to emptyDataFrame<Any>()),
     )
 
-    seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS, UUID.randomUUID(), "wrongSheetName.xlsx")
+    seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_PREMISES, "wrongSheetName.xlsx")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
         it.message == "Unable to complete Excel seed job" &&
         it.throwable != null &&
-        it.throwable.cause!!.message == "Sheet with name Sheet3 not found"
+        it.throwable.cause!!.message == "Sheet with name Sheet2 not found"
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedXlsxScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedXlsxScaffoldingTest.kt
@@ -69,10 +69,9 @@ class SeedXlsxScaffoldingTest : SeedTestBase() {
 
   @Test
   fun `Attempting to process an xlsx file without Sheet3 logs an error`() {
-    withXlsx(
-      "wrongSheetName",
-      "wrongSheetName",
-      emptyDataFrame<Any>(),
+    createXlsxForSeeding(
+      fileName = "wrongSheetName.xlsx",
+      sheets = mapOf("wrongSheetName" to emptyDataFrame<Any>()),
     )
 
     seedXlsxService.seedExcelData(SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS, UUID.randomUUID(), "wrongSheetName.xlsx")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DataFrameUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DataFrameUtils.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
+
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+
+object DataFrameUtils {
+
+  fun createNameValueDataFrame(vararg rows: String): DataFrame<*> {
+    val list = rows.toList()
+
+    check(list.size >= 2) { "Should have at least two entries" }
+    check(list.size % 2 == 0) { "Should contain an even number of entries" }
+
+    return dataFrameOf(list.subList(0, 2), list.subList(2, rows.size))
+  }
+}


### PR DESCRIPTION
Before this PR we had to provide the premises ID when updating/creating rooms from the site survey XLSX. This commit changes the ‘seed XLSX’ API, removing the need to provide the premises ID and instead finding the premises using the QCode defined within the spreadsheet itself