### PR TITLE
Add migration job to fix CAS1 room codes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -17,10 +18,12 @@ import java.util.UUID
 interface RoomRepository : JpaRepository<RoomEntity, UUID> {
   fun findByCode(roomCode: String): RoomEntity?
 
-  fun findByCodeAndPremisesId(roomCode: String, premisesId: UUID): RoomEntity?
-
   @Query("SELECT COUNT(r) = 0 FROM RoomEntity r WHERE r.name = :name AND r.premises.id = :premisesId")
   fun nameIsUniqueForPremises(name: String, premisesId: UUID): Boolean
+
+  @Modifying
+  @Query("UPDATE RoomEntity r SET r.code = :code WHERE r.id = :id")
+  fun updateCode(id: UUID, code: String)
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1IsArs
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1TaskDueMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UpdateApplicationLicenceExpiryDateJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UpdateAssessmentReportPropertiesJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UpdateRoomCodesJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas2.Cas2AssessmentMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas2.Cas2NoteMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas2.Cas2StatusUpdateMigrationJob
@@ -54,6 +55,7 @@ class MigrationJobService(
         MigrationJobType.cas1ArsonSuitableToArsonOffences -> getBean(Cas1ArsonSuitableToArsonOffencesJob::class)
         MigrationJobType.cas1BackfillArsonSuitable -> getBean(Cas1IsArsonSuitableBackfillJob::class)
         MigrationJobType.cas1ApprovedPremisesAssessmentReportProperties -> getBean(Cas1UpdateAssessmentReportPropertiesJob::class)
+        MigrationJobType.cas1RoomCodes -> getBean(Cas1UpdateRoomCodesJob::class)
       }
 
       if (job.shouldRunInTransaction) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1UpdateRoomCodesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1UpdateRoomCodesJob.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1SeedRoomsFromSiteSurveyXlsxJob.Companion.buildRoomCode
+
+@Component
+class Cas1UpdateRoomCodesJob(
+  private val approvedPremisesRepository: ApprovedPremisesRepository,
+  private val roomRepository: RoomRepository,
+  override val shouldRunInTransaction: Boolean = true,
+) : MigrationJob() {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun process(pageSize: Int) {
+    approvedPremisesRepository.findAll().forEach { premises ->
+
+      if (premises.rooms.isNotEmpty()) {
+        premises.rooms.forEach { updateRoomIfRequired(premises, it) }
+      }
+    }
+  }
+
+  private fun updateRoomIfRequired(premises: ApprovedPremisesEntity, room: RoomEntity) {
+    val actualRoomCode = room.code
+    val expectedRoomCode = buildRoomCode(
+      qCode = premises.qCode,
+      roomNumber = room.name,
+    )
+
+    if (actualRoomCode != expectedRoomCode) {
+      log.info("Updating premise ${premises.name} room code from $actualRoomCode to $expectedRoomCode")
+      roomRepository.updateCode(room.id, expectedRoomCode)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
@@ -39,6 +39,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
 
   companion object {
     val javers: Javers = JaversBuilder.javers().withListCompareAlgorithm(ListCompareAlgorithm.AS_SET).build()
+    fun buildRoomCode(qCode: String, roomNumber: String) = "$qCode-$roomNumber"
   }
 
   private val log = LoggerFactory.getLogger(this::class.java)
@@ -76,8 +77,6 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
       }
     }
   }
-
-  private fun buildRoomCode(qCode: String, roomNumber: String) = "$qCode-$roomNumber"
 
   private data class RoomInfo(
     val roomCode: String,

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3865,6 +3865,7 @@ components:
         - update_cas1_arson_suitable_to_arson_offences
         - update_cas1_backfill_arson_suitable
         - update_cas1_approved_premises_assessment_report_properties
+        - update_cas1_room_codes
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8228,6 +8228,7 @@ components:
         - update_cas1_arson_suitable_to_arson_offences
         - update_cas1_backfill_arson_suitable
         - update_cas1_approved_premises_assessment_report_properties
+        - update_cas1_room_codes
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5621,6 +5621,7 @@ components:
         - update_cas1_arson_suitable_to_arson_offences
         - update_cas1_backfill_arson_suitable
         - update_cas1_approved_premises_assessment_report_properties
+        - update_cas1_room_codes
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4474,6 +4474,7 @@ components:
         - update_cas1_arson_suitable_to_arson_offences
         - update_cas1_backfill_arson_suitable
         - update_cas1_approved_premises_assessment_report_properties
+        - update_cas1_room_codes
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -4495,6 +4495,7 @@ components:
         - update_cas1_arson_suitable_to_arson_offences
         - update_cas1_backfill_arson_suitable
         - update_cas1_approved_premises_assessment_report_properties
+        - update_cas1_room_codes
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4000,6 +4000,7 @@ components:
         - update_cas1_arson_suitable_to_arson_offences
         - update_cas1_backfill_arson_suitable
         - update_cas1_approved_premises_assessment_report_properties
+        - update_cas1_room_codes
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenARoom.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenARoom.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+
+fun IntegrationTestBase.givenAnApprovedPremisesRoom(
+  premises: ApprovedPremisesEntity? = null,
+  code: String = randomStringMultiCaseWithNumbers(6),
+  name: String = randomStringMultiCaseWithNumbers(8),
+): RoomEntity {
+  val resolvedPremises = premises ?: approvedPremisesEntityFactory.produceAndPersist {
+    withProbationRegion(givenAProbationRegion())
+    withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+  }
+
+  val room = roomEntityFactory.produceAndPersist {
+    withPremises(resolvedPremises)
+    withCode(code)
+    withName(name)
+  }
+
+  return room
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApprovedPremises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApprovedPremises.kt
@@ -4,14 +4,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 
 fun IntegrationTestBase.givenAnApprovedPremises(
   name: String = randomStringMultiCaseWithNumbers(8),
+  qCode: String = randomStringUpperCase(4),
   supportsSpaceBookings: Boolean = false,
   region: ProbationRegionEntity? = null,
 ): ApprovedPremisesEntity = approvedPremisesEntityFactory
   .produceAndPersist {
     withName(name)
+    withQCode(qCode)
     withProbationRegion(region ?: probationRegionEntityFactory.produceAndPersist())
     withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     withSupportsSpaceBookings(supportsSpaceBookings)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateRoomCodesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateRoomCodesJobTest.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremisesRoom
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJobService
+
+class Cas1UpdateRoomCodesJobTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  @Test
+  fun `Update room codes`() {
+    val premises = givenAnApprovedPremises(
+      qCode = "Q001",
+    )
+
+    val room1WithCorrectCode = givenAnApprovedPremisesRoom(
+      premises = premises,
+      code = "Q001-1",
+      name = "1",
+    )
+
+    val room2WithIncorrectCode = givenAnApprovedPremisesRoom(
+      premises = premises,
+      code = "Q002-2",
+      name = "2",
+    )
+
+    val room3WithIncorrectCode = givenAnApprovedPremisesRoom(
+      premises = premises,
+      code = "3",
+      name = "3",
+    )
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1RoomCodes)
+
+    assertThat(roomRepository.findByIdOrNull(room1WithCorrectCode.id)!!.code).isEqualTo("Q001-1")
+    assertThat(roomRepository.findByIdOrNull(room2WithIncorrectCode.id)!!.code).isEqualTo("Q001-2")
+    assertThat(roomRepository.findByIdOrNull(room3WithIncorrectCode.id)!!.code).isEqualTo("Q001-3")
+  }
+}


### PR DESCRIPTION
When the room codes for NE premises were initially loaded, they used a room code prefixed with a value that isn’t included in the site surveys (i.e. they don’t use QCodes). This commit adds a migration job to update those room codes to match the format expected if loaded from the site surveys