### PR TITLE
CAS-1205 : update characterstics endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CharacteristicEntity.kt
@@ -6,8 +6,10 @@ import jakarta.persistence.Table
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
 import java.util.UUID
 
+@Repository
 interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
 
   companion object Constants {
@@ -29,14 +31,11 @@ interface CharacteristicRepository : JpaRepository<CharacteristicEntity, UUID> {
     const val CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED = "isWheelchairDesignated"
   }
 
-  @Query("SELECT c FROM CharacteristicEntity c WHERE c.serviceScope = :serviceName")
-  fun findAllByServiceScope(serviceName: String): List<CharacteristicEntity>
-
-  @Query("SELECT c FROM CharacteristicEntity c WHERE c.serviceScope = :serviceName AND c.isActive = true")
-  fun findActiveByServiceScope(serviceName: String): List<CharacteristicEntity>
-
-  @Query("SELECT c FROM CharacteristicEntity c WHERE c.isActive = true")
-  fun findActive(): List<CharacteristicEntity>
+  @Query(
+    "SELECT c FROM CharacteristicEntity c WHERE (c.serviceScope = :serviceScope OR :serviceScope = '*' )" +
+      "AND (:modelScope = '*' OR c.modelScope = :modelScope OR c.modelScope = '*') AND c.isActive = true",
+  )
+  fun findActiveByServiceScopeAndModelScope(serviceScope: String, modelScope: String): List<CharacteristicEntity>
 
   fun findByName(name: String): CharacteristicEntity?
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2723,12 +2723,12 @@ paths:
           description: If given, only characteristics for this service will be returned
           schema:
             $ref: '_shared.yml#/components/schemas/ServiceName'
-        - name: includeInactive
+        - name: modelScope
           in: query
           required: false
-          description: Specifies whether inactive characteristics should be provided. Defaults to `false`.
           schema:
-            type: boolean
+            type: string
+            enum: [ PREMISES, BEDSPACE, ROOM ]
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -2725,12 +2725,12 @@ paths:
           description: If given, only characteristics for this service will be returned
           schema:
             $ref: '#/components/schemas/ServiceName'
-        - name: includeInactive
+        - name: modelScope
           in: query
           required: false
-          description: Specifies whether inactive characteristics should be provided. Defaults to `false`.
           schema:
-            type: boolean
+            type: string
+            enum: [ PREMISES, BEDSPACE, ROOM ]
       responses:
         200:
           description: successful operation


### PR DESCRIPTION
this adds functionality to the get reference data endpoint, so the characteristics can be requested for either a premises or a bedspace. It removes the "includeInactive" flag, as this isn't used.