### PR TITLE
Set SQL timeout of 60 seconds

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,11 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         cache:
           use_second_level_cache: true
+      jakarta:
+        persistence:
+          query:
+            # ensure that wait on locks will eventually error, aiding investigations
+            timeout: 60000
       javax.cache:
         provider: org.ehcache.jsr107.EhcacheCachingProvider
         uri: hibernate-ehcache.xml


### PR DESCRIPTION
Before this commit no timeout is set on SQL queries. This means that code waiting on locks can hang for an indeterminate length of time. It would be preferrable if such code errored after a reasonable wait, which also helps investigate timeout issues as we’ll be alerted to the timeout.

This change was tested by adding the following SQL query into an API request:

```
  @Query(value = "select count(*) from pg_sleep(120)", nativeQuery = true)
  fun slowQuery(): Unit
```

The request timeed out after 60 seonds:

```
org.springframework.dao.QueryTimeoutException: JDBC exception executing SQL [select count(*) from pg_sleep(120)] [ERROR: canceling statement due to user request] [n/a]; SQL [n/a]
```

resulting in a 500 being returned

```
GET /cas1/reference-data/departure-reasons - 500
 Request took 60117ms
```