### PR TITLE
Enable ap-and-oasys retry on timeout

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -29,6 +29,7 @@ data class WebClientConfig(
 @Configuration
 class WebClientConfiguration(
   @Value("\${upstream-timeout-ms}") private val upstreamTimeoutMs: Long,
+  @Value("\${ap-and-oasys-upstream-timeout-ms}") private val apAndOasysUpstreamTimeoutMs: Long,
   @Value("\${nomis-user-roles-api-upstream-timeout-ms}") private val nomisUserRolesUpstreamTimeoutMs: Long,
   @Value("\${case-notes-service-upstream-timeout-ms}") private val caseNotesServiceUpstreamTimeoutMs: Long,
   @Value("\${web-clients.max-response-in-memory-size-bytes}") private val defaultMaxResponseInMemorySizeBytes: Int,
@@ -220,12 +221,13 @@ class WebClientConfiguration(
           ReactorClientHttpConnector(
             HttpClient
               .create()
-              .responseTimeout(Duration.ofMillis(upstreamTimeoutMs))
-              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(upstreamTimeoutMs).toMillis().toInt()),
+              .responseTimeout(Duration.ofMillis(apAndOasysUpstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(apAndOasysUpstreamTimeoutMs).toMillis().toInt()),
           ),
         )
         .filter(oauth2Client)
         .build(),
+      retryOnReadTimeout = true,
     )
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -276,6 +276,7 @@ preemptive-cache-lock-duration-ms: 5400000
 arrived-departed-domain-events-disabled: true
 
 upstream-timeout-ms: 10000
+ap-and-oasys-upstream-timeout-ms: 4000
 nomis-user-roles-api-upstream-timeout-ms: 2000
 case-notes-service-upstream-timeout-ms: 25000
 


### PR DESCRIPTION
This commit enables retry on timeout for ap-and-oasys and reduces its timeout threshold from 10 seconds to 4 seconds. Observations have shown that when we do get a timeout and a 500 is returned to the UI a retry triggered by the UI succeeds.

The timeout of 4 seconds is based upon the 99th percentil response time of 340 milliseconds, with only one request taking longer than 4 seconds (without timeout) in January so far.