### PR TITLE
APS-1829 - Enhance test app seed job to include bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1CreateTestApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1CreateTestApplicationsSeedJob.kt
@@ -20,6 +20,7 @@ class Cas1CreateTestApplicationsSeedJob(
     "crn",
     "count",
     "state",
+    "premises_qcode",
   ),
   runInTransaction = false,
 ) {
@@ -34,6 +35,7 @@ class Cas1CreateTestApplicationsSeedJob(
       crn = seedColumns.getStringOrNull("crn")!!,
       count = seedColumns.getIntOrNull("count")!!,
       state = Cas1ApplicationSeedService.ApplicationState.valueOf(seedColumns.getStringOrNull("state")!!),
+      premisesQCode = seedColumns.getStringOrNull("premises_qcode"),
     )
   }
 
@@ -56,6 +58,7 @@ class Cas1CreateTestApplicationsSeedJob(
               crn = crn,
               createIfExistingApplicationForCrn = true,
               state = row.state,
+              premisesQCode = row.premisesQCode,
             )
           }
         }
@@ -71,4 +74,5 @@ data class Cas1CreateTestApplicationsSeedCsvRow(
   val crn: String,
   val count: Int,
   val state: Cas1ApplicationSeedService.ApplicationState,
+  val premisesQCode: String?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CreateTestApplicationSeedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CreateTestApplicationSeedTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
@@ -29,6 +30,8 @@ class SeedCas1CreateTestApplicationSeedTest : SeedTestBase() {
     apOASysContextMockSuccessfulNeedsDetailsCall(crn, NeedsDetailsFactory().produce())
     govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
 
+    val premises = givenAnApprovedPremises(supportsSpaceBookings = true)
+
     postCodeDistrictFactory.produceAndPersist()
 
     withCsv(
@@ -38,7 +41,8 @@ class SeedCas1CreateTestApplicationSeedTest : SeedTestBase() {
           creatorUsername = user.deliusUsername,
           crn = crn,
           count = 1,
-          state = Cas1ApplicationSeedService.ApplicationState.AUTHORISED,
+          state = Cas1ApplicationSeedService.ApplicationState.BOOKED,
+          premisesQCode = premises.qCode,
         ),
       ).toCsv(),
     )
@@ -56,6 +60,7 @@ class SeedCas1CreateTestApplicationSeedTest : SeedTestBase() {
         "crn",
         "count",
         "state",
+        "premises_qcode",
       )
       .newRow()
 
@@ -65,6 +70,7 @@ class SeedCas1CreateTestApplicationSeedTest : SeedTestBase() {
         .withQuotedField(it.crn)
         .withQuotedField(it.count)
         .withQuotedField(it.state)
+        .withQuotedField(it.premisesQCode ?: "")
         .newRow()
     }
 


### PR DESCRIPTION
This commit updates the create test application seed job to support seeding applications with a space bookings. This is required to support load testing.

Example config:

```
creator_username,crn,count,state,premises_qcode
JIMSNOWLDAP,X320741,50,AUTHORISED,
JIMSNOWLDAP,X320741,50,BOOKED,Q713
```

Example output

![Screenshot 2025-01-21 at 15 58 30](https://github.com/user-attachments/assets/dc7e5ce9-bc25-49b3-9729-2332f0b37c80)
