### PR TITLE
CAS-1445 Link CAS3 Booking Service with Controllers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -56,7 +56,6 @@ import java.util.UUID
 
 @Service
 class BookingService(
-  private val premisesService: PremisesService,
   private val offenderService: OffenderService,
   private val workingDayService: WorkingDayService,
   private val bookingRepository: BookingRepository,
@@ -501,10 +500,7 @@ class BookingService(
     return success(dateChangeEntity)
   }
 
-  fun getBookingForPremises(premisesId: UUID, bookingId: UUID): GetBookingForPremisesResult {
-    val premises = premisesService.getPremises(premisesId)
-      ?: return GetBookingForPremisesResult.PremisesNotFound
-
+  fun getBookingForPremises(premises: PremisesEntity, bookingId: UUID): GetBookingForPremisesResult {
     val booking = bookingRepository.findByIdOrNull(bookingId)
       ?: return GetBookingForPremisesResult.BookingNotFound
 
@@ -544,6 +540,5 @@ class BookingService(
 
 sealed interface GetBookingForPremisesResult {
   data class Success(val booking: BookingEntity) : GetBookingForPremisesResult
-  object PremisesNotFound : GetBookingForPremisesResult
   object BookingNotFound : GetBookingForPremisesResult
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2UserService.kt
@@ -47,22 +47,20 @@ class Cas2v2UserService(
 
     return userEntity
   }
-  fun requiresCaseLoadIdCheck(): Boolean {
-    return !userForRequestHasRole(
-      listOf(
-        SimpleGrantedAuthority("ROLE_COURT_BAIL"),
-        SimpleGrantedAuthority("ROLE_PRISON_BAIL"),
-      ),
-    )
-  }
+
+  fun requiresCaseLoadIdCheck(): Boolean = !userForRequestHasRole(
+    listOf(
+      SimpleGrantedAuthority("ROLE_COURT_BAIL"),
+      SimpleGrantedAuthority("ROLE_PRISON_BAIL"),
+    ),
+  )
 
   fun userForRequestHasRole(grantedAuthorities: List<GrantedAuthority>): Boolean {
     val roles = getRolesForUserForRequest()
     return roles?.any { it in grantedAuthorities } ?: false
   }
 
-  fun getRolesForUserForRequest(): MutableCollection<GrantedAuthority>? =
-    httpAuthService.getCas2v2AuthenticatedPrincipalOrThrow().authorities
+  fun getRolesForUserForRequest(): MutableCollection<GrantedAuthority>? = httpAuthService.getCas2v2AuthenticatedPrincipalOrThrow().authorities
 
   private fun getExistingUser(username: String, userType: Cas2v2UserType): Cas2v2UserEntity? = userRepository.findByUsernameAndUserType(username, userType)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
@@ -72,7 +72,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3PremisesService
@@ -106,7 +105,6 @@ class Cas3BookingServiceTest {
   private val mockCas3VoidBedspacesRepository = mockk<Cas3VoidBedspacesRepository>()
   private val mockTurnaroundRepository = mockk<TurnaroundRepository>()
   private val mockAssessmentRepository = mockk<AssessmentRepository>()
-  private val mockUserService = mockk<UserService>()
   private val mockUserAccessService = mockk<UserAccessService>()
   private val mockAssessmentService = mockk<AssessmentService>()
 
@@ -126,7 +124,6 @@ class Cas3BookingServiceTest {
     extensionRepository = mockExtensionRepository,
     cas3PremisesService = mockCas3PremisesService,
     assessmentService = mockAssessmentService,
-    userService = mockUserService,
     userAccessService = mockUserAccessService,
     offenderService = mockOffenderService,
     workingDayService = mockWorkingDayService,
@@ -142,23 +139,10 @@ class Cas3BookingServiceTest {
   @Nested
   inner class GetBookingPremises {
     @Test
-    fun `getBookingForPremises returns PremisesNotFound when premises with provided ID does not exist`() {
-      val premisesId = UUID.fromString("8461d08b-0e3f-426a-a941-0ada4160e6db")
-      val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
-
-      every { mockCas3PremisesService.getPremises(premisesId) } returns null
-
-      assertThat(cas3BookingService.getBookingForPremises(premisesId, bookingId))
-        .isEqualTo(GetBookingForPremisesResult.PremisesNotFound)
-    }
-
-    @Test
     fun `getBookingForPremises returns BookingNotFound when booking with provided ID does not exist`() {
-      val premisesId = UUID.fromString("8461d08b-0e3f-426a-a941-0ada4160e6db")
-      val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
-
-      every { mockCas3PremisesService.getPremises(premisesId) } returns TemporaryAccommodationPremisesEntityFactory()
-        .withId(premisesId)
+      val bookingId = UUID.randomUUID()
+      val premises = TemporaryAccommodationPremisesEntityFactory()
+        .withId(UUID.randomUUID())
         .withYieldedProbationRegion {
           ProbationRegionEntityFactory()
             .withYieldedApArea { ApAreaEntityFactory().produce() }
@@ -169,25 +153,22 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByIdOrNull(bookingId) } returns null
 
-      assertThat(cas3BookingService.getBookingForPremises(premisesId, bookingId))
+      assertThat(cas3BookingService.getBookingForPremises(premises, bookingId))
         .isEqualTo(GetBookingForPremisesResult.BookingNotFound)
     }
 
     @Test
     fun `getBookingForPremises returns BookingNotFound when booking does not belong to Premises`() {
-      val premisesId = UUID.fromString("8461d08b-0e3f-426a-a941-0ada4160e6db")
       val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
 
       val premisesEntityFactory = TemporaryAccommodationPremisesEntityFactory()
-        .withId(premisesId)
+        .withId(UUID.randomUUID())
         .withYieldedProbationRegion {
           ProbationRegionEntityFactory()
             .withYieldedApArea { ApAreaEntityFactory().produce() }
             .produce()
         }
         .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-
-      every { mockCas3PremisesService.getPremises(premisesId) } returns premisesEntityFactory.produce()
 
       val keyWorker = ContextStaffMemberFactory().produce()
 
@@ -197,7 +178,7 @@ class Cas3BookingServiceTest {
         .withStaffKeyWorkerCode(keyWorker.code)
         .produce()
 
-      assertThat(cas3BookingService.getBookingForPremises(premisesId, bookingId))
+      assertThat(cas3BookingService.getBookingForPremises(premisesEntityFactory.withId(UUID.randomUUID()).produce(), bookingId))
         .isEqualTo(GetBookingForPremisesResult.BookingNotFound)
     }
 
@@ -216,8 +197,6 @@ class Cas3BookingServiceTest {
         .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
         .produce()
 
-      every { mockCas3PremisesService.getPremises(premisesId) } returns premisesEntity
-
       val keyWorker = ContextStaffMemberFactory().produce()
 
       val bookingEntity = BookingEntityFactory()
@@ -228,69 +207,8 @@ class Cas3BookingServiceTest {
 
       every { mockBookingRepository.findByIdOrNull(bookingId) } returns bookingEntity
 
-      assertThat(cas3BookingService.getBookingForPremises(premisesId, bookingId))
+      assertThat(cas3BookingService.getBookingForPremises(premisesEntity, bookingId))
         .isEqualTo(GetBookingForPremisesResult.Success(bookingEntity))
-    }
-  }
-
-  @Nested
-  inner class GetBooking {
-    val premises = TemporaryAccommodationPremisesEntityFactory()
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea { ApAreaEntityFactory().produce() }
-          .produce()
-      }
-      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-      .produce()
-
-    private val bookingEntity = BookingEntityFactory()
-      .withArrivalDate(LocalDate.parse("2022-08-25"))
-      .withPremises(premises)
-      .produce()
-
-    private val personSummaryInfo = PersonSummaryInfoResult.Success.Full(
-      crn = bookingEntity.crn,
-      summary = CaseSummaryFactory().produce(),
-    )
-
-    @Test
-    fun `returns a booking`() {
-      every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
-      every { mockUserService.getUserForRequest() } returns user
-      every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns true
-      every { mockOffenderService.getPersonSummaryInfoResults(setOf(bookingEntity.crn), user.cas3LimitedAccessStrategy()) } returns listOf(personSummaryInfo)
-
-      val result = cas3BookingService.getBooking(bookingEntity.id)
-
-      assertThat(result is AuthorisableActionResult.Success).isTrue()
-      result as AuthorisableActionResult.Success
-
-      assertThat(result.entity).isEqualTo(Cas3BookingService.BookingAndPersons(bookingEntity, personSummaryInfo))
-    }
-
-    @Test
-    fun `returns NotFound if the booking cannot be found`() {
-      every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns null
-
-      val result = cas3BookingService.getBooking(bookingEntity.id)
-
-      assertThat(result is AuthorisableActionResult.NotFound).isTrue()
-      result as AuthorisableActionResult.NotFound
-
-      assertThat(result.id).isEqualTo(bookingEntity.id.toString())
-      assertThat(result.entityType).isEqualTo("Booking")
-    }
-
-    @Test
-    fun `returns Unauthorised if the user cannot view the booking`() {
-      every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
-      every { mockUserService.getUserForRequest() } returns user
-      every { mockUserAccessService.userCanViewBooking(user, bookingEntity) } returns false
-
-      val result = cas3BookingService.getBooking(bookingEntity.id)
-
-      assertThat(result is AuthorisableActionResult.Unauthorised).isTrue()
     }
   }
 


### PR DESCRIPTION
This [PR CAS-1455](https://dsdmoj.atlassian.net/browse/CAS-1455) is to link the CAS3 booking service with the controllers and remove getBookings function until split the controllers