### PR TITLE
APS-1835 Deprecate space search apType options

### DIFF
--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -266,11 +266,13 @@ components:
       properties:
         apTypes:
           deprecated: true
-          description: "Searching on multiple types is not supported, instead use apType. If this is used, the first type wll be matched, and type 'normal' will be ignored"
+          description: "Use 'spaceCharacteristics' to filter on premise types"
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/ApType'
         apType:
+          deprecated: true
+          description: "Use 'spaceCharacteristics' to filter on premise types"
           $ref: '_shared.yml#/components/schemas/ApType'
         spaceCharacteristics:
           type: array

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6354,11 +6354,13 @@ components:
       properties:
         apTypes:
           deprecated: true
-          description: "Searching on multiple types is not supported, instead use apType. If this is used, the first type wll be matched, and type 'normal' will be ignored"
+          description: "Use 'spaceCharacteristics' to filter on premise types"
           type: array
           items:
             $ref: '#/components/schemas/ApType'
         apType:
+          deprecated: true
+          description: "Use 'spaceCharacteristics' to filter on premise types"
           $ref: '#/components/schemas/ApType'
         spaceCharacteristics:
           type: array

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -19,6 +19,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesGender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_ESAP
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_PIPE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_RECOVERY_FOCUSSED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_SEMI_SPECIALIST_MENTAL_HEALTH
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import java.time.LocalDate
@@ -285,7 +290,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
   }
 
   @Test
-  fun `Filtering AP type 'normal' returns all APs regardless of type returns only APs of that type - using single ap type option`() {
+  fun `Filtering AP type 'normal' returns all APs regardless of type`() {
     postCodeDistrictFactory.produceAndPersist {
       withOutcode("SE1")
       withLatitude(-0.07)
@@ -408,6 +413,68 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       assertThatResultMatches(results.results[2], expectedPremises[2], expectedApType)
       assertThatResultMatches(results.results[3], expectedPremises[3], expectedApType)
       assertThatResultMatches(results.results[4], expectedPremises[4], expectedApType)
+    }
+  }
+
+  @Test
+  fun `Filtering APs by AP type characteristics returns APs matching the characteristics`() {
+    postCodeDistrictFactory.produceAndPersist {
+      withOutcode("SE1")
+      withLatitude(-0.07)
+      withLongitude(51.48)
+    }
+
+    givenAUser { user, jwt ->
+      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
+
+      fun createAp(characteristics: List<CharacteristicEntity>) = approvedPremisesEntityFactory.produceAndPersist {
+        withYieldedProbationRegion { givenAProbationRegion() }
+        withYieldedLocalAuthorityArea {
+          localAuthorityEntityFactory.produceAndPersist()
+        }
+        withCharacteristicsList(characteristics)
+        withSupportsSpaceBookings(true)
+      }
+
+      val pipe = createAp(getCharacteristics(CAS1_PROPERTY_NAME_PREMISES_PIPE))
+      val pipeAndEsap = createAp(
+        getCharacteristics(
+          CAS1_PROPERTY_NAME_PREMISES_PIPE,
+          CAS1_PROPERTY_NAME_PREMISES_ESAP,
+        ),
+      )
+      createAp(getCharacteristics(CAS1_PROPERTY_NAME_PREMISES_ESAP))
+      createAp(getCharacteristics(CAS1_PROPERTY_NAME_PREMISES_SEMI_SPECIALIST_MENTAL_HEALTH))
+      createAp(getCharacteristics(CAS1_PROPERTY_NAME_PREMISES_RECOVERY_FOCUSSED))
+      createAp(emptyList())
+
+      val searchParameters = Cas1SpaceSearchParameters(
+        applicationId = application.id,
+        startDate = LocalDate.now(),
+        durationInDays = 14,
+        targetPostcodeDistrict = "SE1",
+        requirements = Cas1SpaceSearchRequirements(
+          apTypes = null,
+          apType = null,
+          spaceCharacteristics = listOf(Cas1SpaceCharacteristic.isPIPE),
+        ),
+      )
+
+      val response = webTestClient.post()
+        .uri("/cas1/spaces/search")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(searchParameters)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas1SpaceSearchResults::class.java)
+
+      val results = response.responseBody.blockFirst()!!
+
+      assertThat(results.results.map { it.premises.id }).containsExactlyInAnyOrder(
+        pipe.id,
+        pipeAndEsap.id,
+      )
     }
   }
 
@@ -620,8 +687,16 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
   }
 
   private fun ApType.asCharacteristicEntity() = this.asCharacteristicProperty()?.let {
-    characteristicRepository.findByPropertyName(it, ServiceName.approvedPremises.value)
+    getCharacteristic(it)
   }
 
-  private fun Cas1SpaceCharacteristic.asCharacteristicEntity() = characteristicRepository.findByPropertyName(this.value, ServiceName.approvedPremises.value)!!
+  private fun getCharacteristics(vararg propertyNames: String) =
+    propertyNames.map {
+      getCharacteristic(it)!!
+    }
+
+  private fun getCharacteristic(propertyName: String) =
+    characteristicRepository.findByPropertyName(propertyName, ServiceName.approvedPremises.value)
+
+  private fun Cas1SpaceCharacteristic.asCharacteristicEntity() = getCharacteristic(this.value)!!
 }


### PR DESCRIPTION
We should be using characteristics to filter results on premise types instead of the discrete apType enumeration.

This commit also adds an integration test demonstrating filtering on ap types using characteristics.