### PR TITLE
updated role check on applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -119,12 +119,6 @@ class UserAccessService(
       else -> false
     }
 
-  fun getTemporaryAccommodationApplicationAccessLevelForUser(user: UserEntity): TemporaryAccommodationApplicationAccessLevel = when {
-    user.hasRole(UserRole.CAS3_ASSESSOR) -> TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION
-    user.hasRole(UserRole.CAS3_REFERRER) -> TemporaryAccommodationApplicationAccessLevel.SELF
-    else -> TemporaryAccommodationApplicationAccessLevel.NONE
-  }
-
   fun userCanViewApplication(user: UserEntity, application: ApplicationEntity): Boolean {
     if (user.id == application.createdByUser.id) {
       return true
@@ -225,10 +219,4 @@ class UserAccessService(
       userCanAccessRegion(user, (application as TemporaryAccommodationApplicationEntity).probationRegion.id) &&
       user.hasRole(UserRole.CAS3_REFERRER)
   }
-}
-
-enum class TemporaryAccommodationApplicationAccessLevel {
-  SUBMITTED_IN_REGION,
-  SELF,
-  NONE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -75,10 +75,13 @@ class UserService(
 
   fun getUserForRequest(): UserEntity {
     val username = getDeliusUserNameForRequest()
-    val user = getExistingUserOrCreateDeprecated(username)
-    ensureCas3UserHasCas3ReferrerRole(user)
-
-    return user
+    val userResponse = getExistingUserOrCreate(username)
+    if (userResponse is GetUserResponse.Success) {
+      ensureCas3UserHasCas3ReferrerRole(userResponse.user)
+      return userResponse.user
+    } else {
+      throw InternalServerErrorProblem("Could not find staff record for user $username")
+    }
   }
 
   fun getUserForProfile(username: String): GetUserResponse {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -262,72 +262,21 @@ class ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Get all applications returns 200 - when user is CAS3_ASSESSOR then returns submitted applications in region`() {
+    fun `Get all applications returns 403 - when user is CAS3_ASSESSOR`() {
       givenAProbationRegion { probationRegion ->
-        givenAUser(roles = listOf(UserRole.CAS3_REFERRER), probationRegion = probationRegion) { otherUser, _ ->
-          givenAUser(
-            roles = listOf(UserRole.CAS3_ASSESSOR),
-            probationRegion = probationRegion,
-          ) { assessorUser, jwt ->
-            givenAnOffender { offenderDetails, _ ->
-              temporaryAccommodationApplicationJsonSchemaRepository.deleteAll()
+        givenAUser(
+          roles = listOf(UserRole.CAS3_ASSESSOR),
+          probationRegion = probationRegion,
+        ) { assessorUser, jwt ->
+          givenAnOffender { offenderDetails, _ ->
 
-              val applicationSchema = createApplicationSchema()
-
-              val dateTime = OffsetDateTime.parse("2023-06-01T12:34:56.789+01:00")
-              val application =
-                createTempApplicationEntity(applicationSchema, otherUser, offenderDetails, probationRegion, dateTime)
-
-              val notSubmittedApplication =
-                createTempApplicationEntity(applicationSchema, otherUser, offenderDetails, probationRegion, null)
-
-              val otherProbationRegion = probationRegionEntityFactory.produceAndPersist {
-                withYieldedApArea { givenAnApArea() }
-              }
-
-              val notInRegionApplication =
-                createTempApplicationEntity(
-                  applicationSchema,
-                  otherUser,
-                  offenderDetails,
-                  otherProbationRegion,
-                  dateTime,
-                )
-
-              apDeliusContextAddResponseToUserAccessCall(
-                listOf(
-                  CaseAccessFactory()
-                    .withCrn(offenderDetails.otherIds.crn)
-                    .produce(),
-                ),
-                assessorUser.deliusUsername,
-              )
-
-              val responseBody = webTestClient.get()
-                .uri("/applications")
-                .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
-                .exchange()
-                .expectStatus()
-                .isOk
-                .bodyAsListOfObjects<TemporaryAccommodationApplicationSummary>()
-
-              assertThat(responseBody).anyMatch {
-                application.id == it.id &&
-                  application.crn == it.person.crn &&
-                  application.createdAt.toInstant() == it.createdAt &&
-                  application.createdByUser.id == it.createdByUserId &&
-                  application.submittedAt?.toInstant() == it.submittedAt
-              }
-
-              assertThat(responseBody).noneMatch {
-                notInRegionApplication.id == it.id
-              }
-
-              assertThat(responseBody).noneMatch {
-                notSubmittedApplication.id == it.id
-              }
-            }
+            webTestClient.get()
+              .uri("/applications")
+              .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+              .exchange()
+              .expectStatus()
+              .isForbidden
           }
         }
       }
@@ -347,12 +296,6 @@ class ApplicationTest : IntegrationTestBase() {
       withData("{}")
       withProbationRegion(probationRegion)
     }
-
-    private fun createApplicationSchema(): TemporaryAccommodationApplicationJsonSchemaEntity =
-      temporaryAccommodationApplicationJsonSchemaEntityFactory.produceAndPersist {
-        withAddedAt(OffsetDateTime.now())
-        withId(UUID.randomUUID())
-      }
 
     @Test
     fun `Get all applications returns 200 for TA - when user is CAS3_REFERRER then returns all applications for user`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -37,7 +37,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService.LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TemporaryAccommodationApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
@@ -770,25 +769,6 @@ class UserAccessServiceTest {
 
     assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesInUserRegion)).isFalse
     assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesNotInUserRegion)).isFalse
-  }
-
-  @Test
-  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns SUBMITTED_IN_REGION if the user has the CAS3_ASSESSOR role`() {
-    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
-
-    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION)
-  }
-
-  @Test
-  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns SELF if the user has the CAS3_REFERRER role`() {
-    user.addRoleForUnitTest(CAS3_REFERRER)
-
-    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SELF)
-  }
-
-  @Test
-  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns NONE if the user has no suitable role`() {
-    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.NONE)
   }
 
   @Test


### PR DESCRIPTION
Application endpoint should only be called by CAS3 Refferers, so assessors should never be hitting this endpoint. Added validation so if people don't have the referrer role, they should not be able to access it.

Chunked the calls to delius into batches of 500, as this will throw an error if the person has 501+ open applications (unlikely outside of dev/test)

refactored call to getExistingUserOrCreateDeprecated to use getExistingUserOrCreate