### PR TITLE
Fix/lower case crn in bookings fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -740,7 +740,7 @@ class OffenderService(
     ignoreLaoRestrictions: Boolean,
   ): PersonInfoResult {
     check(ignoreLaoRestrictions || deliusUsername != null) { "If ignoreLao is false, delius username must be provided " }
-    return getPersonInfoResults(setOf(crn.trim().uppercase()), deliusUsername, ignoreLaoRestrictions).first()
+    return getPersonInfoResults(setOf(crn), deliusUsername, ignoreLaoRestrictions).first()
   }
 
   fun getPersonInfoResults(

--- a/src/main/resources/db/migration/all/20250203152144__correct_booking_crn.sql
+++ b/src/main/resources/db/migration/all/20250203152144__correct_booking_crn.sql
@@ -1,0 +1,4 @@
+update bookings
+set crn = upper(crn)
+where crn ~ '[a-z]'
+  and service = 'temporary-accommodation'


### PR DESCRIPTION
Fix an issue where crns were being saved with a lower case leading letter. This also reverts a change from a previous [PR ](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/2831)
 that was suspected to have caused it 
tested the query in preprod, only affects the three incorrect rows.
<img width="387" alt="image" src="https://github.com/user-attachments/assets/2f532a73-f174-4156-b478-c6ed7025d491" />
