### PR TITLE
APS-1756 - Add /cas1/reference-data/departure-reasons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReferenceDataController.kt
@@ -5,8 +5,11 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.ReferenceDataCas1Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1CruManagementArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DepartureReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1CruManagementAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
 
@@ -16,6 +19,8 @@ class Cas1ReferenceDataController(
   private val cas1OutOfServiceBedReasonRepository: Cas1OutOfServiceBedReasonRepository,
   private val cas1CruManagementAreaTransformer: Cas1CruManagementAreaTransformer,
   private val cas1CruManagementAreaRepository: Cas1CruManagementAreaRepository,
+  private val departureReasonRepository: DepartureReasonRepository,
+  private val departureReasonTransformer: DepartureReasonTransformer,
 ) : ReferenceDataCas1Delegate {
 
   override fun getOutOfServiceBedReasons(): ResponseEntity<List<Cas1OutOfServiceBedReason>> {
@@ -31,6 +36,13 @@ class Cas1ReferenceDataController(
     return ResponseEntity.ok(
       cas1CruManagementAreaRepository.findAll()
         .map { cas1CruManagementAreaTransformer.transformJpaToApi(it) },
+    )
+  }
+
+  override fun getDepartureReasons(): ResponseEntity<List<DepartureReason>> {
+    return ResponseEntity.ok(
+      departureReasonRepository.findActiveForCas1()
+        .map { departureReasonTransformer.transformJpaToApi(it) },
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DepartureReasonEntity.kt
@@ -19,6 +19,10 @@ interface DepartureReasonRepository : JpaRepository<DepartureReasonEntity, UUID>
   @Query("SELECT d FROM DepartureReasonEntity d WHERE d.serviceScope = :serviceName OR d.serviceScope = '*'")
   fun findAllByServiceScope(serviceName: String): List<DepartureReasonEntity>
 
+  @Query("SELECT d FROM DepartureReasonEntity d WHERE d.serviceScope = 'approved-premises' OR d.serviceScope = '*' AND d.isActive = true")
+  fun findActiveForCas1(): List<DepartureReasonEntity>
+
+  @Deprecated("This SQL is ambiguous and may return unexpected resulted")
   @Query("SELECT d FROM DepartureReasonEntity d WHERE d.serviceScope = :serviceName OR d.serviceScope = '*' AND d.isActive = true")
   fun findActiveByServiceScope(serviceName: String): List<DepartureReasonEntity>
 

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -986,6 +986,28 @@ paths:
         500:
           $ref: '_shared.yml#/components/responses/500Response'
 
+  /reference-data/departure-reasons:
+    get:
+      tags:
+        - Reference Data
+      operationId: getDepartureReasons
+      summary: Lists all active departure reasons
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/DepartureReason'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+
   /reports/{reportName}:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -988,6 +988,28 @@ paths:
         500:
           $ref: '#/components/responses/500Response'
 
+  /reference-data/departure-reasons:
+    get:
+      tags:
+        - Reference Data
+      operationId: getDepartureReasons
+      summary: Lists all active departure reasons
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DepartureReason'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+
   /reports/{reportName}:
     get:
       tags:


### PR DESCRIPTION
This should be used instead of the service-agnostic endpoint, which can return unexpected results due to the SQL being used. Instead of ‘fixing’ the SQL and potentially disrupting CAS3, we’ve instead introduced a CAS1 specific version