### PR TITLE
Pin OWASP Dep Check Version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   id("org.openapi.generator") version "7.11.0"
   id("io.gatling.gradle") version "3.13.1"
   id("io.gitlab.arturbosch.detekt") version "1.23.7"
+  id("org.owasp.dependencycheck") version "12.1.0"
 }
 
 configurations {


### PR DESCRIPTION
Commit aa4d15e09fa0f68ae6dc49a75017930536c81508 added an ignore list for the owasp dependency check plugin. This led to errors when building, presumably due to it causing a mismatch between the plugin version used in gradle and the cached CVE database. This commit pins the version of the plugin to the latest available version which appears to resolve these issues