### PR TITLE
CAS-1312 Prevent users from archiving a property with an existing bookings

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -106,6 +106,7 @@ generic-service:
 
     FEATURE-FLAGS_GET-ALERTS-FROM-PRISONER-ALERTS-API: true
     FEATURE-FLAGS_CAS2-SQS-LISTENER-ENABLED: false
+    FEATURE-FLAGS_ARCHIVE-PROPERTY-VALIDATE-EXISTING-BOOKINGS: false
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -91,6 +91,7 @@ generic-service:
 
     FEATURE-FLAGS_GET-ALERTS-FROM-PRISONER-ALERTS-API: true
     FEATURE-FLAGS_CAS2-SQS-LISTENER-ENABLED: false
+    FEATURE-FLAGS_ARCHIVE-PROPERTY-VALIDATE-EXISTING-BOOKINGS: false
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -93,6 +93,7 @@ generic-service:
 
     FEATURE-FLAGS_GET-ALERTS-FROM-PRISONER-ALERTS-API: false
     FEATURE-FLAGS_CAS2-SQS-LISTENER-ENABLED: false
+    FEATURE-FLAGS_ARCHIVE-PROPERTY-VALIDATE-EXISTING-BOOKINGS: false
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -90,6 +90,7 @@ generic-service:
 
     FEATURE-FLAGS_GET-ALERTS-FROM-PRISONER-ALERTS-API: true
     FEATURE-FLAGS_CAS2-SQS-LISTENER-ENABLED: false
+    FEATURE-FLAGS_ARCHIVE-PROPERTY-VALIDATE-EXISTING-BOOKINGS: false
 
   namespace_secrets:
     hmpps-approved-premises-api:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -269,6 +269,11 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     nativeQuery = true,
   )
   fun findAllIdsByPremisesId(premisesId: UUID): List<UUID>
+
+  @Query(
+    "SELECT b FROM BookingEntity b WHERE b.service = :serviceName AND b.premises.id = :premisesId AND b.departureDate >= :date AND b.status in :statuses",
+  )
+  fun findFutureBookingsByPremisesIdAndStatus(serviceName: String, premisesId: UUID, date: LocalDate, statuses: List<BookingStatus>): List<BookingEntity>
 }
 
 @Entity


### PR DESCRIPTION
This PR CAS1312 is to prevent users from archiving a property when there are a booking in provisional, confirmed, or active status. 

I added it as a feature until the UI done their change to handle the Api response