### PR TITLE
CAS-1434 - cas2 prisoner locations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2PrisonerLocationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2PrisonerLocationEntity.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -14,8 +13,7 @@ import java.util.UUID
 @Repository
 interface Cas2PrisonerLocationRepository : JpaRepository<Cas2PrisonerLocationEntity, UUID> {
 
-  @Query("SELECT p FROM Cas2PrisonerLocationEntity p WHERE p.application.id = :applicationId and p.endDate is NULL")
-  fun findPrisonerLocation(applicationId: UUID): Cas2PrisonerLocationEntity?
+  fun findAllByStaffIdOrderByOccurredAtDesc(staffId: UUID): List<Cas2PrisonerLocationEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2ApplicationService.kt
@@ -49,6 +49,7 @@ class Cas2ApplicationService(
   private val assessmentService: Cas2AssessmentService,
   private val notifyConfig: NotifyConfig,
   private val objectMapper: ObjectMapper,
+  private val prisonerLocationService: Cas2PrisonerLocationService,
   @Value("\${url-templates.frontend.cas2.application}") private val applicationUrlTemplate: String,
   @Value("\${url-templates.frontend.cas2.submitted-application-overview}") private val submittedApplicationUrlTemplate: String,
 ) {
@@ -265,6 +266,8 @@ class Cas2ApplicationService(
     createCas2ApplicationSubmittedEvent(application)
 
     createAssessment(application)
+
+    prisonerLocationService.createPrisonerLocation(application)
 
     sendEmailApplicationSubmitted(user, application)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2PrisonerLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2PrisonerLocationService.kt
@@ -1,11 +1,18 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
 
+import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2PrisonerLocationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2PrisonerLocationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.HmppsDomainEvent
+import java.util.UUID
 
 @Service
-class Cas2PrisonerLocationService {
+class Cas2PrisonerLocationService(
+  private val prisonerLocationRepository: Cas2PrisonerLocationRepository,
+) {
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -15,5 +22,18 @@ class Cas2PrisonerLocationService {
 
   fun handleLocationChangedEvent(event: HmppsDomainEvent) {
     log.info("Handle location changed event at ${event.occurredAt}")
+  }
+
+  @Transactional
+  fun createPrisonerLocation(application: Cas2ApplicationEntity) {
+    val location = Cas2PrisonerLocationEntity(
+      id = UUID.randomUUID(),
+      application = application,
+      prisonCode = application.referringPrisonCode!!,
+      staffId = application.createdByUser.id,
+      occurredAt = application.createdAt,
+      endDate = null,
+    )
+    prisonerLocationRepository.save(location)
   }
 }

--- a/src/main/resources/db/migration/all/20250303142619__migrate_cas2_application_data_to_prisoner_location_table.sql
+++ b/src/main/resources/db/migration/all/20250303142619__migrate_cas2_application_data_to_prisoner_location_table.sql
@@ -1,0 +1,11 @@
+insert into cas_2_prisoner_locations (id, application_id, prison_code, staff_id, occurred_at, end_date)
+    (select gen_random_uuid(),
+            app.id,
+            app.referring_prison_code,
+            app.created_by_user_id,
+            app.submitted_at,
+            null
+     from cas_2_applications app
+     where submitted_at is not null
+       and referring_prison_code is not null
+       and abandoned_at is not null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -145,6 +145,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
@@ -222,7 +223,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2StatusUpdateTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceReasonTestRepository
@@ -376,7 +376,7 @@ abstract class IntegrationTestBase {
   lateinit var approvedPremisesApplicationRepository: ApprovedPremisesApplicationTestRepository
 
   @Autowired
-  lateinit var cas2ApplicationRepository: Cas2ApplicationTestRepository
+  lateinit var cas2ApplicationRepository: Cas2ApplicationRepository
 
   @Autowired
   lateinit var cas2AssessmentRepository: Cas2AssessmentRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/ApplicationTestRepository.kt
@@ -3,27 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import java.util.UUID
 
 @Repository
 interface ApprovedPremisesApplicationTestRepository : JpaRepository<ApprovedPremisesApplicationEntity, UUID>
 
 @Repository
-interface Cas2ApplicationTestRepository : JpaRepository<Cas2ApplicationEntity, UUID>
-
-@Repository
 interface Cas2v2ApplicationTestRepository : JpaRepository<Cas2v2ApplicationEntity, UUID>
-
-@Repository
-interface Cas2v2UserTestRepository : JpaRepository<Cas2v2UserEntity, UUID>
-
-@Repository
-interface Cas2v2AssessmentTestRepository : JpaRepository<Cas2v2AssessmentEntity, UUID>
 
 @Repository
 interface TemporaryAccommodationApplicationTestRepository : JpaRepository<TemporaryAccommodationApplicationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/Cas2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/Cas2ApplicationServiceTest.kt
@@ -40,6 +40,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2PrisonerLocationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
@@ -62,6 +63,7 @@ class Cas2ApplicationServiceTest {
   private val mockAssessmentService = mockk<Cas2AssessmentService>()
   private val mockObjectMapper = mockk<ObjectMapper>()
   private val mockNotifyConfig = mockk<NotifyConfig>()
+  private val prisonerLocationService = mockk<Cas2PrisonerLocationService>()
 
   private val applicationService = uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2ApplicationService(
     mockApplicationRepository,
@@ -75,6 +77,7 @@ class Cas2ApplicationServiceTest {
     mockAssessmentService,
     mockNotifyConfig,
     mockObjectMapper,
+    prisonerLocationService,
     "http://frontend/applications/#id",
     "http://frontend/assess/applications/#applicationId/overview",
   )
@@ -767,6 +770,8 @@ class Cas2ApplicationServiceTest {
         every { mockLockableApplicationRepository.acquirePessimisticLock(any()) } returns Cas2LockableApplicationEntity(
           UUID.randomUUID(),
         )
+        every { prisonerLocationService.createPrisonerLocation(any()) } just Runs
+
         every { mockObjectMapper.writeValueAsString(submitCas2Application.translatedDocument) } returns "{}"
         every { mockDomainEventService.saveCas2ApplicationSubmittedDomainEvent(any()) } just Runs
       }
@@ -1049,6 +1054,8 @@ class Cas2ApplicationServiceTest {
             },
           )
         }
+
+        verify { prisonerLocationService.createPrisonerLocation(application) }
 
         verify(exactly = 1) {
           mockEmailNotificationService.sendEmail(


### PR DESCRIPTION
Currently, the prisoner's prison is retrieved from the prison API and stored as part of the application when it is submitted. This PR adds functionality to store the location in the cas_2_prisoner_location table, which is needed for the listenders to process POM allocation and prison transfer messages.