### PR TITLE
Capture Delius ID when creating/backfill Space Bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -361,6 +361,15 @@ data class Cas1SpaceBookingEntity(
    */
   @Enumerated(EnumType.STRING)
   val migratedManagementInfoFrom: ManagementInfoSource?,
+  /**
+   * Delius' internal identifier for this referral.
+   *
+   * This will only be set for bookings back-filled from referrals created
+   * in delius, or those where management information was back-filled from
+   * delius when converted from a legacy booking. It is captured for support
+   * purposes
+   */
+  val deliusId: String?,
   @Version
   var version: Long = 1,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
@@ -54,7 +54,14 @@ interface Cas1DeliusBookingImportRepository : JpaRepository<Cas1DeliusBookingImp
 data class Cas1DeliusBookingImportEntity(
   @Id
   val id: UUID,
+  /**
+   * CAS1 ID
+   */
   val bookingId: UUID?,
+  /**
+   * Delius ID
+   */
+  val approvedPremisesReferralId: String,
   val crn: String,
   val eventNumber: String,
   val keyWorkerStaffCode: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
@@ -389,6 +389,7 @@ class Cas1ApplicationSeedService(
         nonArrivalReason = null,
         deliusEventNumber = "2",
         migratedManagementInfoFrom = null,
+        deliusId = null,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BackfillActiveSpaceBookingsCreatedInDelius.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BackfillActiveSpaceBookingsCreatedInDelius.kt
@@ -172,6 +172,7 @@ class Cas1BackfillActiveSpaceBookingsCreatedInDelius(
         nonArrivalNotes = null,
         deliusEventNumber = deliusReferral.eventNumber,
         migratedManagementInfoFrom = managementInfo.source,
+        deliusId = deliusReferral.approvedPremisesReferralId,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingManagementInfoService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingManagementInfoService.kt
@@ -26,6 +26,7 @@ class Cas1BookingManagementInfoService(
 
   fun fromBooking(booking: BookingEntity) = ManagementInfo(
     source = ManagementInfoSource.LEGACY_CAS_1,
+    deliusId = null,
     arrivedAtDate = booking.arrival?.arrivalDateTime?.toLocalDate(),
     arrivedAtTime = booking.arrival?.arrivalDateTime?.toLocalDateTime()?.toLocalTime(),
     departedAtDate = booking.departure?.dateTime?.toLocalDate(),
@@ -42,6 +43,7 @@ class Cas1BookingManagementInfoService(
 
   fun fromDeliusBookingImport(import: Cas1DeliusBookingImportEntity) = ManagementInfo(
     source = ManagementInfoSource.DELIUS,
+    deliusId = import.approvedPremisesReferralId,
     arrivedAtDate = import.arrivalDate,
     arrivedAtTime = null,
     departedAtDate = import.departureDate,
@@ -71,6 +73,7 @@ class Cas1BookingManagementInfoService(
 
 data class ManagementInfo(
   val source: ManagementInfoSource,
+  val deliusId: String?,
   val arrivedAtDate: LocalDate?,
   val arrivedAtTime: LocalTime?,
   val departedAtDate: LocalDate?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -138,6 +138,7 @@ class Cas1BookingToSpaceBookingSeedJob(
         nonArrivalNotes = managementInfo.nonArrivalNotes,
         deliusEventNumber = bookingMadeDomainEvent?.data?.eventDetails?.deliusEventNumber,
         migratedManagementInfoFrom = managementInfo.source,
+        deliusId = managementInfo.deliusId,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusReferralsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusReferralsSeedJob.kt
@@ -21,6 +21,7 @@ class Cas1ImportDeliusReferralsSeedJob(
 ) : SeedJob<Cas1DeliusBookingManagementDataRow>(
   requiredHeaders = setOf(
     "BOOKING_ID",
+    "APPROVED_PREMISES_REFERRAL_ID",
     "CRN",
     "EVENT_NUMBER",
     "KEY_WORKER_STAFF_CODE",
@@ -62,6 +63,7 @@ class Cas1ImportDeliusReferralsSeedJob(
 
     return Cas1DeliusBookingManagementDataRow(
       bookingId = seedColumns.getUuidOrNull("BOOKING_ID"),
+      approvedPremisesReferralId = seedColumns.getStringOrNull("APPROVED_PREMISES_REFERRAL_ID")!!,
       crn = seedColumns.getStringOrNull("CRN")!!,
       eventNumber = seedColumns.getStringOrNull("EVENT_NUMBER")!!,
       keyWorkerStaffCode = seedColumns.getStringOrNullMinus1IsNull("KEY_WORKER_STAFF_CODE"),
@@ -114,6 +116,7 @@ class Cas1ImportDeliusReferralsSeedJob(
       Cas1DeliusBookingImportEntity(
         id = UUID.randomUUID(),
         row.bookingId,
+        row.approvedPremisesReferralId,
         row.crn,
         row.eventNumber,
         row.keyWorkerStaffCode,
@@ -156,6 +159,7 @@ class Cas1ImportDeliusReferralsSeedJob(
 
 data class Cas1DeliusBookingManagementDataRow(
   val bookingId: UUID?,
+  val approvedPremisesReferralId: String,
   val crn: String,
   val eventNumber: String,
   val keyWorkerStaffCode: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -137,6 +137,7 @@ class Cas1SpaceBookingService(
         nonArrivalReason = null,
         deliusEventNumber = application.eventNumber,
         migratedManagementInfoFrom = null,
+        deliusId = null,
       ),
     )
 

--- a/src/main/resources/db/migration/all/20250127085455__add_delius_id_to_referral_imports.sql
+++ b/src/main/resources/db/migration/all/20250127085455__add_delius_id_to_referral_imports.sql
@@ -1,0 +1,2 @@
+TRUNCATE cas1_delius_booking_import;
+ALTER TABLE cas1_delius_booking_import ADD approved_premises_referral_id text NOT NULL;

--- a/src/main/resources/db/migration/all/20250127085906__add_delius_id_to_space_bookings.sql
+++ b/src/main/resources/db/migration/all/20250127085906__add_delius_id_to_space_bookings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas1_space_bookings ADD delius_id text NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -232,5 +232,6 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     nonArrivalReason = this.nonArrivalReason(),
     deliusEventNumber = this.deliusEventNumber(),
     migratedManagementInfoFrom = this.migratedManagementInfoFrom(),
+    deliusId = null,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest.kt
@@ -185,6 +185,7 @@ class SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest : SeedTestBase() {
     val migratedBooking1 = premiseSpaceBookings[0]
 
     assertThat(migratedBooking1.crn).isEqualTo("CRN1")
+    assertThat(migratedBooking1.deliusId).isEqualTo("Delius Referral Id")
     assertThat(migratedBooking1.deliusEventNumber).isEqualTo("67")
     assertThat(migratedBooking1.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking1.placementRequest).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest.kt
@@ -95,6 +95,7 @@ class SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest : SeedTestBase() {
     val deliusBooking = Cas1DeliusBookingImportEntity(
       id = UUID.randomUUID(),
       bookingId = null,
+      approvedPremisesReferralId = "Delius Referral Id",
       crn = "CRN1",
       eventNumber = "67",
       keyWorkerStaffCode = "kw001",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
@@ -163,7 +163,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       Cas1DeliusBookingImportEntity(
         id = UUID.randomUUID(),
         bookingId = booking1ManagementInfoFromDelius.id,
-        approvedPremisesReferralId = "Delius Ref Id",
+        approvedPremisesReferralId = "Delius Ref Id 1",
         crn = "irrelevant",
         eventNumber = "irrelevant",
         keyWorkerStaffCode = "kw001",
@@ -214,7 +214,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       Cas1DeliusBookingImportEntity(
         id = UUID.randomUUID(),
         bookingId = booking2MinimalManagementInfoFromDelius.id,
-        approvedPremisesReferralId = "Delius Ref Id",
+        approvedPremisesReferralId = "Delius Ref Id 2",
         crn = "irrelevant",
         eventNumber = "irrelevant",
         keyWorkerStaffCode = null,
@@ -329,6 +329,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
     val migratedBooking1 = premiseSpaceBookings[0]
     assertBookingIsDeleted(booking1ManagementInfoFromDelius.id)
     assertThat(migratedBooking1.id).isEqualTo(booking1ManagementInfoFromDelius.id)
+    assertThat(migratedBooking1.deliusId).isEqualTo("Delius Ref Id 1")
     assertThat(migratedBooking1.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking1.placementRequest!!.id).isEqualTo(placementRequest1.id)
     assertThat(migratedBooking1.createdBy!!.id).isEqualTo(booking1CreatedByUser.id)
@@ -362,6 +363,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
     val migratedBooking2 = premiseSpaceBookings[1]
     assertBookingIsDeleted(booking1ManagementInfoFromDelius.id)
     assertThat(migratedBooking2.id).isEqualTo(booking2MinimalManagementInfoFromDelius.id)
+    assertThat(migratedBooking2.deliusId).isEqualTo("Delius Ref Id 2")
     assertThat(migratedBooking2.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking2.placementRequest!!.id).isEqualTo(placementRequest2.id)
     assertThat(migratedBooking2.createdBy!!.id).isEqualTo(booking2CreatedByUser.id)
@@ -395,6 +397,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
     val migratedBooking3 = premiseSpaceBookings[2]
     assertBookingIsDeleted(booking3ManagementInfoFromLegacyBooking.id)
     assertThat(migratedBooking3.id).isEqualTo(booking3ManagementInfoFromLegacyBooking.id)
+    assertThat(migratedBooking3.deliusId).isNull()
     assertThat(migratedBooking3.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking3.placementRequest!!.id).isEqualTo(placementRequest3.id)
     assertThat(migratedBooking3.createdBy!!.id).isEqualTo(booking3CreatedByUser.id)
@@ -429,6 +432,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
     val migratedBooking4 = premiseSpaceBookings[3]
     assertBookingIsDeleted(booking4OfflineApplicationNoManagementInfo.id)
     assertThat(migratedBooking4.id).isEqualTo(booking4OfflineApplicationNoManagementInfo.id)
+    assertThat(migratedBooking4.deliusId).isNull()
     assertThat(migratedBooking4.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking4.placementRequest).isNull()
     assertThat(migratedBooking4.createdBy!!.id).isEqualTo(booking4CreatedByUser.id)
@@ -462,6 +466,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
     val migratedBooking5 = premiseSpaceBookings[4]
     assertBookingIsDeleted(booking5OfflineNoDomainEventOrManagementInfo.id)
     assertThat(migratedBooking5.id).isEqualTo(booking5OfflineNoDomainEventOrManagementInfo.id)
+    assertThat(migratedBooking5.deliusId).isNull()
     assertThat(migratedBooking5.premises.id).isEqualTo(premises.id)
     assertThat(migratedBooking5.placementRequest).isNull()
     assertThat(migratedBooking5.createdBy).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
@@ -163,6 +163,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       Cas1DeliusBookingImportEntity(
         id = UUID.randomUUID(),
         bookingId = booking1ManagementInfoFromDelius.id,
+        approvedPremisesReferralId = "Delius Ref Id",
         crn = "irrelevant",
         eventNumber = "irrelevant",
         keyWorkerStaffCode = "kw001",
@@ -213,6 +214,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       Cas1DeliusBookingImportEntity(
         id = UUID.randomUUID(),
         bookingId = booking2MinimalManagementInfoFromDelius.id,
+        approvedPremisesReferralId = "Delius Ref Id",
         crn = "irrelevant",
         eventNumber = "irrelevant",
         keyWorkerStaffCode = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusReferralsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusReferralsTest.kt
@@ -43,6 +43,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
       contents = listOf(
         Cas1DeliusImportDeliusReferralRowRaw(
           crn = "CRN1",
+          approvedPremisesReferralId = "Delius Referral Id",
           eventNumber = "1",
           decisionCode = "A1",
           decisionDescription = "Accepted Code 1",
@@ -57,6 +58,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
     val bookingImport = cas1DeliusBookingImportRepository.findAll()[0]
 
     assertThat(bookingImport.bookingId).isNull()
+    assertThat(bookingImport.approvedPremisesReferralId).isEqualTo("Delius Referral Id")
     assertThat(bookingImport.crn).isEqualTo("CRN1")
     assertThat(bookingImport.eventNumber).isEqualTo("1")
     assertThat(bookingImport.keyWorkerStaffCode).isNull()
@@ -88,6 +90,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
         Cas1DeliusImportDeliusReferralRowRaw(
           bookingId = bookingId.toString(),
           crn = "CRN2",
+          approvedPremisesReferralId = "Delius Referral Id",
           eventNumber = "2",
           keyWorkerStaffCode = "kw1",
           keyWorkerForename = "kwForename",
@@ -118,6 +121,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
     val bookingImport = cas1DeliusBookingImportRepository.findAll()[0]
 
     assertThat(bookingImport.bookingId).isEqualTo(bookingId)
+    assertThat(bookingImport.approvedPremisesReferralId).isEqualTo("Delius Referral Id")
     assertThat(bookingImport.crn).isEqualTo("CRN2")
     assertThat(bookingImport.eventNumber).isEqualTo("2")
     assertThat(bookingImport.keyWorkerStaffCode).isEqualTo("kw1")
@@ -153,6 +157,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
       allDecisionCodes.map { decisionCode ->
         Cas1DeliusImportDeliusReferralRowRaw(
           crn = decisionCode,
+          approvedPremisesReferralId = "Delius Referral Id",
           eventNumber = "1",
           decisionCode = decisionCode,
           decisionDescription = decisionCode,
@@ -170,7 +175,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
   }
 
   @Test
-  fun `Fields containing invalid data are set to null`() {
+  fun `Fields containing data known to be unusable are set to null`() {
     val bookingId = UUID.randomUUID()
 
     withCsv(
@@ -178,6 +183,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
       contents = listOf(
         Cas1DeliusImportDeliusReferralRowRaw(
           bookingId = bookingId.toString(),
+          approvedPremisesReferralId = "Delius Referral Id",
           crn = "CRN1",
           eventNumber = "1",
           expectedArrivalDate = "2024-06-15 00:00:00",
@@ -212,6 +218,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
     val builder = CsvBuilder()
       .withUnquotedFields(
         "BOOKING_ID",
+        "APPROVED_PREMISES_REFERRAL_ID",
         "CRN",
         "EVENT_NUMBER",
         "KEY_WORKER_STAFF_CODE",
@@ -240,6 +247,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
     this.forEach {
       builder
         .withQuotedField(it.bookingId)
+        .withQuotedField(it.approvedPremisesReferralId)
         .withQuotedField(it.crn)
         .withQuotedField(it.eventNumber)
         .withQuotedField(it.keyWorkerStaffCode)
@@ -270,6 +278,7 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
 
   data class Cas1DeliusImportDeliusReferralRowRaw(
     val bookingId: String = "",
+    val approvedPremisesReferralId: String = "",
     val crn: String = "",
     val eventNumber: String = "",
     val keyWorkerStaffCode: String = "",


### PR DESCRIPTION
This PR captures the Delius ID provided in the delius referral export when backfilling booking information from Delius for space bookings. It does this in two places

1. When migrating CAS1 legacy `Bookings` to `SpaceBookings`
2. When creating `SpaceBookings` for accepted referrals created directly in Delius

This will be used to provide a report to Delius of CAS1 bookings ID for backfilled bookings (point 2 above), allowing domain events to be processed 