### PR TITLE
APS-1756 - Use default replicaCount in `test` for load test

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -2,7 +2,6 @@
 # Per environment values which override defaults in approved-premises-api/values.yaml
 
 generic-service:
-  replicaCount: 2
 
   ingress:
     host: approved-premises-api-test.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This ensures that the `test` environment has the same number of replicas as production