### PR TITLE
APS-1943 - Reduce SQL used to build CAS1 space planning model

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -158,8 +158,8 @@ data class Cas1OutOfServiceBedEntity(
   val notes
     get() = latestRevision.notes
 
-  fun isApplicable(now: LocalDate, candidate: BedEntity): Boolean {
-    return bed.id == candidate.id &&
+  fun isApplicable(now: LocalDate, bedId: UUID): Boolean {
+    return bed.id == bedId &&
       cancellation == null &&
       (!now.isBefore(startDate) && !now.isAfter(endDate))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/SqlUtil.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/SqlUtil.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import java.sql.ResultSet
+import java.util.UUID
+
+object SqlUtil {
+  fun ResultSet.getUUID(columnLabel: String): UUID = UUID.fromString(this.getString(columnLabel))
+
+  fun toStringList(array: java.sql.Array?): List<String> {
+    if (array == null) {
+      return emptyList()
+    }
+
+    val result = (array.array as Array<String>).toList()
+
+    return if (result.size == 1 && result[0] == null) {
+      emptyList()
+    } else {
+      result
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
@@ -6,8 +6,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Characteristi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_PIPE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_RECOVERY_FOCUSSED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_SEMI_SPECIALIST_MENTAL_HEALTH
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.SqlUtil
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.SqlUtil.getUUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
-import java.sql.ResultSet
 import java.util.UUID
 
 private const val AP_TYPE_FILTER = """
@@ -120,22 +121,8 @@ class Cas1SpaceSearchRepository(
         rs.getString("postcode"),
         rs.getUUID("ap_area_id"),
         rs.getString("ap_area_name"),
-        toStringList(rs.getArray("characteristics")),
+        SqlUtil.toStringList(rs.getArray("characteristics")),
       )
-    }
-  }
-
-  private fun toStringList(array: java.sql.Array?): List<String> {
-    if (array == null) {
-      return emptyList()
-    }
-
-    val result = (array.array as Array<String>).toList()
-
-    return if (result.size == 1 && result[0] == null) {
-      emptyList()
-    } else {
-      result
     }
   }
 
@@ -199,8 +186,6 @@ class Cas1SpaceSearchRepository(
 
     return query to params
   }
-
-  private fun ResultSet.getUUID(columnLabel: String) = UUID.fromString(this.getString(columnLabel))
 }
 
 data class CandidatePremises(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanRenderer.kt
@@ -44,16 +44,18 @@ object SpacePlanRenderer {
 
     val colWidths = listOf(ROOM_COL_WIDTH) + plan.dayPlans.map { DAY_COL_WIDTH }
 
-    val bedsBody = plan.beds.map { bed ->
-      listOf(
-        bedDescription(bed),
-      ) +
-        plan.dayPlans.map { dayPlan ->
-          val bedState = dayPlan.bedStates.first { it.bed == bed }
-          val bedBooking = dayPlan.planningResult.plan.firstOrNull { it.bed == bed }
-          bedDayDescription(bedState, bedBooking?.booking)
-        }
-    }
+    val bedsBody = plan.beds
+      .sortedBy { it.label }
+      .map { bed ->
+        listOf(
+          bedDescription(bed),
+        ) +
+          plan.dayPlans.map { dayPlan ->
+            val bedState = dayPlan.bedStates.first { it.bed == bed }
+            val bedBooking = dayPlan.planningResult.plan.firstOrNull { it.bed == bed }
+            bedDayDescription(bedState, bedBooking?.booking)
+          }
+      }
 
     val unplannedRow =
       listOf("unplanned".bold()) +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
@@ -1,11 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1PlanningBedSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
 import java.time.LocalDate
 
@@ -16,21 +15,23 @@ class SpacePlanningModelsFactory {
   }
 
   fun allBeds(
-    premises: ApprovedPremisesEntity,
-  ) = premises.rooms.flatMap { it.beds }.map { it.toBed() }
+    beds: List<Cas1PlanningBedSummary>,
+  ) = beds.map { it.toBed() }
 
   fun allBedsDayState(
     day: LocalDate,
-    premises: ApprovedPremisesEntity,
+    beds: List<Cas1PlanningBedSummary>,
     outOfServiceBedRecordsToConsider: List<Cas1OutOfServiceBedEntity>,
-  ) = premises.rooms.flatMap { it.beds }
-    .map { bedEntity ->
-      BedDayState(
-        bed = bedEntity.toBed(),
-        day = day,
-        inactiveReason = bedEntity.getInactiveReason(day, outOfServiceBedRecordsToConsider),
-      )
-    }
+  ): List<BedDayState> {
+    return beds
+      .map { bedSummary ->
+        BedDayState(
+          bed = bedSummary.toBed(),
+          day = day,
+          inactiveReason = bedSummary.getInactiveReason(day, outOfServiceBedRecordsToConsider),
+        )
+      }
+  }
 
   fun spaceBookingsForDay(
     day: LocalDate,
@@ -42,48 +43,46 @@ class SpacePlanningModelsFactory {
         SpaceBooking(
           id = booking.id,
           label = booking.crn,
-          requiredRoomCharacteristics = toRoomCharacteristics(booking.criteria),
+          requiredRoomCharacteristics = toRoomCharacteristics(booking.criteria.mapNotNull { it.propertyName }),
         )
       }
 
-  private fun BedEntity.getInactiveReason(day: LocalDate, outOfServiceBedRecords: List<Cas1OutOfServiceBedEntity>): BedInactiveReason? {
+  private fun Cas1PlanningBedSummary.getInactiveReason(day: LocalDate, outOfServiceBedRecords: List<Cas1OutOfServiceBedEntity>): BedInactiveReason? {
     val outOfServiceRecord = this.findOutOfServiceRecord(day, outOfServiceBedRecords)
     return if (outOfServiceRecord != null) {
       BedOutOfService(outOfServiceRecord.reason.name)
-    } else if (!this.isActive(day)) {
-      BedEnded(this.endDate!!)
+    } else if (!BedEntity.isActive(day, this.bedEndDate)) {
+      BedEnded(this.bedEndDate!!)
     } else {
       null
     }
   }
 
-  private fun BedEntity.findOutOfServiceRecord(
+  private fun Cas1PlanningBedSummary.findOutOfServiceRecord(
     day: LocalDate,
     outOfServiceBedRecords: List<Cas1OutOfServiceBedEntity>,
-  ) = outOfServiceBedRecords.firstOrNull { it.isApplicable(day, candidate = this) }
+  ) = outOfServiceBedRecords.firstOrNull { it.isApplicable(day, bedId = this.bedId) }
 
-  private fun BedEntity.toBed() = Bed(
-    id = this.id,
-    label = this.name,
+  private fun Cas1PlanningBedSummary.toBed() = Bed(
+    id = this.bedId,
+    label = this.bedName,
     room = Room(
-      id = this.room.id,
-      label = this.room.name,
-      characteristics = toRoomCharacteristics(this.room.characteristics),
+      id = this.roomId,
+      label = this.roomName,
+      characteristics = toRoomCharacteristics(this.characteristicsPropertyNames),
     ),
   )
 
-  private fun toRoomCharacteristics(characteristicEntities: List<CharacteristicEntity>) = characteristicEntities
+  private fun toRoomCharacteristics(characteristicPropertyNames: List<String>) = characteristicPropertyNames
     .asSequence()
-    .filter { it.isActive }
-    .filter { it.isModelScopeRoom() }
-    .filter { Cas1SpaceBookingEntity.ROOM_CHARACTERISTICS_OF_INTEREST.contains(it.propertyName) }
+    .filter { Cas1SpaceBookingEntity.ROOM_CHARACTERISTICS_OF_INTEREST.contains(it) }
     .map { toCharacteristic(it) }
     .toSet()
 
-  private fun toCharacteristic(characteristicEntity: CharacteristicEntity) = Characteristic(
-    label = characteristicEntity.propertyName!!,
-    propertyName = characteristicEntity.propertyName!!,
+  private fun toCharacteristic(propertyName: String) = Characteristic(
+    label = propertyName,
+    propertyName = propertyName,
     weighting = DEFAULT_CHARACTERISTIC_WEIGHT,
-    singleRoom = characteristicEntity.propertyName == CAS1_PROPERTY_NAME_SINGLE_ROOM,
+    singleRoom = propertyName == CAS1_PROPERTY_NAME_SINGLE_ROOM,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1PlanningBedSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1PlanningBedSummaryFactory.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1PlanningBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas1PlanningBedSummaryFactory : Factory<Cas1PlanningBedSummary> {
+  private var bedId: Yielded<UUID> = { UUID.randomUUID() }
+  private var bedName: Yielded<String> = { randomStringUpperCase(10) }
+  private var bedEndDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var roomId: Yielded<UUID> = { UUID.randomUUID() }
+  private var roomName: Yielded<String> = { randomStringUpperCase(10) }
+  private var characteristicsPropertyNames: Yielded<List<String>> = { emptyList() }
+
+  fun withBedId(id: UUID) = apply {
+    this.bedId = { id }
+  }
+
+  fun withBedName(name: String) = apply {
+    this.bedName = { name }
+  }
+
+  fun withBedEndDate(bedEndDate: LocalDate) = apply {
+    this.bedEndDate = { bedEndDate }
+  }
+
+  fun withRoomName(name: String) = apply {
+    this.roomName = { name }
+  }
+
+  fun withRoomId(id: UUID) = apply {
+    this.roomId = { id }
+  }
+
+  fun withCharacteristicsPropertyNames(characteristicsPropertyNames: List<String>) = apply {
+    this.characteristicsPropertyNames = { characteristicsPropertyNames }
+  }
+
+  override fun produce(): Cas1PlanningBedSummary {
+    return Cas1PlanningBedSummary(
+      this.bedId(),
+      this.bedName(),
+      this.bedEndDate(),
+      this.roomId(),
+      this.roomName(),
+      this.characteristicsPropertyNames(),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
@@ -3,19 +3,17 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.plann
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1PlanningBedSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_SINGLE_ROOM
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.BedEnded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.BedOutOfService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.Characteristic
@@ -32,40 +30,28 @@ class SpacePlanningModelsFactoryTest {
 
     @Test
     fun `all room and bed properties including active characteristics are correctly mapped`() {
-      val characteristic1 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED).withIsActive(true).withModelScope("room").produce()
-      val characteristic2 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_SUITABLE).withIsActive(true).withModelScope("room").produce()
-      val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withIsActive(true).withModelScope("room").produce()
-      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ENSUITE).withIsActive(false).withModelScope("room").produce()
-      val characteristicNotAllowed = CharacteristicEntityFactory().withPropertyName("not in allow list").withIsActive(true).withModelScope("room").produce()
-      val characteristicPremise = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED).withIsActive(true).withModelScope("premises").produce()
+      val bedSummary = Cas1PlanningBedSummaryFactory()
+        .withBedName("the bed name")
+        .withRoomName("the room name")
+        .withCharacteristicsPropertyNames(
+          listOf(
+            CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+            CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+            CAS1_PROPERTY_NAME_SINGLE_ROOM,
+            "not in allow list",
+          ),
+        ).produce()
 
-      val roomEntity = RoomEntityFactory()
-        .withDefaults()
-        .withName("the room name")
-        .withCharacteristics(characteristic1, characteristicDisabled, characteristic2, characteristicSingleRoom, characteristicPremise, characteristicNotAllowed)
-        .produce()
-
-      val bedEntity = BedEntityFactory()
-        .withDefaults()
-        .withName("the bed name")
-        .withRoom(roomEntity)
-        .produce().apply { roomEntity.beds.add(this) }
-
-      val result = factory.allBeds(
-        premises = ApprovedPremisesEntityFactory()
-          .withDefaults()
-          .withRooms(roomEntity)
-          .produce(),
-      )
+      val result = factory.allBeds(listOf(bedSummary))
 
       assertThat(result).hasSize(1)
 
       val bed = result[0]
-      assertThat(bed.id).isEqualTo(bedEntity.id)
+      assertThat(bed.id).isEqualTo(bedSummary.bedId)
       assertThat(bed.label).isEqualTo("the bed name")
 
       val room = result[0].room
-      assertThat(room.id).isEqualTo(roomEntity.id)
+      assertThat(room.id).isEqualTo(bedSummary.roomId)
       assertThat(room.label).isEqualTo("the room name")
 
       val characteristics = room.characteristics
@@ -73,20 +59,20 @@ class SpacePlanningModelsFactoryTest {
 
       assertThat(characteristics).containsOnly(
         Characteristic(
-          label = characteristic1.propertyName!!,
-          propertyName = characteristic1.propertyName!!,
+          label = CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+          propertyName = CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
           weighting = 100,
           singleRoom = false,
         ),
         Characteristic(
-          label = characteristic2.propertyName!!,
-          propertyName = characteristic2.propertyName!!,
+          label = CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+          propertyName = CAS1_PROPERTY_NAME_ARSON_SUITABLE,
           weighting = 100,
           singleRoom = false,
         ),
         Characteristic(
-          label = characteristicSingleRoom.propertyName!!,
-          propertyName = characteristicSingleRoom.propertyName!!,
+          label = CAS1_PROPERTY_NAME_SINGLE_ROOM,
+          propertyName = CAS1_PROPERTY_NAME_SINGLE_ROOM,
           weighting = 100,
           singleRoom = true,
         ),
@@ -98,27 +84,10 @@ class SpacePlanningModelsFactoryTest {
   inner class AllBedsDayState {
 
     @Test
-    fun `no rooms defined, return empty list`() {
-      val result = factory.allBedsDayState(
-        day = LocalDate.of(2020, 1, 1),
-        premises = ApprovedPremisesEntityFactory()
-          .withDefaults()
-          .withRooms(mutableListOf())
-          .produce(),
-        outOfServiceBedRecordsToConsider = emptyList(),
-      )
-
-      assertThat(result).isEmpty()
-    }
-
-    @Test
     fun `no beds defined, return empty list`() {
       val result = factory.allBedsDayState(
         day = LocalDate.of(2020, 1, 1),
-        premises = ApprovedPremisesEntityFactory()
-          .withDefaults()
-          .withRooms(RoomEntityFactory().withDefaults().produce())
-          .produce(),
+        beds = emptyList(),
         outOfServiceBedRecordsToConsider = emptyList(),
       )
 
@@ -127,31 +96,21 @@ class SpacePlanningModelsFactoryTest {
 
     @Test
     fun `all room and bed properties including active characteristics are correctly mapped`() {
-      val characteristic1 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED).withIsActive(true).withModelScope("room").produce()
-      val characteristic2 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_SUITABLE).withIsActive(true).withModelScope("room").produce()
-      val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withIsActive(true).withModelScope("room").produce()
-      val characteristicNotAllowed = CharacteristicEntityFactory().withPropertyName("not in allow list").withIsActive(true).withModelScope("room").produce()
-      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ENSUITE).withIsActive(false).withModelScope("room").produce()
-      val characteristicPremise = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED).withIsActive(true).withModelScope("premises").produce()
-
-      val roomEntity = RoomEntityFactory()
-        .withDefaults()
-        .withName("the room name")
-        .withCharacteristics(characteristic1, characteristicDisabled, characteristic2, characteristicSingleRoom, characteristicPremise, characteristicNotAllowed)
-        .produce()
-
-      val bedEntity = BedEntityFactory()
-        .withDefaults()
-        .withName("the bed name")
-        .withRoom(roomEntity)
-        .produce().apply { roomEntity.beds.add(this) }
+      val bedSummary = Cas1PlanningBedSummaryFactory()
+        .withBedName("the bed name")
+        .withRoomName("the room name")
+        .withCharacteristicsPropertyNames(
+          listOf(
+            CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+            CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+            CAS1_PROPERTY_NAME_SINGLE_ROOM,
+            "not in allow list",
+          ),
+        ).produce()
 
       val result = factory.allBedsDayState(
         day = LocalDate.of(2020, 1, 1),
-        premises = ApprovedPremisesEntityFactory()
-          .withDefaults()
-          .withRooms(roomEntity)
-          .produce(),
+        beds = listOf(bedSummary),
         outOfServiceBedRecordsToConsider = emptyList(),
       )
 
@@ -162,11 +121,11 @@ class SpacePlanningModelsFactoryTest {
       assertThat(bedDayState.inactiveReason).isNull()
 
       val bed = bedDayState.bed
-      assertThat(bed.id).isEqualTo(bedEntity.id)
+      assertThat(bed.id).isEqualTo(bedSummary.bedId)
       assertThat(bed.label).isEqualTo("the bed name")
 
       val room = bed.room
-      assertThat(room.id).isEqualTo(roomEntity.id)
+      assertThat(room.id).isEqualTo(bedSummary.roomId)
       assertThat(room.label).isEqualTo("the room name")
 
       val characteristics = room.characteristics
@@ -174,20 +133,20 @@ class SpacePlanningModelsFactoryTest {
 
       assertThat(characteristics).containsOnly(
         Characteristic(
-          label = characteristic1.propertyName!!,
-          propertyName = characteristic1.propertyName!!,
+          label = CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
+          propertyName = CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED,
           weighting = 100,
           singleRoom = false,
         ),
         Characteristic(
-          label = characteristic2.propertyName!!,
-          propertyName = characteristic2.propertyName!!,
+          label = CAS1_PROPERTY_NAME_ARSON_SUITABLE,
+          propertyName = CAS1_PROPERTY_NAME_ARSON_SUITABLE,
           weighting = 100,
           singleRoom = false,
         ),
         Characteristic(
-          label = characteristicSingleRoom.propertyName!!,
-          propertyName = characteristicSingleRoom.propertyName!!,
+          label = CAS1_PROPERTY_NAME_SINGLE_ROOM,
+          propertyName = CAS1_PROPERTY_NAME_SINGLE_ROOM,
           weighting = 100,
           singleRoom = true,
         ),
@@ -196,33 +155,21 @@ class SpacePlanningModelsFactoryTest {
 
     @Test
     fun `mark beds with end date in the past as inactive`() {
-      val roomEntity = RoomEntityFactory()
-        .withDefaults()
-        .withName("the room name")
+      val bed1Active = Cas1PlanningBedSummaryFactory()
+        .withBedName("the active bed name")
+        .withRoomName("the room name")
+        .withBedEndDate(LocalDate.of(2020, 4, 5))
         .produce()
 
-      val bed1EntityActive = BedEntityFactory()
-        .withDefaults()
-        .withName("the active bed name")
-        .withEndDate(LocalDate.of(2020, 4, 5))
-        .produce().apply {
-          roomEntity.beds.add(this)
-        }
-
-      val bed2EntityEndedYesterday = BedEntityFactory()
-        .withDefaults()
-        .withName("the ended bed name")
-        .withEndDate(LocalDate.of(2020, 4, 3))
-        .produce().apply {
-          roomEntity.beds.add(this)
-        }
+      val bed2EndedYesterday = Cas1PlanningBedSummaryFactory()
+        .withBedName("the ended bed name")
+        .withRoomName("the room name")
+        .withBedEndDate(LocalDate.of(2020, 4, 3))
+        .produce()
 
       val result = factory.allBedsDayState(
         day = LocalDate.of(2020, 4, 4),
-        premises = ApprovedPremisesEntityFactory()
-          .withDefaults()
-          .withRooms(roomEntity)
-          .produce(),
+        beds = listOf(bed1Active, bed2EndedYesterday),
         outOfServiceBedRecordsToConsider = emptyList(),
       )
 
@@ -230,12 +177,12 @@ class SpacePlanningModelsFactoryTest {
 
       val activeBedDayState = result[0]
       assertThat(activeBedDayState.inactiveReason).isNull()
-      assertThat(activeBedDayState.bed.id).isEqualTo(bed1EntityActive.id)
+      assertThat(activeBedDayState.bed.id).isEqualTo(bed1Active.bedId)
       assertThat(activeBedDayState.bed.label).isEqualTo("the active bed name")
 
       val inactiveBedDayState = result[1]
       assertThat(inactiveBedDayState.inactiveReason).isInstanceOf(BedEnded::class.java)
-      assertThat(inactiveBedDayState.bed.id).isEqualTo(bed2EntityEndedYesterday.id)
+      assertThat(inactiveBedDayState.bed.id).isEqualTo(bed2EndedYesterday.bedId)
       assertThat(inactiveBedDayState.bed.label).isEqualTo("the ended bed name")
     }
 
@@ -260,12 +207,23 @@ class SpacePlanningModelsFactoryTest {
           roomEntity.beds.add(this)
         }
 
+      val bed1ActiveSummary = Cas1PlanningBedSummaryFactory()
+        .withBedId(bed1EntityActive.id)
+        .withBedName("the active bed name")
+        .withRoomName("the room name")
+        .withBedEndDate(LocalDate.of(2020, 4, 5))
+        .produce()
+
+      val bed2EndedYesterdaySummary = Cas1PlanningBedSummaryFactory()
+        .withBedId(bed2EntityOutOfService.id)
+        .withBedName("the oosb bed name")
+        .withRoomName("the room name")
+        .withBedEndDate(LocalDate.of(2020, 4, 3))
+        .produce()
+
       val result = factory.allBedsDayState(
         day = LocalDate.of(2020, 4, 4),
-        premises = ApprovedPremisesEntityFactory()
-          .withDefaults()
-          .withRooms(roomEntity)
-          .produce(),
+        beds = listOf(bed1ActiveSummary, bed2EndedYesterdaySummary),
         outOfServiceBedRecordsToConsider = listOf(
           Cas1OutOfServiceBedEntityFactory()
             .withBed(bed1EntityActive)
@@ -318,26 +276,24 @@ class SpacePlanningModelsFactoryTest {
     }
 
     @Test
-    fun `all booking properties including active room characteristics are correctly mapped`() {
+    fun `all booking properties including characteristics are correctly mapped`() {
       val characteristic1 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED).withIsActive(true).withModelScope("room").produce()
       val characteristic2 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_SUITABLE).withIsActive(true).withModelScope("room").produce()
       val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withModelScope("room").withIsActive(true).produce()
       val characteristicNotAllowed = CharacteristicEntityFactory().withPropertyName("not in allow list").withIsActive(true).withModelScope("room").produce()
-      val characteristicDisabled = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ENSUITE).withIsActive(false).withModelScope("room").produce()
-      val characteristicPremise = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED).withIsActive(true).withModelScope("premises").produce()
 
       val booking1 = Cas1SpaceBookingEntityFactory()
         .withCrn("booking1")
         .withCanonicalArrivalDate(LocalDate.of(2020, 4, 4))
         .withCanonicalDepartureDate(LocalDate.of(2020, 4, 5))
-        .withCriteria(mutableListOf(characteristic1, characteristic2, characteristicPremise))
+        .withCriteria(mutableListOf(characteristic1, characteristic2))
         .produce()
 
       val booking2 = Cas1SpaceBookingEntityFactory()
         .withCrn("booking2")
         .withCanonicalArrivalDate(LocalDate.of(2020, 4, 4))
         .withCanonicalDepartureDate(LocalDate.of(2020, 4, 5))
-        .withCriteria(mutableListOf(characteristicSingleRoom, characteristicDisabled, characteristicPremise, characteristicNotAllowed))
+        .withCriteria(mutableListOf(characteristicSingleRoom, characteristicNotAllowed))
         .produce()
 
       val result = factory.spaceBookingsForDay(


### PR DESCRIPTION
Before this PR the following code in the `SpacePlanningModelsFactory` was used to collect all beds in a given premise;

```
premises.rooms.flatMap { it.beds }
```

This trigger a lazy load for each room, and a lazy load for all beds in each room

This commit updates the `SpacePlanningModelsFactory` to instead use a single native SQL query to retrieve all beds in a single query.

This commit also simplifies characteristic filtering when building models because it’s safe to assume that any characteristic in the  `ROOM_CHARACTERISTICS_OF_INTEREST` list is active and scoped to rooms