### PR TITLE
Refactor Cas3 Queries into Cas3 Repository

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/BookingsController.kt
@@ -11,15 +11,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingSearchService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.Cas3BookingSearchService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingSearchResultTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import java.util.UUID
 
 @Service
 class BookingsController(
-  private val bookingSearchService: BookingSearchService,
+  private val cas3BookingSearchService: Cas3BookingSearchService,
   private val bookingSearchResultTransformer: BookingSearchResultTransformer,
   private val bookingService: BookingService,
   private val bookingTransformer: BookingTransformer,
@@ -50,7 +50,7 @@ class BookingsController(
     val sortOrder = sortOrder ?: SortOrder.ascending
     val sortField = sortField ?: BookingSearchSortField.bookingCreatedAt
 
-    val (results, metadata) = bookingSearchService.findBookings(status, sortOrder, sortField, page, crnOrName)
+    val (results, metadata) = cas3BookingSearchService.findBookings(status, sortOrder, sortField, page, crnOrName)
 
     return ResponseEntity.ok()
       .headers(metadata?.toHeaders())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -71,40 +71,6 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     endDate: LocalDate,
   ): List<BookingSummaryForAvailability>
 
-  @Query(
-    """
-    SELECT
-        bk.id as bookingId,
-        bk.crn as crn,
-        bk.arrival_date as arrivalDate,
-        bk.departure_date as departureDate,
-        bk.premises_id as premisesId,
-        r.id as roomId,
-        a.id as assessmentId, 
-        CASE 
-            WHEN ap.is_registered_sex_offender = TRUE 
-            OR ap.is_concerning_sexual_behaviour = TRUE
-            OR ap.is_history_of_sexual_offence = TRUE 
-         THEN TRUE 
-        ELSE FALSE 
-        END as sexualRisk
-    FROM bookings bk
-             INNER JOIN premises p ON bk.premises_id = p.id
-             INNER JOIN beds b ON bk.bed_id = b.id
-             INNER JOIN rooms r ON b.room_id = r.id
-             LEFT JOIN temporary_accommodation_applications ap ON bk.application_id = ap.id
-             LEFT JOIN assessments a ON ap.id = a.application_id
-             LEFT JOIN cancellations c ON bk.id = c.booking_id
-    WHERE bk.premises_id IN (:premisesIds) AND bk.arrival_date <= :endDate AND bk.departure_date >= :startDate AND c.id IS NULL
-    """,
-    nativeQuery = true,
-  )
-  fun findAllNotCancelledByPremisesIdsAndOverlappingDate(
-    premisesIds: List<UUID>,
-    startDate: LocalDate,
-    endDate: LocalDate,
-  ): List<OverlapBookingsSearchResult>
-
   @Query("SELECT b FROM BookingEntity b WHERE b.arrivalDate <= :endDate AND b.departureDate >= :startDate AND b.bed = :bed")
   fun findAllByOverlappingDateForBed(startDate: LocalDate, endDate: LocalDate, bed: BedEntity): List<BookingEntity>
 
@@ -147,9 +113,85 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   )
   fun findByBedIdAndArrivingBeforeDate(bedId: UUID, date: LocalDate, thisEntityId: UUID?): List<BookingEntity>
 
+  @Query(
+    "SELECT b From BookingEntity b WHERE b.application = :application AND (b.adhoc IS TRUE or b.adhoc IS NULL)",
+  )
+  fun findAllAdhocOrUnknownByApplication(application: ApplicationEntity): List<BookingEntity>
+
+  fun findAllByApplication(application: ApplicationEntity): List<BookingEntity>
+
+  @Modifying
+  @Query("UPDATE BookingEntity b set b.status = :status where b.id = :bookingId")
+  fun updateBookingStatus(bookingId: UUID, status: BookingStatus)
+
+  @Query(
+    "SELECT * FROM bookings WHERE status IS NULL AND service='temporary-accommodation' ",
+    nativeQuery = true,
+  )
+  fun findAllCas3bookingsWithNullStatus(pageable: Pageable?): Slice<BookingEntity>
+
+  @Query(
+    "SELECT b FROM BookingEntity b " +
+      "WHERE b.bed.id = :bedId " +
+      "AND NOT EXISTS (SELECT na FROM NonArrivalEntity na WHERE na.booking = b ) " +
+      "AND b.departureDate >= :date " +
+      "AND SIZE(b.cancellations) = 0 ",
+  )
+  fun findActiveOverlappingBookingByBed(bedId: UUID, date: LocalDate): List<BookingEntity>
+
+  @Query(
+    """
+      SELECT id from bookings where premises_id = :premisesId 
+    """,
+    nativeQuery = true,
+  )
+  fun findAllIdsByPremisesId(premisesId: UUID): List<UUID>
+
+  @Query(
+    "SELECT b FROM BookingEntity b WHERE b.service = :serviceName AND b.premises.id = :premisesId AND b.departureDate >= :date AND b.status in :statuses",
+  )
+  fun findFutureBookingsByPremisesIdAndStatus(serviceName: String, premisesId: UUID, date: LocalDate, statuses: List<BookingStatus>): List<BookingEntity>
+}
+
+@Repository
+interface Cas3BookingRepository : JpaRepository<BookingEntity, UUID> {
+  @Query(
+    """
+    SELECT
+        bk.id as bookingId,
+        bk.crn as crn,
+        bk.arrival_date as arrivalDate,
+        bk.departure_date as departureDate,
+        bk.premises_id as premisesId,
+        r.id as roomId,
+        a.id as assessmentId, 
+        CASE 
+            WHEN ap.is_registered_sex_offender = TRUE 
+            OR ap.is_concerning_sexual_behaviour = TRUE
+            OR ap.is_history_of_sexual_offence = TRUE 
+         THEN TRUE 
+        ELSE FALSE 
+        END as sexualRisk
+    FROM bookings bk
+             INNER JOIN premises p ON bk.premises_id = p.id
+             INNER JOIN beds b ON bk.bed_id = b.id
+             INNER JOIN rooms r ON b.room_id = r.id
+             LEFT JOIN temporary_accommodation_applications ap ON bk.application_id = ap.id
+             LEFT JOIN assessments a ON ap.id = a.application_id
+             LEFT JOIN cancellations c ON bk.id = c.booking_id
+    WHERE bk.premises_id IN (:premisesIds) AND bk.arrival_date <= :endDate AND bk.departure_date >= :startDate AND c.id IS NULL
+    """,
+    nativeQuery = true,
+  )
+  fun findAllNotCancelledByPremisesIdsAndOverlappingDate(
+    premisesIds: List<UUID>,
+    startDate: LocalDate,
+    endDate: LocalDate,
+  ): List<OverlapBookingsSearchResult>
+
   /*
-    This query is to find the closest booking to the start date for the current bedspace search
-    The ClosestBooking is to get the closest booking to the bedspace search start date that is not cancelled
+  This query is to find the closest booking to the start date for the current bedspace search
+  The ClosestBooking is to get the closest booking to the bedspace search start date that is not cancelled
    */
   @Query(
     """
@@ -175,15 +217,6 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     nativeQuery = true,
   )
   fun findClosestBookingBeforeDateForBeds(date: LocalDate, bedIds: List<UUID>): List<BookingEntity>
-
-  fun findAllByCrn(crn: String): List<BookingEntity>
-
-  @Query(
-    "SELECT b From BookingEntity b WHERE b.application = :application AND (b.adhoc IS TRUE or b.adhoc IS NULL)",
-  )
-  fun findAllAdhocOrUnknownByApplication(application: ApplicationEntity): List<BookingEntity>
-
-  fun findAllByApplication(application: ApplicationEntity): List<BookingEntity>
 
   companion object {
     private const val OFFENDERS_QUERY = """
@@ -249,38 +282,6 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     crnOrName: String?,
     pageable: Pageable?,
   ): Page<BookingSearchResult>
-
-  @Modifying
-  @Query("UPDATE BookingEntity b set b.status = :status where b.id = :bookingId")
-  fun updateBookingStatus(bookingId: UUID, status: BookingStatus)
-
-  @Query(
-    "SELECT * FROM bookings WHERE status IS NULL AND service='temporary-accommodation' ",
-    nativeQuery = true,
-  )
-  fun findAllCas3bookingsWithNullStatus(pageable: Pageable?): Slice<BookingEntity>
-
-  @Query(
-    "SELECT b FROM BookingEntity b " +
-      "WHERE b.bed.id = :bedId " +
-      "AND NOT EXISTS (SELECT na FROM NonArrivalEntity na WHERE na.booking = b ) " +
-      "AND b.departureDate >= :date " +
-      "AND SIZE(b.cancellations) = 0 ",
-  )
-  fun findActiveOverlappingBookingByBed(bedId: UUID, date: LocalDate): List<BookingEntity>
-
-  @Query(
-    """
-      SELECT id from bookings where premises_id = :premisesId 
-    """,
-    nativeQuery = true,
-  )
-  fun findAllIdsByPremisesId(premisesId: UUID): List<UUID>
-
-  @Query(
-    "SELECT b FROM BookingEntity b WHERE b.service = :serviceName AND b.premises.id = :premisesId AND b.departureDate >= :date AND b.status in :statuses",
-  )
-  fun findFutureBookingsByPremisesIdAndStatus(serviceName: String, premisesId: UUID, date: LocalDate, statuses: List<BookingStatus>): List<BookingEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/Cas3BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/Cas3BookingSearchService.kt
@@ -8,8 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.BookingSearchResultDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
@@ -18,13 +18,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadataWithSize
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import kotlin.Comparator
 
 @Service
-class BookingSearchService(
+class Cas3BookingSearchService(
   private val offenderService: OffenderService,
   private val userService: UserService,
-  private val bookingRepository: BookingRepository,
+  private val cas3BookingRepository: Cas3BookingRepository,
   @Value("\${pagination.cas3.booking-search-page-size}") private val cas3BookingSearchPageSize: Int,
 ) {
   fun findBookings(
@@ -35,7 +34,7 @@ class BookingSearchService(
     crnOrName: String?,
   ): Pair<List<BookingSearchResultDto>, PaginationMetadata?> {
     val user = userService.getUserForRequest()
-    val findBookings = bookingRepository.findTemporaryAccommodationBookings(
+    val findBookings = cas3BookingRepository.findTemporaryAccommodationBookings(
       status?.name,
       user.probationRegion.id,
       crnOrName,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas3BookingSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas3BookingSearchServiceTest.kt
@@ -21,22 +21,22 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingSearchService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.Cas3BookingSearchService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
 import java.time.OffsetDateTime
 
-class BookingSearchServiceTest {
+class Cas3BookingSearchServiceTest {
   private val mockOffenderService = mockk<OffenderService>()
   private val mockUserService = mockk<UserService>()
-  private val mockBookingRepository = mockk<BookingRepository>()
+  private val mockBookingRepository = mockk<Cas3BookingRepository>()
   private val cas3BookingSearchPageSize = 50
 
-  private val bookingSearchService = BookingSearchService(
+  private val cas3BookingSearchService = Cas3BookingSearchService(
     mockOffenderService,
     mockUserService,
     mockBookingRepository,
@@ -69,7 +69,7 @@ class BookingSearchServiceTest {
     every { mockOffenderService.getOffenderSummariesByCrns(crns, any(), any()) } returns
       crns.map { PersonSummaryInfoResult.Success.Full(it, CaseSummaryFactory().produce()) }
 
-    val (results, metaData) = bookingSearchService.findBookings(
+    val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
@@ -115,7 +115,7 @@ class BookingSearchServiceTest {
         PersonSummaryInfoResult.Success.Restricted("crn3", "crn3noms"),
       )
 
-    val (results, metadata) = bookingSearchService.findBookings(
+    val (results, metadata) = cas3BookingSearchService.findBookings(
       null,
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
@@ -169,7 +169,7 @@ class BookingSearchServiceTest {
       AuthorisableActionResult.NotFound(),
     )
 
-    val (results, metaData) = bookingSearchService.findBookings(
+    val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
@@ -219,7 +219,7 @@ class BookingSearchServiceTest {
         PersonSummaryInfoResult.Success.Full("crn3", CaseSummaryFactory().produce()),
       )
 
-    val (results, metaData) = bookingSearchService.findBookings(
+    val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
       sortOrder,
       BookingSearchSortField.personName,
@@ -271,7 +271,7 @@ class BookingSearchServiceTest {
         PersonSummaryInfoResult.Success.Full("crn3", CaseSummaryFactory().produce()),
       )
 
-    val (results, metaData) = bookingSearchService.findBookings(
+    val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
       sortOrder,
       BookingSearchSortField.personName,
@@ -323,7 +323,7 @@ class BookingSearchServiceTest {
         PersonSummaryInfoResult.Success.Full("crn3", CaseSummaryFactory().produce()),
       )
 
-    val (results, metaData) = bookingSearchService.findBookings(
+    val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
       sortOrder,
       BookingSearchSortField.personCrn,
@@ -352,7 +352,7 @@ class BookingSearchServiceTest {
     every { mockBookingRepository.findTemporaryAccommodationBookings(any(), any(), any(), any()) } returns PageImpl(emptyList())
     every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any()) } returns emptyList()
 
-    val (results, metaData) = bookingSearchService.findBookings(
+    val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
@@ -381,7 +381,7 @@ class BookingSearchServiceTest {
     every { mockBookingRepository.findTemporaryAccommodationBookings(any(), any(), any(), any()) } returns PageImpl(emptyList())
     every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any()) } returns emptyList()
 
-    val (results, metaData) = bookingSearchService.findBookings(
+    val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
       SortOrder.ascending,
       BookingSearchSortField.bookingCreatedAt,
@@ -414,7 +414,7 @@ class BookingSearchServiceTest {
     )
 
     Assertions.assertThrows(DataRetrievalFailureException::class.java) {
-      bookingSearchService.findBookings(
+      cas3BookingSearchService.findBookings(
         null,
         SortOrder.ascending,
         BookingSearchSortField.bookingCreatedAt,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OverlapBookingsSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
@@ -34,7 +34,7 @@ import java.util.UUID
 class Cas3BedSearchServiceTest {
   private val mockBedSearchRepository = mockk<BedSearchRepository>()
   private val mockCharacteristicService = mockk<CharacteristicService>()
-  private val mockBookingRepository = mockk<BookingRepository>()
+  private val mockBookingRepository = mockk<Cas3BookingRepository>()
   private val mockWorkingDayService = mockk<WorkingDayService>()
   private val mockProbationDeliveryUnitRepository = mockk<ProbationDeliveryUnitRepository>()
   private val mockOffenderService = mockk<OffenderService>()


### PR DESCRIPTION
This moves the queries only used by cas3 into their own repository, and renames services that are only used by cas3