### PR TITLE
APS-1863 Remove placementRequest from tasks endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/TypedTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/TypedTask.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -12,6 +11,5 @@ sealed class TypedTask(
   val crn: String,
 ) {
   data class Assessment(val entity: ApprovedPremisesAssessmentEntity) : TypedTask(entity.id, entity.createdAt, entity.application.crn)
-  data class PlacementRequest(val entity: PlacementRequestEntity) : TypedTask(entity.id, entity.createdAt, entity.application.crn)
   data class PlacementApplication(val entity: PlacementApplicationEntity) : TypedTask(entity.id, entity.createdAt, entity.application.crn)
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -379,7 +379,6 @@ components:
       type: string
       enum:
         - Assessment
-        - PlacementRequest
         - PlacementApplication
     LocalAuthorityArea:
       type: object

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4801,7 +4801,6 @@ components:
       type: string
       enum:
         - Assessment
-        - PlacementRequest
         - PlacementApplication
     LocalAuthorityArea:
       type: object

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1735,7 +1735,6 @@ components:
       type: string
       enum:
         - Assessment
-        - PlacementRequest
         - PlacementApplication
     LocalAuthorityArea:
       type: object

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -988,7 +988,6 @@ components:
       type: string
       enum:
         - Assessment
-        - PlacementRequest
         - PlacementApplication
     LocalAuthorityArea:
       type: object

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -479,7 +479,6 @@ components:
       type: string
       enum:
         - Assessment
-        - PlacementRequest
         - PlacementApplication
     LocalAuthorityArea:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -153,23 +153,9 @@ class TasksTest {
 
               val offenderSummaries = getOffenderSummaries(offenderDetails)
 
-              val (task1, _) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-              )
-
               val (task2, _) = givenAnAssessmentForApprovedPremises(
                 allocatedToUser = otherUser,
                 createdByUser = otherUser,
-                crn = offenderDetails.otherIds.crn,
-              )
-
-              val (task3, _) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
                 crn = offenderDetails.otherIds.crn,
               )
 
@@ -190,16 +176,8 @@ class TasksTest {
               )
 
               val expectedTasks = listOf(
-                taskTransformer.transformPlacementRequestToTask(
-                  task1,
-                  offenderSummaries,
-                ),
                 taskTransformer.transformAssessmentToTask(
                   task2,
-                  offenderSummaries,
-                ),
-                taskTransformer.transformPlacementRequestToTask(
-                  task3,
                   offenderSummaries,
                 ),
                 taskTransformer.transformPlacementApplicationToTask(
@@ -265,23 +243,9 @@ class TasksTest {
 
               val offenderSummaries = getOffenderSummaries(offenderDetails)
 
-              val (task1, _) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-              )
-
               val (task2, _) = givenAnAssessmentForApprovedPremises(
                 allocatedToUser = otherUser,
                 createdByUser = otherUser,
-                crn = offenderDetails.otherIds.crn,
-              )
-
-              val (task3, _) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
                 crn = offenderDetails.otherIds.crn,
               )
 
@@ -299,17 +263,6 @@ class TasksTest {
                 allocatedToUser = otherUser,
                 createdByUser = otherUser,
                 crn = offenderDetails.otherIds.crn,
-              )
-
-              val placementRequests = listOf(
-                taskTransformer.transformPlacementRequestToTask(
-                  task1,
-                  offenderSummaries,
-                ),
-                taskTransformer.transformPlacementRequestToTask(
-                  task3,
-                  offenderSummaries,
-                ),
               )
 
               val placementApplications = listOf(
@@ -333,7 +286,6 @@ class TasksTest {
               tasks = mapOf(
                 TaskType.assessment to assessments,
                 TaskType.placementApplication to placementApplications,
-                TaskType.placementRequest to placementRequests,
               )
             }
           }
@@ -341,7 +293,7 @@ class TasksTest {
       }
 
       @ParameterizedTest
-      @EnumSource(value = TaskType::class, names = ["assessment", "placementRequest", "placementApplication"])
+      @EnumSource(value = TaskType::class, names = ["assessment", "placementApplication"])
       fun `Get all tasks filters by a single type`(taskType: TaskType) {
         val url = "/tasks?page=1&sortBy=createdAt&sortDirection=asc&types=${taskType.value}"
         val expectedTasks = tasks[taskType]!!.sortedBy { it.dueDate }
@@ -361,7 +313,7 @@ class TasksTest {
       }
 
       @ParameterizedTest
-      @CsvSource("assessment,placementRequest", "assessment,placementApplication", "placementRequest,placementApplication", "placementApplication,placementRequest")
+      @CsvSource("assessment,placementApplication")
       fun `Get all tasks filters by multiple types`(taskType1: TaskType, taskType2: TaskType) {
         val url = "/tasks?page=1&sortBy=createdAt&sortDirection=asc&types=${taskType1.value}&types=${taskType2.value}"
         val expectedTasks = listOf(
@@ -385,10 +337,9 @@ class TasksTest {
 
       @Test
       fun `Get all tasks returns all task types`() {
-        val url = "/tasks?page=1&sortBy=createdAt&sortDirection=asc&types=Assessment&types=PlacementRequest&types=PlacementApplication"
+        val url = "/tasks?page=1&sortBy=createdAt&sortDirection=asc&types=Assessment&types=PlacementApplication"
         val expectedTasks = listOf(
           tasks[TaskType.assessment]!!,
-          tasks[TaskType.placementRequest]!!,
           tasks[TaskType.placementApplication]!!,
         ).flatten().sortedBy { it.dueDate }
 
@@ -411,7 +362,6 @@ class TasksTest {
         val url = "/tasks?page=1&sortBy=createdAt&sortDirection=asc"
         val expectedTasks = listOf(
           tasks[TaskType.assessment]!!,
-          tasks[TaskType.placementRequest]!!,
           tasks[TaskType.placementApplication]!!,
         ).flatten().sortedBy { it.dueDate }
 
@@ -489,22 +439,6 @@ class TasksTest {
                 apArea = apArea2,
               )
 
-              val (placementRequest) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-                apArea = apArea,
-              )
-
-              givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-                apArea = apArea2,
-              )
-
               val assessments = listOf(
                 taskTransformer.transformAssessmentToTask(
                   assessment,
@@ -519,17 +453,9 @@ class TasksTest {
                 ),
               )
 
-              val placementRequests = listOf(
-                taskTransformer.transformPlacementRequestToTask(
-                  placementRequest,
-                  offenderSummaries,
-                ),
-              )
-
               tasks = mapOf(
                 TaskType.assessment to assessments,
                 TaskType.placementApplication to placementApplications,
-                TaskType.placementRequest to placementRequests,
               )
             }
           }
@@ -537,7 +463,7 @@ class TasksTest {
       }
 
       @ParameterizedTest
-      @EnumSource(value = TaskType::class, names = ["assessment", "placementRequest", "placementApplication"])
+      @EnumSource(value = TaskType::class, names = ["assessment", "placementApplication"])
       fun `it filters by Ap Area and task type`(taskType: TaskType) {
         val expectedTasks = tasks[taskType]
         val url = "/tasks?type=${taskType.value}&apAreaId=${apArea.id}"
@@ -560,7 +486,6 @@ class TasksTest {
       fun `it filters by all areas with no task type`() {
         val expectedTasks = listOf(
           tasks[TaskType.assessment]!!,
-          tasks[TaskType.placementRequest]!!,
           tasks[TaskType.placementApplication]!!,
         ).flatten().sortedBy { it.dueDate }
 
@@ -637,22 +562,6 @@ class TasksTest {
                 cruManagementArea = cruArea2,
               )
 
-              val (placementRequest) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-                cruManagementArea = cruArea,
-              )
-
-              givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-                cruManagementArea = cruArea2,
-              )
-
               val assessments = listOf(
                 taskTransformer.transformAssessmentToTask(
                   assessment,
@@ -667,17 +576,9 @@ class TasksTest {
                 ),
               )
 
-              val placementRequests = listOf(
-                taskTransformer.transformPlacementRequestToTask(
-                  placementRequest,
-                  offenderSummaries,
-                ),
-              )
-
               tasks = mapOf(
                 TaskType.assessment to assessments,
                 TaskType.placementApplication to placementApplications,
-                TaskType.placementRequest to placementRequests,
               )
             }
           }
@@ -708,7 +609,6 @@ class TasksTest {
       fun `it filters by all areas with no task type`() {
         val expectedTasks = listOf(
           tasks[TaskType.assessment]!!,
-          tasks[TaskType.placementRequest]!!,
           tasks[TaskType.placementApplication]!!,
         ).flatten().sortedBy { it.dueDate }
 
@@ -779,20 +679,6 @@ class TasksTest {
                 submittedAt = OffsetDateTime.now(),
               )
 
-              givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-              )
-
-              val (allocatablePlacementRequest) = givenAPlacementRequest(
-                placementRequestAllocatedTo = user,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-              )
-
               val assessments = listOf(
                 taskTransformer.transformAssessmentToTask(
                   allocatableAssessment,
@@ -807,17 +693,9 @@ class TasksTest {
                 ),
               )
 
-              val placementRequests = listOf(
-                taskTransformer.transformPlacementRequestToTask(
-                  allocatablePlacementRequest,
-                  offenderSummaries,
-                ),
-              )
-
               tasks = mapOf(
                 TaskType.assessment to assessments,
                 TaskType.placementApplication to placementApplications,
-                TaskType.placementRequest to placementRequests,
               )
             }
           }
@@ -825,7 +703,7 @@ class TasksTest {
       }
 
       @ParameterizedTest
-      @EnumSource(value = TaskType::class, names = ["assessment", "placementRequest", "placementApplication"])
+      @EnumSource(value = TaskType::class, names = ["assessment", "placementApplication"])
       fun `it filters by user and task type`(taskType: TaskType) {
         val expectedTasks = tasks[taskType]
         val url = "/tasks?type=${taskType.value}&allocatedToUserId=${user.id}"
@@ -848,7 +726,6 @@ class TasksTest {
       fun `it filters by user with all tasks`() {
         val expectedTasks = listOf(
           tasks[TaskType.assessment]!!,
-          tasks[TaskType.placementRequest]!!,
           tasks[TaskType.placementApplication]!!,
         ).flatten().sortedBy { it.dueDate }
 
@@ -889,10 +766,6 @@ class TasksTest {
                   "unallocated" to 3,
                   "withdrawn" to 1,
                 ),
-                TaskType.placementRequest to mapOf(
-                  "allocated" to 2,
-                  "unallocated" to 4,
-                ),
                 TaskType.placementApplication to mapOf(
                   "allocated" to 3,
                   "unallocated" to 2,
@@ -927,24 +800,6 @@ class TasksTest {
                   createdByUser = otherUser,
                   crn = offenderDetails.otherIds.crn,
                   isWithdrawn = true,
-                )
-              }
-
-              repeat(counts[TaskType.placementRequest]!!["allocated"]!!) {
-                givenAPlacementRequest(
-                  placementRequestAllocatedTo = otherUser,
-                  assessmentAllocatedTo = otherUser,
-                  createdByUser = user,
-                  crn = offenderDetails.otherIds.crn,
-                )
-              }
-
-              repeat(counts[TaskType.placementRequest]!!["unallocated"]!!) {
-                givenAPlacementRequest(
-                  null,
-                  assessmentAllocatedTo = otherUser,
-                  createdByUser = user,
-                  crn = offenderDetails.otherIds.crn,
                 )
               }
 
@@ -993,10 +848,6 @@ class TasksTest {
         "assessment,allocated,2",
         "assessment,unallocated,1",
         "assessment,unallocated,1",
-        "placementRequest,allocated,1",
-        "placementRequest,allocated,2",
-        "placementRequest,unallocated,1",
-        "placementRequest,unallocated,2",
         "placementApplication,allocated,1",
         "placementApplication,allocated,2",
         "placementApplication,unallocated,1",
@@ -1026,7 +877,6 @@ class TasksTest {
       ) {
         val itemCount = listOf(
           counts[TaskType.assessment]!![allocatedFilter]!!,
-          counts[TaskType.placementRequest]!![allocatedFilter]!!,
           counts[TaskType.placementApplication]!![allocatedFilter]!!,
         ).sum()
 
@@ -1041,8 +891,6 @@ class TasksTest {
         val itemCount = listOf(
           counts[TaskType.assessment]!!["allocated"]!!,
           counts[TaskType.assessment]!!["unallocated"]!!,
-          counts[TaskType.placementRequest]!!["allocated"]!!,
-          counts[TaskType.placementRequest]!!["unallocated"]!!,
           counts[TaskType.placementApplication]!!["allocated"]!!,
           counts[TaskType.placementApplication]!!["unallocated"]!!,
         ).sum()
@@ -1084,7 +932,6 @@ class TasksTest {
 
               val offenderSummaries = getOffenderSummaries(offenderDetails)
               val assessmentTasks = mutableMapOf<UserQualification, List<Task>>()
-              val placementRequestTasks = mutableMapOf<UserQualification, List<Task>>()
               val placementApplicationTasks = mutableMapOf<UserQualification, List<Task>>()
 
               fun createAssessmentTask(
@@ -1101,25 +948,6 @@ class TasksTest {
 
                 return taskTransformer.transformAssessmentToTask(
                   assessment,
-                  offenderSummaries,
-                )
-              }
-
-              fun createPlacementRequestTask(
-                requiredQualification: UserQualification?,
-                noticeType: Cas1ApplicationTimelinessCategory? = Cas1ApplicationTimelinessCategory.standard,
-              ): Task {
-                val (placementRequest, _) = givenAPlacementRequest(
-                  placementRequestAllocatedTo = otherUser,
-                  assessmentAllocatedTo = otherUser,
-                  createdByUser = user,
-                  crn = offenderDetails.otherIds.crn,
-                  requiredQualification = requiredQualification,
-                  noticeType = noticeType,
-                )
-
-                return taskTransformer.transformPlacementRequestToTask(
-                  placementRequest,
                   offenderSummaries,
                 )
               }
@@ -1155,9 +983,6 @@ class TasksTest {
                 assessmentTasks[qualification] = listOf(
                   createAssessmentTask(qualification),
                 )
-                placementRequestTasks[qualification] = listOf(
-                  createPlacementRequestTask(qualification),
-                )
                 placementApplicationTasks[qualification] = listOf(
                   createPlacementApplicationTask(qualification),
                 )
@@ -1167,10 +992,6 @@ class TasksTest {
                 createAssessmentTask(null, Cas1ApplicationTimelinessCategory.shortNotice),
                 createAssessmentTask(null, Cas1ApplicationTimelinessCategory.emergency),
               )
-              placementRequestTasks[UserQualification.EMERGENCY] = listOf(
-                createPlacementRequestTask(null, Cas1ApplicationTimelinessCategory.shortNotice),
-                createPlacementRequestTask(null, Cas1ApplicationTimelinessCategory.emergency),
-              )
               placementApplicationTasks[UserQualification.EMERGENCY] = listOf(
                 createPlacementApplicationTask(null, Cas1ApplicationTimelinessCategory.shortNotice),
                 createPlacementApplicationTask(null, Cas1ApplicationTimelinessCategory.emergency),
@@ -1178,7 +999,6 @@ class TasksTest {
 
               tasks = mapOf(
                 TaskType.assessment to assessmentTasks,
-                TaskType.placementRequest to placementRequestTasks,
                 TaskType.placementApplication to placementApplicationTasks,
               )
             }
@@ -1193,12 +1013,6 @@ class TasksTest {
         "assessment,EMERGENCY",
         "assessment,RECOVERY_FOCUSED",
         "assessment,MENTAL_HEALTH_SPECIALIST",
-
-        "placementRequest,PIPE",
-        "placementRequest,ESAP",
-        "placementRequest,EMERGENCY",
-        "placementRequest,RECOVERY_FOCUSED",
-        "placementRequest,MENTAL_HEALTH_SPECIALIST",
 
         "placementApplication,PIPE",
         "placementApplication,ESAP",
@@ -1236,7 +1050,6 @@ class TasksTest {
         val url = "/tasks?requiredQualification=${qualification.name.lowercase()}"
         val expectedTasks = listOf(
           tasks[TaskType.assessment]!![qualification]!!,
-          tasks[TaskType.placementRequest]!![qualification]!!,
           tasks[TaskType.placementApplication]!![qualification]!!,
         ).flatten()
 
@@ -1291,22 +1104,6 @@ class TasksTest {
                   name = "ANOTHER",
                 )
 
-                val (placementRequest1, _) = givenAPlacementRequest(
-                  placementRequestAllocatedTo = otherUser,
-                  assessmentAllocatedTo = otherUser,
-                  createdByUser = user,
-                  crn = offenderDetails1.otherIds.crn,
-                  name = "SOMEONE",
-                )
-
-                val (placementRequest2, _) = givenAPlacementRequest(
-                  placementRequestAllocatedTo = otherUser,
-                  assessmentAllocatedTo = otherUser,
-                  createdByUser = user,
-                  crn = offenderDetails2.otherIds.crn,
-                  name = "ANOTHER",
-                )
-
                 val placementApplication1 = givenAPlacementApplication(
                   createdByUser = user,
                   allocatedToUser = user,
@@ -1338,10 +1135,6 @@ class TasksTest {
                     placementApplication1,
                     offenderSummaries1,
                   ),
-                  TaskType.placementRequest to taskTransformer.transformPlacementRequestToTask(
-                    placementRequest1,
-                    offenderSummaries1,
-                  ),
                 )
 
                 crnMatchTasks = mapOf(
@@ -1353,10 +1146,6 @@ class TasksTest {
                     placementApplication2,
                     offenderSummaries2,
                   ),
-                  TaskType.placementRequest to taskTransformer.transformPlacementRequestToTask(
-                    placementRequest2,
-                    offenderSummaries2,
-                  ),
                 )
               }
             }
@@ -1365,7 +1154,7 @@ class TasksTest {
       }
 
       @ParameterizedTest
-      @EnumSource(value = TaskType::class, names = ["assessment", "placementRequest", "placementApplication"])
+      @EnumSource(value = TaskType::class, names = ["assessment", "placementApplication"])
       fun `Get all tasks filters by name and task type`(taskType: TaskType) {
         val url = "/tasks?type=${taskType.value}&crnOrName=someone"
 
@@ -1384,7 +1173,7 @@ class TasksTest {
       }
 
       @ParameterizedTest
-      @EnumSource(value = TaskType::class, names = ["assessment", "placementRequest", "placementApplication"])
+      @EnumSource(value = TaskType::class, names = ["assessment", "placementApplication"])
       fun `Get all tasks filters by CRN and task type`(taskType: TaskType) {
         val url = "/tasks?type=${taskType.value}&crnOrName=$crn"
 
@@ -1407,7 +1196,6 @@ class TasksTest {
         val url = "/tasks?crnOrName=someone"
         val expectedTasks = listOf(
           nameMatchTasks[TaskType.assessment],
-          nameMatchTasks[TaskType.placementRequest],
           nameMatchTasks[TaskType.placementApplication],
         )
 
@@ -1430,7 +1218,6 @@ class TasksTest {
         val url = "/tasks?crnOrName=$crn"
         val expectedTasks = listOf(
           crnMatchTasks[TaskType.assessment],
-          crnMatchTasks[TaskType.placementRequest],
           crnMatchTasks[TaskType.placementApplication],
         )
 
@@ -1484,41 +1271,6 @@ class TasksTest {
                 submittedAt = OffsetDateTime.now(),
               )
 
-              val (placementRequest1, _) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-              )
-
-              val (placementRequest2, _) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-                booking = bookingEntityFactory.produceAndPersist {
-                  withPremises(
-                    approvedPremisesEntityFactory.produceAndPersist {
-                      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                      withYieldedProbationRegion { givenAProbationRegion() }
-                    },
-                  )
-                },
-              )
-
-              val (placementRequest3, _) = givenAPlacementRequest(
-                placementRequestAllocatedTo = otherUser,
-                assessmentAllocatedTo = otherUser,
-                createdByUser = user,
-                crn = offenderDetails.otherIds.crn,
-              )
-
-              placementRequest3.bookingNotMades = mutableListOf(
-                bookingNotMadeFactory.produceAndPersist {
-                  withPlacementRequest(placementRequest3)
-                },
-              )
-
               val placementApplication1 = givenAPlacementApplication(
                 createdByUser = otherUser,
                 allocatedToUser = user,
@@ -1545,10 +1297,6 @@ class TasksTest {
                   assessment1,
                   offenderSummaries,
                 ),
-                taskTransformer.transformPlacementRequestToTask(
-                  placementRequest1,
-                  offenderSummaries,
-                ),
                 taskTransformer.transformPlacementApplicationToTask(
                   placementApplication1,
                   offenderSummaries,
@@ -1561,31 +1309,11 @@ class TasksTest {
                   offenderSummaries,
                 ),
                 taskTransformer.transformAssessmentToTask(
-                  placementRequest1.assessment,
-                  offenderSummaries,
-                ),
-                taskTransformer.transformAssessmentToTask(
-                  placementRequest2.assessment,
-                  offenderSummaries,
-                ),
-                taskTransformer.transformAssessmentToTask(
-                  placementRequest3.assessment,
-                  offenderSummaries,
-                ),
-                taskTransformer.transformAssessmentToTask(
                   assessmentTestRepository.findAllByApplication(placementApplication1.application)[0],
                   offenderSummaries,
                 ),
                 taskTransformer.transformAssessmentToTask(
                   assessmentTestRepository.findAllByApplication(placementApplication2.application)[0],
-                  offenderSummaries,
-                ),
-                taskTransformer.transformPlacementRequestToTask(
-                  placementRequest2,
-                  offenderSummaries,
-                ),
-                taskTransformer.transformPlacementRequestToTask(
-                  placementRequest3,
                   offenderSummaries,
                 ),
                 taskTransformer.transformPlacementApplicationToTask(
@@ -1780,12 +1508,6 @@ class TasksTest {
               tasks = mapOf()
               tasks += assessments.mapValues {
                 taskTransformer.transformAssessmentToTask(
-                  it.value,
-                  offenderSummaries,
-                )
-              }
-              tasks += placementRequests.mapValues {
-                taskTransformer.transformPlacementRequestToTask(
                   it.value,
                   offenderSummaries,
                 )
@@ -2215,48 +1937,6 @@ class TasksTest {
                         0,
                         0,
                       ),
-                    ),
-                  ),
-                ),
-              ),
-            )
-        }
-      }
-    }
-
-    @Test
-    fun `Get a Placement Request Task for an application returns users with MATCHER role`() {
-      val (workflowManager, jwt) = givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER))
-      val (creator, _) = givenAUser()
-      val (matcher, _) = givenAUser(roles = listOf(UserRole.CAS1_MATCHER))
-      val (assessor, _) = givenAUser(roles = listOf(UserRole.CAS1_ASSESSOR))
-
-      givenAnOffender { offenderDetails, _ ->
-        givenAPlacementRequest(
-          placementRequestAllocatedTo = creator,
-          assessmentAllocatedTo = creator,
-          createdByUser = creator,
-          crn = offenderDetails.otherIds.crn,
-        ) { placementRequest, _ ->
-
-          webTestClient.get()
-            .uri("/tasks/placement-request/${placementRequest.id}")
-            .header("Authorization", "Bearer $jwt")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .json(
-              objectMapper.writeValueAsString(
-                TaskWrapper(
-                  task = taskTransformer.transformPlacementRequestToTask(
-                    placementRequest,
-                    getOffenderSummaries(offenderDetails),
-                  ),
-                  users = listOf(
-                    userTransformer.transformJpaToAPIUserWithWorkload(
-                      matcher,
-                      UserWorkload(0, 0, 0),
                     ),
                   ),
                 ),
@@ -2870,65 +2550,6 @@ class TasksTest {
                   .jsonPath("detail")
                   .isEqualTo("This assessment has already been reallocated: ${existingAssessment.id}")
               }
-            }
-          }
-        }
-      }
-    }
-
-    @Test
-    fun `Reallocating a placement request to different assessor returns 201, creates new placement request, deallocates old one`() {
-      givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
-        givenAUser(
-          roles = listOf(UserRole.CAS1_MATCHER),
-        ) { assigneeUser, _ ->
-          givenAnOffender { offenderDetails, _ ->
-            givenAPlacementRequest(
-              createdByUser = user,
-              placementRequestAllocatedTo = user,
-              assessmentAllocatedTo = user,
-              crn = offenderDetails.otherIds.crn,
-            ) { existingPlacementRequest, _ ->
-              webTestClient.post()
-                .uri("/tasks/placement-request/${existingPlacementRequest.id}/allocations")
-                .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
-                .bodyValue(
-                  NewReallocation(
-                    userId = assigneeUser.id,
-                  ),
-                )
-                .exchange()
-                .expectStatus()
-                .isCreated
-                .expectBody()
-                .json(
-                  objectMapper.writeValueAsString(
-                    Reallocation(
-                      user = userTransformer.transformJpaToApi(
-                        assigneeUser,
-                        ServiceName.approvedPremises,
-                      ) as ApprovedPremisesUser,
-                      taskType = TaskType.placementRequest,
-                    ),
-                  ),
-                )
-
-              val placementRequests = placementRequestRepository.findAll()
-              val allocatedPlacementRequest = placementRequests.find { it.allocatedToUser!!.id == assigneeUser.id }
-
-              assertThat(placementRequests.first { it.id == existingPlacementRequest.id }.reallocatedAt).isNotNull
-              assertThat(allocatedPlacementRequest).isNotNull
-
-              val desirableCriteria =
-                allocatedPlacementRequest!!.placementRequirements.desirableCriteria.map { it.propertyName }
-              val essentialCriteria =
-                allocatedPlacementRequest.placementRequirements.essentialCriteria.map { it.propertyName }
-
-              assertThat(desirableCriteria)
-                .isEqualTo(existingPlacementRequest.placementRequirements.desirableCriteria.map { it.propertyName })
-              assertThat(essentialCriteria)
-                .isEqualTo(existingPlacementRequest.placementRequirements.essentialCriteria.map { it.propertyName })
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -20,8 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
@@ -31,8 +29,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Task
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TaskRepository
@@ -48,9 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PlacementApplica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TaskService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
@@ -61,25 +55,21 @@ class TaskServiceTest {
   private val assessmentServiceMock = mockk<AssessmentService>()
   private val userServiceMock = mockk<UserService>()
   private val userAccessServiceMock = mockk<UserAccessService>()
-  private val placementRequestServiceMock = mockk<PlacementRequestService>()
   private val userTransformerMock = mockk<UserTransformer>()
   private val placementApplicationServiceMock = mockk<PlacementApplicationService>()
   private val taskRepositoryMock = mockk<TaskRepository>()
   private val assessmentRepositoryMock = mockk<AssessmentRepository>()
   private val placementApplicationRepositoryMock = mockk<PlacementApplicationRepository>()
-  private val placementRequestRepositoryMock = mockk<PlacementRequestRepository>()
 
   private val taskService = TaskService(
     assessmentServiceMock,
     userServiceMock,
     userAccessServiceMock,
-    placementRequestServiceMock,
     userTransformerMock,
     placementApplicationServiceMock,
     taskRepositoryMock,
     assessmentRepositoryMock,
     placementApplicationRepositoryMock,
-    placementRequestRepositoryMock,
   )
 
   private val requestUserWithPermission = UserEntityFactory()
@@ -155,49 +145,6 @@ class TaskServiceTest {
     )
 
     val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUser.id, assessment.id)
-
-    assertThatCasResult(result).isSuccess().with {
-      Assertions.assertThat(it).isEqualTo(reallocation)
-    }
-  }
-
-  @Test
-  fun `reallocateTask reallocates a placementRequest`() {
-    every { userAccessServiceMock.userCanReallocateTask(any()) } returns true
-
-    val assigneeUser = generateAndStubAssigneeUser()
-    val application = generateApplication()
-    val assessment = ApprovedPremisesAssessmentEntityFactory()
-      .withApplication(application)
-      .withAllocatedToUser(assigneeUser)
-      .produce()
-
-    val placementRequest = PlacementRequestEntityFactory()
-      .withPlacementRequirements(
-        PlacementRequirementsEntityFactory()
-          .withApplication(assessment.application as ApprovedPremisesApplicationEntity)
-          .withAssessment(assessment)
-          .produce(),
-      )
-      .withApplication(application)
-      .withAssessment(assessment)
-      .withAllocatedToUser(assigneeUser)
-      .produce()
-
-    every {
-      placementRequestServiceMock.reallocatePlacementRequest(assigneeUser, placementRequest.id)
-    } returns CasResult.Success(placementRequest)
-
-    val transformedUser = mockk<ApprovedPremisesUser>()
-
-    every { userTransformerMock.transformJpaToApi(assigneeUser, ServiceName.approvedPremises) } returns transformedUser
-
-    val reallocation = Reallocation(
-      taskType = TaskType.placementRequest,
-      user = transformedUser,
-    )
-
-    val result = taskService.reallocateTask(requestUserWithPermission, TaskType.placementRequest, assigneeUser.id, placementRequest.id)
 
     assertThatCasResult(result).isSuccess().with {
       Assertions.assertThat(it).isEqualTo(reallocation)
@@ -302,7 +249,6 @@ class TaskServiceTest {
 
     val assessments = List(3) { generateAssessment() }
     val placementApplications = List(4) { generatePlacementApplication() }
-    val placementRequests = List(4) { generatePlacementRequest() }
 
     val assessmentTasks = assessments.map {
       Task(
@@ -326,23 +272,10 @@ class TaskServiceTest {
         it.decision?.name,
       )
     }
-    val placementRequestTasks = placementRequests.map {
-      val (outcomeRecordedAt, outcome) = it.getOutcomeDetails()
-      Task(
-        it.id,
-        it.createdAt.toLocalDateTime(),
-        TaskEntityType.PLACEMENT_REQUEST,
-        it.application.name,
-        it.allocatedToUser?.name,
-        outcomeRecordedAt?.toLocalDateTime(),
-        outcome?.name,
-      )
-    }
 
     val tasks = listOf(
       assessmentTasks,
       placementApplicationTasks,
-      placementRequestTasks,
     ).flatten()
 
     val page = mockk<Page<Task>>()
@@ -369,7 +302,6 @@ class TaskServiceTest {
     } returns page
     every { assessmentRepositoryMock.findAllById(assessments.map { it.id }) } returns assessments
     every { placementApplicationRepositoryMock.findAllById(placementApplications.map { it.id }) } returns placementApplications
-    every { placementRequestRepositoryMock.findAllById(placementRequests.map { it.id }) } returns placementRequests
 
     val pageCriteria = PageCriteria(TaskSortField.createdAt, SortDirection.asc, 1)
 
@@ -392,7 +324,6 @@ class TaskServiceTest {
     val expectedTasks = listOf(
       assessments.map { TypedTask.Assessment(it) },
       placementApplications.map { TypedTask.PlacementApplication(it) },
-      placementRequests.map { TypedTask.PlacementRequest(it) },
     ).flatten()
 
     Assertions.assertThat(result.first).isEqualTo(expectedTasks)
@@ -456,21 +387,6 @@ class TaskServiceTest {
           }
           .produce(),
       )
-      .produce()
-  }
-
-  private fun generatePlacementRequest(): PlacementRequestEntity {
-    val application = generateApplication()
-    val assessment = generateAssessment(application)
-    return PlacementRequestEntityFactory()
-      .withPlacementRequirements(
-        PlacementRequirementsEntityFactory()
-          .withApplication(application as ApprovedPremisesApplicationEntity)
-          .withAssessment(assessment)
-          .produce(),
-      )
-      .withApplication(application)
-      .withAssessment(assessment)
       .produce()
   }
 }


### PR DESCRIPTION
Placement requests were previously treated as tasks, meaning they can be allocated to specific users (similar to assessments and placement requests). This approach is no longer used and has been replaced by the CRU Dashboard.

This PR removes support for placement requests for the tasks endpoints.

A subsequent PR will remove the PlacementRequest reallocated_at and allocated_to properties from the code