### PR TITLE
CAS-486 Remove duplicate calls to delius when getting applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -98,18 +98,6 @@ class ApplicationsController(
 
     val applications = applicationService.getAllApplicationsForUsername(user, serviceName)
 
-      /*
-      This code is inefficient:
-
-      getPersonDetailAndTransformToSummary will retrieve/check user access (via the call to offenderService),
-      but the prior call to getAllApplicationsForUsername has already retrieved this information
-      and filtered out applications that the user cannot access. This leads to duplicate calls being made.
-
-      This check should be moved into getPersonDetailAndTransformToSummary (or a custom version of it to
-      avoid breaking behaviour for other callers), where we filter out any response from
-      offenderService.getInfoForPerson of type PersonInfoResult.Restricted. This will most likely have
-      to be optional as to not 'break' other functions using getPersonDetailAndTransformToSummary
-       */
     return ResponseEntity.ok(getPersonDetailAndTransformToSummary(applications, user))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -101,17 +101,11 @@ class ApplicationService(
   fun getApplication(applicationId: UUID) = applicationRepository.findByIdOrNull(applicationId)
 
   fun getAllApplicationsForUsername(userEntity: UserEntity, serviceName: ServiceName): List<ApplicationSummary> {
-    val applicationSummaries = when (serviceName) {
+    return when (serviceName) {
       ServiceName.approvedPremises -> getAllApprovedPremisesApplicationsForUser(userEntity)
       ServiceName.cas2 -> throw RuntimeException("CAS2 applications now require NomisUser")
       ServiceName.cas2v2 -> throw RuntimeException("CAS2v2 applications now require Cas2v2User")
       ServiceName.temporaryAccommodation -> getAllTemporaryAccommodationApplicationsForUser(userEntity)
-    }
-
-    val crns = applicationSummaries.map { it.getCrn() }.distinct()
-    val offendersAccess = offenderService.canAccessOffenders(userEntity.deliusUsername, crns)
-    return applicationSummaries.filter {
-      offendersAccess.containsKey(it.getCrn()) && offendersAccess[it.getCrn()] == true
     }
   }
 


### PR DESCRIPTION
This PR is to remove duplicate calls to delius to check if the user have access to the applications when calling Get `/applications` api endpoint