### PR TITLE
fix: includes a missed built api file for TimelineEventContentPayload

### DIFF
--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -1011,7 +1011,6 @@ components:
         - Assessment
         - PlacementRequest
         - PlacementApplication
-        - BookingAppeal
     LocalAuthorityArea:
       type: object
       properties:
@@ -4239,6 +4238,8 @@ components:
           type: string
         createdBy:
           $ref: '#/components/schemas/User'
+        payload:
+          $ref: '#/components/schemas/TimelineEventContentPayload'
         associatedUrls:
           type: array
           items:
@@ -5449,6 +5450,101 @@ components:
         - SHARED_PROPERTY
         - SINGLE_OCCUPANCY
         - WHEELCHAIR_ACCESSIBLE
+    TimelineEventContentPayload:
+      type: object
+      description: "Base schema for all timeline event payloads"
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventType'
+        premises:
+          $ref: '#/components/schemas/NamedId'
+        schemaVersion:
+          type: integer
+      required:
+        - type
+        - premises
+        - schemaVersion
+      discriminator:
+        propertyName: "type"
+        mapping:
+          approved_premises_booking_changed: '#/components/schemas/BookingChangedContentPayload'
+    BookingChangedContentPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/TimelineEventContentPayload"
+      properties:
+        expectedArrival:
+          type: string
+          format: date
+        expectedDeparture:
+          type: string
+          format: date
+        previousExpectedArrival:
+          description: "Only populated if the new value is different, and where schema version = 2"
+          type: string
+          format: date
+        previousExpectedDeparture:
+          description: "Only populated if the new value is different, and where schema version = 2"
+          type: string
+          format: date
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+        previousCharacteristics:
+          description: "Only populated if the new value is different, and where schema version = 2"
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+      required:
+        - expectedArrival
+        - expectedDeparture
+    Cas1SpaceCharacteristic:
+      type: string
+      description: All of the characteristics of both premises and rooms
+      enum:
+        - acceptsChildSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsNonSexualChildOffenders
+        - acceptsSexOffenders
+        - additionalRestrictions
+        - hasArsonInsuranceConditions
+        - hasBrailleSignage
+        - hasCallForAssistance
+        - hasCrib7Bedding
+        - hasEnSuite
+        - hasFixedMobilityAids
+        - hasHearingLoop
+        - hasLift
+        - hasNearbySprinkler
+        - hasSmokeDetector
+        - hasStepFreeAccess
+        - hasStepFreeAccessToCommunalAreas
+        - hasTactileFlooring
+        - hasTurningSpace
+        - hasWheelChairAccessibleBathrooms
+        - hasWideAccessToCommunalAreas
+        - hasWideDoor
+        - hasWideStepFreeAccess
+        - isArsonDesignated
+        - isArsonSuitable
+        - isCatered
+        - isESAP
+        - isFullyFm
+        - isGroundFloor
+        - isGroundFloorNrOffice
+        - isIAP
+        - isPIPE
+        - isRecoveryFocussed
+        - isSemiSpecialistMentalHealth
+        - isSingle
+        - isStepFreeDesignated
+        - isSuitableForVulnerable
+        - isSuitedForSexOffenders
+        - isTopFloorVulnerable
+        - isWheelchairAccessible
+        - isWheelchairDesignated
+
     NewCas2v2Application:
       type: object
       properties:


### PR DESCRIPTION
Just a miss, the TimeLineEventCntent Patyload gets pulled in by the domain events, the change was made by 'bala' in the _shared.yml and I guess our new cas2v2 api wasn't in yet.