### PR TITLE
Remove use of deprecated offender functions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -22,14 +22,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
@@ -77,16 +78,15 @@ class AssessmentController(
         )
         val transformSummaries = when (sortBy) {
           AssessmentSortField.assessmentDueAt -> throw BadRequestProblem(errorDetail = "Sorting by due date is not supported for CAS3")
-          AssessmentSortField.personName -> transformDomainToApi(user, summaries, user.hasQualification(UserQualification.LAO)).sortByName(resolvedSortDirection)
-
-          else -> transformDomainToApi(user, summaries)
+          AssessmentSortField.personName -> transformDomainToApi(summaries, user.cas3LimitedAccessStrategy()).sortByName(resolvedSortDirection)
+          else -> transformDomainToApi(summaries, user.cas3LimitedAccessStrategy())
         }
         Pair(transformSummaries, metadata)
       }
 
       else -> {
         val (summaries, metadata) = assessmentService.getVisibleAssessmentSummariesForUserCAS1(user, domainSummaryStatuses, PageCriteria(resolvedSortBy, resolvedSortDirection, page, perPage))
-        Pair(transformDomainToApi(user, summaries, user.hasQualification(UserQualification.LAO)), metadata)
+        Pair(transformDomainToApi(summaries, user.cas1LimitedAccessStrategy()), metadata)
       }
     }
 
@@ -95,9 +95,12 @@ class AssessmentController(
       .body(summaries)
   }
 
-  private fun transformDomainToApi(user: UserEntity, summaries: List<DomainAssessmentSummary>, ignoreLaoRestrictions: Boolean = false): List<AssessmentSummary> {
+  private fun transformDomainToApi(
+    summaries: List<DomainAssessmentSummary>,
+    limitedAccessStrategy: OffenderService.LimitedAccessStrategy,
+  ): List<AssessmentSummary> {
     val crns = summaries.map { it.crn }
-    val personInfoResults = offenderService.getPersonInfoResults(crns.toSet(), user.deliusUsername, ignoreLaoRestrictions)
+    val personInfoResults = offenderService.getPersonInfoResults(crns.toSet(), limitedAccessStrategy)
 
     return summaries.map {
       val crn = it.crn

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -70,6 +70,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Withdra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3VoidBedspaceService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LimitedAccessStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedDetailTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedSummaryTransformer
@@ -377,8 +378,7 @@ class PremisesController(
     val personInfoResults = async {
       offenderService.getPersonInfoResults(
         crns.toSet(),
-        user.deliusUsername,
-        user.hasQualification(UserQualification.LAO),
+        user.cas3LimitedAccessStrategy(),
       )
     }.await()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -608,6 +608,12 @@ class OffenderService(
   }
 }
 
+/**
+ * If the user has the `LAO` qualification, they can always view LAO offenders
+ *
+ * Note that there are some cases in CAS1 where this strategy should not be used
+ * (e.g. when creating applications the LAO qualification should be ignored)
+ */
 fun UserEntity.cas1LimitedAccessStrategy() = if (this.hasQualification(UserQualification.LAO)) {
   LimitedAccessStrategy.IgnoreLimitedAccess
 } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -545,8 +545,13 @@ class OffenderService(
   fun getPersonInfoResult(
     crn: String,
     limitedAccessStrategy: LimitedAccessStrategy,
+  ) = getPersonInfoResults(setOf(crn), limitedAccessStrategy).first()
+
+  fun getPersonInfoResults(
+    crns: Set<String>,
+    limitedAccessStrategy: LimitedAccessStrategy,
   ) = getPersonInfoResults(
-    crns = setOf(crn),
+    crns = crns,
     deliusUsername = when (limitedAccessStrategy) {
       is LimitedAccessStrategy.IgnoreLimitedAccess -> null
       is LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess -> limitedAccessStrategy.deliusUsername
@@ -555,7 +560,7 @@ class OffenderService(
       is LimitedAccessStrategy.IgnoreLimitedAccess -> true
       is LimitedAccessStrategy.ReturnRestrictedIfLimitedAccess -> false
     },
-  ).first()
+  )
 
   @Deprecated(
     """Use version that takes limitedAccessStrategy, derive from [UserEntity.cas1LimitedAccessStrategy()] 
@@ -570,7 +575,7 @@ class OffenderService(
     return getPersonInfoResults(setOf(crn), deliusUsername, ignoreLaoRestrictions).first()
   }
 
-  fun getPersonInfoResults(
+  private fun getPersonInfoResults(
     crns: Set<String>,
     deliusUsername: String?,
     ignoreLaoRestrictions: Boolean,


### PR DESCRIPTION
Note that the `premisesPremisesIdBookingsGet` function updated in PremisesController now uses the CAS3 strategy as the function is only ever called by CAS3 (previously it included CAS1 logic)