### PR TITLE
Create Offender Risks Service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -14,10 +14,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 
 @Component
-class OffenderRisksDataSource(
+class OffenderRisksService(
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
   private val apOASysContextApiClient: ApOASysContextApiClient,
   private val hmppsTierApiClient: HMPPSTierApiClient,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonAdjudicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonCaseNotesConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonCaseNotesConfigBindingModel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderRisksDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
@@ -52,7 +51,7 @@ class OffenderService(
   private val caseNotesClient: CaseNotesClient,
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
   private val offenderDetailsDataSource: OffenderDetailsDataSource,
-  private val offenderRisksDataSource: OffenderRisksDataSource,
+  private val offenderRisksService: OffenderRisksService,
   private val personTransformer: PersonTransformer,
   prisonCaseNotesConfigBindingModel: PrisonCaseNotesConfigBindingModel,
   adjudicationsConfigBindingModel: PrisonAdjudicationsConfigBindingModel,
@@ -265,6 +264,9 @@ class OffenderService(
     { offenderDetailsDataSource.getUserAccessForOffenderCrn(userDistinguishedName, crn) },
   )
 
+  /**
+   * Returns CasResult.Unauthorised if offender is LAO and user can't access them
+   */
   @Deprecated(
     """
       This function returns the now deprecated [OffenderDetailSummary], which is the community-api data model
@@ -410,7 +412,7 @@ class OffenderService(
     is AuthorisableActionResult.NotFound -> AuthorisableActionResult.NotFound()
     is AuthorisableActionResult.Unauthorised -> AuthorisableActionResult.Unauthorised()
     is AuthorisableActionResult.Success -> AuthorisableActionResult.Success(
-      offenderRisksDataSource.getPersonRisks(crn),
+      offenderRisksService.getPersonRisks(crn),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
@@ -71,7 +71,7 @@ class PersonRisksTest : InitialiseDatabasePerClassTestBase() {
 
   @Test
   fun `Getting risks for a CRN that does not exist returns 404`() {
-    givenAUser { userEntity, jwt ->
+    givenAUser { _, jwt ->
       val crn = "CRN123"
 
       webTestClient.get()
@@ -80,6 +80,25 @@ class PersonRisksTest : InitialiseDatabasePerClassTestBase() {
         .exchange()
         .expectStatus()
         .isNotFound
+    }
+  }
+
+  @Test
+  fun `Getting risks for an LAO without access returns 403`() {
+    givenAUser { _, jwt ->
+      givenAnOffender(
+        offenderDetailsConfigBlock = {
+          withCurrentRestriction(true)
+        },
+      ) { offenderDetails, _ ->
+
+        webTestClient.get()
+          .uri("/people/${offenderDetails.otherIds.crn}/risks")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderRisksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderRisksServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.datasource
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.Called
 import io.mockk.every
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderRisksDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
@@ -22,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Regi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppstier.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RiskLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RoshRatings
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -29,13 +29,13 @@ import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.util.UUID
 
-class OffenderRisksDataSourceTest {
+class OffenderRisksServiceTest {
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
   private val mockApOASysContextApiClient = mockk<ApOASysContextApiClient>()
   private val mockHMPPSTierApiClient = mockk<HMPPSTierApiClient>()
   private val mockSentryService = mockk<SentryService>()
 
-  private val apDeliusContextApiOffenderRisksDataSource = OffenderRisksDataSource(
+  private val apDeliusContextApiOffenderRisksService = OffenderRisksService(
     mockApDeliusContextApiClient,
     mockApOASysContextApiClient,
     mockHMPPSTierApiClient,
@@ -50,7 +50,7 @@ class OffenderRisksDataSourceTest {
     mock404Tier(crn)
     mock404CaseDetail(crn)
 
-    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+    val result = apDeliusContextApiOffenderRisksService.getPersonRisks(crn)
     assertThat(result.roshRisks.status).isEqualTo(RiskStatus.NotFound)
     assertThat(result.tier.status).isEqualTo(RiskStatus.NotFound)
     assertThat(result.mappa.status).isEqualTo(RiskStatus.NotFound)
@@ -68,7 +68,7 @@ class OffenderRisksDataSourceTest {
     mock500CaseDetail(crn)
     mockSentry()
 
-    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+    val result = apDeliusContextApiOffenderRisksService.getPersonRisks(crn)
     assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Error)
     assertThat(result.tier.status).isEqualTo(RiskStatus.Error)
     assertThat(result.mappa.status).isEqualTo(RiskStatus.Error)
@@ -97,7 +97,7 @@ class OffenderRisksDataSourceTest {
     mock500CaseDetail(crn)
     mockSentry()
 
-    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+    val result = apDeliusContextApiOffenderRisksService.getPersonRisks(crn)
     assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Error)
     assertThat(result.tier.status).isEqualTo(RiskStatus.Error)
     assertThat(result.mappa.status).isEqualTo(RiskStatus.Error)
@@ -165,7 +165,7 @@ class OffenderRisksDataSourceTest {
         .produce(),
     )
 
-    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+    val result = apDeliusContextApiOffenderRisksService.getPersonRisks(crn)
 
     assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
     result.roshRisks.value!!.let {
@@ -250,7 +250,7 @@ class OffenderRisksDataSourceTest {
         .produce(),
     )
 
-    val result = apDeliusContextApiOffenderRisksDataSource.getPersonRisks(crn)
+    val result = apDeliusContextApiOffenderRisksService.getPersonRisks(crn)
 
     assertThat(result.roshRisks.status).isEqualTo(RiskStatus.Retrieved)
     result.roshRisks.value!!.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.ExcludedCategoryB
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonAdjudicationsConfigBindingModel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonCaseNotesConfigBindingModel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderRisksDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AdjudicationFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AdjudicationsPageFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AgencyFactory
@@ -47,6 +46,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService.LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService.LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess
@@ -64,7 +64,7 @@ class OffenderServiceTest {
   private val mockCaseNotesClient = mockk<CaseNotesClient>()
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
   private val mockOffenderDetailsDataSource = mockk<OffenderDetailsDataSource>()
-  private val mockOffenderRisksDataSource = mockk<OffenderRisksDataSource>()
+  private val mockOffenderRisksService = mockk<OffenderRisksService>()
   private val mockPersonTransformer = mockk<PersonTransformer>()
 
   private val prisonCaseNotesConfigBindingModel = PrisonCaseNotesConfigBindingModel().apply {
@@ -93,7 +93,7 @@ class OffenderServiceTest {
     mockCaseNotesClient,
     mockApDeliusContextApiClient,
     mockOffenderDetailsDataSource,
-    mockOffenderRisksDataSource,
+    mockOffenderRisksService,
     mockPersonTransformer,
     prisonCaseNotesConfigBindingModel,
     adjudicationsConfigBindingModel,
@@ -302,7 +302,7 @@ class OffenderServiceTest {
         UserOffenderAccess(userRestricted = false, userExcluded = false, restrictionMessage = null),
       )
 
-    every { mockOffenderRisksDataSource.getPersonRisks(crn) } returns expectedRisks
+    every { mockOffenderRisksService.getPersonRisks(crn) } returns expectedRisks
 
     val result = offenderService.getRiskByCrn(crn, deliusUsername)
     assertThat(result is AuthorisableActionResult.Success).isTrue


### PR DESCRIPTION
The PR renames `OffenderRisksDataSource` to `OffenderRisksService`. A subsequent commit will move the function in `OffenderService` into `OffenderRisksService` and callers will call the `OffenderRisksService` directly.

This is part of work to make the `OffenderService` smaller, more manageable and more cohesive.

This PR also adds a missing regression test around retrieving offender risks for LAOs