### PR TITLE
CAS-1205: Update Bed Search Filters

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BedSearchController.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.BedsApiDelegate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchResults
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationBedSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -16,19 +15,13 @@ class BedSearchController(
   private val cas3BedspaceSearchService: Cas3BedspaceSearchService,
   private val bedSearchResultTransformer: BedSearchResultTransformer,
 ) : BedsApiDelegate {
-  override fun bedsSearchPost(bedSearchParameters: BedSearchParameters): ResponseEntity<BedSearchResults> {
+  override fun bedsSearchPost(temporaryAccommodationBedSearchParameters: TemporaryAccommodationBedSearchParameters): ResponseEntity<BedSearchResults> {
     val user = userService.getUserForRequest()
 
-    val searchResult = when (bedSearchParameters) {
-      is TemporaryAccommodationBedSearchParameters -> cas3BedspaceSearchService.findBedspaces(
-        user = user,
-        probationDeliveryUnits = bedSearchParameters.probationDeliveryUnits,
-        startDate = bedSearchParameters.startDate,
-        durationInDays = bedSearchParameters.durationDays,
-        propertyBedAttributes = bedSearchParameters.attributes,
-      )
-      else -> throw RuntimeException("Unsupported BedSearchParameters type: ${bedSearchParameters::class.qualifiedName}")
-    }
+    val searchResult = cas3BedspaceSearchService.findBedspaces(
+      user = user,
+      temporaryAccommodationBedSearchParameters,
+    )
 
     return ResponseEntity.ok(
       bedSearchResultTransformer.transformDomainToApi(extractEntityFromCasResult(searchResult)),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BedspaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BedspaceSearchService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSearchAttributes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationBedSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OverlapBookingsSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
@@ -41,23 +42,20 @@ class Cas3BedspaceSearchService(
   @Suppress("detekt:CyclomaticComplexMethod")
   fun findBedspaces(
     user: UserEntity,
-    probationDeliveryUnits: List<UUID>,
-    startDate: LocalDate,
-    durationInDays: Int,
-    propertyBedAttributes: List<BedSearchAttributes>?,
+    searchParams: TemporaryAccommodationBedSearchParameters,
   ): CasResult<List<Cas3BedSearchResult>> = validatedCasResult {
     val probationDeliveryUnitIds = mutableListOf<UUID>()
 
-    if (durationInDays < 1) {
+    if (searchParams.durationDays < 1) {
       "$.durationDays" hasValidationError "mustBeAtLeast1"
     }
 
-    if (probationDeliveryUnits.isEmpty()) {
+    if (searchParams.probationDeliveryUnits.isEmpty()) {
       "$.probationDeliveryUnits" hasValidationError "empty"
-    } else if (probationDeliveryUnits.size > MAX_NUMBER_PDUS) {
+    } else if (searchParams.probationDeliveryUnits.size > MAX_NUMBER_PDUS) {
       "$.probationDeliveryUnits" hasValidationError "maxNumberProbationDeliveryUnits"
     } else {
-      probationDeliveryUnits.mapIndexed { index, id ->
+      searchParams.probationDeliveryUnits.mapIndexed { index, id ->
         val probationDeliveryUnitEntityExist = probationDeliveryUnitRepository.existsById(id)
         if (!probationDeliveryUnitEntityExist) {
           "$.probationDeliveryUnits[$index]" hasValidationError "doesNotExist"
@@ -71,45 +69,48 @@ class Cas3BedspaceSearchService(
       return fieldValidationError
     }
 
-    val premisesCharacteristicsPropertyNames = propertyBedAttributes?.map {
-      when (it) {
-        BedSearchAttributes.SINGLE_OCCUPANCY -> BedSearchAttributes.SINGLE_OCCUPANCY.value
-        BedSearchAttributes.SHARED_PROPERTY -> BedSearchAttributes.SHARED_PROPERTY.value
-        else -> ""
+    val endDate = searchParams.calculateEndDate()
+
+    val candidateResults = if (searchParams.premisesFilters != null || searchParams.bedspaceFilters != null) {
+      return CasResult.GeneralValidationError("Filters not implemented")
+    } else {
+      val premisesCharacteristicsPropertyNames = searchParams.attributes?.map {
+        when (it) {
+          BedSearchAttributes.SINGLE_OCCUPANCY, BedSearchAttributes.SHARED_PROPERTY -> it.value
+          else -> ""
+        }
       }
-    }
 
-    val premisesCharacteristicIds = getCharacteristicsIds(premisesCharacteristicsPropertyNames, "premises")
+      val premisesCharacteristicIds = getCharacteristicsIds(premisesCharacteristicsPropertyNames, "premises")
 
-    val roomCharacteristicsPropertyNames = propertyBedAttributes?.map {
-      when (it) {
-        BedSearchAttributes.WHEELCHAIR_ACCESSIBLE -> BedSearchAttributes.WHEELCHAIR_ACCESSIBLE.value
-        else -> ""
+      val roomCharacteristicsPropertyNames = searchParams.attributes?.map {
+        when (it) {
+          BedSearchAttributes.WHEELCHAIR_ACCESSIBLE -> it.value
+          else -> ""
+        }
       }
+
+      val roomCharacteristicIds = getCharacteristicsIds(roomCharacteristicsPropertyNames, "room")
+
+      bedSearchRepository.findTemporaryAccommodationBeds(
+        probationDeliveryUnits = probationDeliveryUnitIds,
+        startDate = searchParams.startDate,
+        endDate = endDate,
+        probationRegionId = user.probationRegion.id,
+        premisesCharacteristicIds,
+        roomCharacteristicIds,
+      )
     }
-
-    val roomCharacteristicIds = getCharacteristicsIds(roomCharacteristicsPropertyNames, "room")
-
-    val endDate = startDate.plusDays(durationInDays.toLong() - 1)
-
-    val candidateResults = bedSearchRepository.findTemporaryAccommodationBeds(
-      probationDeliveryUnits = probationDeliveryUnitIds,
-      startDate = startDate,
-      endDate = endDate,
-      probationRegionId = user.probationRegion.id,
-      premisesCharacteristicIds,
-      roomCharacteristicIds,
-    )
 
     val bedIds = candidateResults.map { it.bedId }
-    val bedsWithABookingInTurnaround = bookingRepository.findClosestBookingBeforeDateForBeds(startDate, bedIds)
-      .filter { workingDayService.addWorkingDays(it.departureDate, it.turnaround?.workingDayCount ?: 0) >= startDate }
+    val bedsWithABookingInTurnaround = bookingRepository.findClosestBookingBeforeDateForBeds(searchParams.startDate, bedIds)
+      .filter { workingDayService.addWorkingDays(it.departureDate, it.turnaround?.workingDayCount ?: 0) >= searchParams.startDate }
       .map { it.bed!!.id }
 
     val results = candidateResults.filter { !bedsWithABookingInTurnaround.contains(it.bedId) }
 
     val distinctIds = results.map { it.premisesId }.distinct()
-    val overlappedBookings = bookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(distinctIds, startDate, endDate)
+    val overlappedBookings = bookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(distinctIds, searchParams.startDate, endDate)
     val crns = overlappedBookings.map { it.crn }.distinct().toSet()
     val offenderSummaries = offenderService.getPersonSummaryInfoResults(
       crns = crns.toSet(),
@@ -117,7 +118,7 @@ class Cas3BedspaceSearchService(
     )
 
     val groupedOverlappedBookings = overlappedBookings
-      .map { transformBookingToOverlap(it, startDate, endDate, offenderSummaries.forCrn(it.crn)) }
+      .map { transformBookingToOverlap(it, searchParams.startDate, endDate, offenderSummaries.forCrn(it.crn)) }
       .groupBy { it.premisesId }
 
     results.forEach {
@@ -166,5 +167,11 @@ class Cas3BedspaceSearchService(
         it.isActive && it.matches(ServiceName.temporaryAccommodation.value, modelScope)
       }.map { it.id }.toList()
     }
+  }
+
+  private fun TemporaryAccommodationBedSearchParameters.calculateEndDate(): LocalDate {
+    // Adjust to include the start date in the duration, e.g. 1st January for 1 day should end on the 1st January
+    val adjustedDuration = durationDays - 1
+    return startDate.plusDays(adjustedDuration)
   }
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4121,7 +4121,7 @@ components:
         - rfap
         - mhapStJosephs
         - mhapElliottHouse
-    BedSearchParameters:
+    TemporaryAccommodationBedSearchParameters:
       type: object
       properties:
         serviceName:
@@ -4129,36 +4129,54 @@ components:
         startDate:
           type: string
           format: date
-          description: The date the Bed will need to be free from
         durationDays:
-          type: integer
+          type: long
           description: The number of days the Bed will need to be free from the start_date until
+        probationDeliveryUnits:
+          type: array
+          description: The list of pdus Ids to search within
+          items:
+            type: string
+            format: uuid
+        premisesFilters:
+          $ref: '#/components/schemas/PremisesFilters'
+        bedspaceFilters:
+          $ref: '#/components/schemas/BedspaceFilters'
+        attributes:
+          type: array
+          description: Bedspace and property attributes to filter on
+          items:
+            $ref: "_shared.yml#/components/schemas/BedSearchAttributes"
       required:
-        - serviceName
+        - probationDeliveryUnits
         - startDate
         - durationDays
-      discriminator:
-        propertyName: serviceName
-        mapping:
-          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchParameters'
-    TemporaryAccommodationBedSearchParameters:
-      allOf:
-        - $ref: '#/components/schemas/BedSearchParameters'
-        - type: object
-          properties:
-            probationDeliveryUnits:
-              type: array
-              description: The list of pdus Ids to search within
-              items:
-                type: string
-                format: uuid
-            attributes:
-              type: array
-              description: Bedspace and property attributes to filter on
-              items:
-                $ref: "_shared.yml#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnits
+    PremisesFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BedspaceFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
     BedSearchResults:
       type: object
       properties:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2246,7 +2246,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '_shared.yml#/components/schemas/BedSearchParameters'
+              $ref: '_shared.yml#/components/schemas/TemporaryAccommodationBedSearchParameters'
         required: true
       responses:
         200:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2248,7 +2248,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/BedSearchParameters'
+              $ref: '#/components/schemas/TemporaryAccommodationBedSearchParameters'
         required: true
       responses:
         200:
@@ -8422,7 +8422,7 @@ components:
         - rfap
         - mhapStJosephs
         - mhapElliottHouse
-    BedSearchParameters:
+    TemporaryAccommodationBedSearchParameters:
       type: object
       properties:
         serviceName:
@@ -8430,36 +8430,54 @@ components:
         startDate:
           type: string
           format: date
-          description: The date the Bed will need to be free from
         durationDays:
-          type: integer
+          type: long
           description: The number of days the Bed will need to be free from the start_date until
+        probationDeliveryUnits:
+          type: array
+          description: The list of pdus Ids to search within
+          items:
+            type: string
+            format: uuid
+        premisesFilters:
+          $ref: '#/components/schemas/PremisesFilters'
+        bedspaceFilters:
+          $ref: '#/components/schemas/BedspaceFilters'
+        attributes:
+          type: array
+          description: Bedspace and property attributes to filter on
+          items:
+            $ref: "#/components/schemas/BedSearchAttributes"
       required:
-        - serviceName
+        - probationDeliveryUnits
         - startDate
         - durationDays
-      discriminator:
-        propertyName: serviceName
-        mapping:
-          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchParameters'
-    TemporaryAccommodationBedSearchParameters:
-      allOf:
-        - $ref: '#/components/schemas/BedSearchParameters'
-        - type: object
-          properties:
-            probationDeliveryUnits:
-              type: array
-              description: The list of pdus Ids to search within
-              items:
-                type: string
-                format: uuid
-            attributes:
-              type: array
-              description: Bedspace and property attributes to filter on
-              items:
-                $ref: "#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnits
+    PremisesFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BedspaceFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
     BedSearchResults:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5343,7 +5343,7 @@ components:
         - rfap
         - mhapStJosephs
         - mhapElliottHouse
-    BedSearchParameters:
+    TemporaryAccommodationBedSearchParameters:
       type: object
       properties:
         serviceName:
@@ -5351,36 +5351,54 @@ components:
         startDate:
           type: string
           format: date
-          description: The date the Bed will need to be free from
         durationDays:
-          type: integer
+          type: long
           description: The number of days the Bed will need to be free from the start_date until
+        probationDeliveryUnits:
+          type: array
+          description: The list of pdus Ids to search within
+          items:
+            type: string
+            format: uuid
+        premisesFilters:
+          $ref: '#/components/schemas/PremisesFilters'
+        bedspaceFilters:
+          $ref: '#/components/schemas/BedspaceFilters'
+        attributes:
+          type: array
+          description: Bedspace and property attributes to filter on
+          items:
+            $ref: "#/components/schemas/BedSearchAttributes"
       required:
-        - serviceName
+        - probationDeliveryUnits
         - startDate
         - durationDays
-      discriminator:
-        propertyName: serviceName
-        mapping:
-          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchParameters'
-    TemporaryAccommodationBedSearchParameters:
-      allOf:
-        - $ref: '#/components/schemas/BedSearchParameters'
-        - type: object
-          properties:
-            probationDeliveryUnits:
-              type: array
-              description: The list of pdus Ids to search within
-              items:
-                type: string
-                format: uuid
-            attributes:
-              type: array
-              description: Bedspace and property attributes to filter on
-              items:
-                $ref: "#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnits
+    PremisesFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BedspaceFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
     BedSearchResults:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4712,7 +4712,7 @@ components:
         - rfap
         - mhapStJosephs
         - mhapElliottHouse
-    BedSearchParameters:
+    TemporaryAccommodationBedSearchParameters:
       type: object
       properties:
         serviceName:
@@ -4720,36 +4720,54 @@ components:
         startDate:
           type: string
           format: date
-          description: The date the Bed will need to be free from
         durationDays:
-          type: integer
+          type: long
           description: The number of days the Bed will need to be free from the start_date until
+        probationDeliveryUnits:
+          type: array
+          description: The list of pdus Ids to search within
+          items:
+            type: string
+            format: uuid
+        premisesFilters:
+          $ref: '#/components/schemas/PremisesFilters'
+        bedspaceFilters:
+          $ref: '#/components/schemas/BedspaceFilters'
+        attributes:
+          type: array
+          description: Bedspace and property attributes to filter on
+          items:
+            $ref: "#/components/schemas/BedSearchAttributes"
       required:
-        - serviceName
+        - probationDeliveryUnits
         - startDate
         - durationDays
-      discriminator:
-        propertyName: serviceName
-        mapping:
-          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchParameters'
-    TemporaryAccommodationBedSearchParameters:
-      allOf:
-        - $ref: '#/components/schemas/BedSearchParameters'
-        - type: object
-          properties:
-            probationDeliveryUnits:
-              type: array
-              description: The list of pdus Ids to search within
-              items:
-                type: string
-                format: uuid
-            attributes:
-              type: array
-              description: Bedspace and property attributes to filter on
-              items:
-                $ref: "#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnits
+    PremisesFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BedspaceFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
     BedSearchResults:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4220,7 +4220,7 @@ components:
         - rfap
         - mhapStJosephs
         - mhapElliottHouse
-    BedSearchParameters:
+    TemporaryAccommodationBedSearchParameters:
       type: object
       properties:
         serviceName:
@@ -4228,36 +4228,54 @@ components:
         startDate:
           type: string
           format: date
-          description: The date the Bed will need to be free from
         durationDays:
-          type: integer
+          type: long
           description: The number of days the Bed will need to be free from the start_date until
+        probationDeliveryUnits:
+          type: array
+          description: The list of pdus Ids to search within
+          items:
+            type: string
+            format: uuid
+        premisesFilters:
+          $ref: '#/components/schemas/PremisesFilters'
+        bedspaceFilters:
+          $ref: '#/components/schemas/BedspaceFilters'
+        attributes:
+          type: array
+          description: Bedspace and property attributes to filter on
+          items:
+            $ref: "#/components/schemas/BedSearchAttributes"
       required:
-        - serviceName
+        - probationDeliveryUnits
         - startDate
         - durationDays
-      discriminator:
-        propertyName: serviceName
-        mapping:
-          temporary-accommodation: '#/components/schemas/TemporaryAccommodationBedSearchParameters'
-    TemporaryAccommodationBedSearchParameters:
-      allOf:
-        - $ref: '#/components/schemas/BedSearchParameters'
-        - type: object
-          properties:
-            probationDeliveryUnits:
-              type: array
-              description: The list of pdus Ids to search within
-              items:
-                type: string
-                format: uuid
-            attributes:
-              type: array
-              description: Bedspace and property attributes to filter on
-              items:
-                $ref: "#/components/schemas/BedSearchAttributes"
-          required:
-            - probationDeliveryUnits
+    PremisesFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BedspaceFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
     BedSearchResults:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSearchTest.kt
@@ -1184,7 +1184,7 @@ class BedSearchTest : IntegrationTestBase() {
     @Test
     fun `Searching for a Temporary Accommodation Bed should not return bed when given premises bedspace endDate is same as search start date`() {
       givenAUser { _, jwt ->
-        val durationDays = 7
+        val durationDays = 7L
         val searchStartDate = LocalDate.parse("2023-03-23")
         val searchPdu = createTemporaryAccommodationWithBedSpaceEndDate(searchStartDate, searchStartDate)
 
@@ -1195,7 +1195,7 @@ class BedSearchTest : IntegrationTestBase() {
     @Test
     fun `Searching for a Temporary Accommodation Bed should not return bed when given premises bedspace endDate is between search start date and end date`() {
       givenAUser { _, jwt ->
-        val durationDays = 7
+        val durationDays = 7L
         val searchStartDate = LocalDate.parse("2023-03-23")
         val bedEndDate = searchStartDate.plusDays(2)
         val searchPdu = createTemporaryAccommodationWithBedSpaceEndDate(searchStartDate, bedEndDate)
@@ -1207,7 +1207,7 @@ class BedSearchTest : IntegrationTestBase() {
     @Test
     fun `Searching for a Temporary Accommodation Bed should not return bed when given premises bedspace endDate is same as search end date`() {
       givenAUser { _, jwt ->
-        val durationDays = 7
+        val durationDays = 7L
         val searchStartDate = LocalDate.parse("2023-03-23")
         val bedEndDate = searchStartDate.plusDays(durationDays.toLong() - 1)
         val searchPdu = createTemporaryAccommodationWithBedSpaceEndDate(searchStartDate, bedEndDate)
@@ -1219,7 +1219,7 @@ class BedSearchTest : IntegrationTestBase() {
     @Test
     fun `Searching for a Temporary Accommodation Bed should not return bed when given premises bedspace endDate less than than search start date`() {
       givenAUser { _, jwt ->
-        val durationDays = 7
+        val durationDays = 7L
         val searchStartDate = LocalDate.parse("2023-03-23")
         val bedEndDate = searchStartDate.minusDays(1)
         val searchPdu = createTemporaryAccommodationWithBedSpaceEndDate(searchStartDate, bedEndDate)
@@ -1238,7 +1238,7 @@ class BedSearchTest : IntegrationTestBase() {
         probationRegion = probationRegion,
       ) { _, jwt ->
         val searchStartDate = LocalDate.parse("2023-03-23")
-        val durationDays = 7
+        val durationDays = 7L
         val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
@@ -1317,7 +1317,7 @@ class BedSearchTest : IntegrationTestBase() {
       givenAUser(
         probationRegion = probationRegion,
       ) { _, jwt ->
-        val durationDays = 7
+        val durationDays = 7L
         val searchStartDate = LocalDate.parse("2023-03-23")
         val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
@@ -1382,7 +1382,7 @@ class BedSearchTest : IntegrationTestBase() {
     @Test
     fun `Searching for a Temporary Accommodation Bed should return no bed when given premises has got 2 rooms where one with endDate in the passed and another room with matching end date`() {
       givenAUser { _, jwt ->
-        val durationDays = 7
+        val durationDays = 7L
         val searchStartDate = LocalDate.parse("2023-03-23")
         val bedEndDate = searchStartDate.plusDays(1)
         val searchPdu = createTemporaryAccommodationWithBedSpaceEndDate(searchStartDate, bedEndDate)
@@ -1407,7 +1407,7 @@ class BedSearchTest : IntegrationTestBase() {
         probationRegion = probationRegion,
       ) { _, jwt ->
         val searchStartDate = LocalDate.parse("2024-03-12")
-        val durationDays = 7
+        val durationDays = 7L
         val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
         val premisesOne = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
@@ -1541,7 +1541,7 @@ class BedSearchTest : IntegrationTestBase() {
         probationRegion = probationRegion,
       ) { _, jwt ->
         val searchStartDate = LocalDate.parse("2024-08-12")
-        val durationDays = 7
+        val durationDays = 7L
         val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
         val premisesOne = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
@@ -1644,7 +1644,7 @@ class BedSearchTest : IntegrationTestBase() {
     private fun searchTemporaryAccommodationBedSpaceAndAssertNoAvailability(
       jwt: String,
       searchStartDate: LocalDate,
-      durationDays: Int,
+      durationDays: Long,
       pduId: UUID,
     ) {
       webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationBedSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
@@ -64,10 +65,12 @@ class Cas3BedSearchServiceTest {
 
     val result = bedSearchService.findBedspaces(
       user = user,
-      startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 0,
-      probationDeliveryUnits = listOf(probationDeliveryUnit.id),
-      propertyBedAttributes = null,
+      TemporaryAccommodationBedSearchParameters(
+        startDate = LocalDate.parse("2023-03-22"),
+        durationDays = 0,
+        probationDeliveryUnits = listOf(probationDeliveryUnit.id),
+        attributes = null,
+      ),
     )
 
     assertThat(result).isFieldValidationError("$.durationDays", "mustBeAtLeast1")
@@ -89,10 +92,12 @@ class Cas3BedSearchServiceTest {
 
     val result = bedSearchService.findBedspaces(
       user = user,
-      startDate = LocalDate.parse("2024-08-22"),
-      durationInDays = 30,
-      probationDeliveryUnits = probationDeliveryUnitIds,
-      propertyBedAttributes = null,
+      TemporaryAccommodationBedSearchParameters(
+        startDate = LocalDate.parse("2024-08-22"),
+        durationDays = 30,
+        probationDeliveryUnits = probationDeliveryUnitIds,
+        attributes = null,
+      ),
     )
     assertThat(result).isFieldValidationError("$.probationDeliveryUnits", "maxNumberProbationDeliveryUnits")
   }
@@ -124,10 +129,12 @@ class Cas3BedSearchServiceTest {
 
     val result = bedSearchService.findBedspaces(
       user = user,
-      startDate = LocalDate.parse("2024-08-28"),
-      durationInDays = 84,
-      probationDeliveryUnits = probationDeliveryUnitIds,
-      propertyBedAttributes = null,
+      TemporaryAccommodationBedSearchParameters(
+        startDate = LocalDate.parse("2024-08-28"),
+        durationDays = 84,
+        probationDeliveryUnits = probationDeliveryUnitIds,
+        attributes = null,
+      ),
     )
     assertThat(result).isFieldValidationError("$.probationDeliveryUnits[3]", "doesNotExist")
   }
@@ -223,10 +230,12 @@ class Cas3BedSearchServiceTest {
 
     val result = bedSearchService.findBedspaces(
       user = user,
-      probationDeliveryUnits = listOf(probationDeliveryUnit.id),
-      startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
-      propertyBedAttributes = null,
+      TemporaryAccommodationBedSearchParameters(
+        probationDeliveryUnits = listOf(probationDeliveryUnit.id),
+        startDate = LocalDate.parse("2023-03-22"),
+        durationDays = 7,
+        attributes = null,
+      ),
     )
 
     assertThat(result).isSuccess().hasValueEqualTo(repositorySearchResults)
@@ -415,10 +424,12 @@ class Cas3BedSearchServiceTest {
 
     val result = bedSearchService.findBedspaces(
       user = user,
-      startDate = LocalDate.parse("2023-03-22"),
-      durationInDays = 7,
-      probationDeliveryUnits = listOf(probationDeliveryUnit.id),
-      propertyBedAttributes = null,
+      TemporaryAccommodationBedSearchParameters(
+        startDate = LocalDate.parse("2023-03-22"),
+        durationDays = 7,
+        probationDeliveryUnits = listOf(probationDeliveryUnit.id),
+        attributes = null,
+      ),
     )
     assertThat(result).isSuccess().hasValueEqualTo(expectedResults)
   }


### PR DESCRIPTION
This updates the BedSearchParameters model to TemoraryAccommodationBedSearchParameters (renaming to come later as this will affect the UI), as only cas3 uses it now. It also refactors the controller and service to pass the filter object through instead of individual parameters, this is initial refactoring in order to maintain this endpoint during refactoring to add new filter options.