### PR TITLE
Add premises to Cas1SpaceBookingSummary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -118,23 +118,24 @@ class Cas1SpaceBookingController(
       ),
     )
 
-    val (searchResults, metadata) = extractEntityFromCasResult(result)
+    val searchResultsContainer = extractEntityFromCasResult(result)
 
     val user = userService.getUserForRequest()
     val offenderSummaries = offenderService.getPersonSummaryInfoResults(
-      crns = searchResults.map { it.crn }.toSet(),
+      crns = searchResultsContainer.results.map { it.crn }.toSet(),
       limitedAccessStrategy = user.cas1LimitedAccessStrategy(),
     )
 
-    val summaries = searchResults.map {
+    val summaries = searchResultsContainer.results.map {
       spaceBookingTransformer.transformSearchResultToSummary(
-        it,
-        offenderSummaries.forCrn(it.crn),
+        searchResult = it,
+        premises = searchResultsContainer.premises,
+        personSummaryInfo = offenderSummaries.forCrn(it.crn),
       )
     }
 
     return ResponseEntity.ok()
-      .headers(metadata?.toHeaders())
+      .headers(searchResultsContainer.paginationMetadata?.toHeaders())
       .body(summaries)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceChara
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingAtPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingSearchResult
@@ -168,6 +169,10 @@ class Cas1SpaceBookingTransformer(
   ) = Cas1SpaceBookingSummary(
     id = spaceBooking.id,
     person = personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo),
+    premises = NamedId(
+      spaceBooking.premises.id,
+      spaceBooking.premises.name,
+    ),
     canonicalArrivalDate = spaceBooking.canonicalArrivalDate,
     canonicalDepartureDate = spaceBooking.canonicalDepartureDate,
     expectedArrivalDate = spaceBooking.expectedArrivalDate,
@@ -191,10 +196,15 @@ class Cas1SpaceBookingTransformer(
 
   fun transformSearchResultToSummary(
     searchResult: Cas1SpaceBookingSearchResult,
+    premises: ApprovedPremisesEntity,
     personSummaryInfo: PersonSummaryInfoResult,
   ) = Cas1SpaceBookingSummary(
     id = searchResult.id,
     person = personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo),
+    premises = NamedId(
+      id = premises.id,
+      name = premises.name,
+    ),
     canonicalArrivalDate = searchResult.canonicalArrivalDate,
     canonicalDepartureDate = searchResult.canonicalDepartureDate,
     expectedArrivalDate = searchResult.expectedArrivalDate,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4977,6 +4977,8 @@ components:
           format: uuid
         person:
           $ref: "_shared.yml#/components/schemas/PersonSummary"
+        premises:
+          $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
           description: actual arrival date or, if not known, the expected arrival date
           type: string
@@ -5019,6 +5021,7 @@ components:
       required:
         - id
         - person
+        - premises
         - canonicalArrivalDate
         - canonicalDepartureDate
         - characteristics

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9340,6 +9340,8 @@ components:
           format: uuid
         person:
           $ref: "#/components/schemas/PersonSummary"
+        premises:
+          $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
           description: actual arrival date or, if not known, the expected arrival date
           type: string
@@ -9382,6 +9384,7 @@ components:
       required:
         - id
         - person
+        - premises
         - canonicalArrivalDate
         - canonicalDepartureDate
         - characteristics

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6733,6 +6733,8 @@ components:
           format: uuid
         person:
           $ref: "#/components/schemas/PersonSummary"
+        premises:
+          $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
           description: actual arrival date or, if not known, the expected arrival date
           type: string
@@ -6775,6 +6777,7 @@ components:
       required:
         - id
         - person
+        - premises
         - canonicalArrivalDate
         - canonicalDepartureDate
         - characteristics

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5586,6 +5586,8 @@ components:
           format: uuid
         person:
           $ref: "#/components/schemas/PersonSummary"
+        premises:
+          $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
           description: actual arrival date or, if not known, the expected arrival date
           type: string
@@ -5628,6 +5630,7 @@ components:
       required:
         - id
         - person
+        - premises
         - canonicalArrivalDate
         - canonicalDepartureDate
         - characteristics

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -5607,6 +5607,8 @@ components:
           format: uuid
         person:
           $ref: "#/components/schemas/PersonSummary"
+        premises:
+          $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
           description: actual arrival date or, if not known, the expected arrival date
           type: string
@@ -5649,6 +5651,7 @@ components:
       required:
         - id
         - person
+        - premises
         - canonicalArrivalDate
         - canonicalDepartureDate
         - characteristics

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -5112,6 +5112,8 @@ components:
           format: uuid
         person:
           $ref: "#/components/schemas/PersonSummary"
+        premises:
+          $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
           description: actual arrival date or, if not known, the expected arrival date
           type: string
@@ -5154,6 +5156,7 @@ components:
       required:
         - id
         - person
+        - premises
         - canonicalArrivalDate
         - canonicalDepartureDate
         - characteristics

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -530,7 +530,7 @@ class Cas1SpaceBookingServiceTest {
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
       result as CasResult.Success
-      assertThat(result.value.first).hasSize(3)
+      assertThat(result.value.results).hasSize(3)
 
       assertThat(pageableCaptor.captured.sort.toList()[0].property).isEqualTo(sqlSortField)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RestrictedPersonSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
@@ -348,10 +349,13 @@ class Cas1SpaceBookingTransformerTest {
       every { personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
       every { spaceBookingStatusTransformer.transformToSpaceBookingSummaryStatus(any()) } returns Cas1SpaceBookingSummaryStatus.departed
 
+      val premises = ApprovedPremisesEntityFactory().withDefaults().withName("The booking's premise").produce()
+
       val result = transformer.transformToSummary(
         Cas1SpaceBookingEntityFactory()
           .withId(id)
           .withCrn("the crn")
+          .withPremises(premises)
           .withCanonicalArrivalDate(LocalDate.parse("2023-12-13"))
           .withCanonicalDepartureDate(LocalDate.parse("2023-01-02"))
           .withExpectedArrivalDate(LocalDate.parse("2023-12-13"))
@@ -381,6 +385,8 @@ class Cas1SpaceBookingTransformerTest {
 
       assertThat(result.id).isEqualTo(id)
       assertThat(result.person).isEqualTo(expectedPersonSummary)
+      assertThat(result.premises.id).isEqualTo(premises.id)
+      assertThat(result.premises.name).isEqualTo(premises.name)
       assertThat(result.canonicalArrivalDate).isEqualTo(LocalDate.parse("2023-12-13"))
       assertThat(result.canonicalDepartureDate).isEqualTo(LocalDate.parse("2023-01-02"))
       assertThat(result.tier).isEqualTo("M1")
@@ -404,6 +410,8 @@ class Cas1SpaceBookingTransformerTest {
         PersonSummaryDiscriminator.restrictedPersonSummary,
       )
 
+      val premises = ApprovedPremisesEntityFactory().withDefaults().withName("the premise").produce()
+
       every { personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
       every { spaceBookingStatusTransformer.transformToSpaceBookingSummaryStatus(any()) } returns Cas1SpaceBookingSummaryStatus.departed
 
@@ -426,11 +434,14 @@ class Cas1SpaceBookingTransformerTest {
           keyWorkerName = "the keyworker name",
           characteristicsPropertyNames = null,
         ),
+        premises,
         personSummaryInfo,
       )
 
       assertThat(result.id).isEqualTo(id)
       assertThat(result.person).isEqualTo(expectedPersonSummary)
+      assertThat(result.premises.id).isEqualTo(premises.id)
+      assertThat(result.premises.name).isEqualTo(premises.name)
       assertThat(result.canonicalArrivalDate).isEqualTo(LocalDate.parse("2023-12-13"))
       assertThat(result.canonicalDepartureDate).isEqualTo(LocalDate.parse("2023-01-02"))
       assertThat(result.tier).isEqualTo("A")
@@ -472,6 +483,7 @@ class Cas1SpaceBookingTransformerTest {
           keyWorkerName = null,
           characteristicsPropertyNames = null,
         ),
+        premises = ApprovedPremisesEntityFactory().withDefaults().produce(),
         personSummaryInfo,
       )
 


### PR DESCRIPTION
This is required when showing space bookings on the view placement request screen.

This does add some redundancy when retreiving space bookings when viewing a premise, but this has minimal database overhead as we only fetch the premise once in `Cas1SpaceBookingService`

Captured output locally:

```
    {
        "id": "090d86ad-2e3f-4cb8-a780-d8cb20d5d45d",
        "person": {
            "name": "Aadland Bertrand",
            "isRestricted": false,
            "crn": "X320741",
            "personType": "FullPersonSummary"
        },
        "premises": {
            "id": "d8d0f07b-6e91-42db-b397-b1159de911fc",
            "name": "SWSC Men Premise 1"
        },
        "canonicalArrivalDate": "2028-05-12",
        "canonicalDepartureDate": "2028-07-06",
        "expectedArrivalDate": "2028-05-12",
        "expectedDepartureDate": "2028-07-06",
        "characteristics": [],
        "actualArrivalDate": null,
        "actualDepartureDate": null,
        "isNonArrival": null,
        "tier": null,
        "keyWorkerAllocation": null,
        "status": null
    }
```