### PR TITLE
Fix CAS1 day summary characteristics bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingDaySummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingDaySummaryTransformer.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingDaySummarySearchResult
 
@@ -24,10 +24,10 @@ class Cas1SpaceBookingDaySummaryTransformer {
     person = personSummary,
   )
 
-  private fun characteristicEntityToCharacteristic(characteristics: String?): List<Cas1SpaceBookingCharacteristic> =
+  private fun characteristicEntityToCharacteristic(characteristics: String?): List<Cas1SpaceCharacteristic> =
     characteristics?.let { characteristicList ->
       characteristicList.split(",").map { characteristic ->
-        Cas1SpaceBookingCharacteristic.entries.first { it.value == characteristic }
+        Cas1SpaceCharacteristic.entries.firstOrNull { it.value == characteristic } ?: error("Cannot find characteristics $characteristic")
       }
     } ?: emptyList()
 }

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -578,7 +578,7 @@ components:
         essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceBookingCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
       required:
         - id
         - person

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6587,7 +6587,7 @@ components:
         essentialCharacteristics:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceBookingCharacteristic'
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
       required:
         - id
         - person

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingDaySummaryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingDaySummaryServiceTest.kt
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingDaySummarySortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
@@ -121,7 +122,7 @@ class Cas1SpaceBookingDaySummaryServiceTest {
       canonicalDepartureDate = LocalDate.now().plusDays(6),
       tier = "A2",
       releaseType = "rotl",
-      essentialCharacteristics = listOf(Cas1SpaceBookingCharacteristic.IS_SINGLE, Cas1SpaceBookingCharacteristic.HAS_EN_SUITE),
+      essentialCharacteristics = listOf(Cas1SpaceCharacteristic.isSingle, Cas1SpaceCharacteristic.hasEnSuite),
     )
 
     val booking2DaySummary = Cas1SpaceBookingDaySummary(
@@ -131,7 +132,7 @@ class Cas1SpaceBookingDaySummaryServiceTest {
       canonicalDepartureDate = LocalDate.now().plusDays(36),
       tier = "B3",
       releaseType = "licence",
-      essentialCharacteristics = listOf(Cas1SpaceBookingCharacteristic.IS_SINGLE),
+      essentialCharacteristics = listOf(Cas1SpaceCharacteristic.isSingle),
     )
 
     val roomCharacteristic = CharacteristicEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
@@ -51,7 +51,11 @@ class Cas1PremisesDayTransformerTest {
         canonicalDepartureDate = currentSearchDay.plusDays(1),
         tier = "Tier 1",
         releaseType = "rotl",
-        essentialCharacteristics = listOf(Cas1SpaceBookingCharacteristic.IS_SINGLE, Cas1SpaceBookingCharacteristic.HAS_EN_SUITE),
+        essentialCharacteristics = listOf(
+          Cas1SpaceCharacteristic.isSingle,
+          Cas1SpaceCharacteristic.hasEnSuite,
+          Cas1SpaceCharacteristic.isIAP,
+        ),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingDaySummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingDaySummaryTransformerTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPersonSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingDaySummarySearchResult
@@ -23,8 +23,8 @@ class Cas1SpaceBookingDaySummaryTransformerTest {
   private val transformer = Cas1SpaceBookingDaySummaryTransformer()
 
   @ParameterizedTest
-  @EnumSource(value = Cas1SpaceBookingCharacteristic::class)
-  fun `toCas1SpaceBookingDaySummary`(characteristic: Cas1SpaceBookingCharacteristic) {
+  @EnumSource(value = Cas1SpaceCharacteristic::class)
+  fun `toCas1SpaceBookingDaySummary`(characteristic: Cas1SpaceCharacteristic) {
     val spaceBookingSummary =
       Cas1SpaceBookingDaySummarySearchResultImpl(
         UUID.randomUUID(),
@@ -67,7 +67,7 @@ class Cas1SpaceBookingDaySummaryTransformerTest {
         LocalDate.now().plusDays(3),
         tier = "A1",
         releaseType = "rotl",
-        characteristicsPropertyNames = "isArsonSuitable,hasEnSuite,isSingle,isStepFreeDesignated,isSuitedForSexOffenders,isWheelchairDesignated",
+        characteristicsPropertyNames = "isArsonSuitable,hasEnSuite,isSingle,isStepFreeDesignated,isSuitedForSexOffenders,isWheelchairDesignated,isCatered",
       )
     val personSummary = PersonTransformer()
       .personSummaryInfoToPersonSummary(
@@ -79,13 +79,14 @@ class Cas1SpaceBookingDaySummaryTransformerTest {
       personSummary,
     )
 
-    assertThat(result.essentialCharacteristics.size).isEqualTo(6)
-    assertThat(result.essentialCharacteristics[0]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_ARSON_SUITABLE)
-    assertThat(result.essentialCharacteristics[1]).isEqualTo(Cas1SpaceBookingCharacteristic.HAS_EN_SUITE)
-    assertThat(result.essentialCharacteristics[2]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_SINGLE)
-    assertThat(result.essentialCharacteristics[3]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_STEP_FREE_DESIGNATED)
-    assertThat(result.essentialCharacteristics[4]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_SUITED_FOR_SEX_OFFENDERS)
-    assertThat(result.essentialCharacteristics[5]).isEqualTo(Cas1SpaceBookingCharacteristic.IS_WHEELCHAIR_DESIGNATED)
+    assertThat(result.essentialCharacteristics.size).isEqualTo(7)
+    assertThat(result.essentialCharacteristics[0]).isEqualTo(Cas1SpaceCharacteristic.isArsonSuitable)
+    assertThat(result.essentialCharacteristics[1]).isEqualTo(Cas1SpaceCharacteristic.hasEnSuite)
+    assertThat(result.essentialCharacteristics[2]).isEqualTo(Cas1SpaceCharacteristic.isSingle)
+    assertThat(result.essentialCharacteristics[3]).isEqualTo(Cas1SpaceCharacteristic.isStepFreeDesignated)
+    assertThat(result.essentialCharacteristics[4]).isEqualTo(Cas1SpaceCharacteristic.isSuitedForSexOffenders)
+    assertThat(result.essentialCharacteristics[5]).isEqualTo(Cas1SpaceCharacteristic.isWheelchairDesignated)
+    assertThat(result.essentialCharacteristics[6]).isEqualTo(Cas1SpaceCharacteristic.isCatered)
   }
 }
 


### PR DESCRIPTION
Before this commit the CAS1 premise day summary would return an error if a booking had characteristic outside of the following list

```
  @JsonProperty("hasEnSuite") HAS_EN_SUITE("hasEnSuite"),
    @JsonProperty("isArsonSuitable") IS_ARSON_SUITABLE("isArsonSuitable"),
    @JsonProperty("isSingle") IS_SINGLE("isSingle"),
    @JsonProperty("isStepFreeDesignated") IS_STEP_FREE_DESIGNATED("isStepFreeDesignated"),
    @JsonProperty("isSuitedForSexOffenders") IS_SUITED_FOR_SEX_OFFENDERS("isSuitedForSexOffenders"),
    @JsonProperty("isWheelchairDesignated") IS_WHEELCHAIR_DESIGNATED("isWheelchairDesignated")
```

This commit changes the API to support all characteristics that could be linked to a space booking