### PR TITLE
Clone CAS3 repo to run e2e in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,16 @@ jobs:
         type: string
         default: dev
     steps:
-      - checkout
+      - run:
+          name: Checkout e2e repo
+          command: |
+            git clone https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git .
+      - run:
+          name: install
+          command: apt-get install xz-utils
+      - run:
+          name: Update npm
+          command: 'npm install -g npm@9.8.1'
       - node/install-packages
       - cypress/install
       - persist_to_workspace:


### PR DESCRIPTION
We cant just call `checkout` in circle ci becaus we need to checkout cas 3 repo and not the api repo.

Reintroduce steps that were removed as part of from https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/2893