### PR TITLE
Suppress pebble CVE

### DIFF
--- a/.dependencycheckignore
+++ b/.dependencycheckignore
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        This issue only effects the gatling classpath, which is not deployed to production.
+
+        There is not currently a fix for this issue, but in time the gatling module will
+        be removed as it has been superseded by https://github.com/ministryofjustice/hmpps-load-testing-probation
+        ]]></notes>
+        <packageUrl regex="true">^.*pebble.*$</packageUrl>
+        <vulnerabilityName>CVE-2025-1686</vulnerabilityName>
+    </suppress>
+</suppressions>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -458,3 +458,7 @@ detekt {
   ignoreFailures = false
   baseline = file("./detekt-baseline.xml")
 }
+
+dependencyCheck {
+  suppressionFile = ".dependencycheckignore"
+}


### PR DESCRIPTION
This issue only effects the gatling classpath, which is not deployed to production.

There is not currently a fix for this issue, but in time the gatling module will be removed as it has been superseded by https://github.com/ministryofjustice/:hmpps-load-testing-probation