### PR TITLE
Remove BOOKING_CREATE perm from WORKFLOW_MANAGER

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -72,7 +72,6 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_ADHOC_BOOKING_CREATE,
       UserPermission.CAS1_APPLICATION_WITHDRAW_OTHERS,
       UserPermission.CAS1_BOOKING_CHANGE_DATES,
-      UserPermission.CAS1_BOOKING_CREATE,
       UserPermission.CAS1_BOOKING_WITHDRAW,
       UserPermission.CAS1_PREMISES_VIEW,
       UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
@@ -89,6 +89,7 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
         UserRole.CAS1_ASSESSOR,
         UserRole.CAS1_MATCHER,
         UserRole.CAS1_WORKFLOW_MANAGER,
+        UserRole.CAS1_CRU_MEMBER,
         UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA,
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -446,7 +446,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
     matcherUsername: String,
   ) {
     val managerJwt = givenAUser(
-      roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER),
+      roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER, UserRole.CAS1_CRU_MEMBER),
       staffDetail = StaffDetailFactory.staffDetail(deliusUsername = matcherUsername),
       probationRegion = givenAProbationRegion(apArea = givenAnApArea(name = matcherApAreaName)),
     ).second


### PR DESCRIPTION
Only users with a `CRU Member` role should have the ability to create a booking.

As all CRU users in production have the `CRU Member` role, we can remove this permission from the `Workflow Manager` role

**User with no CRU Member Roles**

![Screenshot 2025-01-29 at 16 46 43](https://github.com/user-attachments/assets/08589358-c9f7-4d0d-a039-44b95ef995ff)

**User with CRU Member Role**

![Screenshot 2025-01-29 at 16 46 54](https://github.com/user-attachments/assets/b0d8f381-5be2-4ced-a07b-7a1e716275d6)

**User with CRU Member Find and Book Beta Role**

![Screenshot 2025-01-29 at 16 47 13](https://github.com/user-attachments/assets/79f8d5c1-bc41-4f66-bd70-4969c880ea9e)
