### PR TITLE
CAS-1343 Rename to void bedspace

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -21,7 +21,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import java.time.LocalDate
 import java.util.UUID
 
@@ -247,7 +247,7 @@ abstract class PremisesEntity(
   @OneToMany(mappedBy = "premises")
   val bookings: MutableList<BookingEntity>,
   @OneToMany(mappedBy = "premises")
-  val voidBedspaces: MutableList<Cas3VoidBedspacesEntity>,
+  val voidBedspaces: MutableList<Cas3VoidBedspaceEntity>,
   @OneToMany(mappedBy = "premises")
   val rooms: MutableList<RoomEntity>,
   @ManyToMany
@@ -280,7 +280,7 @@ class ApprovedPremisesEntity(
   probationRegion: ProbationRegionEntity,
   localAuthorityArea: LocalAuthorityAreaEntity,
   bookings: MutableList<BookingEntity>,
-  lostBeds: MutableList<Cas3VoidBedspacesEntity>,
+  lostBeds: MutableList<Cas3VoidBedspaceEntity>,
   var apCode: String,
   var qCode: String,
   rooms: MutableList<RoomEntity>,
@@ -364,7 +364,7 @@ class TemporaryAccommodationPremisesEntity(
   probationRegion: ProbationRegionEntity,
   localAuthorityArea: LocalAuthorityAreaEntity?,
   bookings: MutableList<BookingEntity>,
-  lostBeds: MutableList<Cas3VoidBedspacesEntity>,
+  lostBeds: MutableList<Cas3VoidBedspaceEntity>,
   rooms: MutableList<RoomEntity>,
   characteristics: MutableList<CharacteristicEntity>,
   status: PropertyStatus,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceCancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceCancellationEntity.kt
@@ -23,7 +23,7 @@ data class Cas3VoidBedspaceCancellationEntity(
   val notes: String?,
   @OneToOne
   @JoinColumn(name = "cas3_void_bedspace_id")
-  val voidBedspace: Cas3VoidBedspacesEntity,
+  val voidBedspace: Cas3VoidBedspaceEntity,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceEntity.kt
@@ -16,20 +16,20 @@ import java.util.Objects
 import java.util.UUID
 
 @Repository
-interface Cas3VoidBedspacesRepository : JpaRepository<Cas3VoidBedspacesEntity, UUID> {
-  @Query("SELECT lb FROM Cas3VoidBedspacesEntity lb WHERE lb.premises.id = :premisesId AND lb.startDate <= :endDate AND lb.endDate >= :startDate")
-  fun findAllByPremisesIdAndOverlappingDate(premisesId: UUID, startDate: LocalDate, endDate: LocalDate): List<Cas3VoidBedspacesEntity>
+interface Cas3VoidBedspacesRepository : JpaRepository<Cas3VoidBedspaceEntity, UUID> {
+  @Query("SELECT lb FROM Cas3VoidBedspaceEntity lb WHERE lb.premises.id = :premisesId AND lb.startDate <= :endDate AND lb.endDate >= :startDate")
+  fun findAllByPremisesIdAndOverlappingDate(premisesId: UUID, startDate: LocalDate, endDate: LocalDate): List<Cas3VoidBedspaceEntity>
 
-  @Query("SELECT MAX(lb.endDate) FROM Cas3VoidBedspacesEntity lb WHERE lb.premises.id = :premisesId")
+  @Query("SELECT MAX(lb.endDate) FROM Cas3VoidBedspaceEntity lb WHERE lb.premises.id = :premisesId")
   fun getHighestBookingDate(premisesId: UUID): LocalDate?
 
-  @Query("SELECT lb FROM Cas3VoidBedspacesEntity lb WHERE lb.bed.id IN :voidBedspaceIds")
-  fun findByBedIds(voidBedspaceIds: List<UUID>): List<Cas3VoidBedspacesEntity>
+  @Query("SELECT lb FROM Cas3VoidBedspaceEntity lb WHERE lb.bed.id IN :voidBedspaceIds")
+  fun findByBedIds(voidBedspaceIds: List<UUID>): List<Cas3VoidBedspaceEntity>
 
   @Query(
     """
     SELECT lb 
-    FROM Cas3VoidBedspacesEntity lb 
+    FROM Cas3VoidBedspaceEntity lb 
     LEFT JOIN lb.cancellation c 
     WHERE lb.bed.id = :bedId AND 
           lb.startDate <= :endDate AND 
@@ -38,19 +38,19 @@ interface Cas3VoidBedspacesRepository : JpaRepository<Cas3VoidBedspacesEntity, U
           c is NULL
   """,
   )
-  fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<Cas3VoidBedspacesEntity>
+  fun findByBedspaceIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<Cas3VoidBedspaceEntity>
 
-  @Query("SELECT lb FROM Cas3VoidBedspacesEntity lb LEFT JOIN lb.cancellation c WHERE lb.startDate <= :endDate AND lb.endDate >= :startDate AND lb.bed = :bed AND c is NULL")
-  fun findAllByOverlappingDateForBed(startDate: LocalDate, endDate: LocalDate, bed: BedEntity): List<Cas3VoidBedspacesEntity>
+  @Query("SELECT lb FROM Cas3VoidBedspaceEntity lb LEFT JOIN lb.cancellation c WHERE lb.startDate <= :endDate AND lb.endDate >= :startDate AND lb.bed = :bed AND c is NULL")
+  fun findAllByOverlappingDateForBedspace(startDate: LocalDate, endDate: LocalDate, bed: BedEntity): List<Cas3VoidBedspaceEntity>
 
-  @Query("SELECT lb FROM Cas3VoidBedspacesEntity lb LEFT JOIN lb.cancellation c WHERE lb.premises.id = :premisesId AND c is NULL")
-  fun findAllActiveForPremisesId(premisesId: UUID): List<Cas3VoidBedspacesEntity>
+  @Query("SELECT lb FROM Cas3VoidBedspaceEntity lb LEFT JOIN lb.cancellation c WHERE lb.premises.id = :premisesId AND c is NULL")
+  fun findAllActiveForPremisesId(premisesId: UUID): List<Cas3VoidBedspaceEntity>
 }
 
 @SuppressWarnings("LongParameterList")
 @Entity
 @Table(name = "cas3_void_bedspaces")
-class Cas3VoidBedspacesEntity(
+class Cas3VoidBedspaceEntity(
   @Id
   val id: UUID,
   var startDate: LocalDate,
@@ -71,7 +71,7 @@ class Cas3VoidBedspacesEntity(
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Cas3VoidBedspacesEntity) return false
+    if (other !is Cas3VoidBedspaceEntity) return false
 
     if (id != other.id) return false
     if (startDate != other.startDate) return false
@@ -85,5 +85,5 @@ class Cas3VoidBedspacesEntity(
 
   override fun hashCode() = Objects.hash(id, startDate, endDate, reason, referenceNumber, notes)
 
-  override fun toString() = "Cas3VoidBedspacesEntity:$id"
+  override fun toString() = "Cas3VoidBedspaceEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUsageReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/BedUsageReportGenerator.kt
@@ -25,7 +25,7 @@ class BedUsageReportGenerator(
 
   override val convert: BedEntity.(properties: BedUsageReportProperties) -> List<BedUsageReportRow> = { properties ->
     val bookings = bookingRepository.findAllByOverlappingDateForBed(properties.startDate, properties.endDate, this)
-    val voids = cas3VoidBedspacesRepository.findAllByOverlappingDateForBed(properties.startDate, properties.endDate, this)
+    val voids = cas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(properties.startDate, properties.endDate, this)
 
     val premises = this.room.premises
     val temporaryAccommodationPremisesEntity = premises as? TemporaryAccommodationPremisesEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/VoidBedspacesReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/VoidBedspacesReportGenerator.kt
@@ -21,7 +21,7 @@ class VoidBedspacesReportGenerator(
     val startOfMonth = LocalDate.of(properties.year, properties.month, 1)
     val endOfMonth = LocalDate.of(properties.year, properties.month, startOfMonth.month.length(startOfMonth.isLeapYear))
 
-    val voidBedspaces = cas3VoidBedspacesRepository.findAllByOverlappingDateForBed(startOfMonth, endOfMonth, this)
+    val voidBedspaces = cas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(startOfMonth, endOfMonth, this)
 
     voidBedspaces.map {
       val bed = it.bed

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -533,7 +533,7 @@ class BookingService(
     endDate: LocalDate,
     thisEntityId: UUID?,
     bedId: UUID,
-  ) = cas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+  ) = cas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
     bedId,
     startDate,
     endDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingService.kt
@@ -97,7 +97,7 @@ class Cas3BookingService(
         return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.lastUnavailableDate} which overlaps with the desired dates"
       }
 
-      getLostBedspaceWithConflictingDates(arrivalDate, expectedLastUnavailableDate, null, bedId)?.let {
+      getVoidBedspaceWithConflictingDates(arrivalDate, expectedLastUnavailableDate, null, bedId)?.let {
         return@validated it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
       }
 
@@ -248,7 +248,7 @@ class Cas3BookingService(
       return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.lastUnavailableDate} which overlaps with the desired dates"
     }
 
-    getLostBedspaceWithConflictingDates(booking.arrivalDate, expectedLastUnavailableDate, null, booking.bed!!.id)?.let {
+    getVoidBedspaceWithConflictingDates(booking.arrivalDate, expectedLastUnavailableDate, null, booking.bed!!.id)?.let {
       return@validated it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
     }
 
@@ -426,7 +426,7 @@ class Cas3BookingService(
       return@validated it.id hasConflictError "A Booking already exists for dates from ${it.arrivalDate} to ${it.lastUnavailableDate} which overlaps with the desired dates"
     }
 
-    getLostBedspaceWithConflictingDates(booking.arrivalDate, expectedLastUnavailableDate, null, bedId)?.let {
+    getVoidBedspaceWithConflictingDates(booking.arrivalDate, expectedLastUnavailableDate, null, bedId)?.let {
       return@validated it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
     }
 
@@ -452,7 +452,7 @@ class Cas3BookingService(
   }
 
   @SuppressWarnings("ThrowsCount")
-  fun getBooking(id: UUID): AuthorisableActionResult<uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService.BookingAndPersons> {
+  fun getBooking(id: UUID): AuthorisableActionResult<BookingAndPersons> {
     val booking = bookingRepository.findByIdOrNull(id)
       ?: return AuthorisableActionResult.NotFound("Booking", id.toString())
 
@@ -469,7 +469,7 @@ class Cas3BookingService(
     )
 
     return AuthorisableActionResult.Success(
-      uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService.BookingAndPersons(
+      BookingAndPersons(
         booking,
         personInfo,
       ),
@@ -540,12 +540,12 @@ class Cas3BookingService(
     return candidateBookings.firstOrNull { it.lastUnavailableDate >= arrivalDate }
   }
 
-  private fun getLostBedspaceWithConflictingDates(
+  private fun getVoidBedspaceWithConflictingDates(
     startDate: LocalDate,
     endDate: LocalDate,
     thisEntityId: UUID?,
     bedId: UUID,
-  ) = cas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+  ) = cas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
     bedId,
     startDate,
     endDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
@@ -16,8 +16,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
@@ -317,7 +317,7 @@ class Cas3PremisesService(
     referenceNumber: String?,
     notes: String?,
     bedId: UUID,
-  ): ValidatableActionResult<Cas3VoidBedspacesEntity> =
+  ): ValidatableActionResult<Cas3VoidBedspaceEntity> =
     validated {
       if (endDate.isBefore(startDate)) {
         "$.endDate" hasValidationError "beforeStartDate"
@@ -338,7 +338,7 @@ class Cas3PremisesService(
       }
 
       val voidBedspacesEntity = cas3VoidBedspacesRepository.save(
-        Cas3VoidBedspacesEntity(
+        Cas3VoidBedspaceEntity(
           id = UUID.randomUUID(),
           premises = premises,
           startDate = startDate,
@@ -361,7 +361,7 @@ class Cas3PremisesService(
     reasonId: UUID,
     referenceNumber: String?,
     notes: String?,
-  ): AuthorisableActionResult<ValidatableActionResult<Cas3VoidBedspacesEntity>> {
+  ): AuthorisableActionResult<ValidatableActionResult<Cas3VoidBedspaceEntity>> {
     val voidBedspace = cas3VoidBedspacesRepository.findByIdOrNull(voidBedspaceId)
       ?: return AuthorisableActionResult.NotFound()
 
@@ -396,7 +396,7 @@ class Cas3PremisesService(
   }
 
   fun cancelVoidBedspace(
-    voidBedspace: Cas3VoidBedspacesEntity,
+    voidBedspace: Cas3VoidBedspaceEntity,
     notes: String?,
   ) = validated<Cas3VoidBedspaceCancellationEntity> {
     if (voidBedspace.cancellation != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3VoidBedspacesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3VoidBedspacesTransformer.kt
@@ -3,14 +3,14 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 
 @Component
 class Cas3VoidBedspacesTransformer(
   private val cas3VoidBedspaceReasonTransformer: Cas3VoidBedspaceReasonTransformer,
   private val cas3VoidBedspaceCancellationTransformer: Cas3VoidBedspaceCancellationTransformer,
 ) {
-  fun transformJpaToApi(jpa: Cas3VoidBedspacesEntity) = LostBed(
+  fun transformJpaToApi(jpa: Cas3VoidBedspaceEntity) = LostBed(
     id = jpa.id,
     startDate = jpa.startDate,
     endDate = jpa.endDate,
@@ -24,7 +24,7 @@ class Cas3VoidBedspacesTransformer(
     roomName = jpa.bed.room.name,
   )
 
-  private fun determineStatus(jpa: Cas3VoidBedspacesEntity) = when {
+  private fun determineStatus(jpa: Cas3VoidBedspaceEntity) = when {
     jpa.cancellation != null -> LostBedStatus.cancelled
     else -> LostBedStatus.active
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceCancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceCancellationEntityFactory.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -12,7 +12,7 @@ class Cas3VoidBedspaceCancellationEntityFactory : Factory<Cas3VoidBedspaceCancel
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(14) }
   private var notes: Yielded<String>? = null
-  private var voidBedspace: Yielded<Cas3VoidBedspacesEntity>? = null
+  private var voidBedspace: Yielded<Cas3VoidBedspaceEntity>? = null
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -26,11 +26,11 @@ class Cas3VoidBedspaceCancellationEntityFactory : Factory<Cas3VoidBedspaceCancel
     this.notes = { notes }
   }
 
-  fun withYieldedVoidBedspace(voidBedspace: Yielded<Cas3VoidBedspacesEntity>) = apply {
+  fun withYieldedVoidBedspace(voidBedspace: Yielded<Cas3VoidBedspaceEntity>) = apply {
     this.voidBedspace = voidBedspace
   }
 
-  fun withVoidBedspace(voidBedspace: Cas3VoidBedspacesEntity) = apply {
+  fun withVoidBedspace(voidBedspace: Cas3VoidBedspaceEntity) = apply {
     this.voidBedspace = { voidBedspace }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceEntityFactory.kt
@@ -5,15 +5,15 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
 import java.util.UUID
 
-class Cas3VoidBedspacesEntityFactory : Factory<Cas3VoidBedspacesEntity> {
+class Cas3VoidBedspaceEntityFactory : Factory<Cas3VoidBedspaceEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
   private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }
@@ -73,7 +73,7 @@ class Cas3VoidBedspacesEntityFactory : Factory<Cas3VoidBedspacesEntity> {
   }
 
   @SuppressWarnings("TooGenericExceptionThrown")
-  override fun produce() = Cas3VoidBedspacesEntity(
+  override fun produce() = Cas3VoidBedspaceEntity(
     id = this.id(),
     startDate = this.startDate(),
     endDate = this.endDate(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchRepositoryTest.kt
@@ -153,7 +153,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withRoom(roomInPremisesOneInPdu)
     }
 
-    cas3VoidBedspacesEntityFactory.produceAndPersist {
+    cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premisesOneInPdu)
       withBed(bedFiveInRoomInPremisesOneInPdu)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -168,7 +168,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withRoom(roomInPremisesOneInPdu)
     }
 
-    cas3VoidBedspacesEntityFactory.produceAndPersist {
+    cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premisesOneInPdu)
       withBed(bedSixInRoomInPremisesOneInPdu)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -183,7 +183,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withRoom(roomInPremisesOneInPdu)
     }
 
-    cas3VoidBedspacesEntityFactory.produceAndPersist {
+    cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premisesOneInPdu)
       withBed(bedSevenInRoomInPremisesOneInPdu)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -198,7 +198,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withRoom(roomInPremisesOneInPdu)
     }
 
-    cas3VoidBedspacesEntityFactory.produceAndPersist {
+    cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premisesOneInPdu)
       withBed(bedEightInRoomInPremisesOneInPdu)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -253,7 +253,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withRoom(roomInPremisesThreeInPdu)
     }
 
-    val cancelledLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+    val cancelledLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premisesThreeInPdu)
       withBed(bedWithCancelledLostBed)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -469,7 +469,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withRoom(roomInPremisesThreeInPdu)
     }
 
-    val cancelledLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+    val cancelledLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premisesThreeInPdu)
       withBed(bedWithCancelledLostBed)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -667,7 +667,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withRoom(roomInPremisesThreeInPdu)
     }
 
-    val cancelledLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+    val cancelledLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premisesThreeInPdu)
       withBed(bedWithCancelledLostBed)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -862,7 +862,7 @@ class BedSearchRepositoryTest : IntegrationTestBase() {
       withRoom(roomInPremisesThreeInPdu)
     }
 
-    val cancelledLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+    val cancelledLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premisesThreeInPdu)
       withBed(bedWithCancelledLostBed)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
@@ -96,7 +96,7 @@ class BedSummaryQueryTest : IntegrationTestBase() {
       withDepartureDate(LocalDate.now().plusDays((20).toLong()))
     }
 
-    cas3VoidBedspacesEntityFactory.produceAndPersist {
+    cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premises)
       withBed(bedWithLostBed)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -130,7 +130,7 @@ class BedSummaryQueryTest : IntegrationTestBase() {
       }
     }
 
-    val cancelledLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+    val cancelledLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
       withPremises(premises)
       withBed(bedWithCancelledLostBed)
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
@@ -81,7 +81,7 @@ class BedSummaryTest : InitialiseDatabasePerClassTestBase() {
         withDepartureDate(LocalDate.now().plusDays((20).toLong()))
       }
 
-      cas3VoidBedspacesEntityFactory.produceAndPersist {
+      cas3VoidBedspaceEntityFactory.produceAndPersist {
         withPremises(premises)
         withBed(bedWithLostBed)
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1624,7 +1624,7 @@ class BookingTest : IntegrationTestBase() {
           }
         }
 
-        val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val existingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBed(bed)
           withPremises(premises)
           withStartDate(LocalDate.parse("2022-07-15"))
@@ -1680,7 +1680,7 @@ class BookingTest : IntegrationTestBase() {
           }
         }
 
-        val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val existingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBed(bed)
           withPremises(premises)
           withStartDate(LocalDate.parse("2022-07-15"))
@@ -1736,7 +1736,7 @@ class BookingTest : IntegrationTestBase() {
           }
         }
 
-        val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val existingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBed(bed)
           withPremises(premises)
           withStartDate(LocalDate.parse("2022-07-15"))
@@ -1933,7 +1933,7 @@ class BookingTest : IntegrationTestBase() {
           }
         }
 
-        val conflictingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBed(bed)
           withPremises(premises)
           withStartDate(LocalDate.parse("2022-07-15"))
@@ -3027,7 +3027,7 @@ class BookingTest : IntegrationTestBase() {
             }
           }
 
-          val conflictingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+          val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
             withBed(bed)
             withPremises(premises)
             withStartDate(LocalDate.parse("2022-07-15"))
@@ -3088,7 +3088,7 @@ class BookingTest : IntegrationTestBase() {
             }
           }
 
-          val conflictingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+          val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
             withBed(bed)
             withPremises(premises)
             withStartDate(LocalDate.parse("2022-07-15"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeletePremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeletePremisesTest.kt
@@ -129,7 +129,7 @@ class DeletePremisesTest : IntegrationTestBase() {
     withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
   }
 
-  private fun createVoidBedspace(premises: PremisesEntity, bed: BedEntity) = cas3VoidBedspacesEntityFactory.produceAndPersist {
+  private fun createVoidBedspace(premises: PremisesEntity, bed: BedEntity) = cas3VoidBedspaceEntityFactory.produceAndPersist {
     withPremises(premises)
     withBed(bed)
     withYieldedReason {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteRoomTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/DeleteRoomTest.kt
@@ -108,7 +108,7 @@ class DeleteRoomTest : IntegrationTestBase() {
     }
   }
 
-  private fun createVoidBedspace(premises: PremisesEntity, bed: BedEntity) = cas3VoidBedspacesEntityFactory.produceAndPersist {
+  private fun createVoidBedspace(premises: PremisesEntity, bed: BedEntity) = cas3VoidBedspaceEntityFactory.produceAndPersist {
     withPremises(premises)
     withBed(bed)
     withYieldedReason {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -99,8 +99,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceCancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspacesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.DomainEventAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.EmailNotificationAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.IntegrationTestDbManager
@@ -193,8 +193,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppsauth.GetTokenResponse
@@ -558,7 +558,7 @@ abstract class IntegrationTestBase {
   lateinit var nonArrivalEntityFactory: PersistedFactory<NonArrivalEntity, UUID, NonArrivalEntityFactory>
   lateinit var cancellationEntityFactory: PersistedFactory<CancellationEntity, UUID, CancellationEntityFactory>
   lateinit var cancellationReasonEntityFactory: PersistedFactory<CancellationReasonEntity, UUID, CancellationReasonEntityFactory>
-  lateinit var cas3VoidBedspacesEntityFactory: PersistedFactory<Cas3VoidBedspacesEntity, UUID, Cas3VoidBedspacesEntityFactory>
+  lateinit var cas3VoidBedspaceEntityFactory: PersistedFactory<Cas3VoidBedspaceEntity, UUID, Cas3VoidBedspaceEntityFactory>
   lateinit var cas3VoidBedspaceReasonEntityFactory: PersistedFactory<Cas3VoidBedspaceReasonEntity, UUID, Cas3VoidBedspaceReasonEntityFactory>
   lateinit var cas3VoidBedspaceCancellationEntityFactory: PersistedFactory<Cas3VoidBedspaceCancellationEntity, UUID, Cas3VoidBedspaceCancellationEntityFactory>
   lateinit var extensionEntityFactory: PersistedFactory<ExtensionEntity, UUID, ExtensionEntityFactory>
@@ -669,7 +669,7 @@ abstract class IntegrationTestBase {
     nonArrivalEntityFactory = PersistedFactory({ NonArrivalEntityFactory() }, nonArrivalRepository)
     cancellationEntityFactory = PersistedFactory({ CancellationEntityFactory() }, cancellationRepository)
     cancellationReasonEntityFactory = PersistedFactory({ CancellationReasonEntityFactory() }, cancellationReasonRepository)
-    cas3VoidBedspacesEntityFactory = PersistedFactory({ Cas3VoidBedspacesEntityFactory() }, cas3VoidBedspacesTestRepository)
+    cas3VoidBedspaceEntityFactory = PersistedFactory({ Cas3VoidBedspaceEntityFactory() }, cas3VoidBedspacesTestRepository)
     cas3VoidBedspaceReasonEntityFactory = PersistedFactory({ Cas3VoidBedspaceReasonEntityFactory() }, cas3VoidBedspaceReasonTestRepository)
     cas3VoidBedspaceCancellationEntityFactory = PersistedFactory({ Cas3VoidBedspaceCancellationEntityFactory() }, cas3VoidBedspaceCancellationTestRepository)
     extensionEntityFactory = PersistedFactory({ ExtensionEntityFactory() }, extensionRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesTest.kt
@@ -44,7 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
@@ -1913,7 +1913,7 @@ class PremisesTest {
     lateinit var bookingTransformer: BookingTransformer
 
     private lateinit var premises: ApprovedPremisesEntity
-    private lateinit var voidBedspaces: List<Cas3VoidBedspacesEntity>
+    private lateinit var voidBedspaces: List<Cas3VoidBedspaceEntity>
     private lateinit var rooms: List<RoomEntity>
     private lateinit var bookings: List<BookingEntity>
 
@@ -1938,14 +1938,14 @@ class PremisesTest {
       }
 
       voidBedspaces = mutableListOf(
-        cas3VoidBedspacesEntityFactory.produceAndPersist {
+        cas3VoidBedspaceEntityFactory.produceAndPersist {
           withPremises(premises)
           withStartDate(startDate.plusDays(1))
           withEndDate(startDate.plusDays(2))
           withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
           withBed(rooms[0].beds[0])
         },
-        cas3VoidBedspacesEntityFactory.produceAndPersist {
+        cas3VoidBedspaceEntityFactory.produceAndPersist {
           withPremises(premises)
           withStartDate(startDate.plusDays(1))
           withEndDate(startDate.plusDays(2))
@@ -1954,7 +1954,7 @@ class PremisesTest {
         },
       )
 
-      val cancelledLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val cancelledLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withPremises(premises)
         withStartDate(startDate.plusDays(1))
         withEndDate(startDate.plusDays(2))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReportsTest.kt
@@ -1311,7 +1311,7 @@ class ReportsTest : IntegrationTestBase() {
             )
           }
 
-          cas3VoidBedspacesEntityFactory.produceAndPersist {
+          cas3VoidBedspaceEntityFactory.produceAndPersist {
             withPremises(premises)
             withBed(bed1)
             withStartDate(LocalDate.of(2023, 4, 5))
@@ -1321,7 +1321,7 @@ class ReportsTest : IntegrationTestBase() {
             }
           }
 
-          cas3VoidBedspacesEntityFactory.produceAndPersist {
+          cas3VoidBedspaceEntityFactory.produceAndPersist {
             withPremises(premises)
             withBed(bed2)
             withStartDate(LocalDate.of(2023, 4, 12))
@@ -1331,7 +1331,7 @@ class ReportsTest : IntegrationTestBase() {
             }
           }
 
-          val voidBedspace3 = cas3VoidBedspacesEntityFactory.produceAndPersist {
+          val voidBedspace3 = cas3VoidBedspaceEntityFactory.produceAndPersist {
             withPremises(premises)
             withBed(bed3)
             withStartDate(LocalDate.of(2023, 4, 1))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
@@ -174,7 +174,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
         withDepartureDate(LocalDate.of(2023, 5, 3))
       }
 
-      val conflictingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withPremises(premises)
         withBed(bed)
         withStartDate(LocalDate.of(2023, 5, 5))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/VoidBedspacesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/VoidBedspacesTest.kt
@@ -65,7 +65,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withYieldedProbationRegion { probationRegion }
       }
 
-      val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -110,7 +110,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      cas3VoidBedspacesEntityFactory.produceAndPersist {
+      cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -135,7 +135,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
       withYieldedProbationRegion { probationRegion }
     }
 
-    val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+    val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
       withStartDate(LocalDate.now().plusDays(2))
       withEndDate(LocalDate.now().plusDays(4))
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -203,7 +203,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -240,7 +240,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -417,7 +417,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
       withYieldedProbationRegion { probationRegion }
     }
 
-    val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+    val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
       withStartDate(LocalDate.now().plusDays(2))
       withEndDate(LocalDate.now().plusDays(4))
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -520,7 +520,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -575,7 +575,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -611,7 +611,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
       withYieldedProbationRegion { probationRegion }
     }
 
-    val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+    val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
       withStartDate(LocalDate.now().plusDays(2))
       withEndDate(LocalDate.now().plusDays(4))
       withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -694,7 +694,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -737,7 +737,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.now().plusDays(2))
         withEndDate(LocalDate.now().plusDays(4))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -900,7 +900,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
 
         val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
-        val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val existingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBed(bed)
           withPremises(premises)
           withStartDate(LocalDate.parse("2022-07-15"))
@@ -951,7 +951,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
 
         val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
-        val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val existingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBed(bed)
           withPremises(premises)
           withStartDate(LocalDate.parse("2022-07-15"))
@@ -1013,7 +1013,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         }
       }
 
-      val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+      val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
         withStartDate(LocalDate.parse("2022-08-16"))
         withEndDate(LocalDate.parse("2022-08-30"))
         withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -1073,7 +1073,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           }
         }
 
-        val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withStartDate(LocalDate.parse("2022-08-16"))
           withEndDate(LocalDate.parse("2022-08-30"))
           withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -1147,7 +1147,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
 
         val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
-        val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withStartDate(LocalDate.parse("2022-08-16"))
           withEndDate(LocalDate.parse("2022-08-30"))
           withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -1155,7 +1155,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           withPremises(premises)
         }
 
-        val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val existingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBed(bed)
           withPremises(premises)
           withStartDate(LocalDate.parse("2022-07-15"))
@@ -1205,7 +1205,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
 
         val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
-        val voidBedspaces = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val voidBedspaces = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withStartDate(LocalDate.parse("2022-08-16"))
           withEndDate(LocalDate.parse("2022-08-30"))
           withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
@@ -1213,7 +1213,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
           withPremises(premises)
         }
 
-        val existingLostBed = cas3VoidBedspacesEntityFactory.produceAndPersist {
+        val existingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBed(bed)
           withPremises(premises)
           withStartDate(LocalDate.parse("2022-07-15"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -2280,7 +2280,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
           bed.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
           bedRepository.save(bed)
 
-          cas3VoidBedspacesEntityFactory.produceAndPersist {
+          cas3VoidBedspaceEntityFactory.produceAndPersist {
             withBed(bed)
             withPremises(premises)
             withStartDate(LocalDate.parse("2023-04-28"))
@@ -2913,7 +2913,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
 
           govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
 
-          cas3VoidBedspacesEntityFactory.produceAndPersist {
+          cas3VoidBedspaceEntityFactory.produceAndPersist {
             withBed(bed)
             withPremises(premises)
             withStartDate(LocalDate.parse("2023-03-28"))
@@ -2921,7 +2921,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
           }
 
-          cas3VoidBedspacesEntityFactory.produceAndPersist {
+          cas3VoidBedspaceEntityFactory.produceAndPersist {
             withBed(bed)
             withPremises(premises)
             withStartDate(LocalDate.parse("2023-04-25"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3VoidBedspacesTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3VoidBedspacesTestRepository.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import java.util.UUID
 
 @Repository
-interface Cas3VoidBedspacesTestRepository : JpaRepository<Cas3VoidBedspacesEntity, UUID>
+interface Cas3VoidBedspacesTestRepository : JpaRepository<Cas3VoidBedspaceEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
@@ -18,8 +18,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspacesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
@@ -61,7 +61,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(temporaryAccommodationRoom)
       .produce()
 
-    val temporaryAccommodationLostBed = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationLostBed = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -81,7 +81,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(approvedPremisesRoom)
       .produce()
 
-    val approvedPremisesLostBed = Cas3VoidBedspacesEntityFactory()
+    val approvedPremisesLostBed = Cas3VoidBedspaceEntityFactory()
       .withBed(approvedPremisesBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -91,8 +91,14 @@ class BedUsageReportGeneratorTest {
 
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationLostBed)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)
+    every {
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBed,
+      )
+    } returns listOf(temporaryAccommodationLostBed)
+    every { mockLostBedsRepository.findAllByOverlappingDateForBedspace(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)
 
     val result = bedUsageReportGenerator.createReport(
       listOf(approvedPremisesBed, temporaryAccommodationBed),
@@ -120,7 +126,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(temporaryAccommodationRoom)
       .produce()
 
-    val temporaryAccommodationLostBed = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationLostBed = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -140,7 +146,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(approvedPremisesRoom)
       .produce()
 
-    val approvedPremisesLostBed = Cas3VoidBedspacesEntityFactory()
+    val approvedPremisesLostBed = Cas3VoidBedspaceEntityFactory()
       .withBed(approvedPremisesBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -163,14 +169,14 @@ class BedUsageReportGeneratorTest {
       )
     } returns emptyList()
     every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-07-01"),
         temporaryAccommodationBed,
       )
     } returns listOf(temporaryAccommodationLostBed)
     every {
-      mockLostBedsRepository.findAllByOverlappingDateForBed(
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-07-01"),
         approvedPremisesBed,
@@ -214,7 +220,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(temporaryAccommodationRoom)
       .produce()
 
-    val temporaryAccommodationLostBed = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationLostBed = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -234,7 +240,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(approvedPremisesRoom)
       .produce()
 
-    val approvedPremisesLostBed = Cas3VoidBedspacesEntityFactory()
+    val approvedPremisesLostBed = Cas3VoidBedspaceEntityFactory()
       .withBed(approvedPremisesBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -244,8 +250,14 @@ class BedUsageReportGeneratorTest {
 
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationLostBed)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)
+    every {
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBed,
+      )
+    } returns listOf(temporaryAccommodationLostBed)
+    every { mockLostBedsRepository.findAllByOverlappingDateForBedspace(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), approvedPremisesBed) } returns listOf(approvedPremisesLostBed)
 
     val bedUsageReportGeneratorWithThreeMonth = BedUsageReportGenerator(
       mockBookingTransformer,
@@ -300,7 +312,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(temporaryAccommodationRoomInProbationRegion)
       .produce()
 
-    val temporaryAccommodationLostBedInProbationArea = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationLostBedInProbationArea = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBedInProbationRegion)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -321,7 +333,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(temporaryAccommodationRoomOutsideProbationRegion)
       .produce()
 
-    val temporaryAccommodationLostBedOutsideProbationArea = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationLostBedOutsideProbationArea = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBedOutsideProbationRegion)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -330,9 +342,21 @@ class BedUsageReportGeneratorTest {
       .produce()
 
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns listOf(temporaryAccommodationLostBedInProbationArea)
+    every {
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBedInProbationRegion,
+      )
+    } returns listOf(temporaryAccommodationLostBedInProbationArea)
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)
+    every {
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBedOutsideProbationRegion,
+      )
+    } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)
 
     val result = bedUsageReportGenerator.createReport(
       listOf(temporaryAccommodationBedInProbationRegion, temporaryAccommodationBedOutsideProbationRegion),
@@ -376,7 +400,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(temporaryAccommodationRoomInProbationRegion)
       .produce()
 
-    val temporaryAccommodationLostBedInProbationArea = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationLostBedInProbationArea = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBedInProbationRegion)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -397,7 +421,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(temporaryAccommodationRoomOutsideProbationRegion)
       .produce()
 
-    val temporaryAccommodationLostBedOutsideProbationArea = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationLostBedOutsideProbationArea = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBedOutsideProbationRegion)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -405,10 +429,34 @@ class BedUsageReportGeneratorTest {
       .withPremises(temporaryAccommodationPremisesOutsideProbationRegion)
       .produce()
 
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedInProbationRegion) } returns listOf(temporaryAccommodationLostBedInProbationArea)
-    every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBedOutsideProbationRegion) } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)
+    every {
+      mockBookingRepository.findAllByOverlappingDateForBed(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBedInProbationRegion,
+      )
+    } returns emptyList()
+    every {
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBedInProbationRegion,
+      )
+    } returns listOf(temporaryAccommodationLostBedInProbationArea)
+    every {
+      mockBookingRepository.findAllByOverlappingDateForBed(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBedOutsideProbationRegion,
+      )
+    } returns emptyList()
+    every {
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBedOutsideProbationRegion,
+      )
+    } returns listOf(temporaryAccommodationLostBedOutsideProbationArea)
 
     val result = bedUsageReportGenerator.createReport(
       listOf(temporaryAccommodationBedInProbationRegion, temporaryAccommodationBedOutsideProbationRegion),
@@ -460,7 +508,7 @@ class BedUsageReportGeneratorTest {
       .produce()
 
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationBooking)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
+    every { mockLostBedsRepository.findAllByOverlappingDateForBedspace(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
 
     every { mockBookingTransformer.determineStatus(temporaryAccommodationBooking) } returns BookingStatus.closed
 
@@ -531,7 +579,7 @@ class BedUsageReportGeneratorTest {
     temporaryAccommodationBooking.turnarounds += turnaround
 
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationBooking)
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
+    every { mockLostBedsRepository.findAllByOverlappingDateForBedspace(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
 
     every { mockBookingTransformer.determineStatus(temporaryAccommodationBooking) } returns BookingStatus.closed
 
@@ -588,7 +636,7 @@ class BedUsageReportGeneratorTest {
       .withRoom(temporaryAccommodationRoom)
       .produce()
 
-    val temporaryAccommodationLostBed = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationLostBed = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -597,7 +645,13 @@ class BedUsageReportGeneratorTest {
       .produce()
 
     every { mockBookingRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns emptyList()
-    every { mockLostBedsRepository.findAllByOverlappingDateForBed(LocalDate.parse("2023-04-01"), LocalDate.parse("2023-04-30"), temporaryAccommodationBed) } returns listOf(temporaryAccommodationLostBed)
+    every {
+      mockLostBedsRepository.findAllByOverlappingDateForBedspace(
+        LocalDate.parse("2023-04-01"),
+        LocalDate.parse("2023-04-30"),
+        temporaryAccommodationBed,
+      )
+    } returns listOf(temporaryAccommodationLostBed)
 
     val result = bedUsageReportGenerator.createReport(
       listOf(temporaryAccommodationBed),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
@@ -20,8 +20,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspacesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.BedUtilisationReportRow
@@ -53,7 +53,7 @@ class BedUtilisationReportGeneratorTest {
     val temporaryAccommodationBed = BedEntityFactory().withRoom(temporaryAccommodationRoom).produce()
 
     val temporaryAccommodationLostBed =
-      Cas3VoidBedspacesEntityFactory().withBed(temporaryAccommodationBed).withStartDate(LocalDate.parse("2023-04-05"))
+      Cas3VoidBedspaceEntityFactory().withBed(temporaryAccommodationBed).withStartDate(LocalDate.parse("2023-04-05"))
         .withEndDate(LocalDate.parse("2023-04-07")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .withPremises(temporaryAccommodationPremises).produce()
 
@@ -64,7 +64,7 @@ class BedUtilisationReportGeneratorTest {
 
     val approvedPremisesBed = BedEntityFactory().withRoom(approvedPremisesRoom).produce()
 
-    Cas3VoidBedspacesEntityFactory().withBed(approvedPremisesBed).withStartDate(LocalDate.parse("2023-04-10"))
+    Cas3VoidBedspaceEntityFactory().withBed(approvedPremisesBed).withStartDate(LocalDate.parse("2023-04-10"))
       .withEndDate(LocalDate.parse("2023-04-17")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
       .withPremises(approvedPremises).produce()
 
@@ -100,7 +100,7 @@ class BedUtilisationReportGeneratorTest {
     val temporaryAccommodationBed = BedEntityFactory().withRoom(temporaryAccommodationRoom).produce()
 
     val temporaryAccommodationLostBed =
-      Cas3VoidBedspacesEntityFactory().withBed(temporaryAccommodationBed).withStartDate(LocalDate.parse("2023-04-05"))
+      Cas3VoidBedspaceEntityFactory().withBed(temporaryAccommodationBed).withStartDate(LocalDate.parse("2023-04-05"))
         .withEndDate(LocalDate.parse("2023-04-07")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .withPremises(temporaryAccommodationPremises).produce()
 
@@ -111,7 +111,7 @@ class BedUtilisationReportGeneratorTest {
 
     val approvedPremisesBed = BedEntityFactory().withRoom(approvedPremisesRoom).produce()
 
-    Cas3VoidBedspacesEntityFactory().withBed(approvedPremisesBed).withStartDate(LocalDate.parse("2023-04-05"))
+    Cas3VoidBedspaceEntityFactory().withBed(approvedPremisesBed).withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
       .withPremises(approvedPremises).produce()
 
@@ -146,7 +146,7 @@ class BedUtilisationReportGeneratorTest {
 
     val temporaryAccommodationBed = BedEntityFactory().withRoom(temporaryAccommodationRoom).produce()
 
-    Cas3VoidBedspacesEntityFactory().withBed(temporaryAccommodationBed).withStartDate(LocalDate.parse("2023-04-05"))
+    Cas3VoidBedspaceEntityFactory().withBed(temporaryAccommodationBed).withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
       .withPremises(temporaryAccommodationPremises).produce()
 
@@ -158,7 +158,7 @@ class BedUtilisationReportGeneratorTest {
     val approvedPremisesBed = BedEntityFactory().withRoom(approvedPremisesRoom).produce()
 
     val approvedPremisesLostBed =
-      Cas3VoidBedspacesEntityFactory().withBed(approvedPremisesBed).withStartDate(LocalDate.parse("2023-04-05"))
+      Cas3VoidBedspaceEntityFactory().withBed(approvedPremisesBed).withStartDate(LocalDate.parse("2023-04-05"))
         .withEndDate(LocalDate.parse("2023-04-07")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .withPremises(approvedPremises).produce()
 
@@ -207,7 +207,7 @@ class BedUtilisationReportGeneratorTest {
       BedEntityFactory().withRoom(temporaryAccommodationRoomInProbationRegion).produce()
 
     val temporaryAccommodationLostBedInProbationArea =
-      Cas3VoidBedspacesEntityFactory().withBed(temporaryAccommodationBedInProbationRegion)
+      Cas3VoidBedspaceEntityFactory().withBed(temporaryAccommodationBedInProbationRegion)
         .withStartDate(LocalDate.parse("2023-04-05")).withEndDate(LocalDate.parse("2023-04-07"))
         .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .withPremises(temporaryAccommodationPremisesInProbationRegion).produce()
@@ -223,7 +223,7 @@ class BedUtilisationReportGeneratorTest {
       BedEntityFactory().withRoom(temporaryAccommodationRoomOutsideProbationRegion).produce()
 
     val temporaryAccommodationLostBedOutsideProbationArea =
-      Cas3VoidBedspacesEntityFactory().withBed(temporaryAccommodationBedOutsideProbationRegion)
+      Cas3VoidBedspaceEntityFactory().withBed(temporaryAccommodationBedOutsideProbationRegion)
         .withStartDate(LocalDate.parse("2023-04-05")).withEndDate(LocalDate.parse("2023-04-07"))
         .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .withPremises(temporaryAccommodationPremisesOutsideProbationRegion).produce()
@@ -277,7 +277,7 @@ class BedUtilisationReportGeneratorTest {
       BedEntityFactory().withRoom(temporaryAccommodationRoomInProbationRegion).produce()
 
     val temporaryAccommodationLostBedInProbationArea =
-      Cas3VoidBedspacesEntityFactory().withBed(temporaryAccommodationBedInProbationRegion)
+      Cas3VoidBedspaceEntityFactory().withBed(temporaryAccommodationBedInProbationRegion)
         .withStartDate(LocalDate.parse("2023-04-05")).withEndDate(LocalDate.parse("2023-04-07"))
         .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .withPremises(temporaryAccommodationPremisesInProbationRegion).produce()
@@ -293,7 +293,7 @@ class BedUtilisationReportGeneratorTest {
       BedEntityFactory().withRoom(temporaryAccommodationRoomOutsideProbationRegion).produce()
 
     val temporaryAccommodationLostBedOutsideProbationArea =
-      Cas3VoidBedspacesEntityFactory().withBed(temporaryAccommodationBedOutsideProbationRegion)
+      Cas3VoidBedspaceEntityFactory().withBed(temporaryAccommodationBedOutsideProbationRegion)
         .withStartDate(LocalDate.parse("2023-04-05")).withEndDate(LocalDate.parse("2023-04-07"))
         .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .withPremises(temporaryAccommodationPremisesOutsideProbationRegion).produce()
@@ -625,12 +625,12 @@ class BedUtilisationReportGeneratorTest {
     val bed = BedEntityFactory().withRoom(room).produce()
 
     val relevantVoidStraddlingStartOfMonth =
-      Cas3VoidBedspacesEntityFactory().withBed(bed).withPremises(premises).withStartDate(LocalDate.parse("2023-03-28"))
+      Cas3VoidBedspaceEntityFactory().withBed(bed).withPremises(premises).withStartDate(LocalDate.parse("2023-03-28"))
         .withEndDate(LocalDate.parse("2023-04-04")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .produce()
 
     val relevantVoidStraddlingEndOfMonth =
-      Cas3VoidBedspacesEntityFactory().withBed(bed).withPremises(premises).withStartDate(LocalDate.parse("2023-04-25"))
+      Cas3VoidBedspaceEntityFactory().withBed(bed).withPremises(premises).withStartDate(LocalDate.parse("2023-04-25"))
         .withEndDate(LocalDate.parse("2023-05-03")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .produce()
 
@@ -724,12 +724,12 @@ class BedUtilisationReportGeneratorTest {
     } returns 1
 
     val relevantVoidStraddlingStartOfMonth =
-      Cas3VoidBedspacesEntityFactory().withBed(bed).withPremises(premises).withStartDate(LocalDate.parse("2023-03-28"))
+      Cas3VoidBedspaceEntityFactory().withBed(bed).withPremises(premises).withStartDate(LocalDate.parse("2023-03-28"))
         .withEndDate(LocalDate.parse("2023-04-04")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .produce()
 
     val relevantVoidStraddlingEndOfMonth =
-      Cas3VoidBedspacesEntityFactory().withBed(bed).withPremises(premises).withStartDate(LocalDate.parse("2023-04-25"))
+      Cas3VoidBedspaceEntityFactory().withBed(bed).withPremises(premises).withStartDate(LocalDate.parse("2023-04-25"))
         .withEndDate(LocalDate.parse("2023-05-03")).withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
         .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/VoidBedspaceReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/VoidBedspaceReportGeneratorTest.kt
@@ -14,8 +14,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliver
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspacesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.VoidBedspacesReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.VoidBedspaceReportRow
@@ -43,7 +43,7 @@ class VoidBedspaceReportGeneratorTest {
       .withRoom(temporaryAccommodationRoom)
       .produce()
 
-    val temporaryAccommodationVoidBedspace = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationVoidBedspace = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -63,7 +63,7 @@ class VoidBedspaceReportGeneratorTest {
       .withRoom(approvedPremisesRoom)
       .produce()
 
-    val approvedPremisesLostBed = Cas3VoidBedspacesEntityFactory()
+    val approvedPremisesLostBed = Cas3VoidBedspaceEntityFactory()
       .withBed(approvedPremisesBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -72,14 +72,14 @@ class VoidBedspaceReportGeneratorTest {
       .produce()
 
     every {
-      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBed(
+      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-04-30"),
         temporaryAccommodationBed,
       )
     } returns listOf(temporaryAccommodationVoidBedspace)
     every {
-      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBed(
+      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-04-30"),
         approvedPremisesBed,
@@ -125,7 +125,7 @@ class VoidBedspaceReportGeneratorTest {
       .withRoom(temporaryAccommodationRoomInProbationRegion)
       .produce()
 
-    val temporaryAccommodationVoidBedspaceInProbationArea = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationVoidBedspaceInProbationArea = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBedInProbationRegion)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -146,7 +146,7 @@ class VoidBedspaceReportGeneratorTest {
       .withRoom(temporaryAccommodationRoomOutsideProbationRegion)
       .produce()
 
-    val temporaryAccommodationVoidBedspaceOutsideProbationArea = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationVoidBedspaceOutsideProbationArea = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBedOutsideProbationRegion)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -155,14 +155,14 @@ class VoidBedspaceReportGeneratorTest {
       .produce()
 
     every {
-      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBed(
+      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-04-30"),
         temporaryAccommodationBedInProbationRegion,
       )
     } returns listOf(temporaryAccommodationVoidBedspaceInProbationArea)
     every {
-      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBed(
+      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-04-30"),
         temporaryAccommodationBedOutsideProbationRegion,
@@ -208,7 +208,7 @@ class VoidBedspaceReportGeneratorTest {
       .withRoom(temporaryAccommodationRoomInProbationRegion)
       .produce()
 
-    val temporaryAccommodationVoidBedspaceInProbationArea = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationVoidBedspaceInProbationArea = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBedInProbationRegion)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -229,7 +229,7 @@ class VoidBedspaceReportGeneratorTest {
       .withRoom(temporaryAccommodationRoomOutsideProbationRegion)
       .produce()
 
-    val temporaryAccommodationVoidBedspaceOutsideProbationArea = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationVoidBedspaceOutsideProbationArea = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBedOutsideProbationRegion)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -238,14 +238,14 @@ class VoidBedspaceReportGeneratorTest {
       .produce()
 
     every {
-      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBed(
+      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-04-30"),
         temporaryAccommodationBedInProbationRegion,
       )
     } returns listOf(temporaryAccommodationVoidBedspaceInProbationArea)
     every {
-      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBed(
+      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-04-30"),
         temporaryAccommodationBedOutsideProbationRegion,
@@ -289,7 +289,7 @@ class VoidBedspaceReportGeneratorTest {
       .withRoom(temporaryAccommodationRoom)
       .produce()
 
-    val temporaryAccommodationVoidBedspace = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationVoidBedspace = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBed)
       .withStartDate(LocalDate.parse("2023-04-05"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -298,7 +298,7 @@ class VoidBedspaceReportGeneratorTest {
       .produce()
 
     every {
-      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBed(
+      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-04-30"),
         temporaryAccommodationBed,
@@ -350,7 +350,7 @@ class VoidBedspaceReportGeneratorTest {
       .withRoom(temporaryAccommodationRoom)
       .produce()
 
-    val temporaryAccommodationVoidBedspace = Cas3VoidBedspacesEntityFactory()
+    val temporaryAccommodationVoidBedspace = Cas3VoidBedspaceEntityFactory()
       .withBed(temporaryAccommodationBed)
       .withStartDate(LocalDate.parse("2023-03-28"))
       .withEndDate(LocalDate.parse("2023-04-07"))
@@ -359,7 +359,7 @@ class VoidBedspaceReportGeneratorTest {
       .produce()
 
     every {
-      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBed(
+      mockCas3VoidBedspacesRepository.findAllByOverlappingDateForBedspace(
         LocalDate.parse("2023-04-01"),
         LocalDate.parse("2023-04-30"),
         temporaryAccommodationBed,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/Cas3ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/util/Cas3ReportsTestHelper.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.reporting.util
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBedspaceReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingCancellationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedUtilisationBookingReportData
@@ -69,7 +69,7 @@ fun convertToCas3BedUtilisationBookingTurnaroundReportData(booking: BookingEntit
   )
 }
 
-fun convertToCas3BedUtilisationLostBedReportData(voidBedspace: Cas3VoidBedspacesEntity): Cas3BedUtilisationVoidBedspaceUtilisationVoidBedspaceReportData {
+fun convertToCas3BedUtilisationLostBedReportData(voidBedspace: Cas3VoidBedspaceEntity): Cas3BedUtilisationVoidBedspaceUtilisationVoidBedspaceReportData {
   return Cas3BedUtilisationVoidBedspaceUtilisationVoidBedspaceReportData(
     bedId = voidBedspace.bed.id.toString(),
     startDate = voidBedspace.startDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -44,8 +44,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspacesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
@@ -1091,7 +1091,7 @@ class BookingServiceTest {
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
-      every { mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+      every { mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
       val result = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -1271,7 +1271,7 @@ class BookingServiceTest {
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
-      every { mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+      every { mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
       val result = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -1329,7 +1329,7 @@ class BookingServiceTest {
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
-      every { mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+      every { mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
       val result = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -1388,7 +1388,7 @@ class BookingServiceTest {
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
-      every { mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+      every { mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
       val result = bookingService.createApprovedPremisesBookingFromPlacementRequest(
         user = user,
@@ -1447,7 +1447,7 @@ class BookingServiceTest {
           .withBed(bed)
           .produce(),
       )
-      every { mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+      every { mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -1501,8 +1501,8 @@ class BookingServiceTest {
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
-      every { mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf(
-        Cas3VoidBedspacesEntityFactory()
+      every { mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf(
+        Cas3VoidBedspaceEntityFactory()
           .withStartDate(arrivalDate)
           .withEndDate(departureDate)
           .withPremises(premises)
@@ -1560,7 +1560,7 @@ class BookingServiceTest {
         .produce()
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
-      every { mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
+      every { mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(bed.id, arrivalDate, departureDate, null) } returns listOf()
 
       every { mockBedRepository.findByIdOrNull(bed.id) } returns bed
 
@@ -2034,7 +2034,7 @@ class BookingServiceTest {
         .withServiceName(ServiceName.temporaryAccommodation)
         .produce()
 
-      val conflictingLostBed = Cas3VoidBedspacesEntityFactory()
+      val conflictingLostBed = Cas3VoidBedspaceEntityFactory()
         .withPremises(temporaryAccommodationPremises)
         .withBed(temporaryAccommodationBed)
         .withStartDate(LocalDate.parse("2023-07-10"))
@@ -2045,7 +2045,7 @@ class BookingServiceTest {
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(temporaryAccommodationBed.id, LocalDate.parse("2023-07-14"), booking.id) } returns emptyList()
       every {
-        mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(
+        mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(
           temporaryAccommodationBed.id, LocalDate.parse("2023-07-12"),
           LocalDate.parse("2023-07-14"),
           null,
@@ -2074,7 +2074,7 @@ class BookingServiceTest {
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(temporaryAccommodationBed.id, LocalDate.parse("2023-07-14"), booking.id) } returns emptyList()
-      every { mockCas3LostBedsRepository.findByBedIdAndOverlappingDate(temporaryAccommodationBed.id, LocalDate.parse("2023-07-16"), LocalDate.parse("2023-07-14"), null) } returns emptyList()
+      every { mockCas3LostBedsRepository.findByBedspaceIdAndOverlappingDate(temporaryAccommodationBed.id, LocalDate.parse("2023-07-16"), LocalDate.parse("2023-07-14"), null) } returns emptyList()
 
       val result = bookingService.createDateChange(
         booking = booking,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PremisesServiceTest.kt
@@ -12,8 +12,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceCancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspacesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
@@ -88,7 +88,7 @@ class PremisesServiceTest {
 
     val premises = approvedPremisesFactory.produce()
 
-    val voidBedspaceEntityOne = Cas3VoidBedspacesEntityFactory()
+    val voidBedspaceEntityOne = Cas3VoidBedspaceEntityFactory()
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))
@@ -104,7 +104,7 @@ class PremisesServiceTest {
       )
       .produce()
 
-    val voidBedspaceEntityTwo = Cas3VoidBedspacesEntityFactory()
+    val voidBedspaceEntityTwo = Cas3VoidBedspaceEntityFactory()
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))
@@ -182,7 +182,7 @@ class PremisesServiceTest {
 
     val premises = approvedPremisesFactory.produce()
 
-    val voidBedspaceEntity = Cas3VoidBedspacesEntityFactory()
+    val voidBedspaceEntity = Cas3VoidBedspaceEntityFactory()
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
@@ -70,7 +70,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -267,7 +266,7 @@ class Cas3BookingServiceTest {
       assertThat(result is AuthorisableActionResult.Success).isTrue()
       result as AuthorisableActionResult.Success
 
-      assertThat(result.entity).isEqualTo(BookingService.BookingAndPersons(bookingEntity, personInfo))
+      assertThat(result.entity).isEqualTo(Cas3BookingService.BookingAndPersons(bookingEntity, personInfo))
     }
 
     @Test
@@ -1246,7 +1245,7 @@ class Cas3BookingServiceTest {
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(any(), any(), any()) } returns listOf()
-      every { mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(any(), any(), any(), any()) } returns listOf()
+      every { mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(any(), any(), any(), any()) } returns listOf()
     }
 
     @Test
@@ -1610,7 +1609,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bedId, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bedId,
           arrivalDate,
           departureDate,
@@ -1661,7 +1660,7 @@ class Cas3BookingServiceTest {
       every { mockBedRepository.findByIdOrNull(bedId) } returns null
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bedId, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bedId,
           arrivalDate,
           departureDate,
@@ -1730,7 +1729,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -1800,7 +1799,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -1886,7 +1885,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -1975,7 +1974,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -2068,7 +2067,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -2159,7 +2158,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -2257,7 +2256,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -2352,7 +2351,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -2439,7 +2438,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -2509,7 +2508,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -2604,7 +2603,7 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(bed.id, departureDate, null) } returns listOf()
       every {
-        mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(
+        mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(
           bed.id,
           arrivalDate,
           departureDate,
@@ -2705,7 +2704,7 @@ class Cas3BookingServiceTest {
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(any(), any(), any()) } returns listOf()
-      every { mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(any(), any(), any(), any()) } returns listOf()
+      every { mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(any(), any(), any(), any()) } returns listOf()
       every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
 
       val negativeDaysResult = cas3BookingService.createTurnaround(booking, -1)
@@ -2748,7 +2747,7 @@ class Cas3BookingServiceTest {
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(any(), any(), any()) } returns listOf()
-      every { mockCas3VoidBedspacesRepository.findByBedIdAndOverlappingDate(any(), any(), any(), any()) } returns listOf()
+      every { mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(any(), any(), any(), any()) } returns listOf()
       every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
 
       val result = cas3BookingService.createTurnaround(booking, 2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3PremisesServiceTest.kt
@@ -15,8 +15,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceCancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspacesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
@@ -24,8 +24,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Availability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -79,7 +79,7 @@ class Cas3PremisesServiceTest {
       .withYieldedRoom { room }
       .produce()
 
-    val voidBedspaceEntity = Cas3VoidBedspacesEntityFactory()
+    val voidBedspaceEntity = Cas3VoidBedspaceEntityFactory()
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))
@@ -167,7 +167,7 @@ class Cas3PremisesServiceTest {
 
     val premises = temporaryAccommodationPremisesFactory.produce()
 
-    val voidBedspaceEntityOne = Cas3VoidBedspacesEntityFactory()
+    val voidBedspaceEntityOne = Cas3VoidBedspaceEntityFactory()
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))
@@ -183,7 +183,7 @@ class Cas3PremisesServiceTest {
       )
       .produce()
 
-    val voidBedspaceEntityTwo = Cas3VoidBedspacesEntityFactory()
+    val voidBedspaceEntityTwo = Cas3VoidBedspaceEntityFactory()
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))
@@ -261,7 +261,7 @@ class Cas3PremisesServiceTest {
 
     val premises = temporaryAccommodationPremisesFactory.produce()
 
-    val voidBedspaceEntity = Cas3VoidBedspacesEntityFactory()
+    val voidBedspaceEntity = Cas3VoidBedspaceEntityFactory()
       .withPremises(premises)
       .withStartDate(startDate.plusDays(1))
       .withEndDate(startDate.plusDays(2))
@@ -345,7 +345,7 @@ class Cas3PremisesServiceTest {
 
     every { cas3VoidBedspaceReasonRepositoryMock.findByIdOrNull(voidBedspaceReason.id) } returns voidBedspaceReason
 
-    every { cas3VoidBedspacesRepositoryMock.save(any()) } answers { it.invocation.args[0] as Cas3VoidBedspacesEntity }
+    every { cas3VoidBedspacesRepositoryMock.save(any()) } answers { it.invocation.args[0] as Cas3VoidBedspaceEntity }
 
     val result = premisesService.createVoidBedspaces(
       premises = premisesEntity,
@@ -373,7 +373,7 @@ class Cas3PremisesServiceTest {
 
     val reasonId = UUID.randomUUID()
 
-    val voidBedspaceEntity = Cas3VoidBedspacesEntityFactory()
+    val voidBedspaceEntity = Cas3VoidBedspaceEntityFactory()
       .withYieldedPremises { premisesEntity }
       .withYieldedReason {
         Cas3VoidBedspaceReasonEntityFactory()
@@ -418,7 +418,7 @@ class Cas3PremisesServiceTest {
     val voidBedspaceReason = Cas3VoidBedspaceReasonEntityFactory()
       .produce()
 
-    val voidBedspacesEntity = Cas3VoidBedspacesEntityFactory()
+    val voidBedspacesEntity = Cas3VoidBedspaceEntityFactory()
       .withYieldedPremises { premisesEntity }
       .withYieldedReason {
         Cas3VoidBedspaceReasonEntityFactory()
@@ -438,7 +438,7 @@ class Cas3PremisesServiceTest {
     every { cas3VoidBedspacesRepositoryMock.findByIdOrNull(voidBedspacesEntity.id) } returns voidBedspacesEntity
     every { cas3VoidBedspaceReasonRepositoryMock.findByIdOrNull(voidBedspaceReason.id) } returns voidBedspaceReason
 
-    every { cas3VoidBedspacesRepositoryMock.save(any()) } answers { it.invocation.args[0] as Cas3VoidBedspacesEntity }
+    every { cas3VoidBedspacesRepositoryMock.save(any()) } answers { it.invocation.args[0] as Cas3VoidBedspaceEntity }
 
     val result = premisesService.updateVoidBedspaces(
       voidBedspaceId = voidBedspacesEntity.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/Cas3VoidBedspacesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/Cas3VoidBedspacesTransformerTest.kt
@@ -14,8 +14,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceCancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspacesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspaceCancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspaceReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspacesTransformer
@@ -50,7 +50,7 @@ class Cas3VoidBedspacesTransformerTest {
     .withYieldedRoom { room }
     .produce()
 
-  private val voidBedspace = Cas3VoidBedspacesEntityFactory()
+  private val voidBedspace = Cas3VoidBedspaceEntityFactory()
     .withYieldedReason {
       Cas3VoidBedspaceReasonEntityFactory()
         .produce()


### PR DESCRIPTION
This PR CAS1343 is to rename functions and variables to void bedspace