### PR TITLE
Create e2e test workflow

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -45,12 +45,12 @@ jobs:
           HMPPS_AUTH_NAME="${!name}"
           npm run test:e2e:ci -- --shard=${{ matrix.shard }}/4
       - name: Store Playwright report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report
       - name: Store test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results
@@ -81,7 +81,7 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
       - name: Store Playwright report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: e2e-tests/playwright-report
@@ -116,12 +116,12 @@ jobs:
   #           --config baseUrl=https://temporary-accommodation-${{ steps.context.outputs.environment }}.hmpps.service.justice.gov.uk \
   #           --spec $TESTS
   #     - name: Store screenshots
-  #       uses: actions/upload-artifact@v3
+  #       uses: actions/upload-artifact@v4
   #       with:
   #         name: screenshots
   #         path: e2e/screenshots
   #     - name: Store videos
-  #       uses: actions/upload-artifact@v3
+  #       uses: actions/upload-artifact@v4
   #       with:
   #         name: videos
   #         path: e2e/videos

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -24,6 +24,8 @@ jobs:
         run: git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git 
       # - name: Checkout branch
         # run:  git checkout ${{ github.event.inputs.branch }}
+      - name: Change directory to cloned repo
+        run: cd hmpps-approved-premises-ui
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,10 +1,14 @@
-name: run-e2e-tests
+name: Run E2E tests
 
 on:
+  push:
+    branches:
+      # - main
+      - 'CHORE/**' # only for now...
   workflow_dispatch:
     inputs:
       branch:
-        description: 'The Github branch to use'
+        description: 'The Github branch to run tests against'
         required: true
 
 jobs:
@@ -17,22 +21,20 @@ jobs:
       - uses: qoomon/actions--context@v1
         id: context
       - name: Clone E2E repo
-        run: |
-          git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git 
-          // TODO - switch to branch based on the input settings
-          // git checkout ${{ github.event.inputs.branch }}
+        run: git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git 
+      # - name: Checkout branch
+        # run:  git checkout ${{ github.event.inputs.branch }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Update npm
         run: npm install -g npm@9.8.1
-
       - name: Install Playwright
         run: npx playwright install
       - name: E2E Check
         run: |
-          SHARD=$(( ${{ strategy.job-index }} + 1 ))
+          SHARD=$(( ${{ matrix.shard }} + 1 ))
           username="HMPPS_AUTH_USERNAME_$SHARD"
           password="HMPPS_AUTH_PASSWORD_$SHARD"
           email="HMPPS_AUTH_EMAIL_$SHARD"
@@ -41,7 +43,7 @@ jobs:
           HMPPS_AUTH_PASSWORD="${!password}"
           HMPPS_AUTH_EMAIL="${!email}"
           HMPPS_AUTH_NAME="${!name}"
-          npm run test:e2e:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+          npm run test:e2e:ci -- --shard=${{ matrix.shard }}/4
       - name: Store Playwright report
         uses: actions/upload-artifact@v2
         with:
@@ -63,8 +65,9 @@ jobs:
     runs-on: [self-hosted, hmpps-github-actions-runner]
     steps:
       - name: Clone E2E repo
-        run: |
-          git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui.git .
+        run:  git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui.git
+      # - name: Checkout branch
+        # run:  git checkout ${{ github.event.inputs.branch }}
       - uses: qoomon/actions--context@v1
         id: context
       - name: Update npm
@@ -73,7 +76,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - run:
       - name: Install Playwright
         run: npx playwright install
       - name: Run E2E tests

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,16 +1,26 @@
 name: run-e2e-tests
 
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The Github branch to use'
+        required: true
 
 jobs:
   cas1_e2e_tests:
     runs-on: [self-hosted, hmpps-github-actions-runner]
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4] # this will create 4 parallel jobs
     steps:
       - uses: qoomon/actions--context@v1
         id: context
       - name: Clone E2E repo
         run: |
-          git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git .
+          git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git 
+          // TODO - switch to branch based on the input settings
+          // git checkout ${{ github.event.inputs.branch }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -22,7 +32,7 @@ jobs:
         run: npx playwright install
       - name: E2E Check
         run: |
-          SHARD="$((${CIRCLE_NODE_INDEX}+1))"
+          SHARD=$(( ${{ strategy.job-index }} + 1 ))
           username="HMPPS_AUTH_USERNAME_$SHARD"
           password="HMPPS_AUTH_PASSWORD_$SHARD"
           email="HMPPS_AUTH_EMAIL_$SHARD"

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,33 +5,34 @@ on:
     branches:
       # - main
       - 'CHORE/**' # only for now...
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'The Github branch to run tests against'
-        required: true
 
 jobs:
   cas1_e2e_tests:
     runs-on: [self-hosted, hmpps-github-actions-runner]
     strategy:
       matrix:
-        shard: [1, 2, 3, 4] # this will create 4 parallel jobs
+        shard: [0, 1, 2, 3]
+      fail-fast: false
+    defaults:
+      run:
+        working-directory: hmpps-approved-premises-ui
     steps:
-      - uses: qoomon/actions--context@v1
-        id: context
+      - name: Remove existing directory if it already exists
+        run: rm -rf hmpps-approved-premises-ui
+        working-directory: ${{ github.workspace }}
       - name: Clone E2E repo
-        run: git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git 
-      # - name: Checkout branch
-        # run:  git checkout ${{ github.event.inputs.branch }}
-      - name: Change directory to cloned repo
-        run: cd hmpps-approved-premises-ui
+        run: git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git
+        working-directory: ${{ github.workspace }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: '18.x'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
       - name: Update npm
         run: npm install -g npm@9.8.1
+      - name: Install dependencies
+        run: npm ci
       - name: Install Playwright
         run: npx playwright install
       - name: E2E Check
@@ -49,81 +50,12 @@ jobs:
       - name: Store Playwright report
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: playwright-report
+          retention-days: 30
       - name: Store test results
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-shard-${{ matrix.shard }}
           path: test-results
-      # - name: Notify Slack on failure - TODO
-      #   if: failure()
-      #   uses: slackapi/slack-github-action@v1.23.0
-      #   with:
-      #     channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-      #     slack-message: 'E2E tests failed. Check the logs for more details.'
-      #     bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-  cas2_e2e_tests:
-    runs-on: [self-hosted, hmpps-github-actions-runner]
-    steps:
-      - name: Clone E2E repo
-        run:  git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui.git
-      # - name: Checkout branch
-        # run:  git checkout ${{ github.event.inputs.branch }}
-      - uses: qoomon/actions--context@v1
-        id: context
-      - name: Update npm
-        run: npm install -g npm@10.1.0
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
-      - name: Install Playwright
-        run: npx playwright install
-      - name: Run E2E tests
-        run: npm run test:e2e
-      - name: Store Playwright report
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: e2e-tests/playwright-report
-      # - name: Notify Slack on failure - TODO
-      #   if: failure()
-      #   uses: slackapi/slack-github-action@v1.23.0
-      #   with:
-      #     channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-      #     slack-message: 'E2E tests failed. Check the logs for more details.'
-      #     bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-  # cas3_e2e_tests: - TODO, work out how to grab cypres env vars from circle ci
-  #   runs-on: [self-hosted, hmpps-github-actions-runner]
-  #   steps:
-  #     - uses: qoomon/actions--context@v1
-  #       id: context
-  #     - name: Checkout e2e repo
-  #       run: |
-  #         git clone https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git .
-  #     - name: Install xz-utils
-  #       run: apt-get install xz-utils
-  #     - name: Use Node.js
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 18.x
-  #     - name: Update npm
-  #       run: npm install -g npm@9.8.1
-  #     - name: E2E Check - ${{ steps.context.outputs.environment }}
-  #       run: |
-  #         TESTS=$(find "${{ github.workspace }}/e2e/tests" -name "*.feature" | paste -sd ',')
-  #         npm run test:e2e:ci -- \
-  #           --env "assessor_username=${{ env.CYPRESS_ASSESSOR_USERNAME}}_${{ steps.context.outputs.environment }},assessor_password=${{ env.CYPRESS_ASSESSOR_PASSWORD}}_${{ steps.context.outputs.environment }},referrer_username=${{ env.CYPRESS_REFERRER_USERNAME}}_${{ steps.context.outputs.environment }},referrer_password=${{ env.CYPRESS_REFERRER_PASSWORD}}_${{ steps.context.outputs.environment }},acting_user_probation_region_id=${{ env.CYPRESS_ACTING_USER_PROBATION_REGION_ID}}_${{ steps.context.outputs.environment }},acting_user_probation_region_name=${{ env.CYPRESS_ACTING_USER_PROBATION_REGION_NAME}}_${{ steps.context.outputs.environment }},environment=${{ env.CYPRESS_ENVIRONMENT}}_${{ steps.context.outputs.environment }}" \
-  #           --config baseUrl=https://temporary-accommodation-${{ steps.context.outputs.environment }}.hmpps.service.justice.gov.uk \
-  #           --spec $TESTS
-  #     - name: Store screenshots
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: screenshots
-  #         path: e2e/screenshots
-  #     - name: Store videos
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: videos
-  #         path: e2e/videos
+          retention-days: 30

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -45,12 +45,12 @@ jobs:
           HMPPS_AUTH_NAME="${!name}"
           npm run test:e2e:ci -- --shard=${{ matrix.shard }}/4
       - name: Store Playwright report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: playwright-report
           path: playwright-report
       - name: Store test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: test-results
@@ -81,7 +81,7 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
       - name: Store Playwright report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: playwright-report
           path: e2e-tests/playwright-report
@@ -116,12 +116,12 @@ jobs:
   #           --config baseUrl=https://temporary-accommodation-${{ steps.context.outputs.environment }}.hmpps.service.justice.gov.uk \
   #           --spec $TESTS
   #     - name: Store screenshots
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       with:
   #         name: screenshots
   #         path: e2e/screenshots
   #     - name: Store videos
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       with:
   #         name: videos
   #         path: e2e/videos

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,0 +1,115 @@
+name: run-e2e-tests
+
+on: [workflow_dispatch]
+
+jobs:
+  cas1_e2e_tests:
+    runs-on: [self-hosted, hmpps-github-actions-runner]
+    steps:
+      - uses: qoomon/actions--context@v1
+        id: context
+      - name: Clone E2E repo
+        run: |
+          git clone https://github.com/ministryofjustice/hmpps-approved-premises-ui.git .
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+      - name: Update npm
+        run: npm install -g npm@9.8.1
+
+      - name: Install Playwright
+        run: npx playwright install
+      - name: E2E Check
+        run: |
+          SHARD="$((${CIRCLE_NODE_INDEX}+1))"
+          username="HMPPS_AUTH_USERNAME_$SHARD"
+          password="HMPPS_AUTH_PASSWORD_$SHARD"
+          email="HMPPS_AUTH_EMAIL_$SHARD"
+          name="HMPPS_AUTH_NAME_$SHARD"
+          HMPPS_AUTH_USERNAME="${!username}"
+          HMPPS_AUTH_PASSWORD="${!password}"
+          HMPPS_AUTH_EMAIL="${!email}"
+          HMPPS_AUTH_NAME="${!name}"
+          npm run test:e2e:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+      - name: Store Playwright report
+        uses: actions/upload-artifact@v2
+        with:
+          name: playwright-report
+          path: playwright-report
+      - name: Store test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: test-results
+      # - name: Notify Slack on failure - TODO
+      #   if: failure()
+      #   uses: slackapi/slack-github-action@v1.23.0
+      #   with:
+      #     channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+      #     slack-message: 'E2E tests failed. Check the logs for more details.'
+      #     bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+  cas2_e2e_tests:
+    runs-on: [self-hosted, hmpps-github-actions-runner]
+    steps:
+      - name: Clone E2E repo
+        run: |
+          git clone https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui.git .
+      - uses: qoomon/actions--context@v1
+        id: context
+      - name: Update npm
+        run: npm install -g npm@10.1.0
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+      - run:
+      - name: Install Playwright
+        run: npx playwright install
+      - name: Run E2E tests
+        run: npm run test:e2e
+      - name: Store Playwright report
+        uses: actions/upload-artifact@v2
+        with:
+          name: playwright-report
+          path: e2e-tests/playwright-report
+      # - name: Notify Slack on failure - TODO
+      #   if: failure()
+      #   uses: slackapi/slack-github-action@v1.23.0
+      #   with:
+      #     channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+      #     slack-message: 'E2E tests failed. Check the logs for more details.'
+      #     bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+  # cas3_e2e_tests: - TODO, work out how to grab cypres env vars from circle ci
+  #   runs-on: [self-hosted, hmpps-github-actions-runner]
+  #   steps:
+  #     - uses: qoomon/actions--context@v1
+  #       id: context
+  #     - name: Checkout e2e repo
+  #       run: |
+  #         git clone https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git .
+  #     - name: Install xz-utils
+  #       run: apt-get install xz-utils
+  #     - name: Use Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 18.x
+  #     - name: Update npm
+  #       run: npm install -g npm@9.8.1
+  #     - name: E2E Check - ${{ steps.context.outputs.environment }}
+  #       run: |
+  #         TESTS=$(find "${{ github.workspace }}/e2e/tests" -name "*.feature" | paste -sd ',')
+  #         npm run test:e2e:ci -- \
+  #           --env "assessor_username=${{ env.CYPRESS_ASSESSOR_USERNAME}}_${{ steps.context.outputs.environment }},assessor_password=${{ env.CYPRESS_ASSESSOR_PASSWORD}}_${{ steps.context.outputs.environment }},referrer_username=${{ env.CYPRESS_REFERRER_USERNAME}}_${{ steps.context.outputs.environment }},referrer_password=${{ env.CYPRESS_REFERRER_PASSWORD}}_${{ steps.context.outputs.environment }},acting_user_probation_region_id=${{ env.CYPRESS_ACTING_USER_PROBATION_REGION_ID}}_${{ steps.context.outputs.environment }},acting_user_probation_region_name=${{ env.CYPRESS_ACTING_USER_PROBATION_REGION_NAME}}_${{ steps.context.outputs.environment }},environment=${{ env.CYPRESS_ENVIRONMENT}}_${{ steps.context.outputs.environment }}" \
+  #           --config baseUrl=https://temporary-accommodation-${{ steps.context.outputs.environment }}.hmpps.service.justice.gov.uk \
+  #           --spec $TESTS
+  #     - name: Store screenshots
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: screenshots
+  #         path: e2e/screenshots
+  #     - name: Store videos
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: videos
+  #         path: e2e/videos


### PR DESCRIPTION
Adding an experimental GH actions workflow that runs on HMPPS runner that may be able to run our E2E tests, on any branch, without merging into main.

This is entirely experimental at this moment, and which may not work.

Planning to get playwite working first and then getting to cypress.
Alas, this has to be deployed to main to check wether it works, BUT once it does - we should not have to merge to main to run our e2e tests. 🤞 🤞🤞