### PR TITLE
Improve FieldValidationError exception message

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
@@ -11,6 +11,9 @@ class BadRequestProblem(@JsonIgnore val invalidParams: Map<String, String>? = nu
     return null
   }
 
+  override val message: String
+    get() = listOfNotNull(this.title, this.detail, this.invalidParams).joinToString(": ")
+
   override fun getParameters(): MutableMap<String, Any> {
     return mutableMapOf(
       "invalid-params" to (


### PR DESCRIPTION
It has been observed that when we log a `BadRequestProblem` exception that has been created for a `FieldValidationError`, the error message is typically not very helpful:

‘There is a problem with your request’

This occurs because a `FieldValidationError` only contains a map of invalid parameters. When this is converted into a `BadRequestProblem` by the `EntityUtils`, no error detail (summary of the error) is provided to the `BadRequestProblem`.

Because the `AbstractThrowableProblem` doesn’t include the error parameters in the default exception message, we are left with the default unhelpful message shown above.

Whilst the ‘correct’ solution may be to include the invalid params in an ‘errorDetail’ string when constructing the `BadRequestPoblem` in `EntityUtils`, i’m concerned that this will lead to duplicated/confusing messages being returned in the problem JSON to the UI. Instead, this commit overrides how exception messages are generated for BadRequestProblem to include the invalid parameter map, if defined.