### PR TITLE
Cas2v2 user entity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -185,6 +185,8 @@ class AuthAwareAuthenticationToken(
     return aPrincipal
   }
 
+  fun authenticationSource(): String = jwt.claims["auth_source"] as String
+
   fun isExternalUser(): Boolean {
     return jwt.claims["auth_source"] == "auth"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -221,6 +221,7 @@ class ApplicationsController(
       .body(applicationsTransformer.transformJpaToApi(application, personInfo))
   }
 
+  @Suppress("TooGenericExceptionThrown")
   private fun createApplication(
     serviceName: ServiceName,
     personInfo: PersonInfoResult.Success.Full,
@@ -260,6 +261,11 @@ class ApplicationsController(
     ServiceName.cas2 -> throw RuntimeException(
       "CAS2 now has its own " +
         "Cas2ApplicationsController",
+    )
+
+    ServiceName.cas2v2 -> throw RuntimeException(
+      "CAS2v2 now has its own " +
+        "Cas2v2ApplicationsController",
     )
   }
 
@@ -467,6 +473,7 @@ class ApplicationsController(
       is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
       is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
       is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
+
       is ValidatableActionResult.Success -> validationResult.entity
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -67,6 +67,7 @@ class AssessmentController(
     val domainSummaryStatuses = statuses?.map { assessmentTransformer.transformApiStatusToDomainSummaryState(it) } ?: emptyList()
 
     val (summaries, metadata) = when (xServiceName) {
+      ServiceName.cas2v2 -> throw UnsupportedOperationException("CAS2v2 not supported")
       ServiceName.cas2 -> throw UnsupportedOperationException("CAS2 not supported")
       ServiceName.temporaryAccommodation -> {
         val (summaries, metadata) = assessmentService.getAssessmentSummariesForUserCAS3(
@@ -79,10 +80,12 @@ class AssessmentController(
         val transformSummaries = when (sortBy) {
           AssessmentSortField.assessmentDueAt -> throw BadRequestProblem(errorDetail = "Sorting by due date is not supported for CAS3")
           AssessmentSortField.personName -> transformDomainToApi(user, summaries, user.hasQualification(UserQualification.LAO)).sortByName(resolvedSortDirection)
+
           else -> transformDomainToApi(user, summaries)
         }
         Pair(transformSummaries, metadata)
       }
+
       else -> {
         val (summaries, metadata) = assessmentService.getVisibleAssessmentSummariesForUserCAS1(user, domainSummaryStatuses, PageCriteria(resolvedSortBy, resolvedSortDirection, page, perPage))
         Pair(transformDomainToApi(user, summaries, user.hasQualification(UserQualification.LAO)), metadata)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -126,6 +126,7 @@ class PremisesController(
   private val cas1WithdrawableService: Cas1WithdrawableService,
 ) : PremisesApiDelegate {
 
+  @Suppress("TooGenericExceptionThrown")
   override fun premisesSummaryGet(
     xServiceName: ServiceName,
     probationRegionId: UUID?,
@@ -139,6 +140,8 @@ class PremisesController(
       }
 
       ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
+      ServiceName.cas2v2 -> throw RuntimeException("CAS2v2 not supported")
+
       ServiceName.temporaryAccommodation -> {
         val user = usersService.getUserForRequest()
         val summaries = cas3PremisesService.getAllPremisesSummaries(user.probationRegion.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2ApplicationEntity.kt
@@ -21,7 +21,6 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -62,7 +61,7 @@ data class Cas2v2ApplicationEntity(
 
   @ManyToOne
   @JoinColumn(name = "created_by_user_id")
-  val createdByUser: NomisUserEntity,
+  val createdByUser: Cas2v2UserEntity,
 
   @Type(JsonType::class)
   var data: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2ApplicationNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2ApplicationNoteEntity.kt
@@ -10,9 +10,6 @@ import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2User
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -30,8 +27,9 @@ data class Cas2v2ApplicationNoteEntity(
   @Id
   val id: UUID,
 
-  @Transient
-  final val createdByUser: Cas2User,
+  @ManyToOne
+  @JoinColumn(name = "created_by_user_id")
+  val createdByUser: Cas2v2UserEntity,
 
   @ManyToOne
   @JoinColumn(name = "application_id")
@@ -46,28 +44,7 @@ data class Cas2v2ApplicationNoteEntity(
   var assessment: Cas2v2AssessmentEntity?,
 ) {
 
-  @ManyToOne
-  @JoinColumn(name = "created_by_nomis_user_id")
-  var createdByNomisUser: NomisUserEntity? = null
-
-  @ManyToOne
-  @JoinColumn(name = "created_by_external_user_id")
-  var createdByExternalUser: ExternalUserEntity? = null
-
-  init {
-    when (this.createdByUser) {
-      is NomisUserEntity -> this.createdByNomisUser = this.createdByUser
-      is ExternalUserEntity -> this.createdByExternalUser = this.createdByUser
-    }
-  }
-
-  fun getUser(): Cas2User {
-    return if (this.createdByNomisUser != null) {
-      this.createdByNomisUser!!
-    } else {
-      this.createdByExternalUser!!
-    }
-  }
+  fun getUser(): Cas2v2UserEntity = this.createdByUser
 
   override fun toString() = "Cas2v2ApplicationNoteEntity: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2StatusUpdateEntity.kt
@@ -12,7 +12,6 @@ import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
 import java.time.OffsetDateTime
@@ -41,7 +40,7 @@ data class Cas2v2StatusUpdateEntity(
 
   @ManyToOne
   @JoinColumn(name = "assessor_id")
-  val assessor: ExternalUserEntity,
+  val assessor: Cas2v2UserEntity,
 
   @ManyToOne
   @JoinColumn(name = "application_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2UnsubmittedApplicationsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2UnsubmittedApplicationsReportRepository.kt
@@ -14,10 +14,10 @@ interface Cas2v2UnsubmittedApplicationsReportRepository : JpaRepository<Cas2v2Ap
         applications.crn AS personCrn,
         applications.noms_number AS personNoms,
         to_char(applications.created_at, 'YYYY-MM-DD"T"HH24:MI:SS') AS startedAt,
-        users.nomis_username AS startedBy
+        users.username AS startedBy
 
       FROM cas_2_v2_applications applications
-      JOIN nomis_users users ON users.id = applications.created_by_user_id
+      JOIN cas_2_v2_users users ON users.id = applications.created_by_user_id
       WHERE applications.submitted_at IS NULL
         AND applications.created_at  > CURRENT_DATE - 365
       ORDER BY startedAt DESC;

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2UserEntity.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2
+
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.converter.StringListConverter
+import java.time.OffsetDateTime
+import java.util.UUID
+
+enum class Cas2v2UserType(val authSource: String) {
+  DELIUS("delius"),
+  NOMIS("nomis"),
+  EXTERNAL("auth"),
+  ;
+
+  companion object {
+    fun fromString(authSource: String): Cas2v2UserType {
+      return entries.first { it.authSource == authSource }
+    }
+  }
+}
+
+@Repository
+interface Cas2v2UserRepository : JpaRepository<Cas2v2UserEntity, UUID> {
+  fun findByUsername(username: String): Cas2v2UserEntity?
+  fun findByUsernameAndUserType(username: String, type: Cas2v2UserType): Cas2v2UserEntity?
+}
+
+@Entity
+@Table(name = "cas_2_v2_users")
+data class Cas2v2UserEntity(
+  @Id
+  val id: UUID,
+  val username: String,
+
+  // Cas2v2User interface implementation
+  var email: String?,
+  var name: String,
+
+  @Enumerated(EnumType.STRING)
+  var userType: Cas2v2UserType,
+
+  // Nomis specific fields that are only expected to have values if the
+  // accountType is Cas2v2UserType.NOMIS
+  var nomisStaffId: Long?,
+  var activeNomisCaseloadId: String? = null,
+
+  // Delius specific fields that are only expected to have values if the
+  // accountType is Cas2v2UserType.DELIUS
+  @Convert(converter = StringListConverter::class)
+  var deliusTeamCodes: List<String>?,
+  var deliusStaffCode: String?,
+
+  var isEnabled: Boolean,
+  var isActive: Boolean,
+
+  @CreationTimestamp
+  private val createdAt: OffsetDateTime? = null,
+
+  @OneToMany(mappedBy = "createdByUser")
+  val applications: MutableList<Cas2v2ApplicationEntity> = mutableListOf(),
+) {
+  override fun toString() = "CAS2V2 user $id"
+
+  fun staffIdentifier() = when (userType) {
+    Cas2v2UserType.NOMIS -> nomisStaffId?.toString() ?: error("Couldn't resolve nomis ID for user $id")
+    Cas2v2UserType.DELIUS -> deliusStaffCode ?: error("Couldn't resolve delius ID for user $id")
+    Cas2v2UserType.EXTERNAL -> ""
+  }
+
+  fun isExternal() = userType == Cas2v2UserType.EXTERNAL
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/ReportGenerator.kt
@@ -38,10 +38,12 @@ abstract class ReportGenerator<Input : Any, Output : Any, Properties>(private va
       .cast()
   }
 
+  @Suppress("TooGenericExceptionThrown")
   protected fun checkServiceType(serviceName: ServiceName, premisesEntity: PremisesEntity) =
     when (serviceName) {
       ServiceName.approvedPremises -> premisesEntity is ApprovedPremisesEntity
       ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
+      ServiceName.cas2v2 -> throw RuntimeException("CAS2v2 not supported")
       ServiceName.temporaryAccommodation -> premisesEntity is TemporaryAccommodationPremisesEntity
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -119,6 +119,11 @@ class ApplicationService(
           "NomisUser",
       )
 
+      ServiceName.cas2v2 -> throw RuntimeException(
+        "CAS2v2 applications now require " +
+          "Cas2v2User",
+      )
+
       ServiceName.temporaryAccommodation -> getAllTemporaryAccommodationApplicationsForUser(userEntity)
     }
 
@@ -701,6 +706,7 @@ class ApplicationService(
         submitApplication.isEsapApplication == true -> ApprovedPremisesType.ESAP
         else -> ApprovedPremisesType.NORMAL
       }
+
       submitApplication.isUsingNewApTypeField -> submitApplication.apType!!.asApprovedPremisesType()
       else -> ApprovedPremisesType.NORMAL
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/HttpAuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/HttpAuthService.kt
@@ -28,7 +28,7 @@ class HttpAuthService {
 
   fun getCas2v2AuthenticatedPrincipalOrThrow(): AuthAwareAuthenticationToken {
     val principal = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken
-    if (!listOf("nomis", "auth").contains(principal.token.claims["auth_source"])) {
+    if (!listOf("auth", "delius", "nomis").contains(principal.token.claims["auth_source"])) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ApplicationService.kt
@@ -343,6 +343,7 @@ class ApplicationService(
                 staffIdentifier = application.createdByUser.nomisStaffId,
                 name = application.createdByUser.name,
                 username = application.createdByUser.nomisUsername,
+                usertype = Cas2StaffMember.Usertype.nomis,
               ),
             ),
           ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2UserAccessService.kt
@@ -1,19 +1,32 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2v2
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserType
 
 @Service("Cas2v2UserAccessService")
 class Cas2v2UserAccessService {
-  fun userCanViewCas2v2Application(user: NomisUserEntity, application: Cas2v2ApplicationEntity): Boolean {
+  fun userCanViewCas2v2Application(user: Cas2v2UserEntity, application: Cas2v2ApplicationEntity): Boolean {
     return if (user.id == application.createdByUser.id) {
       true
     } else if (application.submittedAt == null) {
       false
+    } else if (user.userType == Cas2v2UserType.NOMIS) {
+      offenderIsFromSamePrisonAsUser(application.referringPrisonCode, user.activeNomisCaseloadId)
     } else {
-      offenderIsFromSamePrisonAsUser(application.referringPrisonCode, user.activeCaseloadId)
+      false
     }
+  }
+
+  fun userCanAddNote(user: Cas2v2UserEntity, application: Cas2v2ApplicationEntity): Boolean = when (user.userType) {
+    Cas2v2UserType.NOMIS -> user.id == application.createdByUser.id || offenderIsFromSamePrisonAsUser(
+      application.referringPrisonCode,
+      user.activeNomisCaseloadId,
+    )
+
+    Cas2v2UserType.DELIUS -> user.id == application.createdByUser.id
+    Cas2v2UserType.EXTERNAL -> true
   }
 
   fun offenderIsFromSamePrisonAsUser(referringPrisonCode: String?, activeCaseloadId: String?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2UserService.kt
@@ -1,0 +1,152 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2v2
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ManageUsersApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.NomisUserRolesApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.nomisuserroles.NomisUserDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
+import java.util.UUID
+
+@Service
+class Cas2v2UserService(
+  private val httpAuthService: HttpAuthService,
+  private val userRepository: Cas2v2UserRepository,
+  private val apDeliusContextApiClient: ApDeliusContextApiClient,
+  private val nomisUserRolesApiClient: NomisUserRolesApiClient,
+  private val manageUsersApiClient: ManageUsersApiClient,
+) {
+  fun ensureUserPersisted() {
+    getUserForRequest()
+  }
+
+  fun getUserForRequest(): Cas2v2UserEntity {
+    val authenticatedPrincipal = httpAuthService.getCas2v2AuthenticatedPrincipalOrThrow()
+    val jwt = authenticatedPrincipal.token.tokenValue
+    val username = authenticatedPrincipal.name
+    val userType = Cas2v2UserType.fromString(authenticatedPrincipal.authenticationSource())
+
+    return getUserForUsername(username, jwt, userType)
+  }
+
+  fun getUserForUsername(username: String, jwt: String, userType: Cas2v2UserType): Cas2v2UserEntity {
+    val normalisedUsername = username.uppercase()
+
+    val userEntity = when (userType) {
+      Cas2v2UserType.NOMIS -> getEntityForNomisUser(normalisedUsername, jwt)
+      Cas2v2UserType.DELIUS -> getEntityForDeliusUser(normalisedUsername)
+      Cas2v2UserType.EXTERNAL -> getEntityForExternalUser(normalisedUsername, jwt)
+    }
+
+    return userEntity
+  }
+
+  private fun getExistingUser(username: String, userType: Cas2v2UserType): Cas2v2UserEntity? =
+    userRepository.findByUsernameAndUserType(username, userType)
+
+  private fun getEntityForNomisUser(username: String, jwt: String): Cas2v2UserEntity {
+    val nomisUserDetails: NomisUserDetail = when (
+      val nomisUserDetailResponse = nomisUserRolesApiClient.getUserDetails(jwt)
+    ) {
+      is ClientResult.Success -> nomisUserDetailResponse.body
+      is ClientResult.Failure -> nomisUserDetailResponse.throwException()
+    }
+
+    val existingUser = getExistingUser(username, Cas2v2UserType.NOMIS)
+    if (existingUser != null) {
+      if (existingUser.email != nomisUserDetails.primaryEmail || existingUser.activeNomisCaseloadId != nomisUserDetails.activeCaseloadId) {
+        existingUser.email = nomisUserDetails.primaryEmail
+        existingUser.activeNomisCaseloadId = nomisUserDetails.activeCaseloadId
+
+        return userRepository.save(existingUser)
+      }
+
+      return existingUser
+    }
+
+    return userRepository.save(
+      Cas2v2UserEntity(
+        id = UUID.randomUUID(),
+        name = "${nomisUserDetails.firstName} ${nomisUserDetails.lastName}",
+        username = username,
+        nomisStaffId = nomisUserDetails.staffId,
+        activeNomisCaseloadId = nomisUserDetails.activeCaseloadId,
+        userType = Cas2v2UserType.NOMIS,
+        email = nomisUserDetails.primaryEmail,
+        isEnabled = nomisUserDetails.enabled,
+        isActive = nomisUserDetails.active,
+        deliusTeamCodes = null,
+        deliusStaffCode = null,
+      ),
+    )
+  }
+
+  private fun getEntityForDeliusUser(username: String): Cas2v2UserEntity {
+    val deliusUser: StaffDetail =
+      when (val staffUserDetailsResponse = apDeliusContextApiClient.getStaffDetail(username)) {
+        is ClientResult.Success<*> -> staffUserDetailsResponse.body as StaffDetail
+        is ClientResult.Failure<*> -> staffUserDetailsResponse.throwException()
+      }
+
+    val existingUser = getExistingUser(username, Cas2v2UserType.DELIUS)
+    if (existingUser != null) {
+      val teamsDiffer = deliusUser.teamCodes().sorted() != existingUser.deliusTeamCodes?.sorted()
+      if (deliusUser.email != existingUser.email || teamsDiffer) {
+        existingUser.email = deliusUser.email
+        existingUser.deliusTeamCodes = deliusUser.teamCodes()
+        return userRepository.save(existingUser)
+      }
+
+      return existingUser
+    }
+
+    return userRepository.save(
+      Cas2v2UserEntity(
+        id = UUID.randomUUID(),
+        name = "${deliusUser.name.forename} ${deliusUser.name.surname}",
+        username = username,
+        nomisStaffId = null,
+        activeNomisCaseloadId = null,
+        userType = Cas2v2UserType.DELIUS,
+        email = deliusUser.email,
+        isEnabled = deliusUser.active,
+        isActive = deliusUser.active,
+        deliusTeamCodes = deliusUser.teamCodes(),
+        deliusStaffCode = deliusUser.code,
+      ),
+    )
+  }
+
+  private fun getEntityForExternalUser(username: String, jwt: String): Cas2v2UserEntity {
+    val existingUser = getExistingUser(username, Cas2v2UserType.EXTERNAL)
+    if (existingUser != null) return existingUser
+
+    val externalUserDetailsResponse = manageUsersApiClient.getExternalUserDetails(username, jwt)
+
+    val externalUserDetails = when (externalUserDetailsResponse) {
+      is ClientResult.Success -> externalUserDetailsResponse.body
+      is ClientResult.Failure -> externalUserDetailsResponse.throwException()
+    }
+
+    return userRepository.save(
+      Cas2v2UserEntity(
+        id = UUID.randomUUID(),
+        name = "${externalUserDetails.firstName} ${externalUserDetails.lastName}",
+        username = externalUserDetails.username,
+        deliusTeamCodes = null,
+        deliusStaffCode = null,
+        nomisStaffId = null,
+        activeNomisCaseloadId = null,
+        userType = Cas2v2UserType.EXTERNAL,
+        email = externalUserDetails.email,
+        isEnabled = externalUserDetails.enabled,
+        isActive = true,
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -56,10 +56,12 @@ class UserTransformer(
       name = jpa.name,
     )
 
+  @Suppress("TooGenericExceptionThrown")
   fun transformJpaToApi(jpa: UserEntity, serviceName: ServiceName) = when (serviceName) {
     ServiceName.approvedPremises -> transformCas1JpaToApi(jpa)
     ServiceName.temporaryAccommodation -> transformCas3JpatoApi(jpa)
     ServiceName.cas2 -> throw RuntimeException("CAS2 not supported")
+    ServiceName.cas2v2 -> throw RuntimeException("CAS2v2 not supported")
   }
 
   fun transformCas1JpaToApi(jpa: UserEntity): ApprovedPremisesUser {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2ApplicationStatusTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2ApplicationStatusTransformer.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationStatusDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusDetail
+
+@Component("Cas2v2ApplicationStatusTransformer")
+class Cas2v2ApplicationStatusTransformer {
+  fun transformModelToApi(status: Cas2PersistedApplicationStatus): Cas2v2ApplicationStatus {
+    return Cas2v2ApplicationStatus(
+      id = status.id,
+      name = status.name,
+      label = status.label,
+      description = status.description,
+      statusDetails = status.statusDetails?.map { statusDetail -> transformStatusDetailModelToApi(statusDetail) }
+        ?: emptyList(),
+    )
+  }
+
+  fun transformStatusDetailModelToApi(statusDetail: Cas2PersistedApplicationStatusDetail): Cas2v2ApplicationStatusDetail {
+    return Cas2v2ApplicationStatusDetail(
+      id = statusDetail.id,
+      name = statusDetail.name,
+      label = statusDetail.label,
+    )
+  }
+
+  fun transformStatusDetailListToDetailItemList(statusDetailsList: List<Cas2PersistedApplicationStatusDetail>): List<Cas2StatusDetail> {
+    return statusDetailsList.map { status -> transformStatusDetailToStatusDetailItem(status) }
+  }
+
+  fun transformStatusDetailToStatusDetailItem(statusDetail: Cas2PersistedApplicationStatusDetail): Cas2StatusDetail {
+    return Cas2StatusDetail(
+      name = statusDetail.name,
+      label = statusDetail.label,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2ApplicationsTransformer.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Applicat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import java.util.UUID
 
@@ -17,7 +16,7 @@ import java.util.UUID
 class Cas2v2ApplicationsTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
-  private val nomisUserTransformer: NomisUserTransformer,
+  private val cas2v2UserTransformer: Cas2v2UserTransformer,
   private val statusUpdateTransformer: Cas2v2StatusUpdateTransformer,
   private val timelineEventsTransformer: Cas2v2TimelineEventsTransformer,
   private val cas2v2AssessmentsTransformer: Cas2v2AssessmentsTransformer,
@@ -27,7 +26,7 @@ class Cas2v2ApplicationsTransformer(
     return Cas2v2Application(
       id = jpa.id,
       person = personTransformer.transformModelToPersonApi(personInfo),
-      createdBy = nomisUserTransformer.transformJpaToApi(jpa.createdByUser),
+      createdBy = cas2v2UserTransformer.transformJpaToApi(jpa.createdByUser),
       schemaVersion = jpa.schemaVersion.id,
       outdatedSchema = !jpa.schemaUpToDate,
       createdAt = jpa.createdAt.toInstant(),
@@ -35,7 +34,7 @@ class Cas2v2ApplicationsTransformer(
       data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
       document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
       status = getStatus(jpa),
-      type = "CAS2",
+      type = "CAS2V2",
       telephoneNumber = jpa.telephoneNumber,
       assessment = if (jpa.assessment != null) cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
       timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
@@ -55,7 +54,7 @@ class Cas2v2ApplicationsTransformer(
       submittedAt = jpaSummary.submittedAt?.toInstant(),
       status = getStatusFromSummary(jpaSummary),
       latestStatusUpdate = statusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(jpaSummary),
-      type = "CAS2",
+      type = "CAS2V2",
       hdcEligibilityDate = jpaSummary.hdcEligibilityDate,
       crn = jpaSummary.crn,
       nomsNumber = jpaSummary.nomsNumber,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2StatusUpdateTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2StatusUpdateTransformer.kt
@@ -1,45 +1,44 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdateDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LatestCas2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LatestCas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExternalUserTransformer
 import java.util.UUID
 
 @Component
 class Cas2v2StatusUpdateTransformer(
-  private val externalUserTransformer: ExternalUserTransformer,
+  private val cas2v2UserTransformer: Cas2v2UserTransformer,
 ) {
 
   fun transformJpaToApi(
     jpa: Cas2v2StatusUpdateEntity,
-  ): Cas2StatusUpdate {
-    return Cas2StatusUpdate(
+  ): Cas2v2StatusUpdate {
+    return Cas2v2StatusUpdate(
       id = jpa.id,
       name = jpa.status().name,
       label = jpa.label,
       description = jpa.description,
-      updatedBy = externalUserTransformer.transformJpaToApi(jpa.assessor),
-      updatedAt = jpa.createdAt?.toInstant(),
+      updatedBy = cas2v2UserTransformer.transformJpaToApi(jpa.assessor),
+      updatedAt = jpa.createdAt.toInstant(),
       statusUpdateDetails = jpa.statusUpdateDetails?.map { detail -> transformStatusUpdateDetailsJpaToApi(detail) },
     )
   }
 
-  private fun transformStatusUpdateDetailsJpaToApi(jpa: Cas2v2StatusUpdateDetailEntity): Cas2StatusUpdateDetail {
-    return Cas2StatusUpdateDetail(
+  private fun transformStatusUpdateDetailsJpaToApi(jpa: Cas2v2StatusUpdateDetailEntity): Cas2v2StatusUpdateDetail {
+    return Cas2v2StatusUpdateDetail(
       id = jpa.id,
       name = jpa.statusDetail(jpa.statusUpdate.statusId, jpa.statusDetailId).name,
       label = jpa.label,
     )
   }
 
-  fun transformJpaSummaryToLatestStatusUpdateApi(jpa: Cas2v2ApplicationSummaryEntity): LatestCas2StatusUpdate? {
+  fun transformJpaSummaryToLatestStatusUpdateApi(jpa: Cas2v2ApplicationSummaryEntity): LatestCas2v2StatusUpdate? {
     if (jpa.latestStatusUpdateStatusId !== null) {
-      return LatestCas2StatusUpdate(
+      return LatestCas2v2StatusUpdate(
         statusId = UUID.fromString(jpa.latestStatusUpdateStatusId!!),
         label = jpa.latestStatusUpdateLabel!!,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2SubmissionsTransformer.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Submitte
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import java.util.UUID
 
@@ -15,7 +14,7 @@ import java.util.UUID
 class Cas2v2SubmissionsTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
-  private val nomisUserTransformer: NomisUserTransformer,
+  private val cas2v2UserTransformer: Cas2v2UserTransformer,
   private val cas2v2TimelineEventsTransformer: Cas2v2TimelineEventsTransformer,
   private val cas2v2AssessmentsTransformer: Cas2v2AssessmentsTransformer,
 ) {
@@ -28,7 +27,7 @@ class Cas2v2SubmissionsTransformer(
     return Cas2v2SubmittedApplication(
       id = jpa.id,
       person = personTransformer.transformModelToPersonApi(personInfo),
-      submittedBy = nomisUserTransformer.transformJpaToApi(jpa.createdByUser),
+      submittedBy = cas2v2UserTransformer.transformJpaToApi(jpa.createdByUser),
       schemaVersion = jpa.schemaVersion.id,
       outdatedSchema = !jpa.schemaUpToDate,
       createdAt = jpa.createdAt.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2v2/Cas2v2UserTransformer.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
+
+@Component
+class Cas2v2UserTransformer {
+
+  fun transformJpaToApi(userEntity: Cas2v2UserEntity): Cas2v2User {
+    return Cas2v2User(
+      id = userEntity.id,
+      username = userEntity.username,
+      name = userEntity.name,
+      email = userEntity.email,
+      isActive = userEntity.isActive,
+      authSource = Cas2v2User.AuthSource.valueOf(userEntity.userType.authSource),
+    )
+  }
+}

--- a/src/main/resources/db/migration/all/20250107134233__application_controller_and_linked_services_in_cas2v2.sql
+++ b/src/main/resources/db/migration/all/20250107134233__application_controller_and_linked_services_in_cas2v2.sql
@@ -138,11 +138,11 @@ SELECT a.id,
        asu.created_at AS status_created_at,
        a.abandoned_at
 FROM cas_2_v2_applications a
-         LEFT JOIN (SELECT DISTINCT ON (application_id) su.application_id, su.label, su.status_id, su.created_at
-                    FROM cas_2_v2_status_updates su
-                    ORDER BY su.application_id, su.created_at DESC) as asu
-                   ON a.id = asu.application_id
-         JOIN nomis_users nu ON nu.id = a.created_by_user_id;
+     LEFT JOIN (SELECT DISTINCT ON (application_id) su.application_id, su.label, su.status_id, su.created_at
+                FROM cas_2_v2_status_updates su
+                ORDER BY su.application_id, su.created_at DESC) as asu
+               ON a.id = asu.application_id
+     JOIN nomis_users nu ON nu.id = a.created_by_user_id;
 
 CREATE OR REPLACE VIEW cas_2_v2_application_live_summary AS
 SELECT a.id,

--- a/src/main/resources/db/migration/all/20250122155323__cas2v2_user_entity.sql
+++ b/src/main/resources/db/migration/all/20250122155323__cas2v2_user_entity.sql
@@ -1,0 +1,56 @@
+
+CREATE TABLE cas_2_v2_users
+(
+    id                       UUID    NOT NULL,
+    name                     TEXT    NOT NULL,
+    username                 TEXT    NOT NULL,
+    email                    TEXT,
+    user_type                TEXT    NOT NULL,
+    nomis_staff_id           BIGINT,
+    active_nomis_caseload_id TEXT,
+    delius_staff_code        TEXT,
+    delius_team_codes        TEXT,
+    is_enabled               BOOLEAN NOT NULL,
+    is_active                BOOLEAN NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL,
+    CONSTRAINT pk_cas_2_v2_users PRIMARY KEY (id)
+);
+
+ALTER TABLE cas_2_v2_applications DROP CONSTRAINT FK_CAS_2_V2_APPLICATIONS_ON_CREATED_BY_USER;
+ALTER TABLE cas_2_v2_applications
+    ADD CONSTRAINT FK_CAS_2_V2_APPLICATIONS_ON_CREATED_BY_USER FOREIGN KEY (created_by_user_id) REFERENCES cas_2_v2_users (id);
+
+ALTER TABLE cas_2_v2_application_notes DROP CONSTRAINT FK_CAS_2_V2_APPLICATION_NOTES_ON_CREATED_BY_EXTERNAL_USER;
+ALTER TABLE cas_2_v2_application_notes DROP CONSTRAINT FK_CAS_2_V2_APPLICATION_NOTES_ON_CREATED_BY_NOMIS_USER;
+ALTER TABLE cas_2_v2_application_notes DROP COLUMN created_by_nomis_user_id;
+ALTER TABLE cas_2_v2_application_notes DROP COLUMN created_by_external_user_id;
+ALTER TABLE cas_2_v2_application_notes ADD COLUMN created_by_user_id UUID NOT NULL;
+ALTER TABLE cas_2_v2_application_notes  ADD CONSTRAINT FK_CAS_2_V2_APPLICATION_NOTES_ON_CREATED_BY_USER FOREIGN KEY (created_by_user_id) REFERENCES cas_2_v2_users (id);
+
+ALTER TABLE cas_2_v2_status_updates DROP CONSTRAINT FK_CAS_2_V2_STATUS_UPDATES_ON_ASSESSOR;
+ALTER TABLE cas_2_v2_status_updates
+    ADD CONSTRAINT FK_CAS_2_V2_STATUS_UPDATES_ON_ASSESSOR FOREIGN KEY (assessor_id) REFERENCES cas_2_v2_users (id);
+
+CREATE OR REPLACE VIEW cas_2_v2_application_summary AS
+SELECT a.id,
+       a.crn,
+       a.noms_number,
+       CAST(a.created_by_user_id AS TEXT),
+       u.name,
+       a.created_at,
+       a.submitted_at,
+       a.hdc_eligibility_date,
+       asu.label,
+       CAST(asu.status_id AS TEXT),
+       a.referring_prison_code,
+       a.conditional_release_date,
+       asu.created_at AS status_created_at,
+       a.abandoned_at,
+       a.application_origin,
+       a.bail_hearing_date
+FROM cas_2_v2_applications a
+     LEFT JOIN (SELECT DISTINCT ON (application_id) su.application_id, su.label, su.status_id, su.created_at
+                FROM cas_2_v2_status_updates su
+                ORDER BY su.application_id, su.created_at DESC) as asu
+               ON a.id = asu.application_id
+     JOIN cas_2_v2_users u ON u.id = a.created_by_user_id;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -570,20 +570,20 @@ components:
       required:
         - reason
     WithdrawPlacementRequestReason:
-        type: string
-        enum:
-          - DuplicatePlacementRequest
-          - AlternativeProvisionIdentified
-          - ChangeInCircumstances
-          - ChangeInReleaseDecision
-          - NoCapacityDueToLostBed
-          - NoCapacityDueToPlacementPrioritisation
-          - NoCapacity
-          - ErrorInPlacementRequest
-          - WithdrawnByPP
-          - RelatedApplicationWithdrawn
-          - RelatedPlacementRequestWithdrawn
-          - RelatedPlacementApplicationWithdrawn
+      type: string
+      enum:
+        - DuplicatePlacementRequest
+        - AlternativeProvisionIdentified
+        - ChangeInCircumstances
+        - ChangeInReleaseDecision
+        - NoCapacityDueToLostBed
+        - NoCapacityDueToPlacementPrioritisation
+        - NoCapacity
+        - ErrorInPlacementRequest
+        - WithdrawnByPP
+        - RelatedApplicationWithdrawn
+        - RelatedPlacementRequestWithdrawn
+        - RelatedPlacementApplicationWithdrawn
     PlacementApplicationType:
       type: string
       description: |
@@ -1629,6 +1629,7 @@ components:
           Offline: '#/components/schemas/OfflineApplication'
           CAS1: '#/components/schemas/ApprovedPremisesApplication'
           CAS2: '#/components/schemas/Cas2Application'
+          CAS2V2: 'cas2v2-schemas.yml#/components/schemas/Cas2v2Application'
           CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - type
@@ -3238,10 +3239,12 @@ components:
       enum:
         - approved-premises
         - cas2
+        - cas2v2
         - temporary-accommodation
       x-enum-varnames:
         - approvedPremises
         - cas2
+        - cas2v2
         - temporaryAccommodation
     NewRoom:
       type: object
@@ -3797,6 +3800,7 @@ components:
           $ref: '#/components/schemas/ApType'
         location:
           type: string
+          description: Postcode outcode
           example: B74
         radius:
           type: integer
@@ -4563,7 +4567,7 @@ components:
     FullPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'
-        - type : object
+        - type: object
           properties:
             name:
               type: string

--- a/src/main/resources/static/cas2-domain-events-api.yml
+++ b/src/main/resources/static/cas2-domain-events-api.yml
@@ -245,6 +245,11 @@ components:
         username:
           type: string
           example: SMITHJ_GEN
+        usertype:
+          type: string
+          enum:
+            - nomis
+            - delius
       required:
         - staffIdentifier
         - name

--- a/src/main/resources/static/cas2v2-api.yml
+++ b/src/main/resources/static/cas2v2-api.yml
@@ -267,7 +267,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '_shared.yml#/components/schemas/Cas2AssessmentStatusUpdate'
+              $ref: '_shared.yml#/components/schemas/Cas2v2AssessmentStatusUpdate'
         required: true
       responses:
         200:

--- a/src/main/resources/static/cas2v2-schemas.yml
+++ b/src/main/resources/static/cas2v2-schemas.yml
@@ -16,7 +16,7 @@ components:
           type: string
           example: "M1502750438"
         applicationOrigin:
-          $ref: "#/components/schemas/ApplicationOrigin"
+          $ref: "_shared.yml#/components/schemas/ApplicationOrigin"
         bailHearingDate:
           type: string
           format: date
@@ -69,7 +69,7 @@ components:
         statusUpdates:
           type: array
           items:
-            $ref: '_shared.yml#/components/schemas/Cas2StatusUpdate'
+            $ref: '#/components/schemas/Cas2v2StatusUpdate'
       required:
         - id
     Cas2v2Application:
@@ -78,7 +78,7 @@ components:
         - type: object
           properties:
             createdBy:
-              $ref: '_shared.yml#/components/schemas/NomisUser'
+              $ref: '#/components/schemas/Cas2v2User'
             schemaVersion:
               type: string
               format: uuid
@@ -96,7 +96,7 @@ components:
             telephoneNumber:
               type: string
             assessment:
-              $ref: '_shared.yml#/components/schemas/Cas2v2Assessment'
+              $ref: '#/components/schemas/Cas2v2Assessment'
             timelineEvents:
               type: array
               items:
@@ -124,7 +124,7 @@ components:
           type: string
           format: date-time
         submittedBy:
-          $ref: '_shared.yml#/components/schemas/NomisUser'
+          $ref: '#/components/schemas/Cas2v2User'
         schemaVersion:
           type: string
           format: uuid
@@ -147,6 +147,7 @@ components:
         bailHearingDate:
           type: string
           format: date
+          $ref: '#/components/schemas/Cas2v2Assessment'
       required:
         - id
         - person
@@ -179,7 +180,7 @@ components:
         status:
           $ref: '_shared.yml#/components/schemas/ApplicationStatus'
         latestStatusUpdate:
-          $ref: '_shared.yml#/components/schemas/LatestCas2StatusUpdate'
+          $ref: '#/components/schemas/LatestCas2v2StatusUpdate'
         risks:
           $ref: '_shared.yml#/components/schemas/PersonRisks'
         hdcEligibilityDate:
@@ -265,3 +266,146 @@ components:
         - body
         - createdAt
       description: Notes added to a Cas2v2Application
+    Cas2v2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
+    Cas2v2AssessmentStatusUpdate:
+      type: object
+      properties:
+        newStatus:
+          type: string
+          example: 'moreInfoRequired'
+          description: 'The "name" of the new status to be applied'
+        newStatusDetails:
+          type: array
+          items:
+            type: string
+            example: 'changeOfCircumstances'
+            description: 'The "name" of the new detail belonging to the new status'
+      required:
+        - newStatus
+    Cas2v2StatusUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the HMPPS user.'
+        updatedBy:
+          $ref: '#/components/schemas/Cas2v2User'
+        updatedAt:
+          type: string
+          format: date-time
+        statusUpdateDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2v2StatusUpdateDetail'
+      required:
+        - id
+        - name
+        - label
+        - description
+    Cas2v2StatusUpdateDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - id
+        - name
+        - label
+    LatestCas2v2StatusUpdate:
+      type: object
+      properties:
+        statusId:
+          type: string
+          format: uuid
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - statusId
+        - label
+    Cas2v2ApplicationStatus:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        statusDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2v2ApplicationStatusDetail'
+      required:
+        - id
+        - name
+        - label
+        - description
+        - statusDetails
+    Cas2v2ApplicationStatusDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'changeOfCircumstances'
+        label:
+          type: string
+          example: 'Change of Circumstances'
+      required:
+        - id
+        - name
+        - label

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4871,20 +4871,20 @@ components:
       required:
         - reason
     WithdrawPlacementRequestReason:
-        type: string
-        enum:
-          - DuplicatePlacementRequest
-          - AlternativeProvisionIdentified
-          - ChangeInCircumstances
-          - ChangeInReleaseDecision
-          - NoCapacityDueToLostBed
-          - NoCapacityDueToPlacementPrioritisation
-          - NoCapacity
-          - ErrorInPlacementRequest
-          - WithdrawnByPP
-          - RelatedApplicationWithdrawn
-          - RelatedPlacementRequestWithdrawn
-          - RelatedPlacementApplicationWithdrawn
+      type: string
+      enum:
+        - DuplicatePlacementRequest
+        - AlternativeProvisionIdentified
+        - ChangeInCircumstances
+        - ChangeInReleaseDecision
+        - NoCapacityDueToLostBed
+        - NoCapacityDueToPlacementPrioritisation
+        - NoCapacity
+        - ErrorInPlacementRequest
+        - WithdrawnByPP
+        - RelatedApplicationWithdrawn
+        - RelatedPlacementRequestWithdrawn
+        - RelatedPlacementApplicationWithdrawn
     PlacementApplicationType:
       type: string
       description: |
@@ -5930,6 +5930,7 @@ components:
           Offline: '#/components/schemas/OfflineApplication'
           CAS1: '#/components/schemas/ApprovedPremisesApplication'
           CAS2: '#/components/schemas/Cas2Application'
+          CAS2V2: '#/components/schemas/Cas2v2Application'
           CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - type
@@ -7539,10 +7540,12 @@ components:
       enum:
         - approved-premises
         - cas2
+        - cas2v2
         - temporary-accommodation
       x-enum-varnames:
         - approvedPremises
         - cas2
+        - cas2v2
         - temporaryAccommodation
     NewRoom:
       type: object
@@ -8098,6 +8101,7 @@ components:
           $ref: '#/components/schemas/ApType'
         location:
           type: string
+          description: Postcode outcode
           example: B74
         radius:
           type: integer
@@ -8864,7 +8868,7 @@ components:
     FullPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'
-        - type : object
+        - type: object
           properties:
             name:
               type: string

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1792,20 +1792,20 @@ components:
       required:
         - reason
     WithdrawPlacementRequestReason:
-        type: string
-        enum:
-          - DuplicatePlacementRequest
-          - AlternativeProvisionIdentified
-          - ChangeInCircumstances
-          - ChangeInReleaseDecision
-          - NoCapacityDueToLostBed
-          - NoCapacityDueToPlacementPrioritisation
-          - NoCapacity
-          - ErrorInPlacementRequest
-          - WithdrawnByPP
-          - RelatedApplicationWithdrawn
-          - RelatedPlacementRequestWithdrawn
-          - RelatedPlacementApplicationWithdrawn
+      type: string
+      enum:
+        - DuplicatePlacementRequest
+        - AlternativeProvisionIdentified
+        - ChangeInCircumstances
+        - ChangeInReleaseDecision
+        - NoCapacityDueToLostBed
+        - NoCapacityDueToPlacementPrioritisation
+        - NoCapacity
+        - ErrorInPlacementRequest
+        - WithdrawnByPP
+        - RelatedApplicationWithdrawn
+        - RelatedPlacementRequestWithdrawn
+        - RelatedPlacementApplicationWithdrawn
     PlacementApplicationType:
       type: string
       description: |
@@ -2851,6 +2851,7 @@ components:
           Offline: '#/components/schemas/OfflineApplication'
           CAS1: '#/components/schemas/ApprovedPremisesApplication'
           CAS2: '#/components/schemas/Cas2Application'
+          CAS2V2: '#/components/schemas/Cas2v2Application'
           CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - type
@@ -4460,10 +4461,12 @@ components:
       enum:
         - approved-premises
         - cas2
+        - cas2v2
         - temporary-accommodation
       x-enum-varnames:
         - approvedPremises
         - cas2
+        - cas2v2
         - temporaryAccommodation
     NewRoom:
       type: object
@@ -5019,6 +5022,7 @@ components:
           $ref: '#/components/schemas/ApType'
         location:
           type: string
+          description: Postcode outcode
           example: B74
         radius:
           type: integer
@@ -5785,7 +5789,7 @@ components:
     FullPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'
-        - type : object
+        - type: object
           properties:
             name:
               type: string

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -1161,20 +1161,20 @@ components:
       required:
         - reason
     WithdrawPlacementRequestReason:
-        type: string
-        enum:
-          - DuplicatePlacementRequest
-          - AlternativeProvisionIdentified
-          - ChangeInCircumstances
-          - ChangeInReleaseDecision
-          - NoCapacityDueToLostBed
-          - NoCapacityDueToPlacementPrioritisation
-          - NoCapacity
-          - ErrorInPlacementRequest
-          - WithdrawnByPP
-          - RelatedApplicationWithdrawn
-          - RelatedPlacementRequestWithdrawn
-          - RelatedPlacementApplicationWithdrawn
+      type: string
+      enum:
+        - DuplicatePlacementRequest
+        - AlternativeProvisionIdentified
+        - ChangeInCircumstances
+        - ChangeInReleaseDecision
+        - NoCapacityDueToLostBed
+        - NoCapacityDueToPlacementPrioritisation
+        - NoCapacity
+        - ErrorInPlacementRequest
+        - WithdrawnByPP
+        - RelatedApplicationWithdrawn
+        - RelatedPlacementRequestWithdrawn
+        - RelatedPlacementApplicationWithdrawn
     PlacementApplicationType:
       type: string
       description: |
@@ -2220,6 +2220,7 @@ components:
           Offline: '#/components/schemas/OfflineApplication'
           CAS1: '#/components/schemas/ApprovedPremisesApplication'
           CAS2: '#/components/schemas/Cas2Application'
+          CAS2V2: '#/components/schemas/Cas2v2Application'
           CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - type
@@ -3829,10 +3830,12 @@ components:
       enum:
         - approved-premises
         - cas2
+        - cas2v2
         - temporary-accommodation
       x-enum-varnames:
         - approvedPremises
         - cas2
+        - cas2v2
         - temporaryAccommodation
     NewRoom:
       type: object
@@ -4388,6 +4391,7 @@ components:
           $ref: '#/components/schemas/ApType'
         location:
           type: string
+          description: Postcode outcode
           example: B74
         radius:
           type: integer
@@ -5154,7 +5158,7 @@ components:
     FullPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'
-        - type : object
+        - type: object
           properties:
             name:
               type: string

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -269,7 +269,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/Cas2AssessmentStatusUpdate'
+              $ref: '#/components/schemas/Cas2v2AssessmentStatusUpdate'
         required: true
       responses:
         200:
@@ -1161,20 +1161,20 @@ components:
       required:
         - reason
     WithdrawPlacementRequestReason:
-        type: string
-        enum:
-          - DuplicatePlacementRequest
-          - AlternativeProvisionIdentified
-          - ChangeInCircumstances
-          - ChangeInReleaseDecision
-          - NoCapacityDueToLostBed
-          - NoCapacityDueToPlacementPrioritisation
-          - NoCapacity
-          - ErrorInPlacementRequest
-          - WithdrawnByPP
-          - RelatedApplicationWithdrawn
-          - RelatedPlacementRequestWithdrawn
-          - RelatedPlacementApplicationWithdrawn
+      type: string
+      enum:
+        - DuplicatePlacementRequest
+        - AlternativeProvisionIdentified
+        - ChangeInCircumstances
+        - ChangeInReleaseDecision
+        - NoCapacityDueToLostBed
+        - NoCapacityDueToPlacementPrioritisation
+        - NoCapacity
+        - ErrorInPlacementRequest
+        - WithdrawnByPP
+        - RelatedApplicationWithdrawn
+        - RelatedPlacementRequestWithdrawn
+        - RelatedPlacementApplicationWithdrawn
     PlacementApplicationType:
       type: string
       description: |
@@ -2220,6 +2220,7 @@ components:
           Offline: '#/components/schemas/OfflineApplication'
           CAS1: '#/components/schemas/ApprovedPremisesApplication'
           CAS2: '#/components/schemas/Cas2Application'
+          CAS2V2: '#/components/schemas/Cas2v2Application'
           CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - type
@@ -3829,10 +3830,12 @@ components:
       enum:
         - approved-premises
         - cas2
+        - cas2v2
         - temporary-accommodation
       x-enum-varnames:
         - approvedPremises
         - cas2
+        - cas2v2
         - temporaryAccommodation
     NewRoom:
       type: object
@@ -4388,6 +4391,7 @@ components:
           $ref: '#/components/schemas/ApType'
         location:
           type: string
+          description: Postcode outcode
           example: B74
         radius:
           type: integer
@@ -5154,7 +5158,7 @@ components:
     FullPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'
-        - type : object
+        - type: object
           properties:
             name:
               type: string
@@ -5473,7 +5477,7 @@ components:
         statusUpdates:
           type: array
           items:
-            $ref: '#/components/schemas/Cas2StatusUpdate'
+            $ref: '#/components/schemas/Cas2v2StatusUpdate'
       required:
         - id
     Cas2v2Application:
@@ -5482,7 +5486,7 @@ components:
         - type: object
           properties:
             createdBy:
-              $ref: '#/components/schemas/NomisUser'
+              $ref: '#/components/schemas/Cas2v2User'
             schemaVersion:
               type: string
               format: uuid
@@ -5528,7 +5532,7 @@ components:
           type: string
           format: date-time
         submittedBy:
-          $ref: '#/components/schemas/NomisUser'
+          $ref: '#/components/schemas/Cas2v2User'
         schemaVersion:
           type: string
           format: uuid
@@ -5551,6 +5555,7 @@ components:
         bailHearingDate:
           type: string
           format: date
+          $ref: '#/components/schemas/Cas2v2Assessment'
       required:
         - id
         - person
@@ -5583,7 +5588,7 @@ components:
         status:
           $ref: '#/components/schemas/ApplicationStatus'
         latestStatusUpdate:
-          $ref: '#/components/schemas/LatestCas2StatusUpdate'
+          $ref: '#/components/schemas/LatestCas2v2StatusUpdate'
         risks:
           $ref: '#/components/schemas/PersonRisks'
         hdcEligibilityDate:
@@ -5669,3 +5674,146 @@ components:
         - body
         - createdAt
       description: Notes added to a Cas2v2Application
+    Cas2v2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
+    Cas2v2AssessmentStatusUpdate:
+      type: object
+      properties:
+        newStatus:
+          type: string
+          example: 'moreInfoRequired'
+          description: 'The "name" of the new status to be applied'
+        newStatusDetails:
+          type: array
+          items:
+            type: string
+            example: 'changeOfCircumstances'
+            description: 'The "name" of the new detail belonging to the new status'
+      required:
+        - newStatus
+    Cas2v2StatusUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the HMPPS user.'
+        updatedBy:
+          $ref: '#/components/schemas/Cas2v2User'
+        updatedAt:
+          type: string
+          format: date-time
+        statusUpdateDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2v2StatusUpdateDetail'
+      required:
+        - id
+        - name
+        - label
+        - description
+    Cas2v2StatusUpdateDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - id
+        - name
+        - label
+    LatestCas2v2StatusUpdate:
+      type: object
+      properties:
+        statusId:
+          type: string
+          format: uuid
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - statusId
+        - label
+    Cas2v2ApplicationStatus:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the POM (Prison Offender Manager).'
+        statusDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2v2ApplicationStatusDetail'
+      required:
+        - id
+        - name
+        - label
+        - description
+        - statusDetails
+    Cas2v2ApplicationStatusDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'changeOfCircumstances'
+        label:
+          type: string
+          example: 'Change of Circumstances'
+      required:
+        - id
+        - name
+        - label

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -669,20 +669,20 @@ components:
       required:
         - reason
     WithdrawPlacementRequestReason:
-        type: string
-        enum:
-          - DuplicatePlacementRequest
-          - AlternativeProvisionIdentified
-          - ChangeInCircumstances
-          - ChangeInReleaseDecision
-          - NoCapacityDueToLostBed
-          - NoCapacityDueToPlacementPrioritisation
-          - NoCapacity
-          - ErrorInPlacementRequest
-          - WithdrawnByPP
-          - RelatedApplicationWithdrawn
-          - RelatedPlacementRequestWithdrawn
-          - RelatedPlacementApplicationWithdrawn
+      type: string
+      enum:
+        - DuplicatePlacementRequest
+        - AlternativeProvisionIdentified
+        - ChangeInCircumstances
+        - ChangeInReleaseDecision
+        - NoCapacityDueToLostBed
+        - NoCapacityDueToPlacementPrioritisation
+        - NoCapacity
+        - ErrorInPlacementRequest
+        - WithdrawnByPP
+        - RelatedApplicationWithdrawn
+        - RelatedPlacementRequestWithdrawn
+        - RelatedPlacementApplicationWithdrawn
     PlacementApplicationType:
       type: string
       description: |
@@ -1728,6 +1728,7 @@ components:
           Offline: '#/components/schemas/OfflineApplication'
           CAS1: '#/components/schemas/ApprovedPremisesApplication'
           CAS2: '#/components/schemas/Cas2Application'
+          CAS2V2: '#/components/schemas/Cas2v2Application'
           CAS3: '#/components/schemas/TemporaryAccommodationApplication'
       required:
         - type
@@ -3337,10 +3338,12 @@ components:
       enum:
         - approved-premises
         - cas2
+        - cas2v2
         - temporary-accommodation
       x-enum-varnames:
         - approvedPremises
         - cas2
+        - cas2v2
         - temporaryAccommodation
     NewRoom:
       type: object
@@ -3896,6 +3899,7 @@ components:
           $ref: '#/components/schemas/ApType'
         location:
           type: string
+          description: Postcode outcode
           example: B74
         radius:
           type: integer
@@ -4662,7 +4666,7 @@ components:
     FullPersonSummary:
       allOf:
         - $ref: '#/components/schemas/PersonSummary'
-        - type : object
+        - type: object
           properties:
             name:
               type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -26,7 +26,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var occurredAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
   private var data: Yielded<String> = { "{}" }
-  private var service: Yielded<String> = { randomOf(listOf("CAS1", "CAS2", "CAS3")) }
+  private var service: Yielded<String> = { randomOf(listOf("CAS1", "CAS2", "CAS2V2", "CAS3")) }
   private var triggerSource: Yielded<TriggerSourceType?> = { null }
   private var triggeredByUserId: Yielded<UUID?> = { null }
   private var nomsNumber: Yielded<String?> = { randomStringMultiCaseWithNumbers(8) }
@@ -83,6 +83,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
       when (service) {
         ServiceName.approvedPremises -> "CAS1"
         ServiceName.cas2 -> "CAS2"
+        ServiceName.cas2v2 -> "CAS2V2"
         ServiceName.temporaryAccommodation -> "CAS3"
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2ApplicationEntityFactory.kt
@@ -5,11 +5,11 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomNumberChars
@@ -22,7 +22,7 @@ import java.util.UUID
 class Cas2v2ApplicationEntityFactory : Factory<Cas2v2ApplicationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
-  private var createdByUser: Yielded<NomisUserEntity>? = null
+  private var createdByUser: Yielded<Cas2v2UserEntity>? = null
   private var data: Yielded<String?> = { "{}" }
   private var document: Yielded<String?> = { "{}" }
   private var applicationSchema: Yielded<JsonSchemaEntity> = {
@@ -55,11 +55,11 @@ class Cas2v2ApplicationEntityFactory : Factory<Cas2v2ApplicationEntity> {
     this.nomsNumber = { nomsNumber }
   }
 
-  fun withCreatedByUser(createdByUser: NomisUserEntity) = apply {
+  fun withCreatedByUser(createdByUser: Cas2v2UserEntity) = apply {
     this.createdByUser = { createdByUser }
   }
 
-  fun withYieldedCreatedByUser(createdByUser: Yielded<NomisUserEntity>) = apply {
+  fun withYieldedCreatedByUser(createdByUser: Yielded<Cas2v2UserEntity>) = apply {
     this.createdByUser = createdByUser
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2AssessmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2AssessmentEntityFactory.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
@@ -14,7 +13,7 @@ class Cas2v2AssessmentEntityFactory : Factory<Cas2v2AssessmentEntity> {
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
   private var application: Yielded<Cas2v2ApplicationEntity> = {
     Cas2v2ApplicationEntityFactory()
-      .withCreatedByUser(NomisUserEntityFactory().produce())
+      .withCreatedByUser(Cas2v2UserEntityFactory().produce())
       .produce()
   }
   private var nacroReferralId: String? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2StatusUpdateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2StatusUpdateEntityFactory.kt
@@ -2,12 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
@@ -15,7 +14,7 @@ import java.util.UUID
 
 class Cas2v2StatusUpdateEntityFactory : Factory<Cas2v2StatusUpdateEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var assessor: Yielded<ExternalUserEntity> = { ExternalUserEntityFactory().produce() }
+  private var assessor: Yielded<Cas2v2UserEntity> = { Cas2v2UserEntityFactory().produce() }
   private var assessment: Yielded<Cas2v2AssessmentEntity?> = { null }
   private var application: Yielded<Cas2v2ApplicationEntity>? = null
   private var statusId: Yielded<UUID> = { Cas2ApplicationStatusSeeding.statusList().random().id }
@@ -28,7 +27,7 @@ class Cas2v2StatusUpdateEntityFactory : Factory<Cas2v2StatusUpdateEntity> {
     this.id = { id }
   }
 
-  fun withAssessor(assessor: ExternalUserEntity) = apply {
+  fun withAssessor(assessor: Cas2v2UserEntity) = apply {
     this.assessor = { assessor }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2UserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2UserEntityFactory.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomEmailAddress
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class Cas2v2UserEntityFactory : Factory<Cas2v2UserEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var username: Yielded<String> = { randomStringUpperCase(12) }
+  private var name: Yielded<String> = { randomStringUpperCase(12) }
+  private var email: Yielded<String?> = { randomEmailAddress() }
+  private var nomisStaffId: Yielded<Long?> = { randomInt(100000, 900000).toLong() }
+  private var activeNomisCaseloadId: Yielded<String?> = { null }
+  private var userType: Yielded<Cas2v2UserType> = { Cas2v2UserType.NOMIS }
+  private var deliusStaffCode: Yielded<String?> = { null }
+  private var deliusTeamCodes: Yielded<List<String>?> = { null }
+  private var isEnabled: Yielded<Boolean> = { true }
+  private var isActive: Yielded<Boolean> = { true }
+  private var applications: Yielded<MutableList<Cas2v2ApplicationEntity>> = { mutableListOf() }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withActiveNomisCaseloadId(activeCaseloadId: String) = apply {
+    this.activeNomisCaseloadId = { activeCaseloadId }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withUsername(username: String) = apply {
+    this.username = { username }
+  }
+
+  fun withNomisStaffCode(nomisStaffId: Long) = apply {
+    this.nomisStaffId = { nomisStaffId }
+  }
+
+  fun withDeliusStaffCode(deliusStaffCode: String) = apply {
+    this.deliusStaffCode = { deliusStaffCode }
+  }
+
+  fun withNomisStaffIdentifier(nomisStaffId: Long) = apply {
+    this.nomisStaffId = { nomisStaffId }
+  }
+
+  fun withApplications(applications: MutableList<Cas2v2ApplicationEntity>) = apply {
+    this.applications = { applications }
+  }
+
+  fun withEmail(email: String?) = apply {
+    this.email = { email }
+  }
+
+  fun withUserType(t: Cas2v2UserType) = apply {
+    this.userType = { t }
+  }
+
+  override fun produce(): Cas2v2UserEntity = Cas2v2UserEntity(
+    id = this.id(),
+    username = this.username(),
+    name = this.name(),
+    email = this.email(),
+    nomisStaffId = this.nomisStaffId(),
+    activeNomisCaseloadId = this.activeNomisCaseloadId(),
+    deliusStaffCode = this.deliusStaffCode(),
+    deliusTeamCodes = this.deliusTeamCodes(),
+    userType = this.userType(),
+    isEnabled = this.isEnabled(),
+    isActive = this.isActive(),
+    applications = this.applications(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -184,7 +184,7 @@ class AssessmentTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(ServiceName::class, names = ["cas2"], mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(ServiceName::class, names = ["cas2", "cas2v2"], mode = EnumSource.Mode.EXCLUDE)
     @Suppress("TooGenericExceptionThrown") // The RuntimeException here will never be reached
     fun `Get all assessments returns successfully when an inmate details cache failure occurs`(serviceName: ServiceName) {
       val givenAnAssessment = when (serviceName) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas2v2IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas2v2IntegrationTestBase.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2StatusUpdateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.IntegrationTestDbManager
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.TestPropertiesInitializer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2v2ApplicationJsonSchemaEntity
@@ -19,6 +20,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2v2ApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2v2ApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2v2StatusUpdateTestRepository
@@ -41,11 +44,15 @@ abstract class Cas2v2IntegrationTestBase : IntegrationTestBase() {
   lateinit var cas2v2StatusUpdateRepository: Cas2v2StatusUpdateTestRepository
 
   @Autowired
+  lateinit var cas2v2UserRepository: Cas2v2UserRepository
+
+  @Autowired
   lateinit var cas2v2ApplicationJsonSchemaRepository: Cas2v2ApplicationJsonSchemaTestRepository
 
   lateinit var cas2v2ApplicationEntityFactory: PersistedFactory<Cas2v2ApplicationEntity, UUID, Cas2v2ApplicationEntityFactory>
   lateinit var cas2v2AssessmentEntityFactory: PersistedFactory<Cas2v2AssessmentEntity, UUID, Cas2v2AssessmentEntityFactory>
   lateinit var cas2v2StatusUpdateEntityFactory: PersistedFactory<Cas2v2StatusUpdateEntity, UUID, Cas2v2StatusUpdateEntityFactory>
+  lateinit var cas2v2UserEntityFactory: PersistedFactory<Cas2v2UserEntity, UUID, Cas2v2UserEntityFactory>
   lateinit var cas2v2ApplicationJsonSchemaEntityFactory: PersistedFactory<Cas2v2ApplicationJsonSchemaEntity, UUID, Cas2v2ApplicationJsonSchemaEntityFactory>
 
   override fun setupFactories() {
@@ -54,6 +61,7 @@ abstract class Cas2v2IntegrationTestBase : IntegrationTestBase() {
     cas2v2AssessmentEntityFactory = PersistedFactory({ Cas2v2AssessmentEntityFactory() }, cas2v2AssessmentRepository)
     cas2v2StatusUpdateEntityFactory =
       PersistedFactory({ Cas2v2StatusUpdateEntityFactory() }, cas2v2StatusUpdateRepository)
+    cas2v2UserEntityFactory = PersistedFactory({ Cas2v2UserEntityFactory() }, cas2v2UserRepository)
     cas2v2ApplicationJsonSchemaEntityFactory =
       PersistedFactory({ Cas2v2ApplicationJsonSchemaEntityFactory() }, cas2v2ApplicationJsonSchemaRepository)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2ApplicationAbandonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2ApplicationAbandonTest.kt
@@ -9,17 +9,16 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.Cas2v2IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2LicenceCaseAdminUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2LicenceCaseAdminUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import java.time.OffsetDateTime
 
 class Cas2v2ApplicationAbandonTest : Cas2v2IntegrationTestBase() {
-  @SpykBean
-  lateinit var realApplicationRepository: Cas2v2ApplicationRepository
+  @SpykBean lateinit var realApplicationRepository: Cas2v2ApplicationRepository
 
   val schema = """
         {
@@ -92,7 +91,7 @@ class Cas2v2ApplicationAbandonTest : Cas2v2IntegrationTestBase() {
     inner class PomUsers {
       @Test
       fun `Abandon existing cas2v2 application returns 200 with correct body`() {
-        givenACas2PomUser { submittingUser, jwt ->
+        givenACas2v2PomUser { submittingUser, jwt ->
           givenAnOffender { offenderDetails, _ ->
             val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, submittingUser)
 
@@ -113,7 +112,7 @@ class Cas2v2ApplicationAbandonTest : Cas2v2IntegrationTestBase() {
     inner class LicenceCaseAdminUsers {
       @Test
       fun `Abandon existing cas2v2 application returns 200 with correct body`() {
-        givenACas2LicenceCaseAdminUser { submittingUser, jwt ->
+        givenACas2v2LicenceCaseAdminUser { submittingUser, jwt ->
           givenAnOffender { offenderDetails, _ ->
             val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, submittingUser)
 
@@ -133,7 +132,7 @@ class Cas2v2ApplicationAbandonTest : Cas2v2IntegrationTestBase() {
 
   private fun produceAndPersistBasicApplication(
     crn: String,
-    userEntity: NomisUserEntity,
+    userEntity: Cas2v2UserEntity,
   ): Cas2v2ApplicationEntity {
     val jsonSchema = cas2v2ApplicationJsonSchemaEntityFactory.produceAndPersist {
       withAddedAt(OffsetDateTime.parse("2022-09-21T12:45:00+01:00"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2AssessmentTest.kt
@@ -8,16 +8,16 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.returnResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.Cas2v2IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2Admin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2Assessor
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2Assessor
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -90,8 +90,8 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
     fun `assessors create cas2v2 note returns 201`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-      givenACas2PomUser { referrer, _ ->
-        givenACas2Assessor { assessor, jwt ->
+      givenACas2v2PomUser { referrer, _ ->
+        givenACas2v2Assessor { assessor, jwt ->
           val submittedApplication = createSubmittedApplication(applicationId, referrer)
 
           // with an assessment
@@ -107,7 +107,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
           val rawResponseBody = webTestClient.put()
             .uri("/cas2v2/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
-            .header("X-Service-Name", ServiceName.cas2.value)
+            .header("X-Service-Name", ServiceName.cas2v2.value)
             .bodyValue(
               UpdateCas2Assessment(
                 nacroReferralId = updatedNacroReferralId,
@@ -122,7 +122,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
             .blockFirst()
 
           val responseBody =
-            objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2Assessment>() {})
+            objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2v2Assessment>() {})
 
           Assertions.assertThat(responseBody.nacroReferralId).isEqualTo(updatedNacroReferralId)
           Assertions.assertThat(responseBody.assessorName).isEqualTo(updatedAssessorName)
@@ -130,7 +130,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
       }
     }
 
-    private fun createSubmittedApplication(applicationId: UUID, referrer: NomisUserEntity): Cas2v2ApplicationEntity {
+    private fun createSubmittedApplication(applicationId: UUID, referrer: Cas2v2UserEntity): Cas2v2ApplicationEntity {
       val applicationSchema =
         cas2v2ApplicationJsonSchemaEntityFactory.produceAndPersist()
 
@@ -199,8 +199,8 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
     fun `assessors update cas2v2 assessment returns 200`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-      givenACas2PomUser { referrer, _ ->
-        givenACas2Assessor { assessor, jwt ->
+      givenACas2v2PomUser { referrer, _ ->
+        givenACas2v2Assessor { assessor, jwt ->
           val submittedApplication = createSubmittedApplication(applicationId, referrer)
 
           // with an assessment
@@ -213,7 +213,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
           val rawResponseBody = webTestClient.get()
             .uri("/cas2v2/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
-            .header("X-Service-Name", ServiceName.cas2.value)
+            .header("X-Service-Name", ServiceName.cas2v2.value)
             .exchange()
             .expectStatus()
             .isOk
@@ -222,7 +222,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
             .blockFirst()
 
           val responseBody =
-            objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2Assessment>() {})
+            objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2v2Assessment>() {})
 
           Assertions.assertThat(responseBody.nacroReferralId).isEqualTo(assessment.nacroReferralId)
           Assertions.assertThat(responseBody.assessorName).isEqualTo(assessment.assessorName)
@@ -234,7 +234,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
     fun `admins get cas2 version 2 assessment returns 200`() {
       val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-      givenACas2PomUser { referrer, _ ->
+      givenACas2v2PomUser { referrer, _ ->
         givenACas2Admin { admin, jwt ->
           val submittedApplication = createSubmittedApplication(applicationId, referrer)
 
@@ -248,7 +248,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
           val rawResponseBody = webTestClient.get()
             .uri("/cas2v2/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
-            .header("X-Service-Name", ServiceName.cas2.value)
+            .header("X-Service-Name", ServiceName.cas2v2.value)
             .exchange()
             .expectStatus()
             .isOk
@@ -257,7 +257,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
             .blockFirst()
 
           val responseBody =
-            objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2Assessment>() {})
+            objectMapper.readValue(rawResponseBody, object : TypeReference<Cas2v2Assessment>() {})
 
           Assertions.assertThat(responseBody.nacroReferralId).isEqualTo(assessment.nacroReferralId)
           Assertions.assertThat(responseBody.assessorName).isEqualTo(assessment.assessorName)
@@ -265,7 +265,7 @@ class Cas2v2AssessmentTest : Cas2v2IntegrationTestBase() {
       }
     }
 
-    private fun createSubmittedApplication(applicationId: UUID, referrer: NomisUserEntity): Cas2v2ApplicationEntity {
+    private fun createSubmittedApplication(applicationId: UUID, referrer: Cas2v2UserEntity): Cas2v2ApplicationEntity {
       val applicationSchema =
         cas2v2ApplicationJsonSchemaEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2ReportsTest.kt
@@ -112,12 +112,12 @@ class Cas2v2ReportsTest : Cas2v2IntegrationTestBase() {
         withId(UUID.randomUUID())
       }
 
-      val user1 = nomisUserEntityFactory.produceAndPersist {
-        withNomisUsername("NOMIS_USER_1")
+      val user1 = cas2v2UserEntityFactory.produceAndPersist {
+        withUsername("NOMIS_USER_1")
       }
 
-      val user2 = nomisUserEntityFactory.produceAndPersist {
-        withNomisUsername("NOMIS_USER_2")
+      val user2 = cas2v2UserEntityFactory.produceAndPersist {
+        withUsername("NOMIS_USER_2")
       }
 
       val applicationId1 = UUID.randomUUID()
@@ -411,12 +411,12 @@ class Cas2v2ReportsTest : Cas2v2IntegrationTestBase() {
         withId(UUID.randomUUID())
       }
 
-      val user1 = nomisUserEntityFactory.produceAndPersist {
-        withNomisUsername("NOMIS_USER_1")
+      val user1 = cas2v2UserEntityFactory.produceAndPersist {
+        withUsername("NOMIS_USER_1")
       }
 
-      val user2 = nomisUserEntityFactory.produceAndPersist {
-        withNomisUsername("NOMIS_USER_2")
+      val user2 = cas2v2UserEntityFactory.produceAndPersist {
+        withUsername("NOMIS_USER_2")
       }
 
       val application1 = cas2v2ApplicationEntityFactory.produceAndPersist {
@@ -463,14 +463,14 @@ class Cas2v2ReportsTest : Cas2v2IntegrationTestBase() {
           personCrn = application2.crn,
           personNoms = application2.nomsNumber.toString(),
           startedAt = application2.createdAt.toString().split(".").first(),
-          startedBy = application2.createdByUser.nomisUsername,
+          startedBy = application2.createdByUser.username,
         ),
         UnsubmittedApplicationsReportRow(
           applicationId = application1.id.toString(),
           personCrn = application1.crn,
           personNoms = application1.nomsNumber.toString(),
           startedAt = application1.createdAt.toString().split(".").first(),
-          startedBy = application1.createdByUser.nomisUsername,
+          startedBy = application1.createdByUser.username,
         ),
       )
         .toDataFrame()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2StatusUpdateTest.kt
@@ -14,8 +14,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.Cas2v2IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2Assessor
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2Assessor
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
@@ -81,9 +81,9 @@ class Cas2v2StatusUpdateTest(
     fun `Create cas2v2 status update returns 201 and creates StatusUpdate when given status is valid`() {
       val assessmentId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
-      givenACas2Assessor { _, jwt ->
-        givenACas2PomUser { applicant, _ ->
-          val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+      givenACas2v2Assessor { _, jwt ->
+        givenACas2v2PomUser { applicant, _ ->
+          val jsonSchema = cas2v2ApplicationJsonSchemaEntityFactory.produceAndPersist()
           val application = cas2v2ApplicationEntityFactory.produceAndPersist {
             withCreatedByUser(applicant)
             withApplicationSchema(jsonSchema)
@@ -135,7 +135,7 @@ class Cas2v2StatusUpdateTest(
 
     @Test
     fun `Create cas2v2 status update returns 404 when assessment not found`() {
-      givenACas2Assessor { _, jwt ->
+      givenACas2v2Assessor { _, jwt ->
         webTestClient.post()
           .uri("/cas2v2/assessments/66f7127a-fe03-4b66-8378-5c0b048490f8/status-updates")
           .header("Authorization", "Bearer $jwt")
@@ -150,8 +150,8 @@ class Cas2v2StatusUpdateTest(
 
     @Test
     fun `Create cas2v2 status update returns 400 when new status NOT valid`() {
-      givenACas2Assessor { _, jwt ->
-        givenACas2PomUser { applicant, _ ->
+      givenACas2v2Assessor { _, jwt ->
+        givenACas2v2PomUser { applicant, _ ->
           val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
           val application = cas2v2ApplicationEntityFactory.produceAndPersist {
             withCreatedByUser(applicant)
@@ -186,9 +186,9 @@ class Cas2v2StatusUpdateTest(
         val submittedAt = OffsetDateTime.now()
 
         try {
-          givenACas2Assessor { _, jwt ->
-            givenACas2PomUser { applicant, _ ->
-              val jsonSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist()
+          givenACas2v2Assessor { _, jwt ->
+            givenACas2v2PomUser { applicant, _ ->
+              val jsonSchema = cas2v2ApplicationJsonSchemaEntityFactory.produceAndPersist()
               val application = cas2v2ApplicationEntityFactory.produceAndPersist {
                 withCreatedByUser(applicant)
                 withApplicationSchema(jsonSchema)
@@ -241,6 +241,7 @@ class Cas2v2StatusUpdateTest(
                 .isNotNull()
 
               emailAsserter.assertEmailsRequestedCount(1)
+
               val email = emailAsserter.assertEmailRequested(
                 toEmailAddress = applicant.email!!,
                 templateId = "ef4dc5e3-b1f1-4448-a545-7a936c50fc3a",
@@ -259,6 +260,7 @@ class Cas2v2StatusUpdateTest(
               // to the CAS2 domain
               val expectedFrontEndUrl = applicationUrlTemplate.replace("#id", application.id.toString())
               val persistedDomainEvent = domainEventRepository.findFirstByOrderByCreatedAtDesc()
+
               val domainEventFromJson = objectMapper.readValue(
                 persistedDomainEvent!!.data,
                 Cas2ApplicationStatusUpdatedEvent::class.java,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTestRepository.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import java.util.UUID
 
 @Repository
@@ -17,6 +18,9 @@ interface Cas2ApplicationTestRepository : JpaRepository<Cas2ApplicationEntity, U
 
 @Repository
 interface Cas2v2ApplicationTestRepository : JpaRepository<Cas2v2ApplicationEntity, UUID>
+
+@Repository
+interface Cas2v2UserTestRepository : JpaRepository<Cas2v2UserEntity, UUID>
 
 @Repository
 interface Cas2v2AssessmentTestRepository : JpaRepository<Cas2v2AssessmentEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2ApplicationServiceTest.kt
@@ -24,9 +24,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Ap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2v2ApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2v2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationRepository
@@ -151,7 +151,7 @@ class Cas2v2ApplicationServiceTest {
     )
     val page = mockk<Page<Cas2v2ApplicationSummaryEntity>>()
     val pageCriteria = PageCriteria(sortBy = "submitted_at", sortDirection = SortDirection.asc, page = 3)
-    val user = NomisUserEntityFactory().produce()
+    val user = Cas2v2UserEntityFactory().produce()
     val prisonCode = "BRI"
 
     private fun testPrisonCodeWithIsSubmitted(isSubmitted: Boolean?) {
@@ -211,7 +211,7 @@ class Cas2v2ApplicationServiceTest {
   inner class GetCas2v2ApplicationForUser {
     @Test
     fun `where cas2v2 application does not exist returns NotFound result`() {
-      val user = NomisUserEntityFactory().produce()
+      val user = Cas2v2UserEntityFactory().produce()
       val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
       every { mockCas2v2ApplicationRepository.findByIdOrNull(applicationId) } returns null
@@ -221,13 +221,13 @@ class Cas2v2ApplicationServiceTest {
 
     @Test
     fun `where cas2v2 application is abandoned returns NotFound result`() {
-      val user = NomisUserEntityFactory().produce()
+      val user = Cas2v2UserEntityFactory().produce()
       val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
       every { mockCas2v2ApplicationRepository.findByIdOrNull(any()) } returns
         Cas2v2ApplicationEntityFactory()
           .withCreatedByUser(
-            NomisUserEntityFactory()
+            Cas2v2UserEntityFactory()
               .produce(),
           )
           .withAbandonedAt(OffsetDateTime.now())
@@ -238,14 +238,14 @@ class Cas2v2ApplicationServiceTest {
 
     @Test
     fun `where user cannot access the cas2v2 application returns Unauthorised result`() {
-      val user = NomisUserEntityFactory()
+      val user = Cas2v2UserEntityFactory()
         .produce()
       val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
       every { mockCas2v2ApplicationRepository.findByIdOrNull(any()) } returns
         Cas2v2ApplicationEntityFactory()
           .withCreatedByUser(
-            NomisUserEntityFactory()
+            Cas2v2UserEntityFactory()
               .produce(),
           )
           .produce()
@@ -265,9 +265,9 @@ class Cas2v2ApplicationServiceTest {
         .withSchema("{}")
         .produce()
 
-      val userEntity = NomisUserEntityFactory()
+      val userEntity = Cas2v2UserEntityFactory()
         .withId(userId)
-        .withNomisUsername(distinguishedName)
+        .withUsername(distinguishedName)
         .produce()
 
       val cas2v2ApplicationEntity = Cas2v2ApplicationEntityFactory()
@@ -358,7 +358,7 @@ class Cas2v2ApplicationServiceTest {
 
   @Nested
   inner class UpdateApplication {
-    val user = NomisUserEntityFactory().produce()
+    val user = Cas2v2UserEntityFactory().produce()
 
     @Test
     fun `returns NotFound when cas2v2 application doesn't exist`() {
@@ -383,7 +383,7 @@ class Cas2v2ApplicationServiceTest {
       val cas2v2Application = Cas2v2ApplicationEntityFactory()
         .withId(applicationId)
         .withYieldedCreatedByUser {
-          NomisUserEntityFactory()
+          Cas2v2UserEntityFactory()
             .produce()
         }
         .produce()
@@ -611,7 +611,7 @@ class Cas2v2ApplicationServiceTest {
 
   @Nested
   inner class AbandonApplication {
-    val user = NomisUserEntityFactory().produce()
+    val user = Cas2v2UserEntityFactory().produce()
 
     @Test
     fun `returns NotFound when application doesn't exist`() {
@@ -634,7 +634,7 @@ class Cas2v2ApplicationServiceTest {
       val application = Cas2v2ApplicationEntityFactory()
         .withId(applicationId)
         .withYieldedCreatedByUser {
-          NomisUserEntityFactory()
+          Cas2v2UserEntityFactory()
             .produce()
         }
         .produce()
@@ -752,8 +752,8 @@ class Cas2v2ApplicationServiceTest {
   inner class SubmitApplication {
     val applicationId: UUID = UUID.fromString("fa6e97ce-7b9e-473c-883c-83b1c2af773d")
     val username = "SOMEPERSON"
-    val user = NomisUserEntityFactory()
-      .withNomisUsername(this.username)
+    val user = Cas2v2UserEntityFactory()
+      .withUsername(this.username)
       .produce()
     val hdcEligibilityDate = LocalDate.parse("2023-03-30")
     val conditionalReleaseDate = LocalDate.parse("2023-04-29")
@@ -787,7 +787,7 @@ class Cas2v2ApplicationServiceTest {
 
     @Test
     fun `returns Unauthorised when application doesn't belong to request user`() {
-      val differentUser = NomisUserEntityFactory()
+      val differentUser = Cas2v2UserEntityFactory()
         .produce()
 
       val cas2v2Application = Cas2v2ApplicationEntityFactory()
@@ -1106,7 +1106,7 @@ class Cas2v2ApplicationServiceTest {
     }
   }
 
-  private fun userWithUsername(username: String) = NomisUserEntityFactory()
-    .withNomisUsername(username)
+  private fun userWithUsername(username: String) = Cas2v2UserEntityFactory()
+    .withUsername(username)
     .produce()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2AssessmentServiceTest.kt
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2Assessment
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
@@ -32,7 +32,7 @@ class Cas2v2AssessmentServiceTest {
     fun `saves and returns entity from db`() {
       val cas2v2Application = Cas2v2ApplicationEntityFactory()
         .withCreatedByUser(
-          NomisUserEntityFactory()
+          Cas2v2UserEntityFactory()
             .produce(),
         ).produce()
       val assessEntity = Cas2v2AssessmentEntity(
@@ -67,7 +67,7 @@ class Cas2v2AssessmentServiceTest {
       val assessmentId = UUID.randomUUID()
       val cas2v2Application = Cas2v2ApplicationEntityFactory()
         .withCreatedByUser(
-          NomisUserEntityFactory()
+          Cas2v2UserEntityFactory()
             .produce(),
         ).produce()
       val assessEntity = Cas2v2AssessmentEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2UserAccessServiceTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2v2ApplicationJsonSchemaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2v2.Cas2v2UserAccessService
 import java.time.OffsetDateTime
 
@@ -22,7 +22,7 @@ class Cas2v2UserAccessServiceTest {
 
     @Nested
     inner class WhenApplicationCreatedByUser {
-      private val user = NomisUserEntityFactory()
+      private val user = Cas2v2UserEntityFactory()
         .produce()
 
       @Test
@@ -41,9 +41,9 @@ class Cas2v2UserAccessServiceTest {
 
       @Nested
       inner class WhenApplicationNotSubmitted {
-        private val user = NomisUserEntityFactory()
+        private val user = Cas2v2UserEntityFactory()
           .produce()
-        private val anotherUser = NomisUserEntityFactory()
+        private val anotherUser = Cas2v2UserEntityFactory()
           .produce()
 
         @Test
@@ -59,11 +59,11 @@ class Cas2v2UserAccessServiceTest {
 
       @Nested
       inner class WhenApplicationMadeForDifferentPrison {
-        private val user = NomisUserEntityFactory()
-          .withActiveCaseloadId("my-prison")
+        private val user = Cas2v2UserEntityFactory()
+          .withActiveNomisCaseloadId("my-prison")
           .produce()
-        private val anotherUser = NomisUserEntityFactory()
-          .withActiveCaseloadId("different-prison").produce()
+        private val anotherUser = Cas2v2UserEntityFactory()
+          .withActiveNomisCaseloadId("different-prison").produce()
 
         @Test
         fun `returns false`() {
@@ -79,11 +79,11 @@ class Cas2v2UserAccessServiceTest {
 
         @Nested
         inner class WhenNoPrisonData {
-          private val userWithNoPrison = NomisUserEntityFactory()
-            .withActiveCaseloadId("my-prison")
+          private val userWithNoPrison = Cas2v2UserEntityFactory()
+            .withActiveNomisCaseloadId("my-prison")
             .produce()
-          private val anotherUserWithNoPrison = NomisUserEntityFactory()
-            .withActiveCaseloadId("different-prison").produce()
+          private val anotherUserWithNoPrison = Cas2v2UserEntityFactory()
+            .withActiveNomisCaseloadId("different-prison").produce()
 
           @Test
           fun `returns false`() {
@@ -100,11 +100,11 @@ class Cas2v2UserAccessServiceTest {
 
       @Nested
       inner class WhenCas2v2ApplicationMadeForSamePrison {
-        private val user = NomisUserEntityFactory()
-          .withActiveCaseloadId("my-prison")
+        private val user = Cas2v2UserEntityFactory()
+          .withActiveNomisCaseloadId("my-prison")
           .produce()
-        private val anotherUser = NomisUserEntityFactory()
-          .withActiveCaseloadId("my-prison")
+        private val anotherUser = Cas2v2UserEntityFactory()
+          .withActiveNomisCaseloadId("my-prison")
           .produce()
 
         @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2ApplicationNotesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2ApplicationNotesTransformerTest.kt
@@ -4,18 +4,18 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2ApplicationNotesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class Cas2v2ApplicationNotesTransformerTest {
-  private val user = NomisUserEntityFactory().produce()
+  private val user = Cas2v2UserEntityFactory().produce()
   private val submittedApplication = Cas2v2ApplicationEntityFactory()
     .withCreatedByUser(user)
     .withSubmittedAt(OffsetDateTime.now())
@@ -27,7 +27,9 @@ class Cas2v2ApplicationNotesTransformerTest {
   inner class WithExternalUser {
     @Test
     fun `transforms JPA Cas2v2ApplicationNote db entity to API representation`() {
-      val externalUser = ExternalUserEntityFactory().produce()
+      val externalUser = Cas2v2UserEntityFactory().produce()
+      externalUser.userType = Cas2v2UserType.EXTERNAL
+
       val createdAt = OffsetDateTime.now().randomDateTimeBefore(1)
       val jpaEntity = Cas2v2ApplicationNoteEntity(
         id = UUID.randomUUID(),
@@ -56,7 +58,7 @@ class Cas2v2ApplicationNotesTransformerTest {
   inner class WithNomisUser {
     @Test
     fun `transforms JPA Cas2v2ApplicationNote db entity to API representation`() {
-      val nomisUser = NomisUserEntityFactory().produce()
+      val nomisUser = Cas2v2UserEntityFactory().produce()
       val createdAt = OffsetDateTime.now().randomDateTimeBefore(1)
       val jpaEntity = Cas2v2ApplicationNoteEntity(
         id = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2AssessmentsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2AssessmentsTransformerTest.kt
@@ -4,8 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2AssessmentsTransformer
@@ -19,7 +19,7 @@ class Cas2v2AssessmentsTransformerTest {
     .withStatusUpdates(mutableListOf(mockCas2v2StatusUpdateEntity, mockCas2v2StatusUpdateEntity))
     .produce()
   private val mockCas2v2StatusUpdateTransformer = mockk<Cas2v2StatusUpdateTransformer>()
-  private val mockStatusUpdateApi = mockk<Cas2StatusUpdate>()
+  private val mockStatusUpdateApi = mockk<Cas2v2StatusUpdate>()
   private val cas2v2AssessmentsTransformer = Cas2v2AssessmentsTransformer(mockCas2v2StatusUpdateTransformer)
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2StatusUpdateTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2StatusUpdateTransformerTest.kt
@@ -5,30 +5,30 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ExternalUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2StatusUpdateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExternalUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2StatusUpdateTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2UserTransformer
 import java.time.OffsetDateTime
 
 class Cas2v2StatusUpdateTransformerTest {
-  private val user = NomisUserEntityFactory().produce()
+  private val user = Cas2v2UserEntityFactory().produce()
   private val cas2v2SubmittedApplication = Cas2v2ApplicationEntityFactory()
     .withCreatedByUser(user)
     .withSubmittedAt(OffsetDateTime.now())
     .produce()
 
-  private val mockExternalUserApi = mockk<ExternalUser>()
-  private val mockExternalUserTransformer = mockk<ExternalUserTransformer>()
-  private val cas2v2StatusUpdateTransformer = Cas2v2StatusUpdateTransformer(mockExternalUserTransformer)
+  private val mockCas2v2UserApi = mockk<Cas2v2User>()
+  private val mockCas2v2UserTransformer = mockk<Cas2v2UserTransformer>()
+  private val cas2v2StatusUpdateTransformer = Cas2v2StatusUpdateTransformer(mockCas2v2UserTransformer)
 
   @BeforeEach
   fun setup() {
-    every { mockExternalUserTransformer.transformJpaToApi(any()) } returns mockExternalUserApi
+    every { mockCas2v2UserTransformer.transformJpaToApi(any()) } returns mockCas2v2UserApi
   }
 
   @Test
@@ -40,12 +40,12 @@ class Cas2v2StatusUpdateTransformerTest {
       .withApplication(cas2v2SubmittedApplication)
       .produce()
 
-    val expectedRepresentation = Cas2StatusUpdate(
+    val expectedRepresentation = Cas2v2StatusUpdate(
       id = jpaEntity.id,
       name = status.name,
       label = jpaEntity.label,
       description = jpaEntity.description,
-      updatedBy = mockExternalUserApi,
+      updatedBy = mockCas2v2UserApi,
       updatedAt = jpaEntity.createdAt.toInstant(),
       statusUpdateDetails = null,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2SubmissionsTransformerTest.kt
@@ -10,21 +10,21 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2SubmittedApplicationSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationSummaryEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2AssessmentsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2SubmissionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2TimelineEventsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2UserTransformer
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -33,7 +33,7 @@ import java.util.UUID
 class Cas2v2SubmissionsTransformerTest {
 
   private val mockPersonTransformer = mockk<PersonTransformer>()
-  private val mockNomisUserTransformer = mockk<NomisUserTransformer>()
+  private val mockCas2v2UserTransformer = mockk<Cas2v2UserTransformer>()
   private val mockCas2v2TimelineEventsTransformer = mockk<Cas2v2TimelineEventsTransformer>()
   private val mockCas2v2AssessmentsTransformer = mockk<Cas2v2AssessmentsTransformer>()
 
@@ -46,18 +46,18 @@ class Cas2v2SubmissionsTransformerTest {
   private val applicationTransformer = Cas2v2SubmissionsTransformer(
     objectMapper,
     mockPersonTransformer,
-    mockNomisUserTransformer,
+    mockCas2v2UserTransformer,
     mockCas2v2TimelineEventsTransformer,
     mockCas2v2AssessmentsTransformer,
   )
 
-  private val user = NomisUserEntityFactory().produce()
+  private val user = Cas2v2UserEntityFactory().produce()
 
   private val cas2v2ApplicationFactory = Cas2v2ApplicationEntityFactory().withCreatedByUser(user)
 
   private val submittedCas2v2ApplicationFactory = cas2v2ApplicationFactory
     .withSubmittedAt(OffsetDateTime.now())
-  private val mockStatusUpdate = Cas2StatusUpdate(
+  private val mockStatusUpdate = Cas2v2StatusUpdate(
     id = UUID.fromString("c426c63a-be35-421f-a1a0-fc286b60da41"),
     description = "On Waiting List",
     label = "On Waiting List",
@@ -68,12 +68,12 @@ class Cas2v2SubmissionsTransformerTest {
     statusUpdates = listOf(mockStatusUpdate),
   )
 
-  private val mockNomisUser = mockk<NomisUser>()
+  private val mockCas2v2User = mockk<Cas2v2User>()
 
   @BeforeEach
   fun setup() {
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
-    every { mockNomisUserTransformer.transformJpaToApi(any()) } returns mockNomisUser
+    every { mockCas2v2UserTransformer.transformJpaToApi(any()) } returns mockCas2v2User
     every { mockCas2v2TimelineEventsTransformer.transformApplicationToTimelineEvents(any()) } returns listOf(mockk<Cas2TimelineEvent>())
     every { mockCas2v2AssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns mockAssessment
   }
@@ -94,7 +94,7 @@ class Cas2v2SubmissionsTransformerTest {
 
       val transformation = applicationTransformer.transformJpaToApiRepresentation(jpaEntity, mockk())
 
-      assertThat(transformation.submittedBy).isEqualTo(mockNomisUser)
+      assertThat(transformation.submittedBy).isEqualTo(mockCas2v2User)
 
       assertThat(transformation.assessment.statusUpdates).isEqualTo(
         listOf(mockStatusUpdate),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2TimelineEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2TimelineEventsTransformerTest.kt
@@ -5,19 +5,19 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2StatusUpdateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2v2.Cas2v2TimelineEventsTransformer
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class Cas2v2TimelineEventsTransformerTest {
-  private val user = NomisUserEntityFactory().produce()
+  private val user = Cas2v2UserEntityFactory().produce()
 
   private val cas2v2ApplicationFactory = Cas2v2ApplicationEntityFactory().withCreatedByUser(user)
 
@@ -37,7 +37,7 @@ class Cas2v2TimelineEventsTransformerTest {
         .withLabel("status update")
         .withApplication(submittedCas2v2ApplicationFactory.produce())
         .withAssessor(
-          ExternalUserEntityFactory().withName("Anne Assessor")
+          Cas2v2UserEntityFactory().withName("Anne Assessor")
             .produce(),
         ).produce()
 
@@ -63,12 +63,13 @@ class Cas2v2TimelineEventsTransformerTest {
         .withLabel("status update with details")
         .withApplication(submittedCas2v2ApplicationFactory.produce())
         .withAssessor(
-          ExternalUserEntityFactory().withName("Anne Other Assessor")
+          Cas2v2UserEntityFactory().withName("Anne Other Assessor")
+            .withUserType(Cas2v2UserType.EXTERNAL)
             .produce(),
         )
         .produce()
 
-      val nomisUser = NomisUserEntityFactory().withName("Some Nomis User").produce()
+      val nomisUser = Cas2v2UserEntityFactory().withName("Some Nomis User").withUserType(Cas2v2UserType.NOMIS).produce()
 
       val noteCreatedAt = OffsetDateTime.now().minusDays(3)
       val note = Cas2v2ApplicationNoteEntity(


### PR DESCRIPTION
Adds a new entity for Cas2v2 users where all user types are represented in a single entity (Cas2v2UserEntity) and differentiated by the `userType` field which is a `Cas2v2UserType` containing the different allowed user types for Cas2v2. 

As a result of the change, all of the Cas2v2 classes that contain users have been changed to use the new type instead of NomisUserEntity/UserEntity/ExternalUserEntity.  This removes a dependence on the Cas2 entities but should still allow a future migration to use the entities in this namespace. 

This PR also introduces a CAS2V2 `ServiceName` which is used to ensure that a Cas2v2Application is used instead of Application or Cas2Application when calling APIs.

DomainEvents remain as cas2 domain events with no change