### PR TITLE
Enable retry on timeout for ap-and-delius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -74,6 +74,7 @@ class WebClientConfiguration(
           }.build(),
         )
         .build(),
+      retryOnReadTimeout = true,
     )
   }
 


### PR DESCRIPTION
Typically we reduce the timeout time based upon production data on response times. For ap-and-delius some reponses take up to 9 seconds (due to large bulk requests for offender information), so the default timeout of 10 seconds is suitable