### PR TITLE
CAS3-1343 Add prefix cas3 to void bedspace tables 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ReferenceDataController.kt
@@ -145,7 +145,7 @@ class ReferenceDataController(
 
   override fun referenceDataLostBedReasonsGet(xServiceName: ServiceName?): ResponseEntity<List<LostBedReason>> {
     val voidBedspaceReasons = when (xServiceName == ServiceName.temporaryAccommodation) {
-      true -> cas3VoidBedspaceReasonRepository.findAllByServiceScope(xServiceName.value)
+      true -> cas3VoidBedspaceReasonRepository.findAll()
       false -> throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -42,7 +42,7 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
 
 const val BED_SUMMARY_QUERY =
   """
-    select b.id as id,
+      select b.id as id,
       cast(b.name as text) as name,
       cast(r.name as text) as roomName,
       r.id as roomId,
@@ -62,7 +62,7 @@ const val BED_SUMMARY_QUERY =
       (
         select count(void_bedspace.id)
         from cas3_void_bedspaces void_bedspace
-          left join lost_bed_cancellations cancellation
+          left join cas3_void_bedspace_cancellations cancellation
             on void_bedspace.id = cancellation.lost_bed_id
         where void_bedspace.bed_id = b.id
           and void_bedspace.start_date <= CURRENT_DATE

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -60,17 +60,17 @@ const val BED_SUMMARY_QUERY =
           and non_arrival IS NULL
       ) > 0 as bedBooked,
       (
-        select count(lost_bed.id)
-        from lost_beds lost_bed
+        select count(void_bedspace.id)
+        from cas3_void_bedspaces void_bedspace
           left join lost_bed_cancellations cancellation
-            on lost_bed.id = cancellation.lost_bed_id
-        where lost_bed.bed_id = b.id
-          and lost_bed.start_date <= CURRENT_DATE
-          and lost_bed.end_date >= CURRENT_DATE
+            on void_bedspace.id = cancellation.lost_bed_id
+        where void_bedspace.bed_id = b.id
+          and void_bedspace.start_date <= CURRENT_DATE
+          and void_bedspace.end_date >= CURRENT_DATE
           and cancellation IS NULL
       ) > 0 as bedOutOfService
       from beds b
-           join rooms r on b.room_id = r.id 
+           join rooms r on b.room_id = r.id
   """
 
 @NamedNativeQuery(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -63,7 +63,7 @@ const val BED_SUMMARY_QUERY =
         select count(void_bedspace.id)
         from cas3_void_bedspaces void_bedspace
           left join cas3_void_bedspace_cancellations cancellation
-            on void_bedspace.id = cancellation.lost_bed_id
+            on void_bedspace.id = cancellation.cas3_void_bedspace_id
         where void_bedspace.bed_id = b.id
           and void_bedspace.start_date <= CURRENT_DATE
           and void_bedspace.end_date >= CURRENT_DATE

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceCancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceCancellationEntity.kt
@@ -22,7 +22,7 @@ data class Cas3VoidBedspaceCancellationEntity(
   val createdAt: OffsetDateTime,
   val notes: String?,
   @OneToOne
-  @JoinColumn(name = "lost_bed_id")
+  @JoinColumn(name = "cas3_void_bedspace_id")
   val voidBedspace: Cas3VoidBedspacesEntity,
 ) {
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceCancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceCancellationEntity.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 interface Cas3VoidBedspaceCancellationRepository : JpaRepository<Cas3VoidBedspaceCancellationEntity, UUID>
 
 @Entity
-@Table(name = "lost_bed_cancellations")
+@Table(name = "cas3_void_bedspace_cancellations")
 data class Cas3VoidBedspaceCancellationEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceReasonEntity.kt
@@ -5,25 +5,20 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface Cas3VoidBedspaceReasonRepository : JpaRepository<Cas3VoidBedspaceReasonEntity, UUID> {
-  @Query("SELECT l FROM Cas3VoidBedspaceReasonEntity l WHERE l.serviceScope = :serviceName OR l.serviceScope = '*'")
-  fun findAllByServiceScope(serviceName: String): List<Cas3VoidBedspaceReasonEntity>
-}
+interface Cas3VoidBedspaceReasonRepository : JpaRepository<Cas3VoidBedspaceReasonEntity, UUID>
 
 @Entity
-@Table(name = "lost_bed_reasons")
+@Table(name = "cas3_void_bedspace_reasons")
 @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class Cas3VoidBedspaceReasonEntity(
   @Id
   val id: UUID,
   val name: String,
   val isActive: Boolean,
-  val serviceScope: String,
 ) {
   override fun toString() = "Cas3VoidBedspaceReasonEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspacesEntity.kt
@@ -49,7 +49,7 @@ interface Cas3VoidBedspacesRepository : JpaRepository<Cas3VoidBedspacesEntity, U
 
 @SuppressWarnings("LongParameterList")
 @Entity
-@Table(name = "lost_beds")
+@Table(name = "cas3_void_bedspaces")
 class Cas3VoidBedspacesEntity(
   @Id
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspacesEntity.kt
@@ -56,7 +56,7 @@ class Cas3VoidBedspacesEntity(
   var startDate: LocalDate,
   var endDate: LocalDate,
   @ManyToOne
-  @JoinColumn(name = "lost_bed_reason_id")
+  @JoinColumn(name = "cas3_void_bedspace_reason_id")
   var reason: Cas3VoidBedspaceReasonEntity,
   var referenceNumber: String?,
   var notes: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -57,7 +57,7 @@ class BedSearchRepository(private val namedParameterJdbcTemplate: NamedParameter
          WHERE bb.bed_id = b.id
         ) AND
         NOT EXISTS (SELECT void_bedspace.bed_id FROM cas3_void_bedspaces void_bedspace
-             LEFT JOIN cas3_void_bedspace_cancellations void_bedspace_cancellation ON void_bedspace_cancellation.lost_bed_id = void_bedspace.id
+             LEFT JOIN cas3_void_bedspace_cancellations void_bedspace_cancellation ON void_bedspace_cancellation.cas3_void_bedspace_id = void_bedspace.id
          WHERE
              void_bedspace.bed_id = b.id AND
              (void_bedspace.start_date, void_bedspace.end_date) OVERLAPS (:start_date, :end_date) AND

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -57,11 +57,11 @@ class BedSearchRepository(private val namedParameterJdbcTemplate: NamedParameter
          WHERE bb.bed_id = b.id
         ) AND
         NOT EXISTS (SELECT void_bedspace.bed_id FROM cas3_void_bedspaces void_bedspace
-             LEFT JOIN lost_bed_cancellations lostbeds_cancel ON lostbeds_cancel.lost_bed_id = void_bedspace.id
+             LEFT JOIN cas3_void_bedspace_cancellations void_bedspace_cancellation ON void_bedspace_cancellation.lost_bed_id = void_bedspace.id
          WHERE
              void_bedspace.bed_id = b.id AND
              (void_bedspace.start_date, void_bedspace.end_date) OVERLAPS (:start_date, :end_date) AND
-             lostbeds_cancel.id IS NULL
+             void_bedspace_cancellation.id IS NULL
         ) AND 
         #OPTIONAL_FILTERS
         pdu.id IN (:probation_delivery_unit_ids) AND

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedSearchRepository.kt
@@ -56,11 +56,11 @@ class BedSearchRepository(private val namedParameterJdbcTemplate: NamedParameter
         NOT EXISTS (SELECT bb.bed_id FROM BookedBedspaces bb
          WHERE bb.bed_id = b.id
         ) AND
-        NOT EXISTS (SELECT lostbeds.bed_id FROM lost_beds lostbeds
-             LEFT JOIN lost_bed_cancellations lostbeds_cancel ON lostbeds_cancel.lost_bed_id = lostbeds.id
+        NOT EXISTS (SELECT void_bedspace.bed_id FROM cas3_void_bedspaces void_bedspace
+             LEFT JOIN lost_bed_cancellations lostbeds_cancel ON lostbeds_cancel.lost_bed_id = void_bedspace.id
          WHERE
-             lostbeds.bed_id = b.id AND
-             (lostbeds.start_date, lostbeds.end_date) OVERLAPS (:start_date, :end_date) AND
+             void_bedspace.bed_id = b.id AND
+             (void_bedspace.start_date, void_bedspace.end_date) OVERLAPS (:start_date, :end_date) AND
              lostbeds_cancel.id IS NULL
         ) AND 
         #OPTIONAL_FILTERS

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -121,7 +121,7 @@ interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
     LEFT JOIN beds b ON vb.bed_id = b.id
     LEFT JOIN rooms r ON b.room_id = r.id
     LEFT JOIN premises p ON r.premises_id = p.id
-    LEFT JOIN cas3_void_bedspace_cancellations vbc ON vb.id = vbc.lost_bed_id
+    LEFT JOIN cas3_void_bedspace_cancellations vbc ON vb.id = vbc.cas3_void_bedspace_id
     WHERE
         p.service = 'temporary-accommodation'
       AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -116,17 +116,17 @@ interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
         CAST(b.id AS VARCHAR) AS bedId,
         vb.start_date AS startDate,
         vb.end_date AS endDate,
-        CAST(lbc.id AS VARCHAR) AS cancellationId
+        CAST(vbc.id AS VARCHAR) AS cancellationId
     From cas3_void_bedspaces vb
     LEFT JOIN beds b ON vb.bed_id = b.id
     LEFT JOIN rooms r ON b.room_id = r.id
     LEFT JOIN premises p ON r.premises_id = p.id
-    LEFT JOIN lost_bed_cancellations lbc ON vb.id = lbc.lost_bed_id
+    LEFT JOIN cas3_void_bedspace_cancellations vbc ON vb.id = vbc.lost_bed_id
     WHERE
         p.service = 'temporary-accommodation'
       AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
       AND vb.start_date <= :endDate AND vb.end_date >= :startDate
-      AND lbc.id is NULL
+      AND vbc.id is NULL
     ORDER BY vb.id     
     """,
     nativeQuery = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -114,20 +114,20 @@ interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
     """
     SELECT
         CAST(b.id AS VARCHAR) AS bedId,
-        lb.start_date AS startDate,
-        lb.end_date AS endDate,
+        vb.start_date AS startDate,
+        vb.end_date AS endDate,
         CAST(lbc.id AS VARCHAR) AS cancellationId
-    From lost_beds lb
-    LEFT JOIN beds b ON lb.bed_id = b.id
+    From cas3_void_bedspaces vb
+    LEFT JOIN beds b ON vb.bed_id = b.id
     LEFT JOIN rooms r ON b.room_id = r.id
     LEFT JOIN premises p ON r.premises_id = p.id
-    LEFT JOIN lost_bed_cancellations lbc ON lb.id = lbc.lost_bed_id
+    LEFT JOIN lost_bed_cancellations lbc ON vb.id = lbc.lost_bed_id
     WHERE
         p.service = 'temporary-accommodation'
       AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
-      AND lb.start_date <= :endDate AND lb.end_date >= :startDate
+      AND vb.start_date <= :endDate AND vb.end_date >= :startDate
       AND lbc.id is NULL
-    ORDER BY lb.id     
+    ORDER BY vb.id     
     """,
     nativeQuery = true,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
@@ -331,8 +331,6 @@ class Cas3PremisesService(
       val reason = cas3VoidBedspaceReasonRepository.findByIdOrNull(reasonId)
       if (reason == null) {
         "$.reason" hasValidationError "doesNotExist"
-      } else if (!serviceScopeMatches(reason.serviceScope)) {
-        "$.reason" hasValidationError "incorrectLostBedReasonServiceScope"
       }
 
       if (validationErrors.any()) {
@@ -376,8 +374,6 @@ class Cas3PremisesService(
         val reason = cas3VoidBedspaceReasonRepository.findByIdOrNull(reasonId)
         if (reason == null) {
           "$.reason" hasValidationError "doesNotExist"
-        } else if (!serviceScopeMatches(reason.serviceScope)) {
-          "$.reason" hasValidationError "incorrectLostBedReasonServiceScope"
         }
 
         if (validationErrors.any()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3VoidBedspaceReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3VoidBedspaceReasonTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonEntity
 
 @Component
@@ -10,6 +11,6 @@ class Cas3VoidBedspaceReasonTransformer {
     id = jpa.id,
     name = jpa.name,
     isActive = jpa.isActive,
-    serviceScope = jpa.serviceScope,
+    serviceScope = ServiceName.temporaryAccommodation.value,
   )
 }

--- a/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
+++ b/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
@@ -1,1 +1,2 @@
 ALTER TABLE lost_beds RENAME TO cas3_void_bedspaces;
+ALTER TABLE lost_bed_cancellations RENAME TO cas3_void_bedspace_cancellations;

--- a/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
+++ b/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lost_beds RENAME TO cas3_void_bedspaces;

--- a/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
+++ b/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
@@ -5,3 +5,6 @@ ALTER TABLE lost_bed_cancellations RENAME TO cas3_void_bedspace_cancellations;
 DELETE FROM lost_bed_reasons WHERE service_scope='approved-premises';
 ALTER TABLE lost_bed_reasons DROP COLUMN service_scope;
 ALTER TABLE lost_bed_reasons RENAME TO cas3_void_bedspace_reasons;
+
+ALTER TABLE cas3_void_bedspaces RENAME COLUMN lost_bed_reason_id TO cas3_void_bedspace_reason_id;
+ALTER TABLE cas3_void_bedspace_cancellations RENAME COLUMN lost_bed_id TO cas3_void_bedspace_id;

--- a/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
+++ b/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
@@ -1,2 +1,7 @@
 ALTER TABLE lost_beds RENAME TO cas3_void_bedspaces;
+
 ALTER TABLE lost_bed_cancellations RENAME TO cas3_void_bedspace_cancellations;
+
+DELETE FROM lost_bed_reasons WHERE service_scope='approved-premises';
+ALTER TABLE lost_bed_reasons DROP COLUMN service_scope;
+ALTER TABLE lost_bed_reasons RENAME TO cas3_void_bedspace_reasons;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceReasonEntityFactory.kt
@@ -4,14 +4,12 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.util.UUID
 
 class Cas3VoidBedspaceReasonEntityFactory : Factory<Cas3VoidBedspaceReasonEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }
-  private var serviceScope: Yielded<String> = { randomStringUpperCase(4) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -25,14 +23,9 @@ class Cas3VoidBedspaceReasonEntityFactory : Factory<Cas3VoidBedspaceReasonEntity
     this.isActive = { isActive }
   }
 
-  fun withServiceScope(serviceScope: String) = apply {
-    this.serviceScope = { serviceScope }
-  }
-
   override fun produce(): Cas3VoidBedspaceReasonEntity = Cas3VoidBedspaceReasonEntity(
     id = this.id(),
     name = this.name(),
     isActive = this.isActive(),
-    serviceScope = this.serviceScope(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeletePremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeletePremisesTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
@@ -134,9 +133,7 @@ class DeletePremisesTest : IntegrationTestBase() {
     withPremises(premises)
     withBed(bed)
     withYieldedReason {
-      cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeletePremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeletePremisesTest.kt
@@ -29,7 +29,7 @@ class DeletePremisesTest : IntegrationTestBase() {
       }
     }
 
-    val lostBed = createLostBed(premises, beds.first())
+    val lostBed = createVoidBedspace(premises, beds.first())
 
     webTestClient.delete()
       .uri("/internal/premises/${premises.id}")
@@ -62,7 +62,7 @@ class DeletePremisesTest : IntegrationTestBase() {
       }
     }
 
-    val lostBed = createLostBed(premises, beds.first())
+    val lostBed = createVoidBedspace(premises, beds.first())
 
     every { realBedRepository.delete(match { it.id == beds.last().id }) } throws RuntimeException("Database Exception")
 
@@ -97,7 +97,7 @@ class DeletePremisesTest : IntegrationTestBase() {
       }
     }
 
-    val lostBed = createLostBed(premises, beds.first())
+    val lostBed = createVoidBedspace(premises, beds.first())
 
     val booking = bookingEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -129,7 +129,7 @@ class DeletePremisesTest : IntegrationTestBase() {
     withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
   }
 
-  private fun createLostBed(premises: PremisesEntity, bed: BedEntity) = cas3VoidBedspacesEntityFactory.produceAndPersist {
+  private fun createVoidBedspace(premises: PremisesEntity, bed: BedEntity) = cas3VoidBedspacesEntityFactory.produceAndPersist {
     withPremises(premises)
     withBed(bed)
     withYieldedReason {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteRoomTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteRoomTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
@@ -113,9 +112,7 @@ class DeleteRoomTest : IntegrationTestBase() {
     withPremises(premises)
     withBed(bed)
     withYieldedReason {
-      cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteRoomTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteRoomTest.kt
@@ -23,7 +23,7 @@ class DeleteRoomTest : IntegrationTestBase() {
       withRoom(room)
     }
 
-    val lostBed = createLostBed(room.premises, beds.first())
+    val lostBed = createVoidBedspace(room.premises, beds.first())
 
     webTestClient.delete()
       .uri("/internal/room/${room.id}")
@@ -48,7 +48,7 @@ class DeleteRoomTest : IntegrationTestBase() {
       withRoom(room)
     }
 
-    val lostBed = createLostBed(room.premises, beds.first())
+    val lostBed = createVoidBedspace(room.premises, beds.first())
 
     every { realBedRepository.delete(match { it.id == beds.last().id }) } throws RuntimeException("Database Exception")
 
@@ -75,7 +75,7 @@ class DeleteRoomTest : IntegrationTestBase() {
       withRoom(room)
     }
 
-    val lostBed = createLostBed(room.premises, beds.first())
+    val lostBed = createVoidBedspace(room.premises, beds.first())
 
     val booking = bookingEntityFactory.produceAndPersist {
       withPremises(room.premises)
@@ -108,7 +108,7 @@ class DeleteRoomTest : IntegrationTestBase() {
     }
   }
 
-  private fun createLostBed(premises: PremisesEntity, bed: BedEntity) = cas3VoidBedspacesEntityFactory.produceAndPersist {
+  private fun createVoidBedspace(premises: PremisesEntity, bed: BedEntity) = cas3VoidBedspacesEntityFactory.produceAndPersist {
     withPremises(premises)
     withBed(bed)
     withYieldedReason {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -691,11 +691,7 @@ class ReferenceDataTest : IntegrationTestBase() {
   fun `Get Void Bedspace Reasons for only Temporary Accommodation returns 200 with correct body`() {
     cas3VoidBedspaceReasonTestRepository.deleteAll()
 
-    cas3VoidBedspaceReasonEntityFactory.produceAndPersistMultiple(10)
-
-    val expectedLostBedReasons = cas3VoidBedspaceReasonEntityFactory.produceAndPersistMultiple(10) {
-      withServiceScope(ServiceName.temporaryAccommodation.value)
-    }
+    val expectedLostBedReasons = cas3VoidBedspaceReasonEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = objectMapper.writeValueAsString(
       expectedLostBedReasons.map(cas3VoidBedspaceReasonTransformer::transformJpaToApi),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/VoidBedspacesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/VoidBedspacesTest.kt
@@ -296,9 +296,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withYieldedProbationRegion { probationRegion }
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       webTestClient.post()
         .uri("/premises/${premises.id}/lost-beds")
@@ -340,9 +338,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       webTestClient.post()
         .uri("/premises/${premises.id}/lost-beds")
@@ -392,9 +388,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       webTestClient.post()
         .uri("/premises/${premises.id}/lost-beds")
@@ -534,9 +528,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withPremises(premises)
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       webTestClient.put()
         .uri("/premises/${premises.id}/lost-beds/${voidBedspaces.id}")
@@ -591,9 +583,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withPremises(premises)
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       webTestClient.put()
         .uri("/premises/${premises.id}/lost-beds/${voidBedspaces.id}")
@@ -712,9 +702,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withPremises(premises)
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       webTestClient.post()
         .uri("/premises/${premises.id}/lost-beds/${voidBedspaces.id}/cancellations")
@@ -757,9 +745,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withPremises(premises)
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       webTestClient.post()
         .uri("/premises/${premises.id}/lost-beds/${voidBedspaces.id}/cancellations")
@@ -793,9 +779,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           }
         }
 
-        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-          withServiceScope(ServiceName.temporaryAccommodation.value)
-        }
+        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
         val existingBooking = bookingEntityFactory.produceAndPersist {
           withServiceName(ServiceName.temporaryAccommodation)
@@ -849,9 +833,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           }
         }
 
-        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-          withServiceScope(ServiceName.temporaryAccommodation.value)
-        }
+        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
         val existingBooking = bookingEntityFactory.produceAndPersist {
           withServiceName(ServiceName.temporaryAccommodation)
@@ -916,9 +898,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           }
         }
 
-        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-          withServiceScope(ServiceName.temporaryAccommodation.value)
-        }
+        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
         val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
           withBed(bed)
@@ -969,9 +949,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           }
         }
 
-        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-          withServiceScope(ServiceName.temporaryAccommodation.value)
-        }
+        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
         val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
           withBed(bed)
@@ -1043,9 +1021,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withPremises(premises)
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-        withServiceScope(ServiceName.temporaryAccommodation.value)
-      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       val existingBooking = bookingEntityFactory.produceAndPersist {
         withServiceName(ServiceName.temporaryAccommodation)
@@ -1105,9 +1081,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           withPremises(premises)
         }
 
-        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-          withServiceScope(ServiceName.temporaryAccommodation.value)
-        }
+        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
         val existingBooking = bookingEntityFactory.produceAndPersist {
           withServiceName(ServiceName.temporaryAccommodation)
@@ -1171,9 +1145,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           }
         }
 
-        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-          withServiceScope(ServiceName.temporaryAccommodation.value)
-        }
+        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
         val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
           withStartDate(LocalDate.parse("2022-08-16"))
@@ -1231,9 +1203,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           }
         }
 
-        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist {
-          withServiceScope(ServiceName.temporaryAccommodation.value)
-        }
+        val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
         val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
           withStartDate(LocalDate.parse("2022-08-16"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3PremisesServiceTest.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingSummaryForAvailabilityFactory
@@ -327,32 +326,6 @@ class Cas3PremisesServiceTest {
   }
 
   @Test
-  fun `createVoidBedspaces returns FieldValidationError with correct param to message map when a void bedspace reason with the incorrect service scope is supplied`() {
-    val premisesEntity = temporaryAccommodationPremisesFactory.produce()
-
-    val reasonId = UUID.randomUUID()
-
-    every { cas3VoidBedspaceReasonRepositoryMock.findByIdOrNull(reasonId) } returns Cas3VoidBedspaceReasonEntityFactory()
-      .withServiceScope(ServiceName.approvedPremises.value)
-      .produce()
-
-    val result = premisesService.createVoidBedspaces(
-      premises = premisesEntity,
-      startDate = LocalDate.parse("2022-08-25"),
-      endDate = LocalDate.parse("2022-08-28"),
-      reasonId = reasonId,
-      referenceNumber = "12345",
-      notes = "notes",
-      bedId = UUID.randomUUID(),
-    )
-
-    assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
-    assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reason", "incorrectLostBedReasonServiceScope"),
-    )
-  }
-
-  @Test
   fun `createVoidBedspaces returns Success with correct result when validation passed`() {
     val premisesEntity = temporaryAccommodationPremisesFactory.produce()
 
@@ -368,7 +341,6 @@ class Cas3PremisesServiceTest {
     room.beds += bed
 
     val voidBedspaceReason = Cas3VoidBedspaceReasonEntityFactory()
-      .withServiceScope(ServiceName.temporaryAccommodation.value)
       .produce()
 
     every { cas3VoidBedspaceReasonRepositoryMock.findByIdOrNull(voidBedspaceReason.id) } returns voidBedspaceReason
@@ -405,7 +377,6 @@ class Cas3PremisesServiceTest {
       .withYieldedPremises { premisesEntity }
       .withYieldedReason {
         Cas3VoidBedspaceReasonEntityFactory()
-          .withServiceScope(ServiceName.temporaryAccommodation.value)
           .produce()
       }
       .withBed(
@@ -441,64 +412,16 @@ class Cas3PremisesServiceTest {
   }
 
   @Test
-  fun `updateVoidBedspaces returns FieldValidationError with correct param to message map when a void bedspace reason with the incorrect service scope is supplied`() {
-    val premisesEntity = temporaryAccommodationPremisesFactory.produce()
-
-    val reasonId = UUID.randomUUID()
-
-    val voidBedspaceEntity = Cas3VoidBedspacesEntityFactory()
-      .withYieldedPremises { premisesEntity }
-      .withYieldedReason {
-        Cas3VoidBedspaceReasonEntityFactory()
-          .withServiceScope(ServiceName.temporaryAccommodation.value)
-          .produce()
-      }
-      .withBed(
-        BedEntityFactory().apply {
-          withYieldedRoom {
-            RoomEntityFactory().apply {
-              withPremises(premisesEntity)
-            }.produce()
-          }
-        }.produce(),
-      )
-      .produce()
-
-    every { cas3VoidBedspacesRepositoryMock.findByIdOrNull(voidBedspaceEntity.id) } returns voidBedspaceEntity
-    every { cas3VoidBedspaceReasonRepositoryMock.findByIdOrNull(reasonId) } returns Cas3VoidBedspaceReasonEntityFactory()
-      .withServiceScope(ServiceName.approvedPremises.value)
-      .produce()
-
-    val result = premisesService.updateVoidBedspaces(
-      voidBedspaceId = voidBedspaceEntity.id,
-      startDate = LocalDate.parse("2022-08-25"),
-      endDate = LocalDate.parse("2022-08-28"),
-      reasonId = reasonId,
-      referenceNumber = "12345",
-      notes = "notes",
-    )
-
-    assertThat(result).isInstanceOf(AuthorisableActionResult.Success::class.java)
-    val resultEntity = (result as AuthorisableActionResult.Success).entity
-    assertThat(resultEntity).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
-    assertThat((resultEntity as ValidatableActionResult.FieldValidationError).validationMessages).contains(
-      entry("$.reason", "incorrectLostBedReasonServiceScope"),
-    )
-  }
-
-  @Test
   fun `updateVoidBedspaces returns Success with correct result when validation passed`() {
     val premisesEntity = temporaryAccommodationPremisesFactory.produce()
 
     val voidBedspaceReason = Cas3VoidBedspaceReasonEntityFactory()
-      .withServiceScope(ServiceName.temporaryAccommodation.value)
       .produce()
 
     val voidBedspacesEntity = Cas3VoidBedspacesEntityFactory()
       .withYieldedPremises { premisesEntity }
       .withYieldedReason {
         Cas3VoidBedspaceReasonEntityFactory()
-          .withServiceScope(ServiceName.temporaryAccommodation.value)
           .produce()
       }
       .withBed(


### PR DESCRIPTION
This [PR CAS-1343](https://dsdmoj.atlassian.net/browse/CAS-1343) is to add cas3 prefix to lost bed tables and rename them to void bedspace. Tables:

- lost_beds
- lost_bed_cancellations
- lost_bed_reasons