### PR TITLE
APS-2036 remove redundant calls when retrieving risks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -348,20 +348,10 @@ class ApplicationService(
         return@validatedCasResult fieldValidationError
       }
 
-      var riskRatings: PersonRisks? = null
-
-      if (createWithRisks == true) {
-        val riskRatingsResult = offenderService.getRiskByCrn(crn, user.deliusUsername)
-
-        riskRatings = when (riskRatingsResult) {
-          is AuthorisableActionResult.NotFound ->
-            return@validatedCasResult "$.crn" hasSingleValidationError "doesNotExist"
-
-          is AuthorisableActionResult.Unauthorised ->
-            return@validatedCasResult "$.crn" hasSingleValidationError "userPermission"
-
-          is AuthorisableActionResult.Success -> riskRatingsResult.entity
-        }
+      val riskRatings: PersonRisks? = if (createWithRisks == true) {
+        offenderRisksService.getPersonRisks(crn)
+      } else {
+        null
       }
 
       val prisonName = getPrisonName(personInfo)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -408,6 +408,7 @@ class OffenderService(
     return AuthorisableActionResult.Success(inmateDetail)
   }
 
+  @Deprecated("Use [OffenderRisksService] directly")
   fun getRiskByCrn(crn: String, deliusUsername: String): AuthorisableActionResult<PersonRisks> = when (getOffenderByCrn(crn, deliusUsername)) {
     is AuthorisableActionResult.NotFound -> AuthorisableActionResult.NotFound()
     is AuthorisableActionResult.Unauthorised -> AuthorisableActionResult.Unauthorised()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonRisksTest.kt
@@ -10,12 +10,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisksEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextNoCaseSummariesToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulTierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.MappaDetail
@@ -72,7 +75,16 @@ class PersonRisksTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `Getting risks for a CRN that does not exist returns 404`() {
     givenAUser { _, jwt ->
+
       val crn = "CRN123"
+      apDeliusContextNoCaseSummariesToBulkResponse(crn)
+      apDeliusContextAddSingleResponseToUserAccessCall(
+        caseAccess = CaseAccessFactory()
+          .withUserExcluded(true)
+          .withUserRestricted(true)
+          .withCrn("CRN123")
+          .produce(),
+      )
 
       webTestClient.get()
         .uri("/people/$crn/risks")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -174,6 +174,16 @@ fun IntegrationTestBase.apDeliusContextAddCaseSummaryToBulkResponse(caseSummary:
   }
 }
 
+fun IntegrationTestBase.apDeliusContextNoCaseSummariesToBulkResponse(crn: String) {
+  mockSuccessfulGetCallWithBodyAndJsonResponse(
+    url = "/probation-cases/summaries",
+    requestBody = WireMock.equalToJson(objectMapper.writeValueAsString(listOf(crn))),
+    responseBody = CaseSummaries(
+      cases = emptyList(),
+    ),
+  )
+}
+
 fun IntegrationTestBase.apDeliusContextAddSingleCaseSummaryToBulkResponse(caseSummary: CaseSummary) {
   mockSuccessfulGetCallWithBodyAndJsonResponse(
     url = "/probation-cases/summaries",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -86,6 +86,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService.Cas1ApplicationUpdateFields
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -108,6 +109,7 @@ class ApplicationServiceTest {
   private val mockApplicationRepository = mockk<ApplicationRepository>()
   private val mockJsonSchemaService = mockk<JsonSchemaService>()
   private val mockOffenderService = mockk<OffenderService>()
+  private val mockOffenderRisksService = mockk<OffenderRisksService>()
   private val mockUserService = mockk<UserService>()
   private val mockAssessmentService = mockk<AssessmentService>()
   private val mockOfflineApplicationRepository = mockk<OfflineApplicationRepository>()
@@ -132,6 +134,7 @@ class ApplicationServiceTest {
     mockApplicationRepository,
     mockJsonSchemaService,
     mockOffenderService,
+    mockOffenderRisksService,
     mockUserService,
     mockAssessmentService,
     mockOfflineApplicationRepository,
@@ -401,14 +404,12 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      riskRatings,
-    )
+    every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
 
     val result = applicationService.createApprovedPremisesApplication(offenderDetails, user, 123, "1", "A12HI")
 
     assertThatCasResult(result).isSuccess().with {
-      val approvedPremisesApplication = it as ApprovedPremisesApplicationEntity
+      val approvedPremisesApplication = it
       assertThat(approvedPremisesApplication.riskRatings).isEqualTo(riskRatings)
       assertThat(approvedPremisesApplication.name).isEqualTo("${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -618,9 +618,7 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      riskRatings,
-    )
+    every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
 
     val result = applicationService.createTemporaryAccommodationApplication(
       crn,
@@ -699,9 +697,7 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      riskRatings,
-    )
+    every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
 
     val result = applicationService.createTemporaryAccommodationApplication(
       crn,
@@ -779,9 +775,7 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      riskRatings,
-    )
+    every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
 
     val result = applicationService.createTemporaryAccommodationApplication(
       crn,
@@ -793,7 +787,7 @@ class ApplicationServiceTest {
     )
 
     assertThatCasResult(result).isSuccess().with {
-      val temporaryAccommodationApplication = it as TemporaryAccommodationApplicationEntity
+      val temporaryAccommodationApplication = it
       assertThat(temporaryAccommodationApplication.riskRatings).isEqualTo(riskRatings)
       assertThat(temporaryAccommodationApplication.prisonNameOnCreation).isNull()
     }
@@ -859,9 +853,7 @@ class ApplicationServiceTest {
       )
       .produce()
 
-    every { mockOffenderService.getRiskByCrn(crn, username) } returns AuthorisableActionResult.Success(
-      riskRatings,
-    )
+    every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
 
     val result = applicationService.createTemporaryAccommodationApplication(
       crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
@@ -42,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
@@ -55,6 +56,7 @@ import java.util.UUID
 
 class Cas1ApplicationCas1DomainEventServiceTest {
   private val mockOffenderService = mockk<OffenderService>()
+  private val mockOffenderRisksService = mockk<OffenderRisksService>()
   private val mockDomainEventService = mockk<Cas1DomainEventService>()
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
   private val mockDomainEventTransformer = mockk<DomainEventTransformer>()
@@ -62,6 +64,7 @@ class Cas1ApplicationCas1DomainEventServiceTest {
   private val service = Cas1ApplicationDomainEventService(
     mockDomainEventService,
     mockOffenderService,
+    mockOffenderRisksService,
     mockApDeliusContextApiClient,
     mockDomainEventTransformer,
     UrlTemplate("http://frontend/applications/#id"),
@@ -131,13 +134,8 @@ class Cas1ApplicationCas1DomainEventServiceTest {
         .produce()
 
       every {
-        mockOffenderService.getRiskByCrn(
-          application.crn,
-          user.deliusUsername,
-        )
-      } returns AuthorisableActionResult.Success(
-        risks,
-      )
+        mockOffenderRisksService.getPersonRisks(application.crn)
+      } returns risks
 
       every { mockApDeliusContextApiClient.getCaseDetail(application.crn) } returns ClientResult.Success(
         status = HttpStatus.OK,


### PR DESCRIPTION
This PR removes usage of `offenderService.getRisks` and instead calls the `offenderRiskService` directly. this removes several redundant calls that retrieve the offender