### PR TITLE
APS-1752 - Use qcode for booking to space booking seed job

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas1/SeedCas1BookingToSpaceBookingTest.kt
@@ -295,7 +295,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
 
     withCsv(
       "valid-csv",
-      rowsToCsv(listOf(Cas1BookingToSpaceBookingSeedCsvRow(premises.id))),
+      rowsToCsv(listOf(Cas1BookingToSpaceBookingSeedCsvRow(premises.qCode))),
     )
 
     seedService.seedData(SeedFileType.approvedPremisesBookingToSpaceBooking, "valid-csv.csv")
@@ -586,7 +586,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
 
     withCsv(
       "valid-csv",
-      rowsToCsv(listOf(Cas1BookingToSpaceBookingSeedCsvRow(premises.id))),
+      rowsToCsv(listOf(Cas1BookingToSpaceBookingSeedCsvRow(premises.qCode))),
     )
 
     seedService.seedData(SeedFileType.approvedPremisesBookingToSpaceBooking, "valid-csv.csv")
@@ -614,13 +614,13 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
   private fun rowsToCsv(rows: List<Cas1BookingToSpaceBookingSeedCsvRow>): String {
     val builder = CsvBuilder()
       .withUnquotedFields(
-        "premises_id",
+        "q_code",
       )
       .newRow()
 
     rows.forEach {
       builder
-        .withQuotedField(it.premisesId)
+        .withQuotedField(premises.qCode)
         .newRow()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
@@ -21,7 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingToS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingToSpaceBookingSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
-import java.util.UUID
 
 class Cas1BookingToSpaceBookingSeedJobTest {
 
@@ -45,16 +43,14 @@ class Cas1BookingToSpaceBookingSeedJobTest {
 
   @Test
   fun `fails if premise doesn't support space booking`() {
-    val premiseId = UUID.randomUUID()
-
-    every { approvedPremisesRepository.findByIdOrNull(premiseId) } returns
+    every { approvedPremisesRepository.findByQCode("Q123") } returns
       ApprovedPremisesEntityFactory()
         .withSupportsSpaceBookings(false)
         .withDefaults()
         .produce()
 
     assertThrows<RuntimeException> {
-      seedJob.processRow(Cas1BookingToSpaceBookingSeedCsvRow(premiseId))
+      seedJob.processRow(Cas1BookingToSpaceBookingSeedCsvRow("Q123"))
     }
   }
 }


### PR DESCRIPTION
This commit changes the booking to space booking seed job to use qcodes in the CSV instead of premise ids. QCode are more readible and remain consistent across environments/installs.