### PR TITLE
Improve seed job error handling

### DIFF
--- a/script/run_migration_job
+++ b/script/run_migration_job
@@ -5,7 +5,7 @@
 
 set -e
 
-curl --location --request POST 'http://127.0.0.1:8080/migration-job' \
+curl --fail --show-error --location --request POST 'http://127.0.0.1:8080/migration-job' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jobType": "'$1'"

--- a/script/run_seed_from_excel_job
+++ b/script/run_seed_from_excel_job
@@ -15,7 +15,7 @@ then
   exit 1
 fi
 
-curl --location --request POST 'http://127.0.0.1:8080/seedFromExcel' \
+curl --fail --show-error --location --request POST 'http://127.0.0.1:8080/seedFromExcel' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "seedType": "'"$SEED_JOB_ID"'",

--- a/script/run_seed_job
+++ b/script/run_seed_job
@@ -6,7 +6,7 @@
 
 set -e
 
-curl --location --request POST 'http://127.0.0.1:8080/seed' \
+curl --fail --show-error --location --request POST 'http://127.0.0.1:8080/seed' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "seedType": "'$1'",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -54,11 +54,11 @@ class SeedService(
 
   fun seedData(seedFileType: SeedFileType, filename: String) = seedData(seedFileType, filename) { "${seedConfig.filePrefix}/$filename" }
 
-  @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
+  @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown", "TooGenericExceptionCaught")
   fun seedData(seedFileType: SeedFileType, filename: String, resolveCsvPath: SeedJob<*>.() -> String) {
-    seedLogger.info("Starting seed request: $seedFileType - $filename")
-
     try {
+      seedLogger.info("Starting seed request: $seedFileType - $filename")
+
       if (filename.contains("/") || filename.contains("\\")) {
         throw RuntimeException("Filename must be just the filename of a .csv file in the /seed directory, e.g. for /seed/upload.csv, just `upload` should be supplied")
       }
@@ -108,7 +108,7 @@ class SeedService(
 
       val timeTaken = ChronoUnit.MILLIS.between(seedStarted, LocalDateTime.now())
       seedLogger.info("Seed request complete. Took $timeTaken millis and processed $rowsProcessed rows")
-    } catch (exception: Exception) {
+    } catch (exception: Throwable) {
       seedLogger.error("Unable to complete Seed Job", exception)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedXlsxService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedXlsxService.kt
@@ -21,9 +21,9 @@ class SeedXlsxService(
 ) {
   @SuppressWarnings("TooGenericExceptionThrown", "TooGenericExceptionCaught")
   fun seedExcelData(excelSeedFileType: SeedFromExcelFileType, filename: String) {
-    seedLogger.info("Starting seed request: $excelSeedFileType - $filename")
-
     try {
+      seedLogger.info("Starting seed request: $excelSeedFileType - $filename")
+
       if (filename.contains("/") || filename.contains("\\")) {
         throw RuntimeException("Filename must be just the filename of a .xlsx file in the /seed directory, e.g. for /seed/upload.xlsx, just `upload` should be supplied")
       }
@@ -41,7 +41,7 @@ class SeedXlsxService(
 
       val timeTaken = ChronoUnit.MILLIS.between(seedStarted, LocalDateTime.now())
       seedLogger.info("Excel seed request complete. Took $timeTaken millis")
-    } catch (exception: Exception) {
+    } catch (exception: Throwable) {
       seedLogger.error("Unable to complete Excel seed job", exception)
     }
   }


### PR DESCRIPTION
Before this commit we were not catching `Throwable` types. Because we’re using `@Async` it’s possible that these are swallowed and not logged.