### PR TITLE
CAS-1375 Upper case crn when call getPersonInfoResult in premises service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -719,7 +719,7 @@ class OffenderService(
     ignoreLaoRestrictions: Boolean,
   ): PersonInfoResult {
     check(ignoreLaoRestrictions || deliusUsername != null) { "If ignoreLao is false, delius username must be provided " }
-    return getPersonInfoResults(setOf(crn), deliusUsername, ignoreLaoRestrictions).first()
+    return getPersonInfoResults(setOf(crn.trim().uppercase()), deliusUsername, ignoreLaoRestrictions).first()
   }
 
   fun getPersonInfoResults(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationReportsTest.kt
@@ -304,7 +304,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
 
     val (referrerEntity, _) = referrerDetails
 
-    assertThat(reportRow.crn).isEqualTo(application.crn)
+    assertThat(reportRow.crn).isEqualTo(application.crn.uppercase())
     assertThat(reportRow.tier).isEqualTo("B")
 
     assertThat(reportRow.lastAllocatedToAssessorDate).isEqualTo(assessment.allocatedAt!!.toLocalDate())
@@ -396,7 +396,7 @@ class ApplicationReportsTest : InitialiseDatabasePerClassTestBase() {
   private fun createAndSubmitApplication(apType: ApType, crn: String, withArrivalDate: Boolean = true, shortNotice: Boolean = false): ApprovedPremisesApplicationEntity {
     val (referrer, jwt) = referrerDetails
     val (offenderDetails, _) = givenAnOffender(
-      offenderDetailsConfigBlock = { withCrn(crn) },
+      offenderDetailsConfigBlock = { withCrn(crn.uppercase()) },
     )
 
     apDeliusContextMockSuccessfulCaseDetailCall(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationReportsTest.kt
@@ -396,7 +396,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
 
     val (referrerEntity, _) = referrerDetails
 
-    assertThat(reportRow.crn).isEqualTo(application.crn)
+    assertThat(reportRow.crn).isEqualTo(application.crn.uppercase())
     assertThat(reportRow.tier).isEqualTo("A")
 
     assertThat(reportRow.placementRequestSubmittedAt).isEqualTo(placementApplication.submittedAt!!.toLocalDate())
@@ -489,7 +489,7 @@ class PlacementApplicationReportsTest : IntegrationTestBase() {
 
   private fun createAndSubmitApplication(crn: String): ApprovedPremisesApplicationEntity {
     val (referrer, jwt) = referrerDetails
-    val (offenderDetails, _) = givenAnOffender({ withCrn(crn) })
+    val (offenderDetails, _) = givenAnOffender({ withCrn(crn.uppercase()) })
 
     apDeliusContextMockSuccessfulCaseDetailCall(
       offenderDetails.otherIds.crn,


### PR DESCRIPTION
This [PR CAS-1375](https://dsdmoj.atlassian.net/browse/CAS-1375) is to fix an issue when calling get offender details and the crn is in lower case