### PR TITLE
CAS-1385 Create CAS3 premises summary api endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -80,11 +80,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DateChangeTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesSummaryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RoomTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TurnaroundTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3PremisesSummaryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspaceCancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspacesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
@@ -107,7 +107,7 @@ class PremisesController(
   private val cas3VoidBedspaceService: Cas3VoidBedspaceService,
   private val bedService: BedService,
   private val premisesTransformer: PremisesTransformer,
-  private val premisesSummaryTransformer: PremisesSummaryTransformer,
+  private val cas3PremisesSummaryTransformer: Cas3PremisesSummaryTransformer,
   private val bookingTransformer: BookingTransformer,
   private val cas3VoidBedspacesTransformer: Cas3VoidBedspacesTransformer,
   private val arrivalTransformer: ArrivalTransformer,
@@ -142,7 +142,7 @@ class PremisesController(
         val user = usersService.getUserForRequest()
         val summaries = cas3PremisesService.getAllPremisesSummaries(user.probationRegion.id)
 
-        summaries.map(premisesSummaryTransformer::transformDomainToApi)
+        summaries.map(cas3PremisesSummaryTransformer::transformDomainToApi)
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3PremisesController.kt
@@ -4,10 +4,13 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas3.PremisesCas3Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3PremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FutureBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3FutureBookingTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3PremisesSummaryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.util.UUID
 
@@ -15,8 +18,18 @@ import java.util.UUID
 class Cas3PremisesController(
   private val userService: UserService,
   private val cas3BookingService: Cas3BookingService,
+  private val cas3PremisesService: Cas3PremisesService,
   private val cas3FutureBookingTransformer: Cas3FutureBookingTransformer,
+  private val cas3PremisesSummaryTransformer: Cas3PremisesSummaryTransformer,
 ) : PremisesCas3Delegate {
+  override fun getPremisesSummary(): ResponseEntity<List<Cas3PremisesSummary>> {
+    val user = userService.getUserForRequest()
+    val summaries = cas3PremisesService.getAllPremisesSummaries(user.probationRegion.id)
+    val transformedSummaries = summaries.map(cas3PremisesSummaryTransformer::transformDomainToCas3PremisesSummary)
+
+    return ResponseEntity.ok(transformedSummaries)
+  }
+
   override fun getPremisesFutureBookings(premisesId: UUID, statuses: List<BookingStatus>): ResponseEntity<List<FutureBooking>> {
     val user = userService.getUserForRequest()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -289,19 +289,6 @@ class TemporaryAccommodationPremisesEntity(
   status,
 )
 
-data class ApprovedPremisesSummary(
-  val id: UUID,
-  val name: String,
-  val addressLine1: String,
-  val addressLine2: String?,
-  val postcode: String,
-  val status: PropertyStatus,
-  val bedCount: Int,
-  val apCode: String,
-  val regionName: String,
-  val apAreaName: String,
-)
-
 data class TemporaryAccommodationPremisesSummary(
   val id: UUID,
   val name: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3PremisesSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3PremisesSummaryTransformer.kt
@@ -1,14 +1,13 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3PremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PremisesSummary as ApiPremisesSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesSummary as DomainApprovedPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesSummary as DomainTemporaryAccommodationPremisesSummary
 
 @Component
-class PremisesSummaryTransformer {
+class Cas3PremisesSummaryTransformer {
   fun transformDomainToApi(domain: DomainTemporaryAccommodationPremisesSummary): ApiPremisesSummary = TemporaryAccommodationPremisesSummary(
     id = domain.id,
     name = domain.name,
@@ -22,7 +21,7 @@ class PremisesSummaryTransformer {
     localAuthorityAreaName = domain.localAuthorityAreaName,
   )
 
-  fun transformDomainToApi(domain: DomainApprovedPremisesSummary): ApiPremisesSummary = ApprovedPremisesSummary(
+  fun transformDomainToCas3PremisesSummary(domain: DomainTemporaryAccommodationPremisesSummary): Cas3PremisesSummary = Cas3PremisesSummary(
     id = domain.id,
     name = domain.name,
     addressLine1 = domain.addressLine1,
@@ -30,9 +29,7 @@ class PremisesSummaryTransformer {
     postcode = domain.postcode,
     status = domain.status,
     bedCount = domain.bedCount,
-    apCode = domain.apCode,
-    service = "CAS1",
-    probationRegion = domain.regionName,
-    apArea = domain.apAreaName,
+    pdu = domain.pdu,
+    localAuthorityAreaName = domain.localAuthorityAreaName,
   )
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -49,6 +49,7 @@ paths:
       tags:
         - Premises
       summary: Returns a list of premises
+      description: deprecated, use /cas3/premises/summary
       operationId: premisesSummaryGet
       parameters:
         - name: X-Service-Name

--- a/src/main/resources/static/cas3-api.yml
+++ b/src/main/resources/static/cas3-api.yml
@@ -94,6 +94,27 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
+  /premises/summary:
+    get:
+      tags:
+        - Premises
+      summary: Returns a list of premises
+      operationId: getPremisesSummary
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: 'cas3-schemas.yml#/components/schemas/Cas3PremisesSummary'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/future-bookings:
     get:
       tags:

--- a/src/main/resources/static/cas3-schemas.yml
+++ b/src/main/resources/static/cas3-schemas.yml
@@ -92,3 +92,38 @@ components:
         - bookingId
         - roomId
         - isSexualRisk
+    Cas3PremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        addressLine1:
+          type: string
+          example: one something street
+        addressLine2:
+          type: string
+          example: Blackmore End
+        postcode:
+          type: string
+          example: LS1 3AD
+        pdu:
+          type: string
+        localAuthorityAreaName:
+          type: string
+        bedCount:
+          type: integer
+          example: 22
+        status:
+          $ref: '_shared.yml#/components/schemas/PropertyStatus'
+      required:
+        - id
+        - name
+        - addressLine1
+        - postcode
+        - pdu
+        - bedCount
+        - status

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -51,6 +51,7 @@ paths:
       tags:
         - Premises
       summary: Returns a list of premises
+      description: deprecated, use /cas3/premises/summary
       operationId: premisesSummaryGet
       parameters:
         - name: X-Service-Name

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -96,6 +96,27 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
+  /premises/summary:
+    get:
+      tags:
+        - Premises
+      summary: Returns a list of premises
+      operationId: getPremisesSummary
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas3PremisesSummary'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/future-bookings:
     get:
       tags:
@@ -4835,3 +4856,38 @@ components:
         - bookingId
         - roomId
         - isSexualRisk
+    Cas3PremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        addressLine1:
+          type: string
+          example: one something street
+        addressLine2:
+          type: string
+          example: Blackmore End
+        postcode:
+          type: string
+          example: LS1 3AD
+        pdu:
+          type: string
+        localAuthorityAreaName:
+          type: string
+        bedCount:
+          type: integer
+          example: 22
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+      required:
+        - id
+        - name
+        - addressLine1
+        - postcode
+        - pdu
+        - bedCount
+        - status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PremisesSummaryTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
@@ -8,8 +10,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import java.time.LocalDate
 import java.util.UUID
 class PremisesSummaryTest : IntegrationTestBase() {
-  @Test
-  fun `Get all CAS3 Premises returns OK with correct body`() {
+  @ParameterizedTest
+  @CsvSource("/premises/summary", "/cas3/premises/summary")
+  fun `Get all CAS3 Premises returns OK with correct body`(baseUrl: String) {
     givenAUser { user, jwt ->
       val uuid = UUID.randomUUID()
 
@@ -44,7 +47,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
       }
 
       webTestClient.get()
-        .uri("/premises/summary")
+        .uri(baseUrl)
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .exchange()
@@ -63,8 +66,9 @@ class PremisesSummaryTest : IntegrationTestBase() {
     }
   }
 
-  @Test
-  fun `Get all CAS3 Premises returns premises with all bedspaces are archived`() {
+  @ParameterizedTest
+  @CsvSource("/premises/summary", "/cas3/premises/summary")
+  fun `Get all CAS3 Premises returns premises with all bedspaces are archived`(baseUrl: String) {
     givenAUser { user, jwt ->
       val uuidPremises = UUID.randomUUID()
       val expectedCas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
@@ -102,7 +106,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
       }
 
       webTestClient.get()
-        .uri("/premises/summary")
+        .uri(baseUrl)
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .exchange()
@@ -120,8 +124,9 @@ class PremisesSummaryTest : IntegrationTestBase() {
     }
   }
 
-  @Test
-  fun `Get all CAS3 Premises returns premises without bedspaces`() {
+  @ParameterizedTest
+  @CsvSource("/premises/summary", "/cas3/premises/summary")
+  fun `Get all CAS3 Premises returns premises without bedspaces`(baseUrl: String) {
     givenAUser { user, jwt ->
       val uuidPremises = UUID.randomUUID()
       val expectedCas3Premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
@@ -141,7 +146,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
       }
 
       webTestClient.get()
-        .uri("/premises/summary")
+        .uri(baseUrl)
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .exchange()
@@ -160,8 +165,9 @@ class PremisesSummaryTest : IntegrationTestBase() {
     }
   }
 
-  @Test
-  fun `Get all CAS3 Premises returns bedspace count as expected when there is an archived bedspace`() {
+  @ParameterizedTest
+  @CsvSource("/premises/summary", "/cas3/premises/summary")
+  fun `Get all CAS3 Premises returns bedspace count as expected when there is an archived bedspace`(baseUrl: String) {
     givenAUser { user, jwt ->
       val uuid = UUID.randomUUID()
 
@@ -195,7 +201,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
       }
 
       webTestClient.get()
-        .uri("/premises/summary")
+        .uri(baseUrl)
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .exchange()
@@ -213,8 +219,9 @@ class PremisesSummaryTest : IntegrationTestBase() {
     }
   }
 
-  @Test
-  fun `Get all CAS3 Premises returns a bedspace count as expected when beds are active`() {
+  @ParameterizedTest
+  @CsvSource("/premises/summary", "/cas3/premises/summary")
+  fun `Get all CAS3 Premises returns a bedspace count as expected when beds are active`(baseUrl: String) {
     givenAUser { user, jwt ->
       val uuid = UUID.randomUUID()
 
@@ -248,7 +255,7 @@ class PremisesSummaryTest : IntegrationTestBase() {
       }
 
       webTestClient.get()
-        .uri("/premises/summary")
+        .uri(baseUrl)
         .header("Authorization", "Bearer $jwt")
         .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3PremisesSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3PremisesSummaryTransformerTest.kt
@@ -1,17 +1,16 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3PremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationPremisesSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesSummaryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3PremisesSummaryTransformer
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesSummary as DomainApprovedPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesSummary as DomainTemporaryAccommodationPremisesSummary
 
-class PremisesSummaryTransformerTest {
-  private val premisesSummaryTransformer = PremisesSummaryTransformer()
+class Cas3PremisesSummaryTransformerTest {
+  private val cas3PremisesSummaryTransformer = Cas3PremisesSummaryTransformer()
 
   @Test
   fun `transformDomainToApi transforms the DomainTemporaryAccommodationPremisesSummary into a TemporaryAccommodationPremisesSummary`() {
@@ -28,7 +27,7 @@ class PremisesSummaryTransformerTest {
       localAuthorityAreaName = "Rochford",
     )
 
-    val result = premisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
+    val result = cas3PremisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
 
     assertThat(result).isEqualTo(
       TemporaryAccommodationPremisesSummary(
@@ -47,36 +46,33 @@ class PremisesSummaryTransformerTest {
   }
 
   @Test
-  fun `transformDomainToApi transforms the ApprovedPremisesSummary into an ApprovedPremisesSummary`() {
+  fun `transformDomainToApi transforms the DomainTemporaryAccommodationPremisesSummary into a Cas3PremisesSummary`() {
     val uuid = UUID.randomUUID()
-    val domainPremisesSummary = DomainApprovedPremisesSummary(
+    val domainPremisesSummary = DomainTemporaryAccommodationPremisesSummary(
       id = uuid,
       name = "bob",
       addressLine1 = "address",
       addressLine2 = "address line 2",
       postcode = "123ABC",
+      pdu = "North east",
       status = PropertyStatus.active,
       bedCount = 1,
-      apCode = "APCODE",
-      regionName = "Some region",
-      apAreaName = "Some AP Area name",
+      localAuthorityAreaName = "Rochford",
     )
 
-    val result = premisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
+    val result = cas3PremisesSummaryTransformer.transformDomainToCas3PremisesSummary(domainPremisesSummary)
 
     assertThat(result).isEqualTo(
-      ApprovedPremisesSummary(
+      Cas3PremisesSummary(
         id = uuid,
         name = "bob",
         addressLine1 = "address",
         addressLine2 = "address line 2",
         postcode = "123ABC",
+        pdu = "North east",
         status = PropertyStatus.active,
         bedCount = 1,
-        apCode = "APCODE",
-        service = "CAS1",
-        probationRegion = "Some region",
-        apArea = "Some AP Area name",
+        localAuthorityAreaName = "Rochford",
       ),
     )
   }
@@ -96,7 +92,7 @@ class PremisesSummaryTransformerTest {
       localAuthorityAreaName = null,
     )
 
-    val result = premisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
+    val result = cas3PremisesSummaryTransformer.transformDomainToApi(domainPremisesSummary)
 
     assertThat(result).isEqualTo(
       TemporaryAccommodationPremisesSummary(
@@ -109,6 +105,38 @@ class PremisesSummaryTransformerTest {
         status = PropertyStatus.active,
         bedCount = 1,
         service = "CAS3",
+        localAuthorityAreaName = null,
+      ),
+    )
+  }
+
+  @Test
+  fun `transformDomainToApi transforms the DomainTemporaryAccommodationPremisesSummary into a Cas3PremisesSummary without optional elements`() {
+    val uuid = UUID.randomUUID()
+    val domainPremisesSummary = DomainTemporaryAccommodationPremisesSummary(
+      id = uuid,
+      name = "bob",
+      addressLine1 = "address",
+      addressLine2 = null,
+      postcode = "123ABC",
+      pdu = "North east",
+      status = PropertyStatus.active,
+      bedCount = 1,
+      localAuthorityAreaName = null,
+    )
+
+    val result = cas3PremisesSummaryTransformer.transformDomainToCas3PremisesSummary(domainPremisesSummary)
+
+    assertThat(result).isEqualTo(
+      Cas3PremisesSummary(
+        id = uuid,
+        name = "bob",
+        addressLine1 = "address",
+        addressLine2 = null,
+        postcode = "123ABC",
+        pdu = "North east",
+        status = PropertyStatus.active,
+        bedCount = 1,
         localAuthorityAreaName = null,
       ),
     )


### PR DESCRIPTION
This [PR CAS-1385](https://dsdmoj.atlassian.net/browse/CAS-1385) is : 
- To create a new CAS3 premises summary Api endpoint 
- Depreciate the existing one as is used currently only by CAS3
- The exiting premises summary Api endpoint will be removed after CAS3 UI will migrate to use the new one 