### PR TITLE
APS-1796 Re-enable concurrent process of delius import

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,7 +130,7 @@ tasks.register("bootRunLocal") {
   doFirst {
     tasks.bootRun.configure {
       systemProperty("spring.profiles.active", "local")
-      jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=32323")
+      jvmArgs("-Xmx512m", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=32323")
     }
   }
   finalizedBy("bootRun")
@@ -141,7 +141,7 @@ tasks.register("bootRunDebug") {
   description = "Runs this project as a Spring Boot application with debug configuration"
   doFirst {
     tasks.bootRun.configure {
-      jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=32323")
+      jvmArgs("-Xmx512m", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=32323")
     }
   }
   finalizedBy("bootRun")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusReferralsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ImportDeliusReferralsSeedJob.kt
@@ -45,7 +45,7 @@ class Cas1ImportDeliusReferralsSeedJob(
     "HOSTEL_CODE",
   ),
   runInTransaction = false,
-  processRowsConcurrently = false,
+  processRowsConcurrently = true,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 


### PR DESCRIPTION
This commit makes fixes to the seed job concurrent procesisng to avoid memory issues, and subsequently re-enables concurrent processing for the `CAS1 Improt Delius Referrals Seed Job`.

The fix uses a semaphore to ensure there are only 5 processing or pending co-routines at any moment in time when processing the CSV. We found that if a coroutine was created for every row in the CSV immediately we encountered out of memory exceptions. Note that the import CSV file has 298132 rows.

If we to use a CSV reader that allowed us to stream the CSV rows instead of loading them all in to memory, this restricton may not be required.

The commit also configures locally ran instances of the service to have the same heap space as production (512MB)