### PR TITLE
APS-1127 - Remove Open Entity (Session) In View Interceptor for CAS1 Endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/CasOpenEntityManagerInViewInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/CasOpenEntityManagerInViewInterceptor.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor
 import org.springframework.stereotype.Component
+import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -11,11 +13,25 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 @Component
 class CasOpenEntityManagerInViewInterceptor : OpenEntityManagerInViewInterceptor() {
   override fun preHandle(request: WebRequest) {
+    if (!shouldApply(request)) {
+      return
+    }
     super.preHandle(request)
   }
 
   override fun afterCompletion(request: WebRequest, ex: Exception?) {
+    if (!shouldApply(request)) {
+      return
+    }
     super.afterCompletion(request, ex)
+  }
+
+  private fun shouldApply(webRequest: WebRequest): Boolean {
+    return if (webRequest is ServletWebRequest) {
+      return !webRequest.request.requestURI.startsWith("/cas1")
+    } else {
+      true
+    }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/CasOpenEntityManagerInViewInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/CasOpenEntityManagerInViewInterceptor.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
-import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/CasOpenEntityManagerInViewInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/CasOpenEntityManagerInViewInterceptor.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Component
+class CasOpenEntityManagerInViewInterceptor : OpenEntityManagerInViewInterceptor() {
+  override fun preHandle(request: WebRequest) {
+    super.preHandle(request)
+  }
+
+  override fun afterCompletion(request: WebRequest, ex: Exception?) {
+    super.afterCompletion(request, ex)
+  }
+}
+
+@Configuration
+class CasOpenEntityManagerInViewInterceptorConfigurer {
+  @Bean
+  fun openEntityManagerInViewInterceptor(
+    interceptor: CasOpenEntityManagerInViewInterceptor,
+  ): WebMvcConfigurer {
+    return object : WebMvcConfigurer {
+      override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addWebRequestInterceptor(interceptor)
+      }
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,8 @@ spring:
     type: redis
 
   jpa:
+    # this is managed via CasOpenEntityManagerInViewInterceptor
+    open-in-view: false
     hibernate:
       ddl-auto: none
     properties:


### PR DESCRIPTION
Open Entity (Session) In View (OSIV) is enabled by default in Spring, and whilst simplifying development wrt. lazy loading JPA relationships, it results in a connection being held open from it’s first usage to completion of the API request. This can lead to empty connection pools under load, especially when calls are being made to upstream services in the same thread that may take some time to respond.

Because removing OSIV can cause subtle issues (especially are object equality), we’re only applying it to the /cas1 endpoints in this commit, most of which are not yet in use in production.

For context see https://dsdmoj.atlassian.net/browse/APS-1127