### PR TITLE
APS-1875 - Add new Cas1PremisesBedSummary type.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -38,6 +38,19 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
   """,
   )
   fun findArchivedBedByBedIdAndDate(bedId: UUID, endDate: LocalDate): BedEntity?
+
+  @Query(
+    """
+        SELECT b.id as id,
+        b.name as bedName,
+        r.name as roomName
+        FROM beds b
+        LEFT JOIN rooms r ON b.room_id = r.id
+        WHERE r.premises_id = :premisesId
+    """,
+    nativeQuery = true,
+  )
+  fun findAllCas1BedSummariesForPremises(premisesId: UUID): List<Cas1PremisesBedSummary>
 }
 
 const val BED_SUMMARY_QUERY =
@@ -136,3 +149,9 @@ open class DomainBedSummary(
   val bedBooked: Boolean,
   val bedOutOfService: Boolean,
 )
+
+interface Cas1PremisesBedSummary {
+  fun getId(): UUID
+  fun getBedName(): String
+  fun getRoomName(): String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Overbookin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
@@ -18,6 +19,7 @@ import java.util.UUID
 @Service
 class Cas1PremisesService(
   val premisesRepository: ApprovedPremisesRepository,
+  val bedRepository: BedRepository,
   val premisesService: PremisesService,
   val outOfServiceBedService: Cas1OutOfServiceBedService,
   val spacePlanningService: SpacePlanningService,
@@ -86,6 +88,8 @@ class Cas1PremisesService(
       ),
     )
   }
+
+  fun getBeds(premisesId: UUID) = bedRepository.findAllCas1BedSummariesForPremises(premisesId)
 
   data class Cas1PremisesInfo(
     val entity: ApprovedPremisesEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1BedSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1BedSummaryTransformer.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1PremisesBedSummary as JpaBedSummary
+
+@Component
+class Cas1BedSummaryTransformer {
+  fun transformJpaToApi(summary: JpaBedSummary) = Cas1PremisesBedSummary(
+    id = summary.getId(),
+    roomName = summary.getRoomName(),
+    bedName = summary.getBedName(),
+  )
+
+  fun transformEntityToApi(bed: BedEntity) = Cas1PremisesBedSummary(
+    id = bed.id,
+    roomName = bed.room.name,
+    bedName = bed.name,
+  )
+}

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -539,7 +539,35 @@ paths:
                 $ref: '_shared.yml#/components/schemas/Problem'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
-
+  /premises/{premisesId}/beds:
+    get:
+      tags:
+        - premises
+      summary: Lists all beds for the given premises
+      operationId: getBeds
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to list the beds for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremisesBedSummary'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/capacity:
     get:
       tags:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1289,3 +1289,17 @@ components:
       x-enum-varnames:
         - CREATED_AT
         - TYPE
+    Cas1PremisesBedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        roomName:
+          type: string
+        bedName:
+          type: string
+      required:
+        - id
+        - roomName
+        - bedName

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -541,7 +541,35 @@ paths:
                 $ref: '#/components/schemas/Problem'
         500:
           $ref: '#/components/responses/500Response'
-
+  /premises/{premisesId}/beds:
+    get:
+      tags:
+        - premises
+      summary: Lists all beds for the given premises
+      operationId: getBeds
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to list the beds for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas1PremisesBedSummary'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/capacity:
     get:
       tags:
@@ -7785,3 +7813,17 @@ components:
       x-enum-varnames:
         - CREATED_AT
         - TYPE
+    Cas1PremisesBedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        roomName:
+          type: string
+        bedName:
+          type: string
+      required:
+        - id
+        - roomName
+        - bedName

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1BedSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1BedSummaryTest.kt
@@ -1,0 +1,98 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1BedSummaryTransformer
+import java.util.UUID
+
+class Cas1BedSummaryTest : InitialiseDatabasePerClassTestBase() {
+  lateinit var premises: PremisesEntity
+  lateinit var probationRegion: ProbationRegionEntity
+  lateinit var localAuthorityArea: LocalAuthorityAreaEntity
+
+  @Autowired
+  lateinit var cas1BedSummaryTransformer: Cas1BedSummaryTransformer
+
+  @BeforeEach
+  fun setup() {
+    probationRegion = givenAProbationRegion()
+    localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    this.premises = approvedPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+      withLocalAuthorityArea(localAuthorityArea)
+    }
+  }
+
+  @Test
+  fun `Getting beds for a premises without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/cas1/premises/${premises.id}/beds")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Getting beds for a premises that does not exist returns 404`() {
+    givenAUser { _, jwt ->
+      webTestClient.get()
+        .uri("/cas1/premises/${UUID.randomUUID()}/beds")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "approved-premises")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Getting beds for a premises returns a list of beds`() {
+    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withYieldedRoom {
+          roomEntityFactory.produceAndPersist {
+            withYieldedPremises { premises }
+          }
+        }
+      }
+
+      val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+        withLocalAuthorityArea(localAuthorityArea)
+      }
+
+      bedEntityFactory.produceAndPersist {
+        withYieldedRoom {
+          roomEntityFactory.produceAndPersist {
+            withYieldedPremises { otherPremises }
+          }
+        }
+      }
+
+      val expectedJson = objectMapper.writeValueAsString(
+        listOf(
+          cas1BedSummaryTransformer.transformEntityToApi(bed),
+        ),
+      )
+
+      webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/beds")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
@@ -13,6 +13,7 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OverbookingRange
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
@@ -41,6 +42,9 @@ class Cas1PremisesServiceTest {
 
   @MockK
   lateinit var spaceBookingRepository: Cas1SpaceBookingRepository
+
+  @MockK
+  lateinit var bedRepository: BedRepository
 
   @InjectMockKs
   lateinit var service: Cas1PremisesService


### PR DESCRIPTION
Ref: [APS-1875](https://dsdmoj.atlassian.net/browse/APS-1875)

Create a new `cas1/premises/{premiseId}/beds` endpoint

This will be similar to the existing shared endpoint (`PremisesController.premisesPremisesIdBedsGet`), but it should return what is required for the beds list screen. Create a `Cas1PremisesBedSummary` type for this. Also note that the existing SQL loads information about CAS3 load beds. This is not required

[APS-1875]: https://dsdmoj.atlassian.net/browse/APS-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ