### PR TITLE
Populate actual dates on Cas1SpaceBookingSummary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -172,6 +172,8 @@ class Cas1SpaceBookingTransformer(
     canonicalDepartureDate = spaceBooking.canonicalDepartureDate,
     expectedArrivalDate = spaceBooking.expectedArrivalDate,
     expectedDepartureDate = spaceBooking.expectedDepartureDate,
+    actualArrivalDate = spaceBooking.actualArrivalDate,
+    actualDepartureDate = spaceBooking.actualDepartureDate,
     isNonArrival = spaceBooking.hasNonArrival(),
     tier = spaceBooking.application?.riskRatings?.tier?.value?.level,
     keyWorkerAllocation = spaceBooking.extractKeyWorkerAllocation(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -338,8 +338,15 @@ class Cas1SpaceBookingTransformerTest {
           .withPremises(premises)
           .withCanonicalArrivalDate(LocalDate.parse("2023-12-13"))
           .withCanonicalDepartureDate(LocalDate.parse("2023-01-02"))
-          .withExpectedArrivalDate(LocalDate.parse("2023-12-13"))
-          .withExpectedDepartureDate(LocalDate.parse("2023-01-02"))
+          .withExpectedArrivalDate(LocalDate.parse("2022-12-13"))
+          .withExpectedDepartureDate(LocalDate.parse("2022-01-02"))
+          .withActualArrivalDate(LocalDate.parse("2024-12-13"))
+          .withActualDepartureDate(LocalDate.parse("2024-01-02"))
+          .withCriteria(
+            CharacteristicEntityFactory().withPropertyName("hasTurningSpace").produce(),
+            CharacteristicEntityFactory().withPropertyName("isCatered").produce(),
+          )
+          .withNonArrivalConfirmedAt(Instant.now())
           .withApplication(
             ApprovedPremisesApplicationEntityFactory()
               .withDefaults()
@@ -358,7 +365,6 @@ class Cas1SpaceBookingTransformerTest {
           .withKeyworkerStaffCode("the staff code")
           .withKeyworkerAssignedAt(LocalDateTime.of(2023, 12, 12, 0, 0, 0).toInstant(ZoneOffset.UTC))
           .withKeyworkerName("the keyworker name")
-          .withCriteria(mutableListOf())
           .withDeliusEventNumber("event8")
           .produce(),
         personSummaryInfo,
@@ -370,6 +376,15 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.premises.name).isEqualTo(premises.name)
       assertThat(result.canonicalArrivalDate).isEqualTo(LocalDate.parse("2023-12-13"))
       assertThat(result.canonicalDepartureDate).isEqualTo(LocalDate.parse("2023-01-02"))
+      assertThat(result.expectedArrivalDate).isEqualTo(LocalDate.parse("2022-12-13"))
+      assertThat(result.expectedDepartureDate).isEqualTo(LocalDate.parse("2022-01-02"))
+      assertThat(result.characteristics).containsExactlyInAnyOrder(
+        Cas1SpaceCharacteristic.hasTurningSpace,
+        Cas1SpaceCharacteristic.isCatered,
+      )
+      assertThat(result.actualArrivalDate).isEqualTo(LocalDate.parse("2024-12-13"))
+      assertThat(result.actualDepartureDate).isEqualTo(LocalDate.parse("2024-01-02"))
+      assertThat(result.isNonArrival).isEqualTo(true)
       assertThat(result.tier).isEqualTo("M1")
       assertThat(result.keyWorkerAllocation!!.allocatedAt).isEqualTo(LocalDate.parse("2023-12-12"))
       assertThat(result.keyWorkerAllocation!!.keyWorker.name).isEqualTo("the keyworker name")


### PR DESCRIPTION
This commit ensures `actualArrivalDate` and `actualDepartureDate` are populated on `Cas1SpaceBookingSummary` when mapped from a `Cas1SpaceBookingEntity`. It also adds some missing tests for mappings.