### PR TITLE
APS-1870 standardise site survey room import

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
@@ -147,7 +147,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
   private fun resolveBeds(qCode: String, siteSurveyBeds: List<Cas1SiteSurveyBed>): List<BedInfo> {
     return siteSurveyBeds.map {
       BedInfo(
-        bedName = it.bedNumber,
+        bedName = "${it.roomNumber} - ${it.bedNumber}",
         bedCode = it.uniqueBedRef,
         roomCode = buildRoomCode(qCode, it.roomNumber),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
@@ -78,7 +78,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
     }
   }
 
-  private fun buildRoomCode(qCode: String, roomNumber: String) = "$qCode - $roomNumber"
+  private fun buildRoomCode(qCode: String, roomNumber: String) = "$qCode-$roomNumber"
 
   private data class RoomInfo(
     val roomCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
@@ -56,6 +56,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
     checkRoomCharacteristics(rooms)
 
     val beds = resolveBeds(qCode, siteSurveyBedsInfo)
+    checkBedNamesUnique(beds)
 
     rooms.forEach {
       val existingRoom = roomRepository.findByCode(it.roomCode)
@@ -99,6 +100,12 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
   private fun checkRoomCharacteristics(rooms: List<RoomInfo>) {
     rooms.groupBy { room -> room.roomCode }.forEach { (roomCode, rooms) ->
       rooms.all { it.characteristics == rooms.first().characteristics } || error("Room $roomCode has different characteristics.")
+    }
+  }
+
+  private fun checkBedNamesUnique(beds: List<BedInfo>) {
+    beds.groupBy { bed -> bed.bedName }.forEach { (bedName, beds) ->
+      beds.size == 1 || error("Bed name '$bedName' is not unique.")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SiteSurveyPremiseFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SiteSurveyPremiseFactory.kt
@@ -109,7 +109,11 @@ fun DataFrame<*>.resolveAnswer(question: String, answerCol: Int = 1): String {
 
   if (questionIndex == -1) error("Question '$question' not found on sheet Sheet3.")
 
-  val answer = answers[questionIndex].toString().trim()
+  fun removeDecimalPlaces() = answers[questionIndex].let {
+    if (it is Double) it.toInt() else it
+  }.toString().trim()
+
+  val answer = removeDecimalPlaces()
 
   if (answer.isBlank()) {
     error("Answer for question '$question' cannot be blank")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
@@ -36,7 +36,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     "Can this room be designated as suitable for people requiring step free access? (Must answer yes to Q23 and 25 on previous sheet and Q19 on this sheet)",
   )
 
-  fun MutableList<String>.addCharacteristics(numberOfRooms: Int = 1, activeCharacteristics: Map<String, List<String>> = emptyMap()) {
+  fun MutableList<Any>.addCharacteristics(numberOfRooms: Int = 1, activeCharacteristics: Map<String, List<String>> = emptyMap()) {
     questions.forEach { question ->
       this.add(question)
       this.addAll(activeCharacteristics.getOrDefault(question, MutableList(numberOfRooms) { "No" }))
@@ -55,11 +55,11 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
-      "1",
+      1.0,
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
-      "1",
+      1.0,
     )
     rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf("Yes")))
 
@@ -105,15 +105,15 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW", "SWABI02NEW", "SWABI03NEW")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
-      "1",
-      "2",
-      "3",
+      1.0,
+      2.0,
+      3.0,
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
-      "1",
-      "1",
-      "1",
+      1.0,
+      1.0,
+      1.0,
     )
     rows.addCharacteristics(3, mapOf("Is this room located on the ground floor?" to listOf("No", "Yes", "No")))
 
@@ -178,13 +178,13 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW", "SWABI02NEW")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
-      "1",
-      "1",
+      1.0,
+      1.0,
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
-      "1",
-      "2",
+      1.0,
+      2.0,
     )
     rows.addCharacteristics(2, mapOf("Is this room located on the ground floor?" to listOf("No", "Yes")))
 
@@ -225,7 +225,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       withQCode(qCode)
     }
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW", "SWABI02NEW", "SWABI03NEW")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
       "1",
       "2",
@@ -295,7 +295,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
       "1",
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
@@ -346,7 +346,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
       "1",
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
@@ -405,7 +405,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
       "1",
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
@@ -459,7 +459,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI02a", "SWABI02b")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
       "2",
       "2",
@@ -517,7 +517,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI02")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
       "2",
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
@@ -563,7 +563,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
       "1",
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
@@ -610,7 +610,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01NEW")
-    val rows = mutableListOf(
+    val rows: MutableList<Any> = mutableListOf(
       "Room Number / Name",
       "1",
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
@@ -86,7 +86,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val newBed = bedRepository.findByCodeAndRoomId("SWABI01NEW", newRoom.id)
-    assertThat(newBed!!.name).isEqualTo("1")
+    assertThat(newBed!!.name).isEqualTo("1 - 1")
     assertThat(
       newBed.room.id == newRoom.id &&
         newBed.room.code == "Q999-1",
@@ -136,7 +136,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(room1!!.characteristics).isEmpty()
 
     val bed1 = bedRepository.findByCodeAndRoomId("SWABI01NEW", room1.id)
-    assertThat(bed1!!.name).isEqualTo("1")
+    assertThat(bed1!!.name).isEqualTo("1 - 1")
     assertThat(
       bed1.room.id == room1.id &&
         bed1.room.code == "Q999-1",
@@ -149,7 +149,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val bed2 = bedRepository.findByCodeAndRoomId("SWABI02NEW", room2.id)
-    assertThat(bed2!!.name).isEqualTo("1")
+    assertThat(bed2!!.name).isEqualTo("2 - 1")
     assertThat(
       bed2.room.id == room2.id &&
         bed2.room.code == "Q999-2",
@@ -159,7 +159,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(room3!!.characteristics).isEmpty()
 
     val bed3 = bedRepository.findByCodeAndRoomId("SWABI03NEW", room3.id)
-    assertThat(bed3!!.name).isEqualTo("1")
+    assertThat(bed3!!.name).isEqualTo("3 - 1")
     assertThat(
       bed3.room.id == room3.id &&
         bed3.room.code == "Q999-1",
@@ -256,7 +256,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(room1!!.characteristics).isEmpty()
 
     val bed1 = bedRepository.findByCodeAndRoomId("SWABI01NEW", room1.id)
-    assertThat(bed1!!.name).isEqualTo("1")
+    assertThat(bed1!!.name).isEqualTo("1 - 1")
     assertThat(
       bed1.room.id == room1.id &&
         bed1.room.code == "Q999-1",
@@ -269,14 +269,14 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val bed2 = bedRepository.findByCodeAndRoomId("SWABI02NEW", room2.id)
-    assertThat(bed2!!.name).isEqualTo("1")
+    assertThat(bed2!!.name).isEqualTo("2 - 1")
     assertThat(
       bed2.room.id == room2.id &&
         bed2.room.code == "Q999-2",
     )
 
     val bed3 = bedRepository.findByCodeAndRoomId("SWABI03NEW", room2.id)
-    assertThat(bed3!!.name).isEqualTo("2")
+    assertThat(bed3!!.name).isEqualTo("2 - 2")
     assertThat(
       bed3.room.id == room2.id &&
         bed3.room.code == "Q999-2",
@@ -322,7 +322,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(newRoom!!.characteristics).isEmpty()
 
     val newBed = bedRepository.findByCodeAndRoomId("SWABI01NEW", newRoom.id)
-    assertThat(newBed!!.name).isEqualTo("1")
+    assertThat(newBed!!.name).isEqualTo("1 - 1")
     assertThat(
       newBed.room.id == newRoom.id &&
         newBed.room.code == "Q999-1",
@@ -376,7 +376,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val newBed = bedRepository.findByCodeAndRoomId("SWABI01", updatedRoom.id)
-    assertThat(newBed!!.name).isEqualTo("1")
+    assertThat(newBed!!.name).isEqualTo("1 - 1")
     assertThat(
       newBed.room.id == updatedRoom.id &&
         newBed.room.code == "Q999-1",
@@ -401,7 +401,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     bedEntityFactory.produceAndPersist {
       withRoom(room)
       withCode("SWABI01")
-      withName("1")
+      withName("1 - 1")
     }
 
     val header = listOf("Unique Reference Number for Bed", "SWABI01")
@@ -435,7 +435,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     }
 
     val existingBed = bedRepository.findByCode("SWABI01")
-    assertThat(existingBed!!.name).isEqualTo("1")
+    assertThat(existingBed!!.name).isEqualTo("1 - 1")
     assertThat(
       existingBed.room.id == updatedRoom.id &&
         existingBed.room.code == "Q999-1",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
@@ -78,7 +78,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "example.xlsx",
     )
 
-    val newRoom = roomRepository.findByCode("Q999 - 1")
+    val newRoom = roomRepository.findByCode("Q999-1")
     assertThat(newRoom).isNotNull
     assertThat(newRoom!!.characteristics).anyMatch {
       it.name == "Is this room located on the ground floor?" &&
@@ -89,7 +89,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(newBed!!.name).isEqualTo("1")
     assertThat(
       newBed.room.id == newRoom.id &&
-        newBed.room.code == "Q999 - 1",
+        newBed.room.code == "Q999-1",
     )
   }
 
@@ -132,17 +132,17 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "example.xlsx",
     )
 
-    val room1 = roomRepository.findByCode("Q999 - 1")
+    val room1 = roomRepository.findByCode("Q999-1")
     assertThat(room1!!.characteristics).isEmpty()
 
     val bed1 = bedRepository.findByCodeAndRoomId("SWABI01NEW", room1.id)
     assertThat(bed1!!.name).isEqualTo("1")
     assertThat(
       bed1.room.id == room1.id &&
-        bed1.room.code == "Q999 - 1",
+        bed1.room.code == "Q999-1",
     )
 
-    val room2 = roomRepository.findByCode("Q999 - 2")
+    val room2 = roomRepository.findByCode("Q999-2")
     assertThat(room2!!.characteristics).anyMatch {
       it.name == "Is this room located on the ground floor?" &&
         it.propertyName == "isGroundFloor"
@@ -152,17 +152,17 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(bed2!!.name).isEqualTo("1")
     assertThat(
       bed2.room.id == room2.id &&
-        bed2.room.code == "Q999 - 2",
+        bed2.room.code == "Q999-2",
     )
 
-    val room3 = roomRepository.findByCode("Q999 - 3")
+    val room3 = roomRepository.findByCode("Q999-3")
     assertThat(room3!!.characteristics).isEmpty()
 
     val bed3 = bedRepository.findByCodeAndRoomId("SWABI03NEW", room3.id)
     assertThat(bed3!!.name).isEqualTo("1")
     assertThat(
       bed3.room.id == room3.id &&
-        bed3.room.code == "Q999 - 1",
+        bed3.room.code == "Q999-1",
     )
   }
 
@@ -210,7 +210,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
           it.throwable != null &&
           it.throwable.message == "Unable to process XLSX file" &&
           it.throwable.cause is IllegalStateException &&
-          it.throwable.cause!!.message == "Room Q999 - 1 has different characteristics."
+          it.throwable.cause!!.message == "Room Q999-1 has different characteristics."
       }
   }
 
@@ -252,17 +252,17 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "example.xlsx",
     )
 
-    val room1 = roomRepository.findByCode("Q999 - 1")
+    val room1 = roomRepository.findByCode("Q999-1")
     assertThat(room1!!.characteristics).isEmpty()
 
     val bed1 = bedRepository.findByCodeAndRoomId("SWABI01NEW", room1.id)
     assertThat(bed1!!.name).isEqualTo("1")
     assertThat(
       bed1.room.id == room1.id &&
-        bed1.room.code == "Q999 - 1",
+        bed1.room.code == "Q999-1",
     )
 
-    val room2 = roomRepository.findByCode("Q999 - 2")
+    val room2 = roomRepository.findByCode("Q999-2")
     assertThat(room2!!.characteristics).anyMatch {
       it.name == "Is this room located on the ground floor?" &&
         it.propertyName == "isGroundFloor"
@@ -272,14 +272,14 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(bed2!!.name).isEqualTo("1")
     assertThat(
       bed2.room.id == room2.id &&
-        bed2.room.code == "Q999 - 2",
+        bed2.room.code == "Q999-2",
     )
 
     val bed3 = bedRepository.findByCodeAndRoomId("SWABI03NEW", room2.id)
     assertThat(bed3!!.name).isEqualTo("2")
     assertThat(
       bed3.room.id == room2.id &&
-        bed3.room.code == "Q999 - 2",
+        bed3.room.code == "Q999-2",
     )
   }
 
@@ -318,14 +318,14 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "example.xlsx",
     )
 
-    val newRoom = roomRepository.findByCode("Q999 - 1")
+    val newRoom = roomRepository.findByCode("Q999-1")
     assertThat(newRoom!!.characteristics).isEmpty()
 
     val newBed = bedRepository.findByCodeAndRoomId("SWABI01NEW", newRoom.id)
     assertThat(newBed!!.name).isEqualTo("1")
     assertThat(
       newBed.room.id == newRoom.id &&
-        newBed.room.code == "Q999 - 1",
+        newBed.room.code == "Q999-1",
     )
   }
 
@@ -339,7 +339,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val roomCode = "$qCode - 1"
+    val roomCode = "$qCode-1"
     roomEntityFactory.produceAndPersist {
       withPremises(premises)
       withCode(roomCode)
@@ -379,7 +379,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(newBed!!.name).isEqualTo("1")
     assertThat(
       newBed.room.id == updatedRoom.id &&
-        newBed.room.code == "Q999 - 1",
+        newBed.room.code == "Q999-1",
     )
   }
 
@@ -393,7 +393,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val roomCode = "$qCode - 1"
+    val roomCode = "$qCode-1"
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
       withCode(roomCode)
@@ -438,7 +438,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(existingBed!!.name).isEqualTo("1")
     assertThat(
       existingBed.room.id == updatedRoom.id &&
-        existingBed.room.code == "Q999 - 1",
+        existingBed.room.code == "Q999-1",
     )
   }
 
@@ -452,7 +452,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       withProbationRegion(probationRegion)
       withQCode(qCode)
     }
-    val roomCode = "$qCode - 1"
+    val roomCode = "$qCode-1"
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
       withCode(roomCode)
@@ -494,7 +494,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
           it.throwable != null &&
           it.throwable.message == "Unable to process XLSX file" &&
           it.throwable.cause is IllegalStateException &&
-          it.throwable.cause!!.message == "Bed SWABI02 already exists in room Q999 - 1 but is being added to room Q999 - 2."
+          it.throwable.cause!!.message == "Bed SWABI02 already exists in room Q999-1 but is being added to room Q999-2."
       }
   }
 


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1870

- Change `roomCode` calculation to `$qCode-$roomNumber`. Currently we introduce a space before/after the hyphen, which is not consistent with the CSV import
- Change `bedName` calculation to `${row.roomNumber} - ${row.bedNumber}` (note that there are spaces before/after the hyphen). Currently we’re just using the bed number
- Add validation to ensure all beds have unique names in a given premise. If they don’t, throw an error, halting processing of the row
- When reading Room Name and Bed Number, if the value is numeric, we need to format it to remove any decimal points.