### PR TITLE
APS-1787 pass user into application & assess functions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -347,7 +347,7 @@ class ApplicationsController(
         applicationService.submitApprovedPremisesApplication(
           applicationId,
           submitApplication,
-          username,
+          userService.getUserForRequest(),
           apAreaId,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -165,7 +165,7 @@ class AssessmentController(
     val serializedData = objectMapper.writeValueAsString(assessmentAcceptance.document)
 
     val assessmentAuthResult = assessmentService.acceptAssessment(
-      user = user,
+      acceptingUser = user,
       assessmentId = assessmentId,
       document = serializedData,
       placementRequirements = assessmentAcceptance.requirements,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -661,7 +661,7 @@ class ApplicationService(
   fun submitApprovedPremisesApplication(
     applicationId: UUID,
     submitApplication: SubmitApprovedPremisesApplication,
-    username: String,
+    user: UserEntity,
     apAreaId: UUID,
   ): AuthorisableActionResult<ValidatableActionResult<ApplicationEntity>> {
     lockableApplicationRepository.acquirePessimisticLock(applicationId)
@@ -672,8 +672,6 @@ class ApplicationService(
       ?: return AuthorisableActionResult.NotFound()
 
     val serializedTranslatedDocument = objectMapper.writeValueAsString(submitApplication.translatedDocument)
-
-    val user = userService.getUserForRequest()
 
     if (application.createdByUser != user) {
       return AuthorisableActionResult.Unauthorised()
@@ -779,7 +777,7 @@ class ApplicationService(
       this.licenceExpiryDate = submitApplication.licenseExpiryDate
     }
 
-    cas1ApplicationDomainEventService.applicationSubmitted(application, submitApplication, username)
+    cas1ApplicationDomainEventService.applicationSubmitted(application, submitApplication, user.deliusUsername)
     assessmentService.createApprovedPremisesAssessment(application)
 
     applicationListener.preUpdate(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -168,7 +168,11 @@ class TaskService(
 
     val result = when (taskType) {
       TaskType.assessment -> {
-        assessmentService.reallocateAssessment(assigneeUser, taskId)
+        assessmentService.reallocateAssessment(
+          allocatingUser = requestUser,
+          assigneeUser = assigneeUser,
+          id = taskId,
+        )
       }
       TaskType.placementRequest -> {
         placementRequestService.reallocatePlacementRequest(assigneeUser, taskId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -1445,7 +1445,7 @@ class ApplicationServiceTest {
         applicationService.submitApprovedPremisesApplication(
           applicationId,
           defaultSubmitApprovedPremisesApplication,
-          username,
+          user,
           apAreaId = UUID.randomUUID(),
         ) is AuthorisableActionResult.NotFound,
       ).isTrue
@@ -1458,10 +1458,6 @@ class ApplicationServiceTest {
         .withYieldedCreatedByUser { UserEntityFactory().withDefaultProbationRegion().produce() }
         .produce()
 
-      every { mockUserService.getUserForRequest() } returns UserEntityFactory()
-        .withDeliusUsername(username)
-        .withDefaultProbationRegion()
-        .produce()
       every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
@@ -1469,7 +1465,7 @@ class ApplicationServiceTest {
         applicationService.submitApprovedPremisesApplication(
           applicationId,
           defaultSubmitApprovedPremisesApplication,
-          username,
+          user,
           apAreaId = UUID.randomUUID(),
         ) is AuthorisableActionResult.Unauthorised,
       ).isTrue
@@ -1486,14 +1482,13 @@ class ApplicationServiceTest {
           schemaUpToDate = false
         }
 
-      every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
       val result = applicationService.submitApprovedPremisesApplication(
         applicationId,
         defaultSubmitApprovedPremisesApplication,
-        username,
+        user,
         apAreaId = UUID.randomUUID(),
       )
 
@@ -1520,14 +1515,13 @@ class ApplicationServiceTest {
           schemaUpToDate = true
         }
 
-      every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
       val result = applicationService.submitApprovedPremisesApplication(
         applicationId,
         defaultSubmitApprovedPremisesApplication,
-        username,
+        user,
         apAreaId = UUID.randomUUID(),
       )
 
@@ -1554,7 +1548,6 @@ class ApplicationServiceTest {
           schemaUpToDate = true
         }
 
-      every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
@@ -1577,7 +1570,7 @@ class ApplicationServiceTest {
       val result = applicationService.submitApprovedPremisesApplication(
         applicationId,
         defaultSubmitApprovedPremisesApplication,
-        username,
+        user,
         apAreaId = UUID.randomUUID(),
       )
 
@@ -1603,7 +1596,6 @@ class ApplicationServiceTest {
           schemaUpToDate = true
         }
 
-      every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
 
@@ -1627,7 +1619,7 @@ class ApplicationServiceTest {
       val result = applicationService.submitApprovedPremisesApplication(
         applicationId,
         defaultSubmitApprovedPremisesApplication,
-        username,
+        user,
         apAreaId = UUID.randomUUID(),
       )
 
@@ -1693,7 +1685,7 @@ class ApplicationServiceTest {
         applicationService.submitApprovedPremisesApplication(
           applicationId,
           defaultSubmitApprovedPremisesApplication,
-          username,
+          user,
           apAreaId = apArea.id,
         )
 
@@ -1791,7 +1783,7 @@ class ApplicationServiceTest {
         applicationService.submitApprovedPremisesApplication(
           applicationId,
           defaultSubmitApprovedPremisesApplication,
-          username,
+          user,
           apAreaId = apArea.id,
         )
 
@@ -1878,7 +1870,7 @@ class ApplicationServiceTest {
         applicationService.submitApprovedPremisesApplication(
           applicationId,
           defaultSubmitApprovedPremisesApplication,
-          username,
+          user,
           apAreaId = apArea.id,
         )
 
@@ -1988,7 +1980,7 @@ class ApplicationServiceTest {
         applicationService.submitApprovedPremisesApplication(
           applicationId,
           defaultSubmitApprovedPremisesApplication,
-          username,
+          user,
           apAreaId = apArea.id,
         )
 
@@ -2045,7 +2037,7 @@ class ApplicationServiceTest {
       val result = applicationService.submitApprovedPremisesApplication(
         applicationId,
         defaultSubmitApprovedPremisesApplication,
-        username,
+        user,
         apAreaId = apArea.id,
       )
 
@@ -2056,7 +2048,6 @@ class ApplicationServiceTest {
 
     private fun setupMocksForSuccess(application: ApprovedPremisesApplicationEntity) {
       every { mockObjectMapper.writeValueAsString(defaultSubmitApprovedPremisesApplication.translatedDocument) } returns "{}"
-      every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.findByIdOrNull(applicationId) } returns application
       every { mockJsonSchemaService.checkSchemaOutdated(application) } returns application
       every { mockJsonSchemaService.validate(newestSchema, application.data!!) } returns true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -1817,6 +1817,14 @@ class AssessmentServiceTest {
       }
       .produce()
 
+    val actingUser = UserEntityFactory()
+      .withDeliusUsername("Acting User")
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea { ApAreaEntityFactory().produce() }
+          .produce()
+      }.produce()
+
     @Test
     fun `reallocateAssessment for Approved Premises returns General Validation Error when application already has a submitted assessment`() {
       previousAssessment.apply {
@@ -1826,7 +1834,11 @@ class AssessmentServiceTest {
       every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-      val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+      val result = assessmentService.reallocateAssessment(
+        allocatingUser = actingUser,
+        assigneeUser = assigneeUser,
+        id = previousAssessment.id,
+      )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -1845,7 +1857,11 @@ class AssessmentServiceTest {
       every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-      val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+      val result = assessmentService.reallocateAssessment(
+        allocatingUser = actingUser,
+        assigneeUser = assigneeUser,
+        id = previousAssessment.id,
+      )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -1868,7 +1884,11 @@ class AssessmentServiceTest {
       every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-      val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+      val result = assessmentService.reallocateAssessment(
+        allocatingUser = actingUser,
+        assigneeUser = assigneeUser,
+        id = previousAssessment.id,
+      )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -1908,7 +1928,11 @@ class AssessmentServiceTest {
       every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-      val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+      val result = assessmentService.reallocateAssessment(
+        allocatingUser = actingUser,
+        assigneeUser = assigneeUser,
+        id = previousAssessment.id,
+      )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -1927,7 +1951,11 @@ class AssessmentServiceTest {
       every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-      val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+      val result = assessmentService.reallocateAssessment(
+        allocatingUser = actingUser,
+        assigneeUser = assigneeUser,
+        id = previousAssessment.id,
+      )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -1959,14 +1987,6 @@ class AssessmentServiceTest {
 
       val dueAt = OffsetDateTime.now()
 
-      val actingUser = UserEntityFactory()
-        .withDeliusUsername("Acting User")
-        .withYieldedProbationRegion {
-          ProbationRegionEntityFactory()
-            .withYieldedApArea { ApAreaEntityFactory().produce() }
-            .produce()
-        }.produce()
-
       every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
@@ -1986,11 +2006,13 @@ class AssessmentServiceTest {
 
       every { taskDeadlineServiceMock.getDeadline(any<ApprovedPremisesAssessmentEntity>()) } returns dueAt
 
-      every { userServiceMock.getUserForRequest() } returns actingUser
-
       every { cas1AssessmentDomainEventService.assessmentAllocated(any(), any(), any()) } just Runs
 
-      val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+      val result = assessmentService.reallocateAssessment(
+        allocatingUser = actingUser,
+        assigneeUser = assigneeUser,
+        id = previousAssessment.id,
+      )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -2048,14 +2070,6 @@ class AssessmentServiceTest {
 
       val dueAt = OffsetDateTime.now()
 
-      val actingUser = UserEntityFactory()
-        .withDeliusUsername("Acting User")
-        .withYieldedProbationRegion {
-          ProbationRegionEntityFactory()
-            .withYieldedApArea { ApAreaEntityFactory().produce() }
-            .produce()
-        }.produce()
-
       every { lockableAssessmentRepository.acquirePessimisticLock(previousAssessment.id) } returns LockableAssessmentEntity(previousAssessment.id)
       every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
@@ -2075,11 +2089,13 @@ class AssessmentServiceTest {
 
       every { taskDeadlineServiceMock.getDeadline(any<ApprovedPremisesAssessmentEntity>()) } returns dueAt
 
-      every { userServiceMock.getUserForRequest() } returns actingUser
-
       every { cas1AssessmentDomainEventService.assessmentAllocated(any(), any(), any()) } just Runs
 
-      val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+      val result = assessmentService.reallocateAssessment(
+        allocatingUser = actingUser,
+        assigneeUser = assigneeUser,
+        id = previousAssessment.id,
+      )
 
       assertThat(result is AuthorisableActionResult.Success).isTrue
       val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -2127,6 +2143,10 @@ class AssessmentServiceTest {
       .withProbationRegion(probationRegion)
       .produce()
 
+    val actingUser = UserEntityFactory()
+      .withProbationRegion(probationRegion)
+      .produce()
+
     val application = TemporaryAccommodationApplicationEntityFactory()
       .withCreatedByUser(
         UserEntityFactory()
@@ -2149,7 +2169,11 @@ class AssessmentServiceTest {
 
     every { assessmentRepositoryMock.findByIdOrNull(previousAssessment.id) } returns previousAssessment
 
-    val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+    val result = assessmentService.reallocateAssessment(
+      allocatingUser = actingUser,
+      assigneeUser = assigneeUser,
+      id = previousAssessment.id,
+    )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity
@@ -2174,6 +2198,10 @@ class AssessmentServiceTest {
           .withRole(UserRole.CAS3_ASSESSOR)
           .produce()
       }
+
+    val actingUser = UserEntityFactory()
+      .withProbationRegion(probationRegion)
+      .produce()
 
     val application = TemporaryAccommodationApplicationEntityFactory()
       .withCreatedByUser(
@@ -2207,7 +2235,11 @@ class AssessmentServiceTest {
     every { userServiceMock.getUserForRequest() } returns assigneeUser
     every { assessmentReferralHistoryNoteRepositoryMock.save(any()) } returnsArgument 0
 
-    val result = assessmentService.reallocateAssessment(assigneeUser, previousAssessment.id)
+    val result = assessmentService.reallocateAssessment(
+      allocatingUser = actingUser,
+      assigneeUser = assigneeUser,
+      id = previousAssessment.id,
+    )
 
     assertThat(result is AuthorisableActionResult.Success).isTrue
     val validationResult = (result as AuthorisableActionResult.Success).entity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -135,7 +135,13 @@ class TaskServiceTest {
       .withAllocatedToUser(assigneeUser)
       .produce()
 
-    every { assessmentServiceMock.reallocateAssessment(assigneeUser, assessment.id) } returns AuthorisableActionResult.Success(
+    every {
+      assessmentServiceMock.reallocateAssessment(
+        allocatingUser = requestUserWithPermission,
+        assigneeUser = assigneeUser,
+        id = assessment.id,
+      )
+    } returns AuthorisableActionResult.Success(
       ValidatableActionResult.Success(
         assessment,
       ),


### PR DESCRIPTION
This PR removes usage of `userService.getUserForRequest()` from various service-level functions, instead taking the current user as a function argument.

This allows the functions to be used by seed jobs, where a user isn’t set on the request context