### PR TITLE
APS-2027 - Add deliusEventNumber to Cas1SpaceBookingSummary.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -131,6 +131,7 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
           WHEN apa.id IS NOT NULL THEN apa.name
           ELSE offline_app.name
         END AS personName,
+        b.delius_event_number AS deliusEventNumber,
         $SPACE_BOOKING_SUMMARY_CHARACTERISTICS_SUBQUERY
         $SPACE_BOOKING_SUMMARY_JOIN_CLAUSE
         $SPACE_BOOKING_SUMMARY_WHERE_CLAUSE
@@ -297,6 +298,7 @@ interface Cas1SpaceBookingSearchResult {
   val keyWorkerAssignedAt: Instant?
   val keyWorkerName: String?
   val characteristicsPropertyNames: String?
+  val deliusEventNumber: String?
 }
 
 interface Cas1SpaceBookingAtPremises {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -233,6 +233,7 @@ class Cas1SpaceBookingTransformer(
     characteristics = searchResult.characteristicsPropertyNames?.split(",")?.mapNotNull { propertyName ->
       Cas1SpaceCharacteristic.entries.find { it.name == propertyName }
     } ?: listOf(),
+    deliusEventNumber = searchResult.deliusEventNumber,
 
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -187,6 +187,7 @@ class Cas1SpaceBookingTransformer(
     characteristics = spaceBooking.criteria.mapNotNull { criteria ->
       Cas1SpaceCharacteristic.entries.find { it.name == criteria.propertyName }
     },
+    deliusEventNumber = spaceBooking.deliusEventNumber,
   )
 
   fun transformSearchResultToSummary(

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4644,6 +4644,8 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
           default: []
+        deliusEventNumber:
+          type: string
       required:
         - id
         - person

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -8974,6 +8974,8 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
           default: []
+        deliusEventNumber:
+          type: string
       required:
         - id
         - person

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6400,6 +6400,8 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
           default: []
+        deliusEventNumber:
+          type: string
       required:
         - id
         - person

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5253,6 +5253,8 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
           default: []
+        deliusEventNumber:
+          type: string
       required:
         - id
         - person

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -5274,6 +5274,8 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
           default: []
+        deliusEventNumber:
+          type: string
       required:
         - id
         - person

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4779,6 +4779,8 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
           default: []
+        deliusEventNumber:
+          type: string
       required:
         - id
         - person

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -359,6 +359,7 @@ class Cas1SpaceBookingTransformerTest {
           .withKeyworkerAssignedAt(LocalDateTime.of(2023, 12, 12, 0, 0, 0).toInstant(ZoneOffset.UTC))
           .withKeyworkerName("the keyworker name")
           .withCriteria(mutableListOf())
+          .withDeliusEventNumber("event8")
           .produce(),
         personSummaryInfo,
       )
@@ -374,6 +375,7 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.keyWorkerAllocation!!.keyWorker.name).isEqualTo("the keyworker name")
       assertThat(result.keyWorkerAllocation!!.keyWorker.code).isEqualTo("the staff code")
       assertThat(result.status).isEqualTo(Cas1SpaceBookingSummaryStatus.departed)
+      assertThat(result.deliusEventNumber).isEqualTo("event8")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -415,6 +415,7 @@ class Cas1SpaceBookingTransformerTest {
           keyWorkerAssignedAt = LocalDateTime.of(2023, 12, 12, 0, 0, 0).toInstant(ZoneOffset.UTC),
           keyWorkerName = "the keyworker name",
           characteristicsPropertyNames = null,
+          deliusEventNumber = "event8",
         ),
         premises,
         personSummaryInfo,
@@ -431,6 +432,7 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.keyWorkerAllocation!!.keyWorker.name).isEqualTo("the keyworker name")
       assertThat(result.keyWorkerAllocation!!.keyWorker.code).isEqualTo("the staff code")
       assertThat(result.status).isEqualTo(Cas1SpaceBookingSummaryStatus.departed)
+      assertThat(result.deliusEventNumber).isEqualTo("event8")
     }
 
     @Test
@@ -464,6 +466,7 @@ class Cas1SpaceBookingTransformerTest {
           keyWorkerAssignedAt = null,
           keyWorkerName = null,
           characteristicsPropertyNames = null,
+          deliusEventNumber = "event8",
         ),
         premises = ApprovedPremisesEntityFactory().withDefaults().produce(),
         personSummaryInfo,
@@ -492,6 +495,7 @@ data class Cas1SpaceBookingSearchResultImpl(
   override val keyWorkerAssignedAt: Instant?,
   override val keyWorkerName: String?,
   override val characteristicsPropertyNames: String?,
+  override val deliusEventNumber: String?,
 ) : Cas1SpaceBookingSearchResult
 
 data class Cas1SpaceBookingAtPremisesImpl(


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2027

- Add deliusEventNumber to Cas1SpaceBookingSummary.
- Add deliusEventNumber to transformToSummary() which transforms Cas1SpaceBookingEntity to Cas1SpaceBookingSummary.
- Update associated transformToSummary transformer unit test.

- Add deliusEventNumber to Cas1SpaceBookingSearchResult type.
- Add deliusEventNumber to transformSearchResultToSummary() which transforms Cas1SpaceBookingSearchResult to Cas1SpaceBookingSummary.
- Update associated transformSearchResultToSummary transformer unit test.

Acceptance criteria (unit tests only) discussed in this associated Slack correspondence: https://mojdt.slack.com/archives/C03K0HB0LBE/p1740585245549299
