### PR TITLE
APS-1943 - Optimise CAS1 ‘other space bookings’ query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -333,6 +333,7 @@ class Cas1SpaceBookingController(
       premisesId = booking.premises.id,
       crn = booking.crn,
     ).filter { it.id != booking.id }
+      .sortedBy { it.canonicalArrivalDate }
 
     return spaceBookingTransformer.transformJpaToApi(person, booking, otherBookingsInPremiseForCrn)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -194,7 +194,7 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
       b.premises_id = :premisesId AND 
       b.crn = :crn AND
       b.cancellation_occurred_at IS NULL 
-      ORDER by b.canonical_arrival_date
+      LIMIT 100
     """,
     nativeQuery = true,
   )


### PR DESCRIPTION
This commit changes how we retrieve other space bookings for a given premise and CRN:

* limit the results to 100 - there should never be this many bookings at a premise for a CRN. Adding this limit helps us minimise ‘false negative’ perforamnce issues when loading testing with a single CRN
* move sorting into kotlin. Given that the results will always be quite small, it’s faster to sort in kotlin