### PR TITLE
APS-1796 Add option to seed job to process rows in parallel

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedJob.kt
@@ -5,6 +5,7 @@ import java.io.File
 abstract class SeedJob<RowType>(
   val requiredHeaders: Set<String>? = null,
   val runInTransaction: Boolean = true,
+  val processRowsConcurrently: Boolean = false,
 ) {
   open fun verifyPresenceOfRequiredHeaders(headers: Set<String>) {
     if (requiredHeaders == null) return

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusReferralsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusReferralsSeedJob.kt
@@ -44,6 +44,7 @@ class Cas1ImportDeliusReferralsSeedJob(
     "HOSTEL_CODE",
   ),
   runInTransaction = false,
+  processRowsConcurrently = true,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 


### PR DESCRIPTION
This commit adds an option to seed jobs to process rows in parallel using co-routines. This is disabled by default, and currently only enabled for the Cas1 Import Delius Referrarl Seed Job

Stats from running that job locally with a complete import, showing processing time decreased from 10 minutes to 2.2 minutes.

*With co-routines*
Seed request complete. Took 133923 millis and processed 297603 rows |  2.2 minutes. 221831 rows in cas1_delius_booking_import

*Without co-routines*
Seed request complete. Took 618490 millis and processed 297603 rows |  10 minutes. 221831 rows in cas1_delius_booking_import