### PR TITLE
APS-1970 Capacity Calculation should consider non arrivals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -422,7 +422,9 @@ data class Cas1SpaceBookingEntity(
   fun hasDeparted() = actualDepartureDate != null
   fun hasNonArrival() = nonArrivalConfirmedAt != null
   fun hasArrival() = actualArrivalDate != null
-  fun isResident(day: LocalDate) = canonicalArrivalDate <= day && canonicalDepartureDate > day
+  fun isResident(day: LocalDate) = !isCancelled() &&
+    canonicalArrivalDate <= day &&
+    canonicalDepartureDate > day
 
   @Deprecated("Any usage of this should instead be updated to use individual date and time fields")
   fun actualArrivalAsDateTime(): Instant? = actualArrivalDate?.atTime(actualArrivalTime ?: LocalTime.NOON)?.toInstant()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -422,7 +422,8 @@ data class Cas1SpaceBookingEntity(
   fun hasDeparted() = actualDepartureDate != null
   fun hasNonArrival() = nonArrivalConfirmedAt != null
   fun hasArrival() = actualArrivalDate != null
-  fun isResident(day: LocalDate) = !isCancelled() &&
+  fun isExpectedOrResident(day: LocalDate) = !isCancelled() &&
+    !hasNonArrival() &&
     canonicalArrivalDate <= day &&
     canonicalDepartureDate > day
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -214,7 +214,7 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
     AND b.canonicalDepartureDate >= :rangeStartInclusive 
   """,
   )
-  fun findAllBookingsActiveWithinAGivenRangeWithCriteria(
+  fun findNonCancelledBookingsInRange(
     premisesId: UUID,
     rangeStartInclusive: LocalDate,
     rangeEndInclusive: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningModelsFactory.kt
@@ -35,7 +35,7 @@ class SpacePlanningModelsFactory {
     day: LocalDate,
     spaceBookingsToConsider: List<Cas1SpaceBookingEntity>,
   ): List<SpaceBooking> = spaceBookingsToConsider
-    .filter { it.isResident(day) }
+    .filter { it.isExpectedOrResident(day) }
     .map { booking ->
       SpaceBooking(
         id = booking.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
@@ -132,7 +132,7 @@ class SpacePlanningService(
     range: DateRange,
     excludeSpaceBookingId: UUID? = null,
   ): Map<LocalDate, List<SpaceBooking>> {
-    val spaceBookingsToConsider = spaceBookingRepository.findAllBookingsActiveWithinAGivenRangeWithCriteria(
+    val spaceBookingsToConsider = spaceBookingRepository.findNonCancelledBookingsInRange(
       premisesId = premises.id,
       rangeStartInclusive = range.fromInclusive,
       rangeEndInclusive = range.toInclusive,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
@@ -276,7 +276,7 @@ class SpacePlanningModelsFactoryTest {
     }
 
     @Test
-    fun `all booking properties including characteristics are correctly mapped`() {
+    fun `all booking properties are correctly mapped`() {
       val characteristic1 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_STEP_FREE_DESIGNATED).withIsActive(true).withModelScope("room").produce()
       val characteristic2 = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_ARSON_SUITABLE).withIsActive(true).withModelScope("room").produce()
       val characteristicSingleRoom = CharacteristicEntityFactory().withPropertyName(CAS1_PROPERTY_NAME_SINGLE_ROOM).withModelScope("room").withIsActive(true).produce()
@@ -334,6 +334,66 @@ class SpacePlanningModelsFactoryTest {
           ),
         ),
       )
+    }
+
+    @Test
+    fun `include bookings arriving today`() {
+      val booking1 = Cas1SpaceBookingEntityFactory()
+        .withCanonicalArrivalDate(LocalDate.of(2020, 4, 4))
+        .withCanonicalDepartureDate(LocalDate.of(2020, 4, 5))
+        .produce()
+
+      val result = factory.spaceBookingsForDay(
+        day = LocalDate.of(2020, 4, 4),
+        spaceBookingsToConsider = listOf(booking1),
+      )
+
+      assertThat(result.map { it.id }).containsExactly(booking1.id)
+    }
+
+    @Test
+    fun `exclude bookings arriving after today`() {
+      val booking1 = Cas1SpaceBookingEntityFactory()
+        .withCanonicalArrivalDate(LocalDate.of(2020, 4, 5))
+        .withCanonicalDepartureDate(LocalDate.of(2020, 4, 6))
+        .produce()
+
+      val result = factory.spaceBookingsForDay(
+        day = LocalDate.of(2020, 4, 4),
+        spaceBookingsToConsider = listOf(booking1),
+      )
+
+      assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `exclude bookings departing before today`() {
+      val booking1 = Cas1SpaceBookingEntityFactory()
+        .withCanonicalArrivalDate(LocalDate.of(2020, 4, 1))
+        .withCanonicalDepartureDate(LocalDate.of(2020, 4, 3))
+        .produce()
+
+      val result = factory.spaceBookingsForDay(
+        day = LocalDate.of(2020, 4, 4),
+        spaceBookingsToConsider = listOf(booking1),
+      )
+
+      assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `exclude bookings departing today`() {
+      val booking1 = Cas1SpaceBookingEntityFactory()
+        .withCanonicalArrivalDate(LocalDate.of(2020, 4, 1))
+        .withCanonicalDepartureDate(LocalDate.of(2020, 4, 4))
+        .produce()
+
+      val result = factory.spaceBookingsForDay(
+        day = LocalDate.of(2020, 4, 4),
+        spaceBookingsToConsider = listOf(booking1),
+      )
+
+      assertThat(result).isEmpty()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
@@ -395,5 +395,21 @@ class SpacePlanningModelsFactoryTest {
 
       assertThat(result).isEmpty()
     }
+
+    @Test
+    fun `exclude cancelled bookings`() {
+      val booking1 = Cas1SpaceBookingEntityFactory()
+        .withCanonicalArrivalDate(LocalDate.of(2020, 4, 4))
+        .withCanonicalDepartureDate(LocalDate.of(2020, 4, 5))
+        .withCancellationOccurredAt(LocalDate.now())
+        .produce()
+
+      val result = factory.spaceBookingsForDay(
+        day = LocalDate.of(2020, 4, 4),
+        spaceBookingsToConsider = listOf(booking1),
+      )
+
+      assertThat(result).isEmpty()
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/planning/SpacePlanningModelsFactoryTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.Be
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.Characteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningModelsFactory
+import java.time.Instant
 import java.time.LocalDate
 
 class SpacePlanningModelsFactoryTest {
@@ -402,6 +403,22 @@ class SpacePlanningModelsFactoryTest {
         .withCanonicalArrivalDate(LocalDate.of(2020, 4, 4))
         .withCanonicalDepartureDate(LocalDate.of(2020, 4, 5))
         .withCancellationOccurredAt(LocalDate.now())
+        .produce()
+
+      val result = factory.spaceBookingsForDay(
+        day = LocalDate.of(2020, 4, 4),
+        spaceBookingsToConsider = listOf(booking1),
+      )
+
+      assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `exclude non arrivals`() {
+      val booking1 = Cas1SpaceBookingEntityFactory()
+        .withCanonicalArrivalDate(LocalDate.of(2020, 4, 4))
+        .withCanonicalDepartureDate(LocalDate.of(2020, 4, 5))
+        .withNonArrivalConfirmedAt(Instant.now())
         .produce()
 
       val result = factory.spaceBookingsForDay(


### PR DESCRIPTION
This PR also adds some regression tests and some additional checks to protect `spaceBookingsForEachDay` from callers providing cancelled bookings 