### PR TITLE
APS-1127 - Disable lazy-load-no-transactions in tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -104,6 +104,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.DomainEventAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.EmailNotificationAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.IntegrationTestDbManager
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.OpenEntityInTestManager
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.TestPropertiesInitializer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MockFeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MutableClockConfiguration
@@ -261,7 +262,12 @@ import java.time.Duration
 import java.util.TimeZone
 import java.util.UUID
 
-@ExtendWith(IntegrationTestDbManager.IntegrationTestListener::class)
+@ExtendWith(value =
+  [
+    IntegrationTestDbManager.IntegrationTestListener::class,
+    OpenEntityInTestManager.IntegrationTestListener::class,
+  ]
+)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ContextConfiguration(initializers = [TestPropertiesInitializer::class])
 @ActiveProfiles("test")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/config/OpenEntityInTestManager.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/config/OpenEntityInTestManager.kt
@@ -48,7 +48,7 @@ class OpenEntityInTestManager : BeanFactoryAware {
 
   fun clear() {
     val emf = obtainEntityManagerFactory()
-    if (!TransactionSynchronizationManager.hasResource(emf)) {
+    if (TransactionSynchronizationManager.hasResource(emf)) {
       val emHolder =
         TransactionSynchronizationManager.unbindResource(this.obtainEntityManagerFactory()) as EntityManagerHolder
       emHolder.entityManager.clear()
@@ -115,7 +115,6 @@ class OpenEntityInTestManager : BeanFactoryAware {
       if (!isPerClass(context)) {
         getManager().setup()
       }
-      getManager().clear()
     }
 
     override fun afterAll(context: ExtensionContext?) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/config/OpenEntityInTestManager.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/config/OpenEntityInTestManager.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.EntityManagerFactory
+import jakarta.persistence.PersistenceException
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.BeanFactoryAware
+import org.springframework.beans.factory.ListableBeanFactory
+import org.springframework.dao.DataAccessResourceFailureException
+import org.springframework.orm.jpa.EntityManagerFactoryUtils
+import org.springframework.orm.jpa.EntityManagerHolder
+import org.springframework.stereotype.Component
+import org.springframework.test.context.event.annotation.AfterTestClass
+import org.springframework.test.context.event.annotation.BeforeTestClass
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.util.Assert
+
+/**
+ * A simplified version of [org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor]
+ * used to ensure we can lazy load relationships within the integration test scope, without
+ * having to set `enable_lazy_load_no_trans` in application-test.yml which will also apply to the
+ * code under test.
+ *
+ * This means we can effectively test code where the Open Entity in View Interceptor
+ * is disabled.
+ */
+@Component
+class OpenEntityInTestManager : BeanFactoryAware {
+
+  private val logger: Log = LogFactory.getLog(this.javaClass)
+
+  private var entityManagerFactory: EntityManagerFactory? = null
+  private var persistenceUnitName: String? = null
+
+  @BeforeTestClass
+  fun beforeTest() {
+    val emf = obtainEntityManagerFactory()
+    if (!TransactionSynchronizationManager.hasResource(emf)) {
+      logger.debug("Opening JPA EntityManager in OpenEntityManagerInTestUtil")
+
+      try {
+        val em = createEntityManager()
+        val emHolder = EntityManagerHolder(em)
+        TransactionSynchronizationManager.bindResource(emf, emHolder)
+      } catch (e: PersistenceException) {
+        throw DataAccessResourceFailureException("Could not create JPA EntityManager", e)
+      }
+    }
+  }
+
+  @AfterTestClass
+  fun afterCompletion() {
+    if(TransactionSynchronizationManager.hasResource(this.obtainEntityManagerFactory())) {
+      val emHolder =
+        TransactionSynchronizationManager.unbindResource(this.obtainEntityManagerFactory()) as EntityManagerHolder
+      logger.debug("Closing JPA EntityManager in OpenEntityManagerInViewInterceptor")
+      EntityManagerFactoryUtils.closeEntityManager(emHolder.entityManager)
+    }
+  }
+
+  private fun obtainEntityManagerFactory(): EntityManagerFactory? {
+    val emf = entityManagerFactory
+    Assert.state(emf != null, "No EntityManagerFactory set")
+    return emf
+  }
+
+  @Throws(BeansException::class)
+  override fun setBeanFactory(beanFactory: BeanFactory) {
+    if (entityManagerFactory == null) {
+      check(beanFactory is ListableBeanFactory) { "Cannot retrieve EntityManagerFactory by persistence unit name in a non-listable BeanFactory: $beanFactory" }
+
+      entityManagerFactory =
+        EntityManagerFactoryUtils.findEntityManagerFactory(beanFactory, this.persistenceUnitName)
+    }
+  }
+
+  private fun createEntityManager(): EntityManager {
+    val emf = obtainEntityManagerFactory()
+    return emf!!.createEntityManager()
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,7 +20,6 @@ spring:
     database: postgresql
     properties:
       hibernate:
-        enable_lazy_load_no_trans: true
         # disable cache during integration tests as it blocks us from
         # dynamically adding test reference data
         cache:


### PR DESCRIPTION
It’s not clear why this configuration was added when running integration tests.

If it’s enabled, it hides issues we may have in actual deployemnts where lazy loads are attempted without transactions. Whilst that is not currently an issue because we use Open Session in View, it will be an issue when we start removing Open Session in View (which is planned)

See https://docs.jboss.org/hibernate/orm/6.6/userguide/html_single/Hibernate_User_Guide.html#settings-hibernate.enable_lazy_load_no_trans