### PR TITLE
CAS-1373 - Updated to allow retries for ReadTimeoutException

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/BaseHMPPSClient.kt
@@ -152,8 +152,15 @@ abstract class BaseHMPPSClient(
   }
 
   private fun isApplicableForRetry(throwable: Throwable): Boolean {
-    return !isTimeoutException(throwable) &&
-      (throwable !is WebClientResponseException || RETRY_ERROR_CODES.contains(throwable.statusCode.value()))
+    return when {
+      isTimeoutException(throwable) && webClientConfig.retryOnReadTimeout -> true
+      !isTimeoutException(throwable) && hasRetryableException(throwable) -> true
+      else -> false
+    }
+  }
+
+  private fun hasRetryableException(throwable: Throwable): Boolean {
+    return (throwable !is WebClientResponseException || RETRY_ERROR_CODES.contains(throwable.statusCode.value()))
   }
 
   // Timeout for NO_RESPONSE is wrapped in a WebClientRequestException

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -22,11 +22,13 @@ import java.time.Duration
 data class WebClientConfig(
   val webClient: WebClient,
   val maxRetryAttempts: Long = 1,
+  val retryOnReadTimeout: Boolean = false,
 )
 
 @Configuration
 class WebClientConfiguration(
   @Value("\${upstream-timeout-ms}") private val upstreamTimeoutMs: Long,
+  @Value("\${nomis-user-roles-api-upstream-timeout-ms}") private val nomisUserRolesUpstreamTimeoutMs: Long,
   @Value("\${case-notes-service-upstream-timeout-ms}") private val caseNotesServiceUpstreamTimeoutMs: Long,
   @Value("\${web-clients.max-response-in-memory-size-bytes}") private val defaultMaxResponseInMemorySizeBytes: Int,
   @Value("\${web-clients.prison-api-max-response-in-memory-size-bytes}") private val prisonApiMaxResponseInMemorySizeBytes: Int,
@@ -221,11 +223,12 @@ class WebClientConfiguration(
           ReactorClientHttpConnector(
             HttpClient
               .create()
-              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+              .responseTimeout(Duration.ofMillis(nomisUserRolesUpstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(nomisUserRolesUpstreamTimeoutMs).toMillis().toInt()),
           ),
         )
         .build(),
+      retryOnReadTimeout = true,
     )
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -269,6 +269,7 @@ preemptive-cache-lock-duration-ms: 5400000
 arrived-departed-domain-events-disabled: true
 
 upstream-timeout-ms: 10000
+nomis-user-roles-api-upstream-timeout-ms: 2000
 case-notes-service-upstream-timeout-ms: 25000
 
 web-clients:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -173,6 +173,7 @@ arrived-departed-domain-events-disabled: false
 manual-bookings-domain-events-disabled: false
 
 upstream-timeout-ms: 500
+nomis-user-roles-api-upstream-timeout-ms: 500
 
 pagination:
   default-page-size: 10


### PR DESCRIPTION
- reduced timeout limit to 2 seconds (99 percentile time is 52ms)
- added flag to allow retries on read timeout errors
