### PR TITLE
APS-2014 remove characteristic pairs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -938,13 +938,7 @@ class PremisesController(
       throw ForbiddenProblem()
     }
 
-    val validationResult = when (val bedResult = cas1BedService.getBedAndRoomCharacteristics(bedId)) {
-      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(bedId, "Bed")
-      is AuthorisableActionResult.Success -> bedResult.entity
-      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
-    }
-
-    return ResponseEntity.ok(bedDetailTransformer.transformToApi(validationResult))
+    return ResponseEntity.ok(bedDetailTransformer.transformToApi(extractEntityFromCasResult(cas1BedService.getBedAndRoomCharacteristics(bedId))))
   }
 
   @SuppressWarnings("ThrowsCount")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -57,7 +57,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotImplementedPr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.GetBookingForPremisesResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -66,6 +65,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RoomService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3PremisesService
@@ -105,7 +105,7 @@ class PremisesController(
   private val bookingService: BookingService,
   private val cas3BookingService: Cas3BookingService,
   private val cas3VoidBedspaceService: Cas3VoidBedspaceService,
-  private val bedService: BedService,
+  private val cas1BedService: Cas1BedService,
   private val premisesTransformer: PremisesTransformer,
   private val cas3PremisesSummaryTransformer: Cas3PremisesSummaryTransformer,
   private val bookingTransformer: BookingTransformer,
@@ -938,7 +938,7 @@ class PremisesController(
       throw ForbiddenProblem()
     }
 
-    val validationResult = when (val bedResult = bedService.getBedAndRoomCharacteristics(bedId)) {
+    val validationResult = when (val bedResult = cas1BedService.getBedAndRoomCharacteristics(bedId)) {
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(bedId, "Bed")
       is AuthorisableActionResult.Success -> bedResult.entity
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedSummaryService
@@ -67,13 +66,7 @@ class Cas1PremisesController(
       throw ForbiddenProblem()
     }
 
-    val bedAndCharacteristics = when (val bedResult = cas1BedService.getBedAndRoomCharacteristics(bedId)) {
-      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
-      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(bedResult.id!!, bedResult.entityType!!)
-      is AuthorisableActionResult.Success -> bedResult.entity
-    }
-
-    return ResponseEntity.ok(cas1BedDetailTransformer.transformToApi(bedAndCharacteristics))
+    return ResponseEntity.ok(cas1BedDetailTransformer.transformToApi(extractEntityFromCasResult(cas1BedService.getBedAndRoomCharacteristics(bedId))))
   }
 
   override fun getPremisesById(premisesId: UUID): ResponseEntity<Cas1Premises> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -18,8 +18,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermissio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BedService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedSummaryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingDaySummaryService
@@ -39,7 +39,7 @@ class Cas1PremisesController(
   val cas1PremisesService: Cas1PremisesService,
   val cas1PremisesTransformer: Cas1PremisesTransformer,
   val cas1PremiseCapacityTransformer: Cas1PremiseCapacitySummaryTransformer,
-  private val bedService: BedService,
+  private val cas1BedService: Cas1BedService,
   private val cas1BedSummaryTransformer: Cas1BedSummaryTransformer,
   private val cas1BedDetailTransformer: Cas1BedDetailTransformer,
   private val cas1PremisesDayTransformer: Cas1PremisesDayTransformer,
@@ -67,7 +67,7 @@ class Cas1PremisesController(
       throw ForbiddenProblem()
     }
 
-    val bedAndCharacteristics = when (val bedResult = bedService.getBedAndRoomCharacteristics(bedId)) {
+    val bedAndCharacteristics = when (val bedResult = cas1BedService.getBedAndRoomCharacteristics(bedId)) {
       is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
       is AuthorisableActionResult.NotFound -> throw NotFoundProblem(bedResult.id!!, bedResult.entityType!!)
       is AuthorisableActionResult.Success -> bedResult.entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BedService.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActi
 import java.util.UUID
 
 @Service
-class BedService(
+class Cas1BedService(
   private val bedRepository: BedRepository,
   private val characteristicRepository: CharacteristicRepository,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BedService.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import java.util.UUID
 
 @Service
@@ -14,11 +14,11 @@ class Cas1BedService(
   private val characteristicRepository: CharacteristicRepository,
 ) {
 
-  fun getBedAndRoomCharacteristics(id: UUID): AuthorisableActionResult<Pair<DomainBedSummary, List<CharacteristicEntity>>> {
-    val bedDetail = bedRepository.getDetailById(id) ?: return AuthorisableActionResult.NotFound()
+  fun getBedAndRoomCharacteristics(id: UUID): CasResult<Pair<DomainBedSummary, List<CharacteristicEntity>>> {
+    val bedDetail = bedRepository.getDetailById(id) ?: return CasResult.NotFound("Bed", id.toString())
     val characteristics = characteristicRepository.findAllForRoomId(bedDetail.roomId)
 
-    return AuthorisableActionResult.Success(
+    return CasResult.Success(
       Pair(bedDetail, characteristics),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1BedDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1BedDetailTransformer.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BedDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedSummaryTransformer
+
+@Component
+class Cas1BedDetailTransformer(
+  private val bedSummaryTransformer: BedSummaryTransformer,
+) {
+  fun transformToApi(summaryAndCharacteristics: Pair<DomainBedSummary, List<CharacteristicEntity>>): Cas1BedDetail {
+    val summary = summaryAndCharacteristics.first
+    val characteristics = summaryAndCharacteristics.second
+
+    val bedSummary = bedSummaryTransformer.transformToApi(summary)
+    val spaceCharacteristics = characteristics.map {
+      Cas1SpaceCharacteristic.valueOf(it.propertyName!!)
+    }
+
+    return Cas1BedDetail(
+      id = bedSummary.id,
+      name = bedSummary.name,
+      roomName = bedSummary.roomName,
+      status = bedSummary.status,
+      characteristics = spaceCharacteristics,
+    )
+  }
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -734,6 +734,8 @@ paths:
           $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/beds/{bedId}:
     get:
+      description: Deprecated, use /cas1/premises/{premisesId}/beds/{bedId} instead
+      deprecated: true
       tags:
         - Rooms
       summary: Gets a given bed for a given premises

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -780,6 +780,40 @@ paths:
           $ref: '_shared.yml#/components/responses/403Response'
         500:
           $ref: '_shared.yml#/components/responses/500Response'
+  /premises/{premisesId}/beds/{bedId}:
+    get:
+      tags:
+        - Premises
+      summary: Gets a given bed for a given premises
+      operationId: getBed
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises that the bed is in
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bedId
+          in: path
+          description: ID of the bed to return
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: 'cas1-schemas.yml#/components/schemas/Cas1BedDetail'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/capacity:
     get:
       tags:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -719,6 +719,28 @@ components:
         - requestsForPlacementWithPii
         - placements
         - placementsWithPii
+    Cas1BedDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        roomName:
+          type: string
+        status:
+          $ref: '_shared.yml#/components/schemas/BedStatus'
+        characteristics:
+          type: array
+          items:
+            $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
+      required:
+        - id
+        - name
+        - roomName
+        - status
+        - characteristics
     Cas1OutOfServiceBedSummary:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -736,6 +736,8 @@ paths:
           $ref: '#/components/responses/500Response'
   /premises/{premisesId}/beds/{bedId}:
     get:
+      description: Deprecated, use /cas1/premises/{premisesId}/beds/{bedId} instead
+      deprecated: true
       tags:
         - Rooms
       summary: Gets a given bed for a given premises

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -782,6 +782,40 @@ paths:
           $ref: '#/components/responses/403Response'
         500:
           $ref: '#/components/responses/500Response'
+  /premises/{premisesId}/beds/{bedId}:
+    get:
+      tags:
+        - Premises
+      summary: Gets a given bed for a given premises
+      operationId: getBed
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises that the bed is in
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bedId
+          in: path
+          description: ID of the bed to return
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas1BedDetail'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/capacity:
     get:
       tags:
@@ -7054,6 +7088,28 @@ components:
         - requestsForPlacementWithPii
         - placements
         - placementsWithPii
+    Cas1BedDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        roomName:
+          type: string
+        status:
+          $ref: '#/components/schemas/BedStatus'
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+      required:
+        - id
+        - name
+        - roomName
+        - status
+        - characteristics
     Cas1OutOfServiceBedSummary:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1BedDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1BedDetailTest.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BedDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+import java.util.UUID
+
+class Cas1BedDetailTest : InitialiseDatabasePerClassTestBase() {
+  lateinit var premises: PremisesEntity
+  lateinit var probationRegion: ProbationRegionEntity
+  lateinit var localAuthorityArea: LocalAuthorityAreaEntity
+
+  @BeforeEach
+  fun setup() {
+    probationRegion = givenAProbationRegion()
+    localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+    this.premises = approvedPremisesEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+      withLocalAuthorityArea(localAuthorityArea)
+    }
+  }
+
+  @Test
+  fun `Getting a bed for a premises without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/cas1/premises/${premises.id}/beds/${UUID.randomUUID()}")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Getting a bed for a premises that does not exist returns 404`() {
+    givenAUser { _, jwt ->
+      webTestClient.get()
+        .uri("/cas1/premises/${UUID.randomUUID()}/beds/${UUID.randomUUID()}")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", "approved-premises")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+
+  @Test
+  fun `Getting a bed for a premises returns the bed`() {
+    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withYieldedRoom {
+          roomEntityFactory.produceAndPersist {
+            withYieldedPremises { premises }
+            withCharacteristics(*(listOf("hasEnSuite", "isGroundFloor").map { characteristicRepository.findByPropertyNameAndScopes(it, ServiceName.approvedPremises.value, "room")!! }).toTypedArray())
+          }
+        }
+      }
+
+      val response = webTestClient.get()
+        .uri("/cas1/premises/${premises.id}/beds/${bed.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1BedDetail>()
+
+      Assertions.assertThat(response.id).isEqualTo(bed.id)
+      Assertions.assertThat(response.characteristics).containsExactlyInAnyOrder(Cas1SpaceCharacteristic.hasEnSuite, Cas1SpaceCharacteristic.isGroundFloor)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1BedDetailTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1BedDetailTransformerTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedSummaryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1BedDetailTransformer
+
+class Cas1BedDetailTransformerTest {
+  private val bedSummaryTransformer = mockk<BedSummaryTransformer>()
+  private val cas1BedDetailTransformer = Cas1BedDetailTransformer(bedSummaryTransformer)
+
+  @Test
+  fun `transformToApi transforms correctly`() {
+    val domainSummary = BedSummaryFactory()
+      .withName("bed name")
+      .produce()
+
+    every { bedSummaryTransformer.transformToApi(any()) } returns BedSummary(
+      id = domainSummary.id,
+      name = domainSummary.name,
+      roomName = domainSummary.roomName,
+      status = getStatus(domainSummary),
+    )
+
+    val result = cas1BedDetailTransformer.transformToApi(
+      Pair(
+        domainSummary,
+        listOf(
+          CharacteristicEntityFactory().withPropertyName("arsonOffences").produce(),
+          CharacteristicEntityFactory().withPropertyName("hasWheelChairAccessibleBathrooms").produce(),
+        ),
+      ),
+    )
+
+    Assertions.assertThat(result.name).isEqualTo("bed name")
+    Assertions.assertThat(result.characteristics).containsExactlyInAnyOrder(Cas1SpaceCharacteristic.arsonOffences, Cas1SpaceCharacteristic.hasWheelChairAccessibleBathrooms)
+  }
+
+  private fun getStatus(summary: DomainBedSummary): BedStatus {
+    if (summary.bedBooked) {
+      return BedStatus.occupied
+    } else if (summary.bedOutOfService) {
+      return BedStatus.outOfService
+    } else {
+      return BedStatus.available
+    }
+  }
+}


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2014

- Create a new `/cas1/premises/{premisesId}/beds/{bedId}` endpoint that returns a `Cas1BedDetail`.
- `Cas1BedDetail` will be the same as `BedDetail` but characteristics will be a list of `Cas1SpaceCharacteristic`
- Deprecate `/premises/{premisesId}/beds/{bedId}` and add a note saying `/cas1/premises/{premisesId}/beds/{bedId}` should be used