### PR TITLE
CAS1343 Update lost bed tables constraints

### DIFF
--- a/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
+++ b/src/main/resources/db/migration/all/20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql
@@ -1,3 +1,6 @@
+ALTER TABLE lost_beds DROP CONSTRAINT lost_bed_reason_id_fk;
+ALTER TABLE lost_bed_cancellations DROP CONSTRAINT lost_bed_cancellations_lost_bed_id_fkey;
+
 ALTER TABLE lost_beds RENAME TO cas3_void_bedspaces;
 
 ALTER TABLE lost_bed_cancellations RENAME TO cas3_void_bedspace_cancellations;
@@ -7,4 +10,7 @@ ALTER TABLE lost_bed_reasons DROP COLUMN service_scope;
 ALTER TABLE lost_bed_reasons RENAME TO cas3_void_bedspace_reasons;
 
 ALTER TABLE cas3_void_bedspaces RENAME COLUMN lost_bed_reason_id TO cas3_void_bedspace_reason_id;
+ALTER TABLE cas3_void_bedspaces ADD CONSTRAINT cas3_void_bedspaces_cas3_void_bedspace_reason_id_fk FOREIGN KEY (cas3_void_bedspace_reason_id) REFERENCES cas3_void_bedspace_reasons(id);
+
 ALTER TABLE cas3_void_bedspace_cancellations RENAME COLUMN lost_bed_id TO cas3_void_bedspace_id;
+ALTER TABLE cas3_void_bedspace_cancellations ADD CONSTRAINT cas3_void_bedspace_cancellations_cas3_void_bedspace_id_fk FOREIGN KEY (cas3_void_bedspace_id) REFERENCES cas3_void_bedspaces(id);


### PR DESCRIPTION
This PR CAS-1343 is to:

- Remove lost bed tables constraints for tables lost_beds and lost_bed_cancellations
- Add new void bedspace tables constraints for tables cas3_void_bedspaces and cas3_void_bedspace_cancellations
- Remove the entry from flyway_schema_history in dev database:
```
DELETE FROM  flyway_schema_history
WHERE script = '20250107135009__add_prefix_cas3_to_lost_beds_tables_and_rename_them_to_void_bedspaces.sql';
```
