### PR TITLE
Rollback seed transaction if any errors occur

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -124,6 +124,7 @@ class SeedService(
     return rowsProcessed
   }
 
+  @SuppressWarnings("TooGenericExceptionThrown")
   private fun <T> processCsv(job: SeedJob<T>, resolveCsvPath: SeedJob<T>.() -> String): Int {
     var rowNumber = 1
     val errors = mutableListOf<String>()
@@ -147,7 +148,7 @@ class SeedService(
       throw RuntimeException("Unable to process CSV at row $rowNumber", exception)
     }
     if (errors.isNotEmpty()) {
-      seedLogger.error("The following row-level errors were raised: ${errors.joinToString("\n")}")
+      throw RuntimeException("The following row-level errors were raised: ${errors.joinToString("\n")}")
     }
 
     return rowNumber - 1


### PR DESCRIPTION
Previously a RuntimeException would not trigger a rollback of a seed job.

This commit ensures an exception is thrown if the seed job fails for any reason, which will lead to the transaction being rolled back