### PR TITLE
Deprecate load tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Authorization: Bearer {the JWT}
 
 ## Coding Notes
 
+### Load tests
+* The Gatling load tests in this repository are now deprecated as we have migrated load tests to the new  [hmpps-load-testing-probation](https://github.com/ministryofjustice/hmpps-load-testing-probation) repo
+
 ### Documentation
 
 * Architectural decisions are documented in [doc/architecture/decisions](doc/architecture/decisions)

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/ApplyJourneyStressSimulation.kt
@@ -18,6 +18,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
+@Deprecated(message = "No longer used as migrated Performance tests to hmpps-load-testing-probation")
 @Suppress("MagicNumber")
 class ApplyJourneyStressSimulation : Simulation() {
   private val applicationIdKey = "application_id"

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/BookingsTimeSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/simulations/BookingsTimeSimulation.kt
@@ -25,6 +25,7 @@ import java.time.LocalDate
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
+@Deprecated(message = "No longer used as migrated Performance tests to hmpps-load-testing-probation")
 @Suppress("MagicNumber")
 class BookingsTimeSimulation : Simulation() {
   private val arrivalDateKey = "arrival_date"


### PR DESCRIPTION
The Gatling load tests in this repository are now deprecated as we have migrated load tests to the new `hmpps-load-testing-probation` repo