### PR TITLE
Aps 1722 soft delete timeline note

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationTimelineNoteEntity.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 
 interface ApplicationTimelineNoteRepository : JpaRepository<ApplicationTimelineNoteEntity, UUID> {
 
-  fun findApplicationTimelineNoteEntitiesByApplicationId(applicationId: UUID): List<ApplicationTimelineNoteEntity>
+  fun findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(applicationId: UUID): List<ApplicationTimelineNoteEntity>
 }
 
 @Entity
@@ -28,4 +28,5 @@ data class ApplicationTimelineNoteEntity(
   val body: String,
   @Column(name = "cas1_space_booking_id")
   val cas1SpaceBookingId: UUID?,
+  var deletedAt: OffsetDateTime?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1OutOfServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1PlanSpacePlanningDryRunSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1RemoveAssessmentDetailsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1SeedPremisesFromCsvJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1SoftDeleteApplicationTimelineNotes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateEventNumberSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateSpaceBookingSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UsersSeedJob
@@ -94,6 +95,7 @@ class SeedService(
         SeedFileType.approvedPremisesCreateTestApplications -> getBean(Cas1CreateTestApplicationsSeedJob::class)
         SeedFileType.temporaryAccommodationReferralRejection -> getBean(Cas3ReferralRejectionSeedJob::class)
         SeedFileType.approvedPremisesBackfillActiveSpaceBookingsCreatedInDelius -> getBean(Cas1BackfillActiveSpaceBookingsCreatedInDelius::class)
+        SeedFileType.approvedPremisesDeleteApplicationTimelineNotes -> getBean(Cas1SoftDeleteApplicationTimelineNotes::class)
       }
 
       val seedStarted = LocalDateTime.now()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SoftDeleteApplicationTimelineNotes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SoftDeleteApplicationTimelineNotes.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedLogger
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Component
+class Cas1SoftDeleteApplicationTimelineNotes(
+  val applicationTimelineNoteRepository: ApplicationTimelineNoteRepository,
+  private val seedLogger: SeedLogger,
+) : SeedJob<ApprovedPremisesApplicationIdNoteIdCsvRow>(
+  requiredHeaders = setOf("applicationId", "timelineNoteId"),
+) {
+
+  override fun deserializeRow(columns: Map<String, String>) = ApprovedPremisesApplicationIdNoteIdCsvRow(
+    columns["applicationId"]!!.trim(),
+    columns["timelineNoteId"]!!.trim(),
+  )
+
+  override fun processRow(row: ApprovedPremisesApplicationIdNoteIdCsvRow) {
+    val applicationId = row.applicationId
+    val timelineNoteId = row.timelineNoteId
+
+    val timelineNote = applicationTimelineNoteRepository.findByIdOrNull(UUID.fromString(timelineNoteId))
+
+    timelineNote?.let {
+      if (it.applicationId.toString() != applicationId) {
+        seedLogger.error("Timeline note with id $timelineNoteId does not belong to application with id $applicationId.")
+      } else {
+        softDeleteTimelineNote(it)
+      }
+    } ?: seedLogger.error("Timeline note with id $timelineNoteId not found.")
+  }
+
+  private fun softDeleteTimelineNote(timelineNote: ApplicationTimelineNoteEntity) {
+    timelineNote.deletedAt = OffsetDateTime.now()
+    applicationTimelineNoteRepository.save(timelineNote)
+    seedLogger.info("Soft deleted timeline note with id ${timelineNote.id}.")
+  }
+}
+
+data class ApprovedPremisesApplicationIdNoteIdCsvRow(
+  val applicationId: String,
+  val timelineNoteId: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationTimelineNoteService.kt
@@ -13,7 +13,7 @@ class ApplicationTimelineNoteService(
 ) {
 
   fun getApplicationTimelineNotesByApplicationId(applicationId: UUID): List<ApplicationTimelineNoteEntity> =
-    applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(applicationId)
+    applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(applicationId)
 
   fun saveApplicationTimelineNote(
     applicationId: UUID,
@@ -29,6 +29,7 @@ class ApplicationTimelineNoteService(
         createdAt = OffsetDateTime.now(),
         body = note,
         cas1SpaceBookingId = cas1SpaceBookingId,
+        deletedAt = null,
       ),
     )
   }

--- a/src/main/resources/db/migration/all/20250113125352__add_deleted_at_to_application_timeline_notes.sql
+++ b/src/main/resources/db/migration/all/20250113125352__add_deleted_at_to_application_timeline_notes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE application_timeline_notes ADD deleted_at timestamptz NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3728,6 +3728,7 @@ components:
         - approved_premises_update_space_booking
         - approved_premises_backfill_active_space_bookings_created_in_delius
         - approved_premises_create_test_applications
+        - approved_premises_delete_application_timeline_notes
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:
       type: string

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8029,6 +8029,7 @@ components:
         - approved_premises_update_space_booking
         - approved_premises_backfill_active_space_bookings_created_in_delius
         - approved_premises_create_test_applications
+        - approved_premises_delete_application_timeline_notes
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:
       type: string

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4950,6 +4950,7 @@ components:
         - approved_premises_update_space_booking
         - approved_premises_backfill_active_space_bookings_created_in_delius
         - approved_premises_create_test_applications
+        - approved_premises_delete_application_timeline_notes
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:
       type: string

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4319,6 +4319,7 @@ components:
         - approved_premises_update_space_booking
         - approved_premises_backfill_active_space_bookings_created_in_delius
         - approved_premises_create_test_applications
+        - approved_premises_delete_application_timeline_notes
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:
       type: string

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3827,6 +3827,7 @@ components:
         - approved_premises_update_space_booking
         - approved_premises_backfill_active_space_bookings_created_in_delius
         - approved_premises_create_test_applications
+        - approved_premises_delete_application_timeline_notes
         - temporary_accommodation_referral_rejection
     SeedFromExcelFileType:
       type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApplicationTimelineNoteEntityFactory.kt
@@ -21,6 +21,7 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var body: Yielded<String> = { randomStringUpperCase(12) }
   private var cas1SpaceBookingId: Yielded<UUID?> = { null }
+  private var deletedAt: Yielded<OffsetDateTime?> = { null }
 
   fun withDefaults() = apply {
   }
@@ -45,6 +46,10 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
     this.body = { body }
   }
 
+  fun withDeletedAt(deletedAt: OffsetDateTime) = apply {
+    this.deletedAt = { deletedAt }
+  }
+
   override fun produce(): ApplicationTimelineNoteEntity = ApplicationTimelineNoteEntity(
     id = this.id(),
     applicationId = this.applicationId(),
@@ -52,5 +57,6 @@ class ApplicationTimelineNoteEntityFactory : Factory<ApplicationTimelineNoteEnti
     createdAt = this.createdAt(),
     body = this.body(),
     cas1SpaceBookingId = this.cas1SpaceBookingId(),
+    deletedAt = this.deletedAt(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -2901,7 +2901,7 @@ class ApplicationTest : IntegrationTestBase() {
           .isOk
 
         val savedNote =
-          applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(applicationId)
+          applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(applicationId)
         savedNote.map {
           assertThat(it.body).isEqualTo("some note")
           assertThat(it.applicationId).isEqualTo(applicationId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.domainevents.DomainEventSummaryImpl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Cas1DomainEventsFactory
+import java.time.OffsetDateTime
 
 class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
@@ -77,6 +78,7 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
     }
 
     notes = createTimelineNotes(application, 5)
+    createTimelineNotes(application, 2, isDeleted = true)
     createTimelineNotes(otherApplication, 3)
   }
 
@@ -177,7 +179,12 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
     }
   }
 
-  private fun createTimelineNotes(applicationEntity: ApprovedPremisesApplicationEntity, count: Int) = applicationTimelineNoteEntityFactory.produceAndPersistMultiple(count) {
+  private fun createTimelineNotes(
+    applicationEntity: ApprovedPremisesApplicationEntity,
+    count: Int,
+    isDeleted: Boolean = false,
+  ) = applicationTimelineNoteEntityFactory.produceAndPersistMultiple(count) {
     withApplicationId(applicationEntity.id)
+    if (isDeleted) withDeletedAt(OffsetDateTime.now())
   }.toMutableList()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTimelineTest.kt
@@ -77,9 +77,9 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
       return@map createDomainEvent(it, application, assessment, user)
     }
 
-    notes = createTimelineNotes(application, 5)
+    notes = createTimelineNotes(application, 5, isDeleted = false)
     createTimelineNotes(application, 2, isDeleted = true)
-    createTimelineNotes(otherApplication, 3)
+    createTimelineNotes(otherApplication, 3, isDeleted = false)
   }
 
   @Test
@@ -182,7 +182,7 @@ class ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
   private fun createTimelineNotes(
     applicationEntity: ApprovedPremisesApplicationEntity,
     count: Int,
-    isDeleted: Boolean = false,
+    isDeleted: Boolean,
   ) = applicationTimelineNoteEntityFactory.produceAndPersistMultiple(count) {
     withApplicationId(applicationEntity.id)
     if (isDeleted) withDeletedAt(OffsetDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
@@ -48,7 +48,7 @@ class Cas1RedactAssessmentDetailsTest : SeedTestBase() {
     assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.data).isNull()
     assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment1NoJson.id)!!.document).isNull()
     assertThat(
-      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(assessment1NoJson.id).none {
+      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(assessment1NoJson.id).none {
         it.body == "Assessment details redacted"
       },
     )
@@ -56,7 +56,7 @@ class Cas1RedactAssessmentDetailsTest : SeedTestBase() {
     assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasJson.id)!!.data).isEqualTo(expectedJson)
     assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment2HasJson.id)!!.document).isEqualTo(expectedJson)
     assertThat(
-      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(assessment2HasJson.id).any {
+      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(assessment2HasJson.id).any {
         it.body == "Assessment details redacted"
       },
     )
@@ -64,7 +64,7 @@ class Cas1RedactAssessmentDetailsTest : SeedTestBase() {
     assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.data).isEqualTo(sampleJson)
     assertThat(approvedPremisesAssessmentRepository.findByIdOrNull(assessment3Unmodified.id)!!.document).isEqualTo(sampleJson)
     assertThat(
-      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(assessment3Unmodified.id).none {
+      applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(assessment3Unmodified.id).none {
         it.body == "Assessment details redacted"
       },
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
@@ -111,7 +111,7 @@ class SeedCas1DuplicateApplicationTest : SeedTestBase() {
         assertThat(newApplication.isEsapApplication).isEqualTo(sourceApplication.isEsapApplication)
         assertThat(newApplication.isPipeApplication).isEqualTo(sourceApplication.isPipeApplication)
 
-        val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(newApplication.id)
+        val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(newApplication.id)
         assertThat(notes).hasSize(1)
         assertThat(notes)
           .extracting("body")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1SoftDeleteApplicationTimelineNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1SoftDeleteApplicationTimelineNotesTest.kt
@@ -1,0 +1,142 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesApplicationIdNoteIdCsvRow
+import kotlin.collections.forEach
+
+class SeedCas1SoftDeleteApplicationTimelineNotesTest : SeedTestBase() {
+
+  @Test
+  fun `should succeed for valid application id and timeline note id`() {
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist { withDefaults() })
+      withCreatedByUser(givenAUser().first)
+    }
+
+    val noteIds = applicationTimelineNoteEntityFactory.produceAndPersistMultiple(3) {
+      withApplicationId(application.id)
+    }.map { it.id }
+
+    withCsv(
+      csvName = "timeline_notes",
+      contents = listOf(
+        ApprovedPremisesApplicationIdNoteIdCsvRow(
+          applicationId = application.id.toString(),
+          timelineNoteId = noteIds[1].toString(),
+        ),
+        ApprovedPremisesApplicationIdNoteIdCsvRow(
+          applicationId = application.id.toString(),
+          timelineNoteId = noteIds[2].toString(),
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesDeleteApplicationTimelineNotes, "timeline_notes.csv")
+
+    assertThat(applicationTimelineNoteRepository.getReferenceById(noteIds[0]).deletedAt).isNull()
+    assertThat(applicationTimelineNoteRepository.getReferenceById(noteIds[1]).deletedAt).isNotNull()
+    assertThat(applicationTimelineNoteRepository.getReferenceById(noteIds[2]).deletedAt).isNotNull()
+  }
+
+  @Test
+  fun `should log error if application timeline note id is not found`() {
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist { withDefaults() })
+      withCreatedByUser(givenAUser().first)
+    }
+
+    val noteId = applicationTimelineNoteEntityFactory.produceAndPersist {
+      withApplicationId(application.id)
+    }.id
+
+    withCsv(
+      csvName = "timeline_notes",
+      contents = listOf(
+        ApprovedPremisesApplicationIdNoteIdCsvRow(
+          applicationId = application.id.toString(),
+          timelineNoteId = "9d4ac9fa-cf8e-42dd-aa02-9ac10750dcc7",
+        ),
+        ApprovedPremisesApplicationIdNoteIdCsvRow(
+          applicationId = application.id.toString(),
+          timelineNoteId = noteId.toString(),
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesDeleteApplicationTimelineNotes, "timeline_notes.csv")
+
+    assertThat(logEntries)
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Timeline note with id 9d4ac9fa-cf8e-42dd-aa02-9ac10750dcc7 not found."
+      }
+    assertThat(applicationTimelineNoteRepository.getReferenceById(noteId).deletedAt).isNotNull()
+  }
+
+  @Test
+  fun `should log error if application does not have note with note id`() {
+    val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist { withDefaults() })
+      withCreatedByUser(givenAUser().first)
+    }
+
+    val noteId = applicationTimelineNoteEntityFactory.produceAndPersist {
+      withApplicationId(application.id)
+    }.id
+
+    val anotherApplication = approvedPremisesApplicationEntityFactory.produceAndPersist {
+      withApplicationSchema(approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist { withDefaults() })
+      withCreatedByUser(givenAUser().first)
+    }
+
+    val noteIdForAnotherApplication = applicationTimelineNoteEntityFactory.produceAndPersist {
+      withApplicationId(anotherApplication.id)
+    }.id
+
+    withCsv(
+      csvName = "timeline_notes",
+      contents = listOf(
+        ApprovedPremisesApplicationIdNoteIdCsvRow(
+          applicationId = application.id.toString(),
+          timelineNoteId = noteIdForAnotherApplication.toString(),
+        ),
+        ApprovedPremisesApplicationIdNoteIdCsvRow(
+          applicationId = application.id.toString(),
+          timelineNoteId = noteId.toString(),
+        ),
+      ).toCsv(),
+    )
+
+    seedService.seedData(SeedFileType.approvedPremisesDeleteApplicationTimelineNotes, "timeline_notes.csv")
+
+    assertThat(logEntries)
+      .anyMatch {
+        it.level == "error" &&
+          it.message == "Timeline note with id $noteIdForAnotherApplication does not belong to application with id ${application.id}."
+      }
+    assertThat(applicationTimelineNoteRepository.getReferenceById(noteId).deletedAt).isNotNull()
+  }
+
+  private fun List<ApprovedPremisesApplicationIdNoteIdCsvRow>.toCsv(): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "applicationId",
+        "timelineNoteId",
+      )
+      .newRow()
+
+    this.forEach {
+      builder
+        .withQuotedField(it.applicationId)
+        .withQuotedField(it.timelineNoteId)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -112,7 +112,7 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
         assertMatchRequestWithdrawnEmail(cruEmail, placementRequest1)
         assertMatchRequestWithdrawnEmail(cruEmail, placementRequest3)
 
-        val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(application.id)
+        val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(application.id)
         assertThat(notes).hasSize(2)
         assertThat(notes)
           .extracting("body")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
@@ -72,7 +72,7 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
     assertThat(updatedApplication.offenceId).isEqualTo(NEW_OFFENCE_ID)
     assertThat(updatedApplication.convictionId).isEqualTo(NEW_CONVICTION_ID)
 
-    val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(application.id)
+    val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(application.id)
     assertThat(notes).hasSize(1)
     assertThat(notes)
       .extracting("body")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
@@ -131,7 +131,7 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
   }
 
   private fun assertNoteAdded(application: ApplicationEntity, message: String) {
-    val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(application.id)
+    val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(application.id)
     assertThat(notes).hasSize(1)
     assertThat(notes)
       .extracting("body")
@@ -139,7 +139,7 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
   }
 
   private fun assertNoteNotAdded(application: ApplicationEntity) {
-    val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId(application.id)
+    val notes = applicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationIdAndDeletedAtIsNull(application.id)
     assertThat(notes).isEmpty()
   }
 


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1722

- add a nullable column `application_timeline_notes.deleted_at` of type `timestamptz`. Default to null
- update the code that returns the application timelines to filter out notes where `deleted_at` is not null (i.e. update `ApplicationTimelineNoteRepository.findApplicationTimelineNoteEntitiesByApplicationId)`
- add a seed job that given a list of `application_id` and `application_timeline_note_id`, will soft delete timeline notes by setting `deleted_at` to the current date/time.
- Validate that the `application_timeline_note_id` belongs to the given `application_id` (this is an additional level of validation to ensure we’re not deleting the wrong timeline note)
- once deployed to production we should soft delete the timeline note amended for APS-1720