### PR TITLE
Updated Get Applications logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -96,7 +96,7 @@ class ApplicationsController(
 
     val user = userService.getUserForRequest()
 
-    val applications = applicationService.getAllApplicationsForUsername(user.deliusUsername, serviceName)
+    val applications = applicationService.getAllApplicationsForUsername(user, serviceName)
 
       /*
       This code is inefficient:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -119,12 +119,6 @@ class UserAccessService(
       else -> false
     }
 
-  fun getTemporaryAccommodationApplicationAccessLevelForUser(user: UserEntity): TemporaryAccommodationApplicationAccessLevel = when {
-    user.hasRole(UserRole.CAS3_ASSESSOR) -> TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION
-    user.hasRole(UserRole.CAS3_REFERRER) -> TemporaryAccommodationApplicationAccessLevel.SELF
-    else -> TemporaryAccommodationApplicationAccessLevel.NONE
-  }
-
   fun userCanViewApplication(user: UserEntity, application: ApplicationEntity): Boolean {
     if (user.id == application.createdByUser.id) {
       return true
@@ -225,10 +219,4 @@ class UserAccessService(
       userCanAccessRegion(user, (application as TemporaryAccommodationApplicationEntity).probationRegion.id) &&
       user.hasRole(UserRole.CAS3_REFERRER)
   }
-}
-
-enum class TemporaryAccommodationApplicationAccessLevel {
-  SUBMITTED_IN_REGION,
-  SELF,
-  NONE,
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -153,26 +153,12 @@ class ApplicationServiceTest {
   )
 
   @Test
-  fun `Get all applications where Probation Officer with provided distinguished name does not exist returns empty list`() {
-    val distinguishedName = "SOMEPERSON"
-
-    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns null
-
-    assertThat(
-      applicationService.getAllApplicationsForUsername(
-        distinguishedName,
-        ServiceName.approvedPremises,
-      ),
-    ).isEmpty()
-  }
-
-  @Test
   fun `Get all applications where Probation Officer exists returns applications returned from repository`() {
     val userId = UUID.fromString("8a0624b8-8e92-47ce-b645-b65ea5a197d0")
-    val distinguishedName = "SOMEPERSON"
+    val deliusUsername = "SOMEPERSON"
     val userEntity = UserEntityFactory()
       .withId(userId)
-      .withDeliusUsername(distinguishedName)
+      .withDeliusUsername(deliusUsername)
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
           .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -200,16 +186,16 @@ class ApplicationServiceTest {
       },
     )
 
-    every { mockUserRepository.findByDeliusUsername(distinguishedName) } returns userEntity
+    every { mockUserRepository.findByDeliusUsername(deliusUsername) } returns userEntity
     every { mockApplicationRepository.findNonWithdrawnApprovedPremisesSummariesForUser(userId) } returns applicationSummaries
     every { mockJsonSchemaService.checkSchemaOutdated(any()) } answers { it.invocation.args[0] as ApplicationEntity }
 
     val crns = applicationSummaries.map { it.getCrn() }.distinct()
-    every { mockOffenderService.canAccessOffenders(distinguishedName, crns) } returns mapOf(crns.first() to true)
+    every { mockOffenderService.canAccessOffenders(deliusUsername, crns) } returns mapOf(crns.first() to true)
 
     assertThat(
       applicationService.getAllApplicationsForUsername(
-        distinguishedName,
+        userEntity = userEntity,
         ServiceName.approvedPremises,
       ),
     ).containsAll(applicationSummaries)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -37,7 +37,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService.LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TemporaryAccommodationApplicationAccessLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
@@ -770,25 +769,6 @@ class UserAccessServiceTest {
 
     assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesInUserRegion)).isFalse
     assertThat(userAccessService.currentUserCanViewPremisesStaff(temporaryAccommodationPremisesNotInUserRegion)).isFalse
-  }
-
-  @Test
-  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns SUBMITTED_IN_REGION if the user has the CAS3_ASSESSOR role`() {
-    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
-
-    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SUBMITTED_IN_REGION)
-  }
-
-  @Test
-  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns SELF if the user has the CAS3_REFERRER role`() {
-    user.addRoleForUnitTest(CAS3_REFERRER)
-
-    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.SELF)
-  }
-
-  @Test
-  fun `getTemporaryAccommodationApplicationAccessLevelForUser returns NONE if the user has no suitable role`() {
-    assertThat(userAccessService.getTemporaryAccommodationApplicationAccessLevelForUser(user)).isEqualTo(TemporaryAccommodationApplicationAccessLevel.NONE)
   }
 
   @Test


### PR DESCRIPTION
Previously if a user with ASSESSOR role called the getApplications endpoint, it would return all applications in a region. This endpoint now returns all applications that were created by the user.