### PR TITLE
APS-1769 Update Cas1ImportDeliusBookingDataSeedJob to new format

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
@@ -18,7 +18,8 @@ interface Cas1DeliusBookingImportRepository : JpaRepository<Cas1DeliusBookingImp
 @Table(name = "cas1_delius_booking_import")
 data class Cas1DeliusBookingImportEntity(
   @Id
-  val bookingId: UUID,
+  val id: UUID,
+  val bookingId: UUID?,
   val crn: String,
   val eventNumber: String,
   val keyWorkerStaffCode: String?,
@@ -37,4 +38,5 @@ data class Cas1DeliusBookingImportEntity(
   val nonArrivalReasonCode: String?,
   val nonArrivalReasonDescription: String?,
   val nonArrivalNotes: String?,
+  val premisesQcode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedColumns.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedColumns.kt
@@ -10,7 +10,7 @@ data class SeedColumns(
 ) {
   fun getStringOrNull(label: String) = columns[label]?.trim()?.ifBlank { null }
 
-  fun getUuidOrNull(label: String) = columns[label]?.let { UUID.fromString(it.trim()) }
+  fun getUuidOrNull(label: String): UUID? = getStringOrNull(label)?.let { UUID.fromString(it) }
 
   fun getIntOrNull(label: String) = columns[label]?.toIntOrNull()
 
@@ -25,7 +25,6 @@ data class SeedColumns(
 
   fun getDateFromUtcDateTimeOrNull(label: String): LocalDate? {
     val rawValue = getStringOrNull(label) ?: return null
-
     return LocalDate.parse(rawValue.substring(startIndex = 0, endIndex = 10))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1CruManagem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DomainEventReplaySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1DuplicateApplicationSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1FurtherInfoBugFixSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ImportDeliusBookingDataSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1ImportDeliusReferralsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1LinkedBookingToPlacementRequestSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServiceBedSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1PlanSpacePlanningDryRunSeedJob
@@ -87,7 +87,7 @@ class SeedService(
         SeedFileType.approvedPremisesCruManagementAreas -> getBean(Cas1CruManagementAreaSeedJob::class)
         SeedFileType.approvedPremisesBookingToSpaceBooking -> getBean(Cas1BookingToSpaceBookingSeedJob::class)
         SeedFileType.approvedPremisesSpacePlanningDryRun -> getBean(Cas1PlanSpacePlanningDryRunSeedJob::class)
-        SeedFileType.approvedPremisesImportDeliusBookingManagementData -> getBean(Cas1ImportDeliusBookingDataSeedJob::class)
+        SeedFileType.approvedPremisesImportDeliusReferrals -> getBean(Cas1ImportDeliusReferralsSeedJob::class)
         SeedFileType.approvedPremisesUpdateSpaceBooking -> getBean(Cas1UpdateSpaceBookingSeedJob::class)
         SeedFileType.temporaryAccommodationReferralRejection -> getBean(Cas3ReferralRejectionSeedJob::class)
       }

--- a/src/main/resources/db/migration/all/20250102135809__delius_booking_import_changes.sql
+++ b/src/main/resources/db/migration/all/20250102135809__delius_booking_import_changes.sql
@@ -1,0 +1,10 @@
+TRUNCATE cas1_delius_booking_import;
+
+ALTER TABLE cas1_delius_booking_import ADD COLUMN id uuid NOT NULL;
+ALTER TABLE cas1_delius_booking_import DROP CONSTRAINT cas1_delius_booking_import_pk;
+ALTER TABLE cas1_delius_booking_import ADD CONSTRAINT cas1_delius_booking_import_pk PRIMARY KEY (id);
+
+ALTER TABLE cas1_delius_booking_import ALTER COLUMN booking_id DROP NOT NULL;
+CREATE INDEX cas1_delius_booking_import_booking_id_idx ON cas1_delius_booking_import (booking_id);
+
+ALTER TABLE cas1_delius_booking_import ADD COLUMN premises_qcode TEXT NOT NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3724,7 +3724,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
-        - approved_premises_import_delius_booking_management_data
+        - approved_premises_import_delius_referrals
         - approved_premises_update_space_booking
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8025,7 +8025,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
-        - approved_premises_import_delius_booking_management_data
+        - approved_premises_import_delius_referrals
         - approved_premises_update_space_booking
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4946,7 +4946,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
-        - approved_premises_import_delius_booking_management_data
+        - approved_premises_import_delius_referrals
         - approved_premises_update_space_booking
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4315,7 +4315,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
-        - approved_premises_import_delius_booking_management_data
+        - approved_premises_import_delius_referrals
         - approved_premises_update_space_booking
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3823,7 +3823,7 @@ components:
         - approved_premises_out_of_service_beds
         - approved_premises_cru_management_areas
         - approved_premises_space_planning_dry_run
-        - approved_premises_import_delius_booking_management_data
+        - approved_premises_import_delius_referrals
         - approved_premises_update_space_booking
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
@@ -142,6 +142,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
 
     deliusBookingImportRepository.save(
       Cas1DeliusBookingImportEntity(
+        id = UUID.randomUUID(),
         bookingId = booking1ManagementInfoFromDelius.id,
         crn = "irrelevant",
         eventNumber = "irrelevant",
@@ -161,6 +162,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
         nonArrivalReasonCode = "narc1",
         nonArrivalReasonDescription = null,
         nonArrivalNotes = "the non arrival notes",
+        premisesQcode = "hostel code",
       ),
     )
 
@@ -189,6 +191,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
 
     deliusBookingImportRepository.save(
       Cas1DeliusBookingImportEntity(
+        id = UUID.randomUUID(),
         bookingId = booking2MinimalManagementInfoFromDelius.id,
         crn = "irrelevant",
         eventNumber = "irrelevant",
@@ -208,6 +211,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
         nonArrivalReasonCode = null,
         nonArrivalReasonDescription = null,
         nonArrivalNotes = null,
+        premisesQcode = "hostel code",
       ),
     )
 


### PR DESCRIPTION
Renamed seed job from Cas1ImportDeliusBookingDataSeedJob to Cas1ImportDeliusReferralsSeedJob

The import CSV now includes referrals that were not created via CAS1, meaning they don’t have a booking ID. This commit accounts for this change

* Made booking_id optional and added new a ‘random’ primary key column
* Mapped Hostel_Code value to premises_qcode
* Validated code and date fields to return null if values are recognised as invalid