### PR TITLE
Return empty staff list if team info not found for a given qcode

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -56,6 +56,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerEr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotImplementedProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
@@ -836,6 +837,10 @@ class PremisesController(
     }
 
     val staffMembersResult = staffMemberService.getStaffMembersForQCode(premises.qCode)
+
+    if (staffMembersResult is CasResult.NotFound) {
+      return ResponseEntity.ok(emptyList())
+    }
 
     val staffMembers = extractEntityFromCasResult(staffMembersResult)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/NoOpSentryService.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/NoOpSentryService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks
 
+import org.assertj.core.api.Assertions.assertThat
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Primary
@@ -27,6 +28,10 @@ class NoOpSentryService : SentryService {
   }
 
   fun getRaisedExceptions() = capturedExceptions
+
+  fun assertErrorMessageRaised(message: String) {
+    assertThat(capturedErrors).contains(message)
+  }
 
   @BeforeTestMethod
   fun beforeTestMethod() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -11,15 +12,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 
 class StaffMemberServiceTest {
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
-  private val staffMemberService = StaffMemberService(mockApDeliusContextApiClient)
+  private val mockSentryService = mockk<SentryService>()
+  private val staffMemberService = StaffMemberService(mockApDeliusContextApiClient, mockSentryService)
 
-  private val qCode = "Qcode"
+  private val qCode = "Q123"
 
   @Nested
   inner class GetStaffMemberByCode {
@@ -64,9 +66,13 @@ class StaffMemberServiceTest {
         body = null,
       )
 
+      every { mockSentryService.captureErrorMessage(any()) } returns Unit
+
       val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
 
       assertThatCasResult(result).isNotFound("Team", qCode)
+
+      verify { mockSentryService.captureErrorMessage("404 returned when finding staff members for qcode 'Q123'") }
     }
 
     @Test
@@ -116,9 +122,13 @@ class StaffMemberServiceTest {
         body = null,
       )
 
+      every { mockSentryService.captureErrorMessage(any()) } returns Unit
+
       val result = staffMemberService.getStaffMembersForQCode(qCode)
 
       assertThatCasResult(result).isNotFound("Team", qCode)
+
+      verify { mockSentryService.captureErrorMessage("404 returned when finding staff members for qcode 'Q123'") }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
@@ -40,57 +40,57 @@ class StaffMemberServiceTest {
 
       assertThat(result.value).isEqualTo(staffMembers[2])
     }
-  }
 
-  @Test
-  fun `it returns Unauthorised when Delius returns Unauthorised`() {
-    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Failure.StatusCode(
-      HttpMethod.GET,
-      "/staff-members/code",
-      HttpStatus.UNAUTHORIZED,
-      body = null,
-    )
+    @Test
+    fun `it returns Unauthorised when Delius returns Unauthorised`() {
+      every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/staff-members/code",
+        HttpStatus.UNAUTHORIZED,
+        body = null,
+      )
 
-    val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
+      val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
 
-    assertThat(result is CasResult.Unauthorised).isTrue
-  }
+      assertThat(result is CasResult.Unauthorised).isTrue
+    }
 
-  @Test
-  fun `it returns NotFound when Delius returns NotFound`() {
-    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Failure.StatusCode(
-      HttpMethod.GET,
-      "/staff-members/code",
-      HttpStatus.NOT_FOUND,
-      body = null,
-    )
+    @Test
+    fun `it returns NotFound when Delius returns NotFound`() {
+      every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/staff-members/code",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
 
-    val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
+      val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
 
-    assertThat(result is CasResult.NotFound).isTrue
-    result as CasResult.NotFound
+      assertThat(result is CasResult.NotFound).isTrue
+      result as CasResult.NotFound
 
-    assertThat(result.id).isEqualTo(qCode)
-    assertThat(result.entityType).isEqualTo("Team")
-  }
+      assertThat(result.id).isEqualTo(qCode)
+      assertThat(result.entityType).isEqualTo("Team")
+    }
 
-  @Test
-  fun `it returns a NotFound when a staff member for the QCode cannot me found`() {
-    val staffMembers = ContextStaffMemberFactory().produceMany().take(5).toList()
+    @Test
+    fun `it returns NotFound when a staff member for the QCode cannot be found in the results`() {
+      val staffMembers = ContextStaffMemberFactory().produceMany().take(5).toList()
 
-    every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Success(
-      status = HttpStatus.OK,
-      body = StaffMembersPage(
-        content = staffMembers,
-      ),
-    )
+      every { mockApDeliusContextApiClient.getStaffMembers(qCode) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = StaffMembersPage(
+          content = staffMembers,
+        ),
+      )
 
-    val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
+      val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
 
-    assertThat(result is CasResult.NotFound).isTrue
-    result as CasResult.NotFound
+      assertThat(result is CasResult.NotFound).isTrue
+      result as CasResult.NotFound
 
-    assertThat(result.id).isEqualTo("code")
-    assertThat(result.entityType).isEqualTo("Staff Code")
+      assertThat(result.id).isEqualTo("code")
+      assertThat(result.entityType).isEqualTo("Staff Code")
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StaffMemberServiceTest.kt
@@ -36,10 +36,9 @@ class StaffMemberServiceTest {
 
       val result = staffMemberService.getStaffMemberByCodeForPremise(staffMembers[2].code, qCode)
 
-      assertThat(result is CasResult.Success).isTrue
-      result as CasResult.Success
-
-      assertThat(result.value).isEqualTo(staffMembers[2])
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it).isEqualTo(staffMembers[2])
+      }
     }
 
     @Test
@@ -53,7 +52,7 @@ class StaffMemberServiceTest {
 
       val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
 
-      assertThat(result is CasResult.Unauthorised).isTrue
+      assertThatCasResult(result).isUnauthorised()
     }
 
     @Test
@@ -67,11 +66,7 @@ class StaffMemberServiceTest {
 
       val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
 
-      assertThat(result is CasResult.NotFound).isTrue
-      result as CasResult.NotFound
-
-      assertThat(result.id).isEqualTo(qCode)
-      assertThat(result.entityType).isEqualTo("Team")
+      assertThatCasResult(result).isNotFound("Team", qCode)
     }
 
     @Test
@@ -87,11 +82,7 @@ class StaffMemberServiceTest {
 
       val result = staffMemberService.getStaffMemberByCodeForPremise("code", qCode)
 
-      assertThat(result is CasResult.NotFound).isTrue
-      result as CasResult.NotFound
-
-      assertThat(result.id).isEqualTo("code")
-      assertThat(result.entityType).isEqualTo("Staff Code")
+      assertThatCasResult(result).isNotFound("Staff Code", "code")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
@@ -6,6 +6,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 
 fun <T> assertThat(actual: CasResult<T>): CasResultAssertions<T> = CasResultAssertions(actual)
 
+fun <T> assertThatCasResult(actual: CasResult<T>): CasResultAssertions<T> = CasResultAssertions(actual)
+
 class CasResultAssertions<T>(actual: CasResult<T>) : AbstractAssert<CasResultAssertions<T>, CasResult<T>>(
   actual,
   CasResultAssertions::class.java,


### PR DESCRIPTION
If probation-integration returns a 404 when retrieving team details for a premise we want the API to return an empty list for staff, as to not block usage of the corresponding UI. In this scenario a sentry alert will be raised.