### PR TITLE
chore/upgrade openapi plugin version from 7.7 to 7.11.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.apache.commons.io.FileUtils
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.1.2"
   kotlin("plugin.spring") version "2.0.21"
-  id("org.openapi.generator") version "7.7.0"
+  id("org.openapi.generator") version "7.11.0"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.9.22"
   id("io.gatling.gradle") version "3.13.1"
   id("io.gitlab.arturbosch.detekt") version "1.23.7"
@@ -239,6 +239,7 @@ openApiGenerate {
   typeMappings.put("DateTime", "Instant")
   importMappings.put("Instant", "java.time.Instant")
   templateDir.set("$rootDir/openapi")
+  additionalProperties.put("removeEnumValuePrefix", "true")
 }
 
 registerAdditionalOpenApiGenerateTask(


### PR DESCRIPTION
Running the gradle openApiGenerate task currently results in the following issues:

"More than one inline schema specified in allOf:. Only the first one is recognized. All others are ignored."

Resolving these issues requires:

- upgrading the openAPI generator plugin version from 7.7 to 7.11
- setting new property `removeEnumValuePrefix = true`

See more information in the comment descriptions.

After these changes the gradle openApiGenerate task should run without complaining about the inline schema issues.