### PR TITLE
Deprecate space booking canonical date API fields

### DIFF
--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4626,10 +4626,12 @@ components:
         premises:
           $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
+          deprecated: true
           description: actual arrival date or, if not known, the expected arrival date
           type: string
           format: date
         canonicalDepartureDate:
+          deprecated: true
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -392,10 +392,12 @@ components:
           pattern: '^([01][0-9]|2[0-3]):([0-5][0-9])$'
           example: '23:15'
         canonicalArrivalDate:
-          description: actual arrival date or, if not known, the expected arrival date
+          deprecated: true
+          description: actual arrival date or, if not known, the expected arrival date.
           type: string
           format: date
         canonicalDepartureDate:
+          deprecated: true
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8989,10 +8989,12 @@ components:
         premises:
           $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
+          deprecated: true
           description: actual arrival date or, if not known, the expected arrival date
           type: string
           format: date
         canonicalDepartureDate:
+          deprecated: true
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6382,10 +6382,12 @@ components:
         premises:
           $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
+          deprecated: true
           description: actual arrival date or, if not known, the expected arrival date
           type: string
           format: date
         canonicalDepartureDate:
+          deprecated: true
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date
@@ -6845,10 +6847,12 @@ components:
           pattern: '^([01][0-9]|2[0-3]):([0-5][0-9])$'
           example: '23:15'
         canonicalArrivalDate:
-          description: actual arrival date or, if not known, the expected arrival date
+          deprecated: true
+          description: actual arrival date or, if not known, the expected arrival date.
           type: string
           format: date
         canonicalDepartureDate:
+          deprecated: true
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5235,10 +5235,12 @@ components:
         premises:
           $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
+          deprecated: true
           description: actual arrival date or, if not known, the expected arrival date
           type: string
           format: date
         canonicalDepartureDate:
+          deprecated: true
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -5256,10 +5256,12 @@ components:
         premises:
           $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
+          deprecated: true
           description: actual arrival date or, if not known, the expected arrival date
           type: string
           format: date
         canonicalDepartureDate:
+          deprecated: true
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4761,10 +4761,12 @@ components:
         premises:
           $ref: "#/components/schemas/NamedId"
         canonicalArrivalDate:
+          deprecated: true
           description: actual arrival date or, if not known, the expected arrival date
           type: string
           format: date
         canonicalDepartureDate:
+          deprecated: true
           description: actual departure date or, if not known, the expected departure date
           type: string
           format: date


### PR DESCRIPTION
The UI is going to stop using these in favour of expected and actual arrival/departure dates