### PR TITLE
APS-1879 tidy up user seed jobs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AbstractUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AbstractUsersSeedJob.kt
@@ -7,15 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService.GetUserResponse
 
-/**
- * Seeds users, along with their roles and qualifications.
- *
- *  NB: this clears roles and qualifications.
- *
- *  If you want to seed users without touching the pre-existing
- *  roles/qualifications of pre-existing users, then consider
- *  using ApStaffUsersSeedJob.
- */
 @SuppressWarnings("TooGenericExceptionThrown", "TooGenericExceptionCaught")
 abstract class AbstractUsersSeedJob(
   private val useRolesForServices: List<ServiceName>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AllCasUsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/AllCasUsersSeedJob.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
-
-import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-
-@Component
-class AllCasUsersSeedJob(userService: UserService) : AbstractUsersSeedJob(ServiceName.entries, userService)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApStaffUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesBookingCancelSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BackfillActiveSpaceBookingsCreatedInDelius
@@ -72,8 +71,8 @@ class SeedService(
       val job: SeedJob<*> = when (seedFileType) {
         SeedFileType.approvedPremises -> getBean(Cas1SeedPremisesFromCsvJob::class)
         SeedFileType.approvedPremisesRooms -> getBean(ApprovedPremisesRoomsSeedJob::class)
-        SeedFileType.user -> getBean(AllCasUsersSeedJob::class)
-        SeedFileType.approvedPremisesApStaffUsers -> getBean(ApStaffUsersSeedJob::class)
+        SeedFileType.user -> getBean(UsersSeedJob::class)
+        SeedFileType.usersBasic -> getBean(UsersBasicSeedJob::class)
         SeedFileType.nomisUsers -> getBean(NomisUsersSeedJob::class)
         SeedFileType.externalUsers -> getBean(ExternalUsersSeedJob::class)
         SeedFileType.cas2Applications -> getBean(Cas2ApplicationsSeedJob::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/UsersSeedJob.kt
@@ -1,18 +1,16 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas3
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.AbstractUsersSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersBasicSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
 /**
  * Seeds users, along with their roles and qualifications.
  *
- * NB: this clears any existing CAS3 roles and qualifications
+ * NB: this clears roles and qualifications for both CAS1 and CAS3
  *
  * If you want to seed users without touching the pre-existing roles/qualifications
  * of pre-existing users, then consider using [UsersBasicSeedJob].
  */
 @Component
-class Cas3UsersSeedJob(userService: UserService) : AbstractUsersSeedJob(listOf(ServiceName.temporaryAccommodation), userService)
+class UsersSeedJob(userService: UserService) : AbstractUsersSeedJob(ServiceName.entries, userService)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UsersSeedJob.kt
@@ -3,7 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.AbstractUsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UsersBasicSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 
+/**
+ * Seeds users, along with their roles and qualifications.
+ *
+ * NB: this clears any existing CAS1 roles and qualifications
+ *
+ * If you want to seed users without touching the pre-existing roles/qualifications
+ * of pre-existing users, then consider using [UsersBasicSeedJob].
+ */
 @Component
 class Cas1UsersSeedJob(userService: UserService) : AbstractUsersSeedJob(listOf(ServiceName.approvedPremises), userService)

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3725,7 +3725,7 @@ components:
         - characteristics
         - update_noms_number
         - update_users_from_api
-        - approved_premises_ap_staff_users
+        - users_basic
         - approved_premises_cancel_bookings
         - approved_premises_assessment_more_info_bug_fix
         - approved_premises_redact_assessment_details

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8147,7 +8147,7 @@ components:
         - characteristics
         - update_noms_number
         - update_users_from_api
-        - approved_premises_ap_staff_users
+        - users_basic
         - approved_premises_cancel_bookings
         - approved_premises_assessment_more_info_bug_fix
         - approved_premises_redact_assessment_details

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5081,7 +5081,7 @@ components:
         - characteristics
         - update_noms_number
         - update_users_from_api
-        - approved_premises_ap_staff_users
+        - users_basic
         - approved_premises_cancel_bookings
         - approved_premises_assessment_more_info_bug_fix
         - approved_premises_redact_assessment_details

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4334,7 +4334,7 @@ components:
         - characteristics
         - update_noms_number
         - update_users_from_api
-        - approved_premises_ap_staff_users
+        - users_basic
         - approved_premises_cancel_bookings
         - approved_premises_assessment_more_info_bug_fix
         - approved_premises_redact_assessment_details

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -4355,7 +4355,7 @@ components:
         - characteristics
         - update_noms_number
         - update_users_from_api
-        - approved_premises_ap_staff_users
+        - users_basic
         - approved_premises_cancel_bookings
         - approved_premises_assessment_more_info_bug_fix
         - approved_premises_redact_assessment_details

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3825,7 +3825,7 @@ components:
         - characteristics
         - update_noms_number
         - update_users_from_api
-        - approved_premises_ap_staff_users
+        - users_basic
         - approved_premises_cancel_bookings
         - approved_premises_assessment_more_info_bug_fix
         - approved_premises_redact_assessment_details


### PR DESCRIPTION
This commit renames the `ApStaffUsersSeedJob` to `UsersBasicSeedJob` to better reflect it’s purpose, and improves documentation on the users seed jobs.

It also improves the logs to indicate if a user already existed