### PR TITLE
Move /cas1/space/search to /cas1/premises/search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceSearchController.kt
@@ -3,24 +3,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.SpaceSearchesCas1Delegate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchResults
 
 @Service
 class Cas1SpaceSearchController(
-  private val spaceSearchService: Cas1SpaceSearchService,
-  private val spaceSearchResultTransformer: Cas1SpaceSearchResultsTransformer,
-  private val userAccessService: UserAccessService,
+  private val cas1PremisesController: Cas1PremisesController,
 ) : SpaceSearchesCas1Delegate {
-  override fun spaceSearch(cas1SpaceSearchParameters: Cas1SpaceSearchParameters): ResponseEntity<Cas1SpaceSearchResults> {
-    userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_SPACE_BOOKING_CREATE)
-
-    val results = spaceSearchService.findSpaces(cas1SpaceSearchParameters)
-
-    return ResponseEntity.ok(spaceSearchResultTransformer.transformDomainToApi(results))
-  }
+  override fun spaceSearch(cas1SpaceSearchParameters: Cas1PremisesSearchParameters): ResponseEntity<Cas1PremisesSearchResults> = cas1PremisesController.premisesSearch(cas1SpaceSearchParameters)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesSearchService.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
@@ -15,12 +15,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicSe
 import java.util.UUID
 
 @Service
-class Cas1SpaceSearchService(
+class Cas1PremisesSearchService(
   private val characteristicService: CharacteristicService,
   private val spaceSearchRepository: Cas1SpaceSearchRepository,
   private val applicationRepository: ApprovedPremisesApplicationRepository,
 ) {
-  fun findSpaces(searchParameters: Cas1SpaceSearchParameters): List<CandidatePremises> {
+  fun findSpaces(searchParameters: Cas1PremisesSearchParameters): List<CandidatePremises> {
     val applicationId = searchParameters.applicationId
     val application = applicationRepository.findByIdOrNull(searchParameters.applicationId)
       ?: throw NotFoundProblem(applicationId, "Application")
@@ -36,7 +36,7 @@ class Cas1SpaceSearchService(
     )
   }
 
-  private fun getRequiredCharacteristics(parameters: Cas1SpaceSearchParameters): RequiredCharacteristics {
+  private fun getRequiredCharacteristics(parameters: Cas1PremisesSearchParameters): RequiredCharacteristics {
     val requirements = parameters.requirements
     val apType = requirements.apType
     return RequiredCharacteristics(
@@ -49,7 +49,7 @@ class Cas1SpaceSearchService(
     )
   }
 
-  private fun getSpaceCharacteristics(parameters: Cas1SpaceSearchParameters): GroupedCharacteristics {
+  private fun getSpaceCharacteristics(parameters: Cas1PremisesSearchParameters): GroupedCharacteristics {
     val requirements = parameters.requirements
     val propertyNames =
       (

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesSearchResultsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesSearchResultsTransformer.kt
@@ -3,24 +3,24 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchResultSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchResults
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult as ApiSpaceSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchResult as ApiPremisesSearchResult
 
 @Component
-class Cas1SpaceSearchResultsTransformer {
+class Cas1PremisesSearchResultsTransformer {
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
   @SuppressWarnings("SwallowedException")
-  fun transformDomainToApi(results: List<CandidatePremises>) = Cas1SpaceSearchResults(
+  fun transformDomainToApi(results: List<CandidatePremises>) = Cas1PremisesSearchResults(
     resultsCount = results.size,
     results = results.map { candidatePremises ->
-      ApiSpaceSearchResult(
+      ApiPremisesSearchResult(
         premises = Cas1PremisesSearchResultSummary(
           id = candidatePremises.premisesId,
           apType = candidatePremises.apType.asApiType(),

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -82,15 +82,16 @@ paths:
           $ref: '_shared.yml#/components/responses/500Response'
   /spaces/search:
     post:
+      deprecated: true
       tags:
         - space searches
-      summary: Search for accommodation "spaces" which are available and match the given requirements
+      summary: Use /cas1/premises/search
       operationId: spaceSearch
       requestBody:
         content:
           'application/json':
             schema:
-              $ref: 'cas1-schemas.yml#/components/schemas/Cas1SpaceSearchParameters'
+              $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremisesSearchParameters'
         required: true
       responses:
         200:
@@ -98,7 +99,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: 'cas1-schemas.yml#/components/schemas/Cas1SpaceSearchResults'
+                $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremisesSearchResults'
         400:
           description: invalid params
           content:
@@ -449,6 +450,37 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+  /premises/search:
+    post:
+      tags:
+        - premises
+      summary: Search for premises
+      operationId: "premisesSearch"
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremisesSearchParameters'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremisesSearchResults'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
         401:
           $ref: '_shared.yml#/components/responses/401Response'
         403:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -218,7 +218,7 @@ components:
           $ref: '_shared.yml#/components/schemas/ApType'
         spaceCharacteristics:
           deprecated: true
-          description: use Cas1SpaceSearchParameters.spaceCharacteristics
+          description: use Cas1PremisesSearchParameters.spaceCharacteristics
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
@@ -230,7 +230,7 @@ components:
             $ref: '_shared.yml#/components/schemas/Gender'
       required:
         - gender
-    Cas1SpaceSearchParameters:
+    Cas1PremisesSearchParameters:
       type: object
       properties:
         applicationId:
@@ -262,7 +262,7 @@ components:
         - durationInDays
         - targetPostcodeDistrict
         - requirements
-    Cas1SpaceSearchResults:
+    Cas1PremisesSearchResults:
       type: object
       properties:
         resultsCount:
@@ -271,11 +271,11 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceSearchResult'
+            $ref: '#/components/schemas/Cas1PremisesSearchResult'
       required:
         - resultsCount
         - results
-    Cas1SpaceSearchResult:
+    Cas1PremisesSearchResult:
       type: object
       properties:
         premises:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -92,7 +92,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/Cas1SpaceSearchParameters'
+              $ref: '#/components/schemas/Cas1PremisesSearchParameters'
         required: true
       responses:
         200:
@@ -100,7 +100,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/Cas1SpaceSearchResults'
+                $ref: '#/components/schemas/Cas1PremisesSearchResults'
         400:
           description: invalid params
           content:
@@ -451,6 +451,37 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /premises/search:
+    post:
+      tags:
+        - premises
+      summary: Search for premises
+      operationId: "premisesSearch"
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Cas1PremisesSearchParameters'
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas1PremisesSearchResults'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
         401:
           $ref: '#/components/responses/401Response'
         403:
@@ -6553,7 +6584,7 @@ components:
           $ref: '#/components/schemas/ApType'
         spaceCharacteristics:
           deprecated: true
-          description: use Cas1SpaceSearchParameters.spaceCharacteristics
+          description: use Cas1PremisesSearchParameters.spaceCharacteristics
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
@@ -6565,7 +6596,7 @@ components:
             $ref: '#/components/schemas/Gender'
       required:
         - gender
-    Cas1SpaceSearchParameters:
+    Cas1PremisesSearchParameters:
       type: object
       properties:
         applicationId:
@@ -6597,7 +6628,7 @@ components:
         - durationInDays
         - targetPostcodeDistrict
         - requirements
-    Cas1SpaceSearchResults:
+    Cas1PremisesSearchResults:
       type: object
       properties:
         resultsCount:
@@ -6606,11 +6637,11 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Cas1SpaceSearchResult'
+            $ref: '#/components/schemas/Cas1PremisesSearchResult'
       required:
         - resultsCount
         - results
-    Cas1SpaceSearchResult:
+    Cas1PremisesSearchResult:
       type: object
       properties:
         premises:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesSearchTest.kt
@@ -7,11 +7,11 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchResults
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
@@ -25,14 +25,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Characteristi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_RECOVERY_FOCUSSED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_SEMI_SPECIALIST_MENTAL_HEALTH
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremisesSearchResultsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import java.time.LocalDate
 import java.util.UUID
 
-class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
+class Cas1PremisesSearchTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
-  lateinit var transformer: Cas1SpaceSearchResultsTransformer
+  lateinit var transformer: Cas1PremisesSearchResultsTransformer
 
   @BeforeEach
   fun setup() {
@@ -44,7 +44,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `Search for Spaces without JWT returns 401`() {
     webTestClient.post()
-      .uri("/cas1/spaces/search")
+      .uri("/cas1/premises/search")
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -53,7 +53,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
   @Test
   fun `Requires CAS1_SPACE_BOOKING_CREATE permission`() {
     givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = UUID.randomUUID(),
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -66,7 +66,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
@@ -132,7 +132,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withSupportsSpaceBookings(false)
       }
 
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -145,13 +145,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
         .expectStatus()
         .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
+        .returnResult(Cas1PremisesSearchResults::class.java)
 
       val results = response.responseBody.blockFirst()!!
 
@@ -209,7 +209,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withGender(ApprovedPremisesGender.entries.first { it != gender })
       }
 
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -222,13 +222,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
         .expectStatus()
         .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
+        .returnResult(Cas1PremisesSearchResults::class.java)
 
       val results = response.responseBody.blockFirst()!!
 
@@ -276,7 +276,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withSupportsSpaceBookings(true)
       }
 
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -290,13 +290,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
         .expectStatus()
         .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
+        .returnResult(Cas1PremisesSearchResults::class.java)
 
       val results = response.responseBody.blockFirst()!!
 
@@ -338,7 +338,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         }
       }
 
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -352,13 +352,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
         .expectStatus()
         .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
+        .returnResult(Cas1PremisesSearchResults::class.java)
 
       val results = response.responseBody.blockFirst()!!
 
@@ -403,7 +403,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         withSupportsSpaceBookings(true)
       }
 
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -417,13 +417,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
         .expectStatus()
         .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
+        .returnResult(Cas1PremisesSearchResults::class.java)
 
       val results = response.responseBody.blockFirst()!!
 
@@ -475,7 +475,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       createAp(getCharacteristics(CAS1_PROPERTY_NAME_PREMISES_RECOVERY_FOCUSSED))
       createAp(emptyList())
 
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -489,13 +489,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
         .expectStatus()
         .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
+        .returnResult(Cas1PremisesSearchResults::class.java)
 
       val results = response.responseBody.blockFirst()!!
 
@@ -507,7 +507,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
   }
 
   private fun assertThatResultMatches(
-    actual: Cas1SpaceSearchResult,
+    actual: Cas1PremisesSearchResult,
     expected: ApprovedPremisesEntity,
     expectedApType: ApType = ApType.normal,
     expectedCharacteristics: List<Cas1SpaceCharacteristic>? = null,
@@ -582,7 +582,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         }
       }
 
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -595,13 +595,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
         .expectStatus()
         .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
+        .returnResult(Cas1PremisesSearchResults::class.java)
 
       val results = response.responseBody.blockFirst()!!
 
@@ -668,7 +668,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         }
       }
 
-      val searchParameters = Cas1SpaceSearchParameters(
+      val searchParameters = Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.now(),
         durationInDays = 14,
@@ -681,13 +681,13 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       )
 
       val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
+        .uri("/cas1/premises/search")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(searchParameters)
         .exchange()
         .expectStatus()
         .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
+        .returnResult(Cas1PremisesSearchResults::class.java)
 
       val results = response.responseBody.blockFirst()!!
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesSearchServiceTest.kt
@@ -18,8 +18,8 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
@@ -30,14 +30,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Spac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesSearchService
 import java.time.LocalDate
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.enums.enumEntries
 
 @ExtendWith(MockKExtension::class)
-class Cas1SpaceSearchServiceTest {
+class Cas1PremisesSearchServiceTest {
   @MockK
   private lateinit var characteristicService: CharacteristicService
 
@@ -48,7 +48,7 @@ class Cas1SpaceSearchServiceTest {
   private lateinit var applicationRepository: ApprovedPremisesApplicationRepository
 
   @InjectMockKs
-  private lateinit var service: Cas1SpaceSearchService
+  private lateinit var service: Cas1PremisesSearchService
 
   @Test
   fun `findSpaces throws error if the associated application cannot be found`() {
@@ -58,7 +58,7 @@ class Cas1SpaceSearchServiceTest {
 
     assertThatThrownBy {
       service.findSpaces(
-        Cas1SpaceSearchParameters(
+        Cas1PremisesSearchParameters(
           applicationId,
           startDate = LocalDate.parse("2024-08-01"),
           durationInDays = 14,
@@ -147,7 +147,7 @@ class Cas1SpaceSearchServiceTest {
     every { applicationRepository.findByIdOrNull(application.id) } returns application
 
     val result = service.findSpaces(
-      Cas1SpaceSearchParameters(
+      Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.parse("2024-08-01"),
         durationInDays = 14,
@@ -260,7 +260,7 @@ class Cas1SpaceSearchServiceTest {
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
     service.findSpaces(
-      Cas1SpaceSearchParameters(
+      Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.parse("2024-08-01"),
         durationInDays = 14,
@@ -365,7 +365,7 @@ class Cas1SpaceSearchServiceTest {
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
     service.findSpaces(
-      Cas1SpaceSearchParameters(
+      Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.parse("2024-08-01"),
         durationInDays = 14,
@@ -469,7 +469,7 @@ class Cas1SpaceSearchServiceTest {
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
     service.findSpaces(
-      Cas1SpaceSearchParameters(
+      Cas1PremisesSearchParameters(
         applicationId = application.id,
         startDate = LocalDate.parse("2024-08-01"),
         durationInDays = 14,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesSearchResultsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesSearchResultsTransformerTest.kt
@@ -5,12 +5,12 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceSearchResultsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremisesSearchResultsTransformer
 import java.math.BigDecimal
 import java.util.UUID
 
-class Cas1SpaceSearchResultsTransformerTest {
-  private val transformer = Cas1SpaceSearchResultsTransformer()
+class Cas1PremisesSearchResultsTransformerTest {
+  private val transformer = Cas1PremisesSearchResultsTransformer()
 
   @Test
   fun `transformDomainToApi transforms correctly`() {


### PR DESCRIPTION
The space search API is really providing a search on premises (not spaces). This PR creates a copy of the API on `/cas1/premises/search` and deprecates the existing API.

It also renames some API types to reflect this change:

* Cas1SpaceSearchParameters -> Cas1PremisesSearchParameters
* Cas1SpaceSearchResults -> Cas1PremisesSearchResults
* Cas1SpaceSearchResult -> Cas1PremisesSearchResult