### PR TITLE
APS-1773 - Placement Request with Space Booking should not appear as be unable to match

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -86,14 +86,6 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
               AND c.id IS NULL
           ) THEN 'matched'
           WHEN EXISTS (
-            SELECT
-              1
-            from
-              booking_not_mades bnm
-            WHERE
-              bnm.placement_request_id = pq.id
-          ) THEN 'unableToMatch'
-          WHEN EXISTS (
             SELECT 
                 1 
             FROM 
@@ -101,7 +93,15 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
             WHERE
                 sb.placement_request_id = pq.id AND
                 sb.cancellation_occurred_at IS NULL
-          ) THEN 'matched'    
+          ) THEN 'matched'   
+          WHEN EXISTS (
+            SELECT
+              1
+            from
+              booking_not_mades bnm
+            WHERE
+              bnm.placement_request_id = pq.id
+          ) THEN 'unableToMatch' 
           ELSE 'notMatched'
         END
       ) = :status)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -154,7 +154,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard returns all results when no page is provided`() {
+    fun `Returns all results when no page is provided`() {
       val matchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.matched.name)
       val notMatchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched.name)
       val unableToMatchPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.unableToMatch.name)
@@ -167,7 +167,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard returns paginated results when a page is provided`() {
+    fun `Returns paginated results when a page is provided`() {
       val pageable = PageRequest.of(1, 2, Sort.by("created_at"))
       val matchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.matched.name, pageable = pageable)
       val notMatchedPlacementRequests = realPlacementRequestRepository.allForDashboard(PlacementRequestStatus.notMatched.name, pageable = pageable)
@@ -179,7 +179,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard returns all results when no criteria is provided`() {
+    fun `Returns all results when no criteria is provided`() {
       val pageable = PageRequest.of(0, 20, Sort.by("created_at"))
       val allPlacementRequests = realPlacementRequestRepository.allForDashboard(pageable = pageable)
 
@@ -197,7 +197,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard only returns results for CRN when specified `() {
+    fun `Only returns results for CRN when specified `() {
       val crn = "CRN456"
       val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, crn = crn)
 
@@ -208,7 +208,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard only returns results for CRN when specified (case insensitive) `() {
+    fun `Only returns results for CRN when specified (case insensitive) `() {
       val crn = "CRN456"
       val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, crn = crn)
 
@@ -219,7 +219,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard only returns results when name is specified in crnOrName`() {
+    fun `Only returns results when name is specified in crnOrName`() {
       val name = "John Smith".uppercase()
       val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, name = name)
 
@@ -230,7 +230,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard only returns results for tier when specified`() {
+    fun `Only returns results for tier when specified`() {
       val tier = "A2"
       val requestsForCrn = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, tier = tier)
 
@@ -241,7 +241,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard allows sorting by an application's created_at date`() {
+    fun `Allows sorting by an application's created_at date`() {
       val pageable = PageRequest.of(0, 20, Sort.by("application_date"))
       val allPlacementRequests = realPlacementRequestRepository.allForDashboard(pageable = pageable)
 
@@ -259,7 +259,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard only returns results where start date after arrivalDateFrom when specified`() {
+    fun `Only returns results where start date after arrivalDateFrom when specified`() {
       val expectedArrival = LocalDate.parse("2030-08-08")
       val requestsForDate = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, expectedArrival = expectedArrival)
 
@@ -270,7 +270,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard only returns results where start date is before arrivalDateTo when specified`() {
+    fun `Only returns results where start date is before arrivalDateTo when specified`() {
       val expectedArrival = LocalDate.parse("2023-08-08")
       val requestsForDate = createPlacementRequests(2, isWithdrawn = false, isReallocated = false, isParole = true, expectedArrival = expectedArrival)
 
@@ -281,7 +281,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard only returns parole results where requestType of 'parole' is specified`() {
+    fun `Only returns parole results where requestType of 'parole' is specified`() {
       createPlacementRequests(1, isWithdrawn = false, isReallocated = false, isParole = false)
       val requestsWithTypeParole = createPlacementRequests(1, isWithdrawn = false, isReallocated = false, isParole = true)
 
@@ -292,7 +292,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `allForDashboard only returns non parole results where requestType of 'standardRelease' is specified`() {
+    fun `Only returns non parole results where requestType of 'standardRelease' is specified`() {
       createPlacementRequests(1, isWithdrawn = false, isReallocated = false, isParole = true)
       val requestsWithTypeStandardRelease = createPlacementRequests(1, isWithdrawn = false, isReallocated = false, isParole = false)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -16,6 +16,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import java.time.LocalDate
 
+/**
+Some of these tests are duplicated in [PlacementRequestsTest]
+
+Ideally all tests should be via the API, where possible
+ */
 class PlacementRequestRepositoryTest : IntegrationTestBase() {
   @Autowired
   lateinit var realPlacementRequestRepository: PlacementRequestRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -193,39 +193,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `It returns the unmatched placement requests by default when the user is a manager`() {
-      givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
-        givenAnOffender { unmatchedOffender, unmatchedInmate ->
-          givenAPlacementRequest(
-            placementRequestAllocatedTo = user,
-            assessmentAllocatedTo = user,
-            createdByUser = user,
-            crn = unmatchedOffender.otherIds.crn,
-          ) { unmatchedPlacementRequest, _ ->
-            webTestClient.get()
-              .uri("/placement-requests/dashboard")
-              .header("Authorization", "Bearer $jwt")
-              .exchange()
-              .expectStatus()
-              .isOk
-              .expectBody()
-              .json(
-                objectMapper.writeValueAsString(
-                  listOf(
-                    placementRequestTransformer.transformJpaToApi(
-                      unmatchedPlacementRequest,
-                      PersonInfoResult.Success.Full(unmatchedOffender.otherIds.crn, unmatchedOffender, unmatchedInmate),
-                    ),
-                  ),
-                ),
-              )
-          }
-        }
-      }
-    }
-
-    @Test
-    fun `It returns the unmatched placement requests and withdrawn placement requests when the user is a manager and status is not defined`() {
+    fun `If status filter is not defined, returns the unmatched placement requests and withdrawn placement requests`() {
       givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         givenAnOffender { unmatchedOffender, unmatchedInmate ->
           givenAPlacementRequest(
@@ -263,7 +231,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `It returns the unmatched placement requests and ignores the withdrawn placement requests when the user is a manager and status is notMatched`() {
+    fun `If status filter is 'notMatched', returns the unmatched placement requests, ignoring withdrawn`() {
       givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         givenAnOffender { unmatchedOffender, unmatchedInmate ->
           givenAPlacementRequest(
@@ -297,7 +265,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `It returns the matched placement requests and ignores the withdrawn placement requests when the user is a manager and status is matched`() {
+    fun `If status filter is 'matched', returns the matched placement requests, ignoring withdrawn`() {
       givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         givenAnOffender { matchedOffender, matchedInmate ->
 
@@ -366,7 +334,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `It returns the unable to match placement requests and ignores the withdrawn placement requests when the user is a manager and status is unableToMatch`() {
+    fun `If status filter is 'unableToMatch', returns the unable to match placement requests, ignoring withdrawn`() {
       givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         givenAnOffender { unableToMatchOffender, unableToMatchInmate ->
 
@@ -423,7 +391,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `It returns paginated placement requests when the user is a manager`() {
+    fun `Returns paginated placement requests`() {
       givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
         givenAnOffender { offenderDetails, inmateDetails ->
           val placementRequest = createPlacementRequest(offenderDetails, user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 
 @SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.givenACas1SpaceBooking(
@@ -15,9 +16,10 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
   deliusEventNumber: String? = null,
   offlineApplication: OfflineApplicationEntity? = null,
   criteria: List<CharacteristicEntity>? = null,
+  placementRequest: PlacementRequestEntity? = null,
 ): Cas1SpaceBookingEntity {
   val (user) = givenAUser()
-  val placementRequest = if (offlineApplication == null) {
+  val placementRequestToUse = placementRequest ?: if (offlineApplication == null) {
     givenAPlacementRequest(
       placementRequestAllocatedTo = user,
       assessmentAllocatedTo = user,
@@ -30,8 +32,8 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
 
   return cas1SpaceBookingEntityFactory.produceAndPersist {
     withCrn(crn)
-    withPlacementRequest(placementRequest)
-    withApplication(placementRequest?.application)
+    withPlacementRequest(placementRequestToUse)
+    withApplication(placementRequestToUse?.application)
     withOfflineApplication(offlineApplication)
     withCreatedBy(user)
     withDeliusEventNumber(deliusEventNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -185,7 +185,7 @@ fun IntegrationTestBase.givenAPlacementRequest(
   assessmentSubmittedAt: OffsetDateTime = OffsetDateTime.now(),
   placementApplication: PlacementApplicationEntity? = null,
   block: (placementRequest: PlacementRequestEntity, application: ApplicationEntity) -> Unit,
-) {
+): Pair<PlacementRequestEntity, ApprovedPremisesApplicationEntity> {
   val result = givenAPlacementRequest(
     placementRequestAllocatedTo,
     assessmentAllocatedTo,
@@ -206,4 +206,6 @@ fun IntegrationTestBase.givenAPlacementRequest(
   )
 
   block(result.first, result.second)
+
+  return result
 }


### PR DESCRIPTION
Before this commit if a placement request had been marked as ‘unable to match’ but then previously had a space booking created, it was still being returned on the placement request dashboard as unable to match.

This commit also improves the placement request dashboard API tests cover additional scenarios, improving regression testing