### PR TITLE
APS-1796 - Disable concurrent seed jobs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusReferralsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusReferralsSeedJob.kt
@@ -45,7 +45,7 @@ class Cas1ImportDeliusReferralsSeedJob(
     "HOSTEL_CODE",
   ),
   runInTransaction = false,
-  processRowsConcurrently = true,
+  processRowsConcurrently = false,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 


### PR DESCRIPTION
Running the delius import seed job concurrently in preproduction is causing memory issues. Whilst we investigate and resolve we’re disabling this behaviour to unblock our ability to import delius referrals for testing