### PR TITLE
Deprecate Cas1SpaceSearchRequirements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
@@ -51,8 +51,12 @@ class Cas1SpaceSearchService(
 
   private fun getSpaceCharacteristics(parameters: Cas1SpaceSearchParameters): GroupedCharacteristics {
     val requirements = parameters.requirements
-    val propertyNames = requirements.spaceCharacteristics?.map { it.value } ?: listOf()
-    val characteristics = characteristicService.getCharacteristicsByPropertyNames(propertyNames, ServiceName.approvedPremises)
+    val propertyNames =
+      (
+        (requirements.spaceCharacteristics?.map { it.value } ?: listOf()) +
+          (parameters.spaceCharacteristics?.map { it.value } ?: listOf())
+        ).toSet()
+    val characteristics = characteristicService.getCharacteristicsByPropertyNames(propertyNames.toList(), ServiceName.approvedPremises)
 
     return GroupedCharacteristics(
       characteristics.filter { it.isPremisesCharacteristic() }.map { it.id },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
@@ -26,7 +25,7 @@ class Cas1SpaceSearchService(
     val application = applicationRepository.findByIdOrNull(searchParameters.applicationId)
       ?: throw NotFoundProblem(applicationId, "Application")
 
-    val requiredCharacteristics = getRequiredCharacteristics(searchParameters.requirements)
+    val requiredCharacteristics = getRequiredCharacteristics(searchParameters)
 
     return spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
       targetPostcodeDistrict = searchParameters.targetPostcodeDistrict,
@@ -37,7 +36,8 @@ class Cas1SpaceSearchService(
     )
   }
 
-  private fun getRequiredCharacteristics(requirements: Cas1SpaceSearchRequirements): RequiredCharacteristics {
+  private fun getRequiredCharacteristics(parameters: Cas1SpaceSearchParameters): RequiredCharacteristics {
+    val requirements = parameters.requirements
     val apType = requirements.apType
     return RequiredCharacteristics(
       apType = if (apType != null) {
@@ -45,11 +45,12 @@ class Cas1SpaceSearchService(
       } else {
         requirements.apTypes?.map { it.asApprovedPremisesType() }?.firstOrNull()
       },
-      groupedCharacteristics = getSpaceCharacteristics(requirements),
+      groupedCharacteristics = getSpaceCharacteristics(parameters),
     )
   }
 
-  private fun getSpaceCharacteristics(requirements: Cas1SpaceSearchRequirements): GroupedCharacteristics {
+  private fun getSpaceCharacteristics(parameters: Cas1SpaceSearchParameters): GroupedCharacteristics {
+    val requirements = parameters.requirements
     val propertyNames = requirements.spaceCharacteristics?.map { it.value } ?: listOf()
     val characteristics = characteristicService.getCharacteristicsByPropertyNames(propertyNames, ServiceName.approvedPremises)
 

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -203,6 +203,7 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceBookingCharacteristic'
     Cas1SpaceSearchRequirements:
+      deprecated: true
       type: object
       properties:
         apTypes:
@@ -216,6 +217,8 @@ components:
           description: "Use 'spaceCharacteristics' to filter on premise types"
           $ref: '_shared.yml#/components/schemas/ApType'
         spaceCharacteristics:
+          deprecated: true
+          description: use Cas1SpaceSearchParameters.spaceCharacteristics
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
@@ -247,7 +250,12 @@ components:
           description: The 'target' location, in the form of a postcode district
           example: SE5
         requirements:
+          deprecated: true
           $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
+        spaceCharacteristics:
+          type: array
+          items:
+            $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
       required:
         - applicationId
         - startDate

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6658,6 +6658,7 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceBookingCharacteristic'
     Cas1SpaceSearchRequirements:
+      deprecated: true
       type: object
       properties:
         apTypes:
@@ -6671,6 +6672,8 @@ components:
           description: "Use 'spaceCharacteristics' to filter on premise types"
           $ref: '#/components/schemas/ApType'
         spaceCharacteristics:
+          deprecated: true
+          description: use Cas1SpaceSearchParameters.spaceCharacteristics
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
@@ -6702,7 +6705,12 @@ components:
           description: The 'target' location, in the form of a postcode district
           example: SE5
         requirements:
+          deprecated: true
           $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
+        spaceCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
       required:
         - applicationId
         - startDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -58,6 +58,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
           spaceCharacteristics = null,
@@ -136,6 +137,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
           spaceCharacteristics = null,
@@ -212,6 +214,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
           spaceCharacteristics = null,
@@ -278,6 +281,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
           apTypes = emptyList(),
           apType = apType,
@@ -339,6 +343,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
           apTypes = emptyList(),
           apType = ApType.normal,
@@ -403,6 +408,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
           apTypes = listOf(apType),
           apType = null,
@@ -474,10 +480,11 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = listOf(Cas1SpaceCharacteristic.isPIPE),
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
           apType = null,
-          spaceCharacteristics = listOf(Cas1SpaceCharacteristic.isPIPE),
+          spaceCharacteristics = null,
         ),
       )
 
@@ -580,9 +587,10 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = listOf(characteristic),
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
-          spaceCharacteristics = listOf(characteristic),
+          spaceCharacteristics = null,
         ),
       )
 
@@ -665,9 +673,10 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
+        spaceCharacteristics = Cas1SpaceCharacteristic.entries.slice(1..2),
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
-          spaceCharacteristics = Cas1SpaceCharacteristic.entries.slice(1..3),
+          spaceCharacteristics = listOf(Cas1SpaceCharacteristic.entries[3]),
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
@@ -63,9 +63,9 @@ class Cas1SpaceSearchServiceTest {
           startDate = LocalDate.parse("2024-08-01"),
           durationInDays = 14,
           targetPostcodeDistrict = "TB1",
+          spaceCharacteristics = Cas1SpaceCharacteristic.entries,
           requirements = Cas1SpaceSearchRequirements(
             apTypes = ApType.entries,
-            spaceCharacteristics = Cas1SpaceCharacteristic.entries,
           ),
         ),
       )
@@ -474,9 +474,9 @@ class Cas1SpaceSearchServiceTest {
         startDate = LocalDate.parse("2024-08-01"),
         durationInDays = 14,
         targetPostcodeDistrict = "TB1",
+        spaceCharacteristics = spaceCharacteristics,
         requirements = Cas1SpaceSearchRequirements(
           apTypes = ApType.entries,
-          spaceCharacteristics = spaceCharacteristics,
         ),
       ),
     )


### PR DESCRIPTION
To simplify the space search API we want to remove `Cas1SpaceSearchRequirements`. Before this commit only one of the 4 properties in this class were being used.

This commit deprecates all fields on `Cas1SpaceSearchRequirements` and introduces a new `spaceCharacteristics` property on `Cas1SpaceSearchParameters` to replace the deprecated field