### PR TITLE
APS-1792 - Simplify user seeding in local+dev+test

### DIFF
--- a/src/main/resources/db/migration/dev/R__8_create_cas3_application_and_assessment.sql
+++ b/src/main/resources/db/migration/dev/R__8_create_cas3_application_and_assessment.sql
@@ -18,7 +18,7 @@ insert into
 values
   (
     '959c59d1-fb85-4795-9703-4d7d23412c6b',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae',
+    (SELECT id from users where delius_username = 'TESTER.TESTY'),
     'X371199',
     '{}',
     'temporary-accommodation',
@@ -107,7 +107,7 @@ insert into
 values
   (
     'd045bd6a-0829-4cbb-9360-12c8cb522069',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae',
+    (SELECT id from users where delius_username = 'TESTER.TESTY'),
     'X371199',
     '{}',
     'temporary-accommodation',
@@ -196,7 +196,7 @@ insert into
 values
   (
     'dbfd396f-1334-4dd3-b228-eb17710b40f5',
-    'b5825da0-1553-4398-90ac-6a8e0c8a4cae',
+    (SELECT id from users where delius_username = 'TESTER.TESTY'),
     'X371199',
     '{}',
     'temporary-accommodation',

--- a/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
+++ b/src/main/resources/db/migration/local+dev+test/R__1_create_dev_users.sql
@@ -1,6 +1,8 @@
 -- ${flyway:timestamp}
 
---These are randomly generated names
+-- This should managed by the user seed job via 3__user.csv.
+-- Note that the seed job will pull most user details (e.g. probation region, ap area id etc.) from delius when the user is created/updated
+-- Also note that CAS1 specific users are added via the Cas1AutoScript. They could instead be loaded via an approved premises users seed job
 
 INSERT INTO "users" (id, name, delius_username, probation_region_id, delius_staff_code, ap_area_id, created_at, cas1_cru_management_area_id) VALUES
     ('aa30f20a-84e3-4baa-bef0-3c9bd51879ad', 'Default User', 'JIMSNOWLDAP', '43606be0-9836-441d-9bc1-5586de9ac931', 'STAFFCODE', '2cc6bc0f-58cf-4d82-99dd-dfc67b7f5c33', now(), '667cc74b-60f9-4848-822b-2e8f7712cdf1'), -- Premises & AP: South West
@@ -9,47 +11,18 @@ INSERT INTO "users" (id, name, delius_username, probation_region_id, delius_staf
     ('b5825da0-1553-4398-90ac-6a8e0c8a4cae', 'Tester Testy', 'TESTER.TESTY', 'c5acff6c-d0d2-4b89-9f4d-89a15cfa3891', 'STAFFCODE', '6025b8c6-883f-4300-bc26-2b01fbd6e272', now(), '64ad8602-5130-41da-bb2b-1c287b88fd90') -- Premises & AP: North East
 ON CONFLICT (id) DO NOTHING;
 
-UPDATE
-  users
-SET
-  "delius_username" = 'JIMSNOWLDAP'
-WHERE
-  id = 'aa30f20a-84e3-4baa-bef0-3c9bd51879ad';
-
+-- assign CAS3_ASSESSOR and CAS3_REPORTER to TEMPORARY-ACCOMMODATION-E2E-TESTER
 INSERT INTO
   "user_role_assignments" ("id", "role", "user_id")
 VALUES
   (
-    'f1118a4e-bb6f-4b16-83ad-08ef92314610',
-    'CAS3_ASSESSOR',
-    'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
+   '426b4846-ac0c-4e27-a350-873c5aaf62fd',
+   'CAS3_ASSESSOR',
+   (select id from users where delius_username = 'TEMPORARY-ACCOMMODATION-E2E-TESTER')
   ),
   (
-    '77c6cc54-5d01-41d2-9987-5b293d6d2e07',
-    'CAS3_REFERRER',
-    'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
-  ),
-  (
-    '482a4ab7-a6e4-4bf8-a0fc-8516eca9efa2',
-    'CAS3_REPORTER',
-    'aa30f20a-84e3-4baa-bef0-3c9bd51879ad'
+  'f0ebbb07-dff5-4be6-97bf-7b393df12145',
+  'CAS3_REPORTER',
+  (select id from users where delius_username = 'TEMPORARY-ACCOMMODATION-E2E-TESTER')
   )
-   ON CONFLICT (id)
-DO
-  NOTHING;
-
--- Copy all roles from JIMSNOWLDAP to TEMPORARY-ACCOMMODATION-E2E-TESTER
-INSERT INTO
-  "user_role_assignments" ("id", "role", "user_id")
-SELECT
-  gen_random_uuid() AS id,
-  role AS role,
-  (SELECT id FROM users where delius_username='TEMPORARY-ACCOMMODATION-E2E-TESTER') AS user_id
-FROM
-  "user_role_assignments"
-WHERE
-  "user_id" = (SELECT id FROM users where delius_username='JIMSNOWLDAP')
-  AND ("role" = 'CAS3_ASSESSOR' OR "role" = 'CAS3_REPORTER')
-ON CONFLICT (id)
-DO
-  NOTHING;
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
This commit tidies up some SQL migration scripts related to test users, making them more readible

As noted in comments, seeding of test users should ideally be managed by the user seed job via 3__user.csv.

To test this i diff’d the output from the following SQL. The only difference was the IDs for users generated by the seed job, as expected

```
select
u.id,
u.name,
u.email,
u.delius_username,
a.name as "new application area",
cru_management_area.name as "cru management area (default)",
cru_management_area_override.name as "cru management area (override)",
string_agg(r.role,', ' ORDER BY r.role) roles
from users u
inner join ap_areas a on a.id = u.ap_area_id
left outer join user_role_assignments r on u.id = r.user_id
left outer join cas1_cru_management_areas cru_management_area on cru_management_area.id = u.cas1_cru_management_area_id
left outer join cas1_cru_management_areas cru_management_area_override on cru_management_area_override.id = u.cas1_cru_management_area_override_id
GROUP BY u.id, u.name, u.email, u.delius_username, u.is_active, a.name, cru_management_area.name, cru_management_area_override.name
ORDER by name desc;
```