### PR TITLE
APS-1863 Remove placement requests from task calculations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -303,6 +303,7 @@ data class PlacementRequestEntity(
   @OneToMany(mappedBy = "placementRequest", fetch = FetchType.LAZY)
   var spaceBookings: MutableList<Cas1SpaceBookingEntity>,
 
+  @Deprecated("Placement requests are no longer allocated to users")
   @ManyToOne
   @JoinColumn(name = "allocated_to_user_id")
   var allocatedToUser: UserEntity?,
@@ -310,6 +311,15 @@ data class PlacementRequestEntity(
   @OneToMany(mappedBy = "placementRequest", fetch = FetchType.LAZY)
   var bookingNotMades: MutableList<BookingNotMadeEntity>,
 
+  @Deprecated(
+    """
+    Placement requests are no longer allocated to users
+    
+    Note that because placement requests with a value in this field are excluded from
+    lists of active placement requests, we need to be careful if/when removing this
+    column to ensure such placement requests are still not shown
+    """,
+  )
   var reallocatedAt: OffsetDateTime?,
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -322,6 +332,7 @@ data class PlacementRequestEntity(
   @Enumerated(value = EnumType.STRING)
   var withdrawalReason: PlacementRequestWithdrawalReason?,
 
+  @Deprecated("Placement requests are no longer allocated to users and don't have a due at concept")
   var dueAt: OffsetDateTime?,
 
   @Version

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -219,42 +219,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID>, JpaSpecificationExec
           placement_application.allocated_to_user_id = u.id
           and placement_application.reallocated_at is null
           and placement_application.submitted_at > current_date - interval '30' day
-      ) as completedPlacementApplicationsInTheLastThirtyDays,
-      (
-        SELECT
-          count(*)
-        from
-          placement_requests placement_request
-        where
-          placement_request.allocated_to_user_id = u.id
-          and placement_request.booking_id is null
-          and placement_request.reallocated_at is null
-          and placement_request.is_withdrawn != true
-      ) as pendingPlacementRequests,
-      (
-        SELECT
-          count(*)
-        from
-          placement_requests placement_request
-          left join bookings booking on booking.id = placement_request.booking_id
-        where
-          placement_request.allocated_to_user_id = u.id
-          and placement_request.booking_id is not null
-          and placement_request.reallocated_at is null
-          and booking.created_at > current_date - interval '7' day
-      ) as completedPlacementRequestsInTheLastSevenDays,
-      (
-        SELECT
-          count(*)
-        from
-          placement_requests placement_request
-          left join bookings booking on booking.id = placement_request.booking_id
-        where
-          placement_request.allocated_to_user_id = u.id
-          and placement_request.booking_id is not null
-          and placement_request.reallocated_at is null
-          and booking.created_at > current_date - interval '30' day
-      ) as completedPlacementRequestsInTheLastThirtyDays
+      ) as completedPlacementApplicationsInTheLastThirtyDays
     FROM
       users u
     WHERE
@@ -397,9 +362,6 @@ interface UserWorkload {
   fun getPendingAssessments(): Int
   fun getCompletedAssessmentsInTheLastSevenDays(): Int
   fun getCompletedAssessmentsInTheLastThirtyDays(): Int
-  fun getPendingPlacementRequests(): Int
-  fun getCompletedPlacementRequestsInTheLastSevenDays(): Int
-  fun getCompletedPlacementRequestsInTheLastThirtyDays(): Int
   fun getPendingPlacementApplications(): Int
   fun getCompletedPlacementApplicationsInTheLastSevenDays(): Int
   fun getCompletedPlacementApplicationsInTheLastThirtyDays(): Int

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskService.kt
@@ -202,18 +202,15 @@ class TaskService(
       it.getUserId() to UserWorkload(
         numTasksPending = listOf(
           it.getPendingAssessments(),
-          it.getPendingPlacementRequests(),
           it.getPendingPlacementApplications(),
         ).sum(),
         numTasksCompleted7Days = listOf(
           it.getCompletedAssessmentsInTheLastSevenDays(),
           it.getCompletedPlacementApplicationsInTheLastSevenDays(),
-          it.getCompletedPlacementRequestsInTheLastSevenDays(),
         ).sum(),
         numTasksCompleted30Days = listOf(
           it.getCompletedAssessmentsInTheLastThirtyDays(),
           it.getCompletedPlacementApplicationsInTheLastThirtyDays(),
-          it.getCompletedPlacementRequestsInTheLastThirtyDays(),
         ).sum(),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -2257,12 +2257,6 @@ class TasksTest {
                   createPlacementApplication(null, allocatableUser, user, crn, decision = WITHDRAW)
                   createPlacementApplication(null, allocatableUser, user, crn, decision = WITHDRAWN_BY_PP)
 
-                  val numPlacementRequestsPending = 2
-                  repeat(numPlacementRequestsPending) {
-                    createPlacementRequest(null, allocatableUser, user, crn)
-                  }
-                  createPlacementRequest(null, allocatableUser, user, crn, isWithdrawn = true)
-
                   val numAssessmentsCompletedBetween1And7DaysAgo = 4
                   repeat(numAssessmentsCompletedBetween1And7DaysAgo) {
                     val days = kotlin.random.Random.nextInt(1, 7).toLong()
@@ -2273,12 +2267,6 @@ class TasksTest {
                   repeat(numPlacementApplicationsCompletedBetween1And7DaysAgo) {
                     val days = kotlin.random.Random.nextInt(1, 7).toLong()
                     createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
-                  }
-
-                  val numPlacementRequestsCompletedBetween1And7DaysAgo = 1
-                  repeat(numPlacementRequestsCompletedBetween1And7DaysAgo) {
-                    val days = kotlin.random.Random.nextInt(1, 7).toLong()
-                    createPlacementRequest(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
                   }
 
                   val numAssessmentsCompletedBetween8And30DaysAgo = 4
@@ -2293,27 +2281,18 @@ class TasksTest {
                     createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
                   }
 
-                  val numPlacementRequestsCompletedBetween8And30DaysAgo = 2
-                  repeat(numPlacementRequestsCompletedBetween8And30DaysAgo) {
-                    val days = kotlin.random.Random.nextInt(8, 30).toLong()
-                    createPlacementRequest(OffsetDateTime.now().minusDays(days), allocatableUser, user, crn)
-                  }
-
                   val numPendingTasks = listOf(
                     numAssessmentsPending,
-                    numPlacementRequestsPending,
                     numPlacementApplicationsPending,
                   ).sum()
                   val numTasksCompletedInTheLast7Days = listOf(
                     numAssessmentsCompletedBetween1And7DaysAgo,
                     numPlacementApplicationsCompletedBetween1And7DaysAgo,
-                    numPlacementRequestsCompletedBetween1And7DaysAgo,
                   ).sum()
                   val numTasksCompletedInTheLast30Days = listOf(
                     numTasksCompletedInTheLast7Days,
                     numAssessmentsCompletedBetween8And30DaysAgo,
                     numPlacementApplicationsCompletedBetween8And30DaysAgo,
-                    numPlacementRequestsCompletedBetween8And30DaysAgo,
                   ).sum()
 
                   webTestClient.get()
@@ -2365,36 +2344,6 @@ class TasksTest {
         decision = null,
         reallocated = false,
         submittedAt = completedAt,
-        isWithdrawn = isWithdrawn,
-      )
-    }
-
-    private fun createPlacementRequest(
-      completedAt: OffsetDateTime?,
-      allocatedUser: UserEntity,
-      createdByUser: UserEntity,
-      crn: String,
-      isWithdrawn: Boolean = false,
-    ) {
-      val booking = if (completedAt != null) {
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withProbationRegion(createdByUser.probationRegion)
-        }
-        bookingEntityFactory.produceAndPersist {
-          withPremises(premises)
-          withCreatedAt(completedAt)
-        }
-      } else {
-        null
-      }
-
-      givenAPlacementRequest(
-        placementRequestAllocatedTo = allocatedUser,
-        assessmentAllocatedTo = createdByUser,
-        createdByUser = createdByUser,
-        crn = crn,
-        booking = booking,
         isWithdrawn = isWithdrawn,
       )
     }


### PR DESCRIPTION
Placement requests have not been assigned and treated as Tasks since February 2024.

For this reason, this commit removes placement requests from the workload calculations as they’ll always return a value of 0. It also deprecates the various task-specific fields on the `PlacementRequestEntity`