### PR TITLE
Re-add ApprovedPremisesBedSearchResult

### DIFF
--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1035,24 +1035,15 @@ components:
         - updatedReferenceNumber
         - updatedReason
         - updatedNotes
-    ApprovedPremisesBedSearchParameters:
+    ApprovedPremisesBedSearchResult:
       deprecated: true
       description: This is no longer returned by any APIs so should be removed once removed from UI Code
       allOf:
-        - $ref: '_shared.yml#/components/schemas/BedSearchParameters'
+        - $ref: '_shared.yml#/components/schemas/BedSearchResult'
         - type: object
           properties:
-            postcodeDistrict:
-              type: string
-              description: The postcode district to search outwards from
-            maxDistanceMiles:
-              type: integer
-              description: Maximum number of miles from the postcode district to search, only required if more than 50 miles which is the default
-            requiredCharacteristics:
-              type: array
-              items:
-                $ref: '_shared.yml#/components/schemas/PlacementCriteria'
+            distanceMiles:
+              type: number
+              description: how many miles away from the postcode district the Premises this Bed belongs to is
           required:
-            - postcodeDistrict
-            - maxDistanceMiles
-            - requiredCharacteristics
+            - distanceMiles

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7052,24 +7052,15 @@ components:
         - updatedReferenceNumber
         - updatedReason
         - updatedNotes
-    ApprovedPremisesBedSearchParameters:
+    ApprovedPremisesBedSearchResult:
       deprecated: true
       description: This is no longer returned by any APIs so should be removed once removed from UI Code
       allOf:
-        - $ref: '#/components/schemas/BedSearchParameters'
+        - $ref: '#/components/schemas/BedSearchResult'
         - type: object
           properties:
-            postcodeDistrict:
-              type: string
-              description: The postcode district to search outwards from
-            maxDistanceMiles:
-              type: integer
-              description: Maximum number of miles from the postcode district to search, only required if more than 50 miles which is the default
-            requiredCharacteristics:
-              type: array
-              items:
-                $ref: '#/components/schemas/PlacementCriteria'
+            distanceMiles:
+              type: number
+              description: how many miles away from the postcode district the Premises this Bed belongs to is
           required:
-            - postcodeDistrict
-            - maxDistanceMiles
-            - requiredCharacteristics
+            - distanceMiles


### PR DESCRIPTION
This commit temporarily re-adds ApprovedPremisesBedSearchResult until it can be fully removed from the UI code

It also removes ApprovedPremisesBedSearchParameters which was incorrectly re-added