### PR TITLE
Use Lateral Joins in CAS1 Reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationV2ReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationV2ReportRepository.kt
@@ -90,7 +90,7 @@ LEFT OUTER JOIN LATERAL (
   SELECT assessments.*
   FROM assessments
   WHERE reallocated_at IS NULL AND application_id = application.id
-  ORDER BY application_id, created_at ASC
+  ORDER BY created_at ASC
   LIMIT 1
 ) initial_assessment ON TRUE -- ON condition is mandatory with LEFT OUTER JOIN, but satisfied already in lateral join subquery
 
@@ -107,7 +107,7 @@ LEFT OUTER JOIN LATERAL (
   SELECT assessment_clarification_notes.*
   FROM assessment_clarification_notes
   WHERE assessment_id = initial_assessment.id
-  ORDER BY assessment_id, created_at ASC
+  ORDER BY created_at ASC
   LIMIT 1
 ) initial_assessment_clarification_notes ON TRUE -- ON condition is mandatory with LEFT OUTER JOIN, but satisfied already in lateral join subquery
 
@@ -115,7 +115,7 @@ LEFT OUTER JOIN LATERAL (
   SELECT appeals.*
   FROM appeals
   WHERE application_id = application.id
-  ORDER BY application_id, created_at DESC
+  ORDER BY created_at DESC
   LIMIT 1
 ) latest_appeal ON TRUE -- ON condition is mandatory with LEFT OUTER JOIN, but satisfied already in lateral join subquery
 
@@ -123,7 +123,7 @@ LEFT OUTER JOIN LATERAL (
   SELECT assess.*
   FROM assessments assess INNER JOIN approved_premises_assessments apa_assess ON assess.id = apa_assess.assessment_id
   WHERE assess.application_id = application.id AND assess.reallocated_at IS NULL AND apa_assess.created_from_appeal is TRUE
-  ORDER by assess.application_id, assess.created_at DESC
+  ORDER by assess.created_at DESC
   LIMIT 1
 ) latest_appeal_assessment ON TRUE -- ON condition is mandatory with LEFT OUTER JOIN, but satisfied already in lateral join subquery
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationV2ReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ApplicationV2ReportRepository.kt
@@ -137,8 +137,7 @@ LEFT JOIN domain_events_metadata latest_appeal_assessment_ap_type_metadata ON la
 LEFT JOIN users as latest_appeal_assessment_assessor on latest_appeal_assessment_assessor.id = latest_appeal_assessment.allocated_to_user_id
 LEFT JOIN ap_areas as ap_area on ap_area.id = apa.ap_area_id
 
-WHERE application.service = 'approved-premises' AND
-      application.submitted_at IS NOT NULL
+WHERE application.submitted_at IS NOT NULL
     """
 
     const val QUERY =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1RequestForPlacementReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1RequestForPlacementReportRepository.kt
@@ -58,13 +58,13 @@ class Cas1RequestForPlacementReportRepository(
     INNER JOIN approved_premises_applications apa ON apa.id = paa.application_id 
     INNER JOIN raw_applications_report ON raw_applications_report.application_id = paa.application_id
     INNER JOIN applications a ON a.id = apa.id
-    LEFT OUTER JOIN (
-      SELECT DISTINCT ON (application_id)
-             assessments.*
+    LEFT OUTER JOIN LATERAL (
+      SELECT assessments.*
       FROM assessments
-      WHERE reallocated_at IS NULL
+      WHERE application_id = a.id AND reallocated_at IS NULL
       ORDER BY application_id, created_at DESC
-    ) latest_assessment on latest_assessment.application_id = a.id
+      LIMIT 1
+    ) latest_assessment on TRUE -- ON condition is mandatory with LEFT OUTER JOIN, but satisfied already in lateral join subquery
     LEFT OUTER JOIN placement_requests pr ON pr.application_id = a.id AND 
                     pr.reallocated_at IS NULL AND 
                     pr.placement_application_id IS NULL
@@ -109,14 +109,17 @@ UNION ALL
     INNER JOIN raw_applications_report ON raw_applications_report.application_id = pa.application_id
     INNER JOIN placement_application_dates pa_date ON pa.id = pa_date.placement_application_id
     INNER JOIN approved_premises_applications apa ON pa.application_id = apa.id
-    LEFT OUTER JOIN (
-      SELECT DISTINCT ON (m.value)
-             d.occurred_at,
+    LEFT OUTER JOIN LATERAL (
+      SELECT d.occurred_at,
              m.value as placement_application_id
       FROM domain_events d
       INNER JOIN domain_events_metadata m ON m.domain_event_id = d.id AND m.name = 'CAS1_PLACEMENT_APPLICATION_ID'
-      WHERE d.type = 'APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN'
-    ) withdrawn_event ON withdrawn_event.placement_application_id = CAST(pa.id as text)
+      WHERE
+        d.application_id = pa.application_id AND
+      	d.type = 'APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN' 
+      	AND m.value = CAST(pa.id as text)
+      LIMIT 1
+    ) withdrawn_event ON TRUE -- ON condition is mandatory with LEFT OUTER JOIN, but satisfied already in lateral join subquery
     
   WHERE
     pa.submitted_at IS NOT NULL AND

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1RequestForPlacementReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1RequestForPlacementReportRepository.kt
@@ -62,7 +62,7 @@ class Cas1RequestForPlacementReportRepository(
       SELECT assessments.*
       FROM assessments
       WHERE application_id = a.id AND reallocated_at IS NULL
-      ORDER BY application_id, created_at DESC
+      ORDER BY created_at DESC
       LIMIT 1
     ) latest_assessment on TRUE -- ON condition is mandatory with LEFT OUTER JOIN, but satisfied already in lateral join subquery
     LEFT OUTER JOIN placement_requests pr ON pr.application_id = a.id AND 


### PR DESCRIPTION
This PR replaces LEFT OUTER JOINs with more efficient LEFT OUTER JOIN LATERAL joins, allowing us to better filter subquery results within the subquery itself