### PR TITLE
CAS-1238 get application returns not found when Cas3 application was deleted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -184,6 +184,10 @@ class ApplicationService(
     val applicationEntity = applicationRepository.findByIdOrNull(applicationId)
       ?: return CasResult.NotFound("Application", applicationId.toString())
 
+    if (applicationEntity is TemporaryAccommodationApplicationEntity && applicationEntity.deletedAt != null) {
+      return CasResult.NotFound("Application", applicationId.toString())
+    }
+
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
       ?: throw RuntimeException("Could not get user")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -230,6 +230,35 @@ class ApplicationServiceTest {
     val distinguishedName = "SOMEPERSON"
     val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
 
+    val probationRegion = ProbationRegionEntityFactory()
+      .withYieldedApArea { ApAreaEntityFactory().produce() }
+      .produce()
+    val deletedApplication = TemporaryAccommodationApplicationEntityFactory()
+      .withId(applicationId)
+      .withYieldedCreatedByUser {
+        UserEntityFactory()
+          .withProbationRegion(probationRegion)
+          .produce()
+      }
+      .withProbationRegion(probationRegion)
+      .withDeletedAt(OffsetDateTime.now().minusDays(10))
+      .produce()
+
+    every { mockApplicationRepository.findByIdOrNull(applicationId) } returns deletedApplication
+
+    assertThat(
+      applicationService.getApplicationForUsername(
+        applicationId,
+        distinguishedName,
+      ) is CasResult.NotFound,
+    ).isTrue
+  }
+
+  @Test
+  fun `getApplicationForUsername where temporary accommodation application was deleted returns NotFound result`() {
+    val distinguishedName = "SOMEPERSON"
+    val applicationId = UUID.fromString("c1750938-19fc-48a1-9ae9-f2e119ffc1f4")
+
     every { mockApplicationRepository.findByIdOrNull(applicationId) } returns null
 
     assertThat(


### PR DESCRIPTION
This [PR CAS-1238](https://dsdmoj.atlassian.net/browse/CAS-1238) is to change get application to return not found response when Cas3 application was deleted