### PR TITLE
APS-1921 SQL modifications for allForCas1Dashboard()

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -134,6 +134,7 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
 
   @Query(
     """
+    WITH UNFILTERED AS (
       SELECT
       pq.duration AS requestedPlacementDuration,
       pq.expected_arrival AS requestedPlacementArrivalDate,
@@ -142,108 +143,57 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
       apa.risk_ratings -> 'tier' -> 'value' ->> 'level' AS personTier,
       pq.application_id AS applicationId,
       apa.name as personName,
-      CASE
-        WHEN (pq.is_parole) THEN 'parole'
-        ELSE 'standardRequest'
-      END as requestType,      
-      CASE
-        WHEN EXISTS (
-          SELECT
-            1
-          FROM
-            cancellations c
-            right join bookings booking on c.booking_id = booking.id
-          WHERE
-            booking.id = pq.booking_id
-            AND c.id IS NULL
-        ) THEN 'matched'
-        WHEN EXISTS (
-          SELECT 
-              1 
-          FROM 
-              cas1_space_bookings sb 
-          WHERE
-              sb.placement_request_id = pq.id AND
-              sb.cancellation_occurred_at IS NULL
-        ) THEN 'matched'   
-        WHEN EXISTS (
-          SELECT
-            1
-          FROM
-            booking_not_mades bnm
-          WHERE
-            bnm.placement_request_id = pq.id
-        ) THEN 'unableToMatch' 
-        ELSE 'notMatched'
-      END AS placementRequestStatus,
+      pq.reallocated_at as reallocatedAt,
+      pq.is_withdrawn as isWithdrawn,
+      pq.booking_id as bookingId,
+      pq.is_parole as isParole,
+      area.id as apAreaId,
+      pq.created_at as created_at,
+      apa.cas1_cru_management_area_id as cruManagementAreaId,
+      CASE WHEN (pq.is_parole) THEN 'parole' ELSE 'standardRelease' END AS requestType,      
+      (SELECT EXISTS (SELECT 1 FROM cancellations c right join bookings booking on c.booking_id = booking.id WHERE booking.id = pq.booking_id AND c.id IS NULL)) AS hasLegacyBooking,
+      (SELECT EXISTS (SELECT 1 FROM cas1_space_bookings sb WHERE sb.placement_request_id = pq.id AND sb.cancellation_occurred_at IS NULL)) AS hasSpaceBooking,   
+      (SELECT EXISTS (SELECT 1 FROM booking_not_mades bnm WHERE bnm.placement_request_id = pq.id)) AS hasBookingNotMade,
       application.submitted_at::date AS applicationSubmittedDate,
-      pq.is_parole AS isParole,
-      premises.name AS bookingPremisesName,
-      bookings.arrival_date AS bookingArrivalDate
+      CASE WHEN legacyBookingCancellations.id IS NULL THEN legacyBookingPremises.name ELSE NULL END AS legacyBookingPremisesName,
+      CASE WHEN legacyBookingCancellations.id IS NULL THEN legacyBookings.arrival_date ELSE NULL END AS legacyBookingArrivalDate,
+      spaceBookingPremises.name AS spaceBookingPremisesName,
+      spaceBookings.canonical_arrival_date AS spaceBookingArrivalDate
       FROM
       placement_requests pq
       LEFT JOIN approved_premises_applications apa ON apa.id = pq.application_id
       LEFT JOIN ap_areas area ON area.id = apa.ap_area_id
       LEFT JOIN applications application ON application.id = pq.application_id
-      LEFT JOIN bookings ON pq.booking_id = bookings.id
-      LEFT JOIN premises ON bookings.premises_id = premises.id
+      LEFT JOIN bookings legacyBookings ON pq.booking_id = legacyBookings.id
+      LEFT JOIN premises legacyBookingPremises ON legacyBookings.premises_id = legacyBookingPremises.id
+      LEFT JOIN cas1_space_bookings spaceBookings ON spaceBookings.placement_request_id = pq.id AND spaceBookings.cancellation_occurred_at IS NULL
+      LEFT JOIN premises spaceBookingPremises ON spaceBookings.premises_id = spaceBookingPremises.id
+      LEFT JOIN cancellations legacyBookingCancellations ON legacyBookingCancellations.booking_id = legacyBookings.id
+      WHERE
+      (:crn IS NULL OR (SELECT EXISTS (SELECT 1 FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crn))) IS TRUE)
+      AND (:crnOrName IS NULL OR (
+       (SELECT EXISTS (SELECT 1 FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crnOrName))) IS TRUE OR 
+       (SELECT EXISTS (SELECT 1 FROM approved_premises_applications apa WHERE apa.id = pq.application_id AND apa.name LIKE UPPER('%' || :crnOrName || '%'))) IS TRUE))
+    ),
+    EXC_STATUS AS (
+      SELECT *,
+      COALESCE (legacyBookingPremisesName, spaceBookingPremisesName) AS bookingPremisesName,
+      COALESCE (legacyBookingArrivalDate, spaceBookingArrivalDate) AS bookingArrivalDate,
+      CASE WHEN hasLegacyBooking THEN 'matched' WHEN hasSpaceBooking THEN 'matched' WHEN hasBookingNotMade THEN 'unableToMatch' ELSE 'notMatched' END AS placementRequestStatus
+      FROM UNFILTERED
+      WHERE
+      reallocatedAt IS NULL
+      AND (:tier IS NULL OR personTier = :tier)
+      AND (CAST(:arrivalDateFrom AS DATE) IS NULL OR requestedPlacementArrivalDate >= :arrivalDateFrom) 
+      AND (CAST(:arrivalDateTo AS DATE) IS NULL OR requestedPlacementArrivalDate <= :arrivalDateTo)
+      AND (:requestType IS NULL OR requestType = :requestType)
+      AND (:apAreaId IS NULL OR apAreaId = :apAreaId)
+      AND (:cruManagementAreaId IS NULL OR cruManagementAreaId = :cruManagementAreaId)
+    )
+    SELECT * FROM EXC_STATUS
     WHERE
-      pq.reallocated_at IS NULL 
-      AND (:status IS NULL OR pq.is_withdrawn IS FALSE)
-      AND (:status IS NULL OR (
-        CASE
-          WHEN EXISTS (
-            SELECT
-              1
-            from
-              cancellations c
-              right join bookings booking on c.booking_id = booking.id
-            WHERE
-              booking.id = pq.booking_id
-              AND c.id IS NULL
-          ) THEN 'matched'
-          WHEN EXISTS (
-            SELECT 
-                1 
-            FROM 
-                cas1_space_bookings sb 
-            WHERE
-                sb.placement_request_id = pq.id AND
-                sb.cancellation_occurred_at IS NULL
-          ) THEN 'matched'   
-          WHEN EXISTS (
-            SELECT
-              1
-            from
-              booking_not_mades bnm
-            WHERE
-              bnm.placement_request_id = pq.id
-          ) THEN 'unableToMatch' 
-          ELSE 'notMatched'
-        END
-      ) = :status)
-      AND (:crn IS NULL OR EXISTS (SELECT 1 FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crn)))
-      AND (
-        :crnOrName IS NULL OR 
-        (
-            (EXISTS (SELECT 1 FROM applications a WHERE a.id = pq.application_id AND a.crn = UPPER(:crnOrName)))
-            OR
-            (EXISTS (SELECT 1 FROM approved_premises_applications apa WHERE apa.id = pq.application_id AND apa.name LIKE UPPER('%' || :crnOrName || '%')))
-        )
-      )
-      AND (:tier IS NULL OR EXISTS (SELECT 1 FROM approved_premises_applications apa WHERE apa.id = pq.application_id AND apa.risk_ratings -> 'tier' -> 'value' ->> 'level' = :tier)) 
-      AND (CAST(:arrivalDateFrom AS date) IS NULL OR pq.expected_arrival >= :arrivalDateFrom) 
-      AND (CAST(:arrivalDateTo AS date) IS NULL OR pq.expected_arrival <= :arrivalDateTo)
-      AND (
-        :requestType IS NULL OR 
-        (
-            (:requestType = 'parole' AND pq.is_parole IS TRUE)
-            OR
-            (:requestType = 'standardRelease' AND pq.is_parole IS FALSE)
-        )
-      )
-      AND ((CAST(:apAreaId AS pg_catalog.uuid) IS NULL) OR area.id = :apAreaId)
-      AND ((CAST(:cruManagementAreaId AS pg_catalog.uuid) IS NULL) OR apa.cas1_cru_management_area_id = :cruManagementAreaId)    
+    (:status IS NULL OR isWithdrawn IS FALSE)
+    AND (:status IS NULL OR placementRequestStatus = :status)    
     """,
     nativeQuery = true,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestService.kt
@@ -102,7 +102,7 @@ class PlacementRequestService(
   ): Pair<List<Cas1PlacementRequestSummary>, PaginationMetadata?> {
     val pageable = pageCriteria.toPageable(
       when (pageCriteria.sortBy) {
-        PlacementRequestSortField.applicationSubmittedAt -> "application.submitted_at"
+        PlacementRequestSortField.applicationSubmittedAt -> "applicationSubmittedDate"
         PlacementRequestSortField.createdAt -> "created_at"
         PlacementRequestSortField.expectedArrival -> "requestedPlacementArrivalDate"
         PlacementRequestSortField.duration -> "requestedPlacementDuration"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -102,15 +102,6 @@ class PlacementRequestsTest : IntegrationTestBase() {
       realPlacementRequestRepository.save(placementRequest)
     }
 
-    private fun createSpaceBooking(placementRequest: PlacementRequestEntity): Cas1SpaceBookingEntity {
-      val spaceBooking = givenACas1SpaceBooking(
-        crn = placementRequest.application.crn,
-        placementRequest = placementRequest,
-      )
-      placementRequest.spaceBookings.add(spaceBooking)
-      return spaceBooking
-    }
-
     private fun createBookingNotMadeRecord(placementRequest: PlacementRequestEntity) {
       placementRequest.bookingNotMades = mutableListOf(
         bookingNotMadeFactory.produceAndPersist {
@@ -251,7 +242,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
             crn = matchedOffender.otherIds.crn,
             isWithdrawn = true,
           ) { placementRequest, _ ->
-            createSpaceBooking(placementRequest)
+            givenACas1SpaceBooking(
+              crn = placementRequest.application.crn,
+              placementRequest = placementRequest,
+            )
           }
 
           val (placementRequestWithSpaceBooking) = givenAPlacementRequest(
@@ -260,7 +254,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
             createdByUser = user,
             crn = matchedOffender.otherIds.crn,
           ) { placementRequest, _ ->
-            createSpaceBooking(placementRequest)
+            givenACas1SpaceBooking(
+              crn = placementRequest.application.crn,
+              placementRequest = placementRequest,
+            )
           }
 
           val (placementRequestPreviouslyUnableToMatchNowHasSpaceBooking) = givenAPlacementRequest(
@@ -270,7 +267,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
             crn = matchedOffender.otherIds.crn,
           ) { placementRequest, _ ->
             createBookingNotMadeRecord(placementRequest)
-            createSpaceBooking(placementRequest)
+            givenACas1SpaceBooking(
+              crn = placementRequest.application.crn,
+              placementRequest = placementRequest,
+            )
           }
 
           val result = webTestClient.get()
@@ -350,7 +350,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
             crn = unableToMatchOffender.otherIds.crn,
           ) { placementRequest, _ ->
             createBookingNotMadeRecord(placementRequest)
-            createSpaceBooking(placementRequest)
+            givenACas1SpaceBooking(
+              crn = placementRequest.application.crn,
+              placementRequest = placementRequest,
+            )
           }
 
           val (hasCancelledSpaceBookingPlacementRequest) = givenAPlacementRequest(
@@ -360,7 +363,10 @@ class PlacementRequestsTest : IntegrationTestBase() {
             crn = unableToMatchOffender.otherIds.crn,
           ) { placementRequest, _ ->
             createBookingNotMadeRecord(placementRequest)
-            val spaceBooking = createSpaceBooking(placementRequest)
+            val spaceBooking = givenACas1SpaceBooking(
+              crn = placementRequest.application.crn,
+              placementRequest = placementRequest,
+            )
             spaceBooking.cancellationOccurredAt = LocalDate.now()
             cas1SpaceBookingRepository.save(spaceBooking)
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -27,10 +27,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
@@ -38,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -45,6 +49,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestDetailTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PlacementRequestSummaryTransformer
@@ -60,6 +65,9 @@ class PlacementRequestsTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var cas1PlacementRequestSummaryTransformer: Cas1PlacementRequestSummaryTransformer
+
+  @Autowired
+  lateinit var personTransformer: PersonTransformer
 
   @Autowired
   lateinit var realPlacementRequestRepository: PlacementRequestRepository
@@ -1111,30 +1119,34 @@ class PlacementRequestsTest : IntegrationTestBase() {
   }
 
   @Nested
+  @SuppressWarnings("LargeClass")
   inner class Search {
 
-    private fun createBooking(placementRequest: PlacementRequestEntity) {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
+    private fun createBooking(
+      placementRequest: PlacementRequestEntity,
+      premises: ApprovedPremisesEntity? = approvedPremisesEntityFactory.produceAndPersist {
         withProbationRegion(probationRegion)
         withLocalAuthorityArea(
           localAuthorityEntityFactory.produceAndPersist(),
         )
-      }
-
+      },
+      arrivalDate: LocalDate? = LocalDate.now(),
+    ): BookingEntity {
       placementRequest.booking = bookingEntityFactory.produceAndPersist {
-        withPremises(premises)
+        withPremises(premises as PremisesEntity)
+        withArrivalDate(arrivalDate!!)
       }
       realPlacementRequestRepository.save(placementRequest)
+
+      return placementRequest.booking!!
     }
 
-    private fun createSpaceBooking(placementRequest: PlacementRequestEntity): Cas1SpaceBookingEntity {
-      val spaceBooking = givenACas1SpaceBooking(
-        crn = placementRequest.application.crn,
-        placementRequest = placementRequest,
-      )
-      placementRequest.spaceBookings.add(spaceBooking)
-      return spaceBooking
-    }
+    private fun createSpaceBooking(placementRequest: PlacementRequestEntity, premises: ApprovedPremisesEntity? = null, canonicalArrivalDate: LocalDate? = LocalDate.now()): Cas1SpaceBookingEntity = givenACas1SpaceBooking(
+      premises = premises,
+      crn = placementRequest.application.crn,
+      placementRequest = placementRequest,
+      canonicalArrivalDate = canonicalArrivalDate!!,
+    )
 
     private fun createBookingNotMadeRecord(placementRequest: PlacementRequestEntity) {
       placementRequest.bookingNotMades = mutableListOf(
@@ -1163,6 +1175,173 @@ class PlacementRequestsTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .isForbidden
+      }
+    }
+
+    @Test
+    fun `should return 1 placement request when there are 0 active bookings`() {
+      givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        givenAnOffender { unmatchedOffender, unmatchedInmate ->
+          givenAPlacementRequest(
+            placementRequestAllocatedTo = user,
+            assessmentAllocatedTo = user,
+            createdByUser = user,
+            crn = unmatchedOffender.otherIds.crn,
+          ) { placementRequest, _ ->
+
+            // create a cancelled booking
+            createBookingNotMadeRecord(placementRequest)
+            createBooking(placementRequest)
+            val cancellation = cancellationEntityFactory.produceAndPersist {
+              withBooking(placementRequest.booking!!)
+              withReason(cancellationReasonEntityFactory.produceAndPersist())
+            }
+            placementRequest.booking!!.cancellations.add(cancellation)
+
+            // create a cancelled space booking
+            createBookingNotMadeRecord(placementRequest)
+            val spaceBooking = createSpaceBooking(placementRequest)
+            spaceBooking.cancellationOccurredAt = LocalDate.now()
+            cas1SpaceBookingRepository.save(spaceBooking)
+
+            // should return 1 placement request from GET /cas1/placement-requests
+            val summaries = webTestClient.get()
+              .uri("/cas1/placement-requests")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .bodyAsListOfObjects<Cas1PlacementRequestSummary>()
+
+            assertThat(summaries).hasSize(1)
+
+            assertThat(summaries[0].id).isEqualTo(placementRequest.id)
+            assertThat(summaries[0].person.crn).isEqualTo(unmatchedOffender.otherIds.crn)
+            assertThat(summaries[0].placementRequestStatus).isEqualTo(Cas1PlacementRequestSummary.PlacementRequestStatus.unableToMatch)
+            assertThat(summaries[0].isParole).isEqualTo(placementRequest.isParole)
+            assertThat(summaries[0].requestedPlacementDuration).isEqualTo(placementRequest.duration)
+            assertThat(summaries[0].requestedPlacementArrivalDate).isEqualTo(placementRequest.expectedArrival)
+            assertThat(summaries[0].personTier).isEqualTo(placementRequest.application.riskRatings?.tier?.value?.level)
+            assertThat(summaries[0].applicationId).isEqualTo(placementRequest.application.id)
+            assertThat(summaries[0].applicationSubmittedDate).isEqualTo(placementRequest.application.submittedAt!!.toLocalDate())
+            assertThat(summaries[0].firstBookingPremisesName).isNull()
+            assertThat(summaries[0].firstBookingArrivalDate).isNull()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `should return 1 placement request when it has an active booking`() {
+      givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        givenAnOffender { unmatchedOffender, unmatchedInmate ->
+          givenAPlacementRequest(
+            placementRequestAllocatedTo = user,
+            assessmentAllocatedTo = user,
+            createdByUser = user,
+            crn = unmatchedOffender.otherIds.crn,
+          ) { placementRequest, _ ->
+
+            // create a cancelled space booking
+            createBookingNotMadeRecord(placementRequest)
+            val spaceBooking = createSpaceBooking(placementRequest)
+            spaceBooking.cancellationOccurredAt = LocalDate.now()
+            cas1SpaceBookingRepository.save(spaceBooking)
+
+            // create a booking
+            createBooking(
+              placementRequest,
+              premises = givenAnApprovedPremises("legacy_booking_premises"),
+              arrivalDate = LocalDate.parse("2025-01-01"),
+            )
+
+            // should return 1 placement request from GET /cas1/placement-requests
+            val summaries = webTestClient.get()
+              .uri("/cas1/placement-requests")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .bodyAsListOfObjects<Cas1PlacementRequestSummary>()
+
+            assertThat(summaries).hasSize(1)
+
+            val person = personTransformer.transformModelToPersonApi(
+              PersonInfoResult.Success.Full(unmatchedOffender.otherIds.crn, unmatchedOffender, unmatchedInmate),
+            )
+
+            assertThat(summaries[0].id).isEqualTo(placementRequest.id)
+            assertThat(summaries[0].person).isEqualTo(person)
+            assertThat(summaries[0].placementRequestStatus).isEqualTo(cas1PlacementRequestSummaryTransformer.getStatus(placementRequest))
+            assertThat(summaries[0].isParole).isEqualTo(placementRequest.isParole)
+            assertThat(summaries[0].requestedPlacementDuration).isEqualTo(placementRequest.duration)
+            assertThat(summaries[0].requestedPlacementArrivalDate).isEqualTo(placementRequest.expectedArrival)
+            assertThat(summaries[0].personTier).isEqualTo(placementRequest.application.riskRatings?.tier?.value?.level)
+            assertThat(summaries[0].applicationId).isEqualTo(placementRequest.application.id)
+            assertThat(summaries[0].applicationSubmittedDate).isEqualTo(placementRequest.application.submittedAt!!.toLocalDate())
+            assertThat(summaries[0].firstBookingPremisesName).isEqualTo("legacy_booking_premises")
+            assertThat(summaries[0].firstBookingArrivalDate).isEqualTo(LocalDate.parse("2025-01-01"))
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `should return 1 placement request when it has an active space booking`() {
+      givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { user, jwt ->
+        givenAnOffender { unmatchedOffender, unmatchedInmate ->
+          givenAPlacementRequest(
+            placementRequestAllocatedTo = user,
+            assessmentAllocatedTo = user,
+            createdByUser = user,
+            crn = unmatchedOffender.otherIds.crn,
+          ) { placementRequest, _ ->
+
+            // create a cancelled booking
+            val booking = createBooking(placementRequest)
+
+            cancellationEntityFactory.produceAndPersist {
+              withBooking(booking)
+              withReason(cancellationReasonEntityFactory.produceAndPersist())
+            }
+
+            // create a cancelled space booking
+            createBookingNotMadeRecord(placementRequest)
+            val spaceBooking = createSpaceBooking(placementRequest)
+            spaceBooking.cancellationOccurredAt = LocalDate.now()
+            cas1SpaceBookingRepository.save(spaceBooking)
+
+            // create a space booking
+            createSpaceBooking(
+              placementRequest,
+              premises = givenAnApprovedPremises("space_booking_premises"),
+              canonicalArrivalDate = LocalDate.parse("2025-01-01"),
+            )
+
+            // should return 1 placement request from GET /cas1/placement-requests
+            val summaries = webTestClient.get()
+              .uri("/cas1/placement-requests")
+              .header("Authorization", "Bearer $jwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .bodyAsListOfObjects<Cas1PlacementRequestSummary>()
+
+            assertThat(summaries).hasSize(1)
+
+            assertThat(summaries[0].id).isEqualTo(placementRequest.id)
+            assertThat(summaries[0].person.crn).isEqualTo(unmatchedOffender.otherIds.crn)
+            assertThat(summaries[0].placementRequestStatus).isEqualTo(Cas1PlacementRequestSummary.PlacementRequestStatus.matched)
+            assertThat(summaries[0].isParole).isEqualTo(placementRequest.isParole)
+            assertThat(summaries[0].requestedPlacementDuration).isEqualTo(placementRequest.duration)
+            assertThat(summaries[0].requestedPlacementArrivalDate).isEqualTo(placementRequest.expectedArrival)
+            assertThat(summaries[0].personTier).isEqualTo(placementRequest.application.riskRatings?.tier?.value?.level)
+            assertThat(summaries[0].applicationId).isEqualTo(placementRequest.application.id)
+            assertThat(summaries[0].applicationSubmittedDate).isEqualTo(placementRequest.application.submittedAt!!.toLocalDate())
+            assertThat(summaries[0].firstBookingPremisesName).isEqualTo("space_booking_premises")
+            assertThat(summaries[0].firstBookingArrivalDate).isEqualTo(LocalDate.parse("2025-01-01"))
+          }
+        }
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
@@ -20,6 +20,7 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
   criteria: List<CharacteristicEntity>? = null,
   placementRequest: PlacementRequestEntity? = null,
   expectedArrivalDate: LocalDate = LocalDate.now(),
+  canonicalArrivalDate: LocalDate = expectedArrivalDate,
   expectedDepartureDate: LocalDate = LocalDate.now(),
   nonArrivalConfirmedAt: Instant? = null,
   cancellationOccurredAt: LocalDate? = null,
@@ -39,7 +40,7 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
   return cas1SpaceBookingEntityFactory.produceAndPersist {
     withCrn(crn)
     withExpectedArrivalDate(expectedArrivalDate)
-    withCanonicalArrivalDate(expectedArrivalDate)
+    withCanonicalArrivalDate(canonicalArrivalDate)
     withExpectedDepartureDate(expectedDepartureDate)
     withCanonicalDepartureDate(expectedDepartureDate)
     withPlacementRequest(placementRequestToUse)


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1921

_First:_

Rewrite the existing query as-is to use a CTE that returns all placement requests meeting the criteria other than status, but does outputs a status value

Use that first query as input into the second query that will then apply any status filtering, if required, removing duplication of status logic

_Then:_

Update the first query to output fields required for the change required on this ticket e.g.

- booking_arrival
- booking_premises_name
- space_booking_arrival
- space_booking_premise_name

Then in the second query add logic to pick the non null values to output (either booking or space booking)

Also see Slack chat [here](https://mojdt.slack.com/archives/C03K0HB0LBE/p1739185989519529).