### PR TITLE
Preload & Simplify Open Api Docs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
@@ -38,15 +38,6 @@ class SwaggerConfiguration {
   }
 
   @Bean
-  fun cas1Only(): GroupedOpenApi {
-    return GroupedOpenApi.builder()
-      .group("CAS1")
-      .displayName("CAS1")
-      .pathsToMatch("/**/cas1/**")
-      .build()
-  }
-
-  @Bean
   fun cas1Shared(): GroupedOpenApi {
     return GroupedOpenApi.builder()
       .group("CAS1Shared")
@@ -66,15 +57,6 @@ class SwaggerConfiguration {
   }
 
   @Bean
-  fun cas2Only(): GroupedOpenApi {
-    return GroupedOpenApi.builder()
-      .group("CAS2")
-      .displayName("CAS2")
-      .pathsToMatch("/**/cas2/**")
-      .build()
-  }
-
-  @Bean
   fun cas2Shared(): GroupedOpenApi {
     return GroupedOpenApi.builder()
       .group("CAS2Shared")
@@ -89,15 +71,6 @@ class SwaggerConfiguration {
       .group("CAS2DomainEvents")
       .displayName("CAS2 Domain Events")
       .pathsToMatch("/**/events/cas2/**")
-      .build()
-  }
-
-  @Bean
-  fun cas3Only(): GroupedOpenApi {
-    return GroupedOpenApi.builder()
-      .group("CAS3")
-      .displayName("CAS3")
-      .pathsToMatch("/**/cas3/**")
       .build()
   }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,9 @@ spring:
     ansi:
       enabled: ALWAYS
 
+springdoc:
+  pre-loading-enabled: false
+
 hmpps.sqs:
   provider: localstack
   topics:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,7 @@ springdoc:
     urls-primary-name: "All CAS"
   remove-broken-reference-definitions: false
   writer-with-order-by-keys: true
+  pre-loading-enabled: true
 
 server:
   port: 8080

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -51,6 +51,9 @@ spring:
   cache:
     type: none
 
+springdoc:
+  pre-loading-enabled: false
+
 hmpps.sqs:
   useWebToken: false
   provider: localstack


### PR DESCRIPTION
We have found that the intial load of open api docs takes quite some time leading to ‘broken pipe’ errors, presumably because the client gives up and times out.

This commit preloads the open docs in all environments other than local. Local tests suggests that the initilisation runs concurrent from start, so shouldn’t have too much of an effect on startup times. Regardless, we have disabled this for local deployments where the endpoints are rarely used.

This commit also removes the CAS-specific open api docs that don’t include shared elements.