### PR TITLE
Collate existing room errors on site survey import 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
@@ -66,15 +66,20 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
       }
     }
 
+    val bedErrors = mutableListOf<String>()
     beds.forEach {
       val existingBed = bedRepository.findByCode(it.bedCode)
       if (existingBed == null) {
         createBed(it)
       } else {
         if (existingBed.room.code != it.roomCode) {
-          error("Bed ${it.bedCode} already exists in room ${existingBed.room.code} but is being added to room ${it.roomCode}.")
+          bedErrors.add("Bed ${it.bedCode} already exists in room ${existingBed.room.code} but is being added to room ${it.roomCode}.")
         }
       }
+    }
+
+    if (bedErrors.isNotEmpty()) {
+      error(bedErrors.joinToString(","))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
@@ -34,10 +34,23 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
     "Can this room be designated as suitable for people requiring step free access? (Must answer yes to Q23 and 25 on previous sheet and Q19 on this sheet)",
   )
 
-  fun MutableList<Any>.addCharacteristics(numberOfRooms: Int = 1, activeCharacteristics: Map<String, List<String>> = emptyMap()) {
+  data class Answers(
+    val question: String,
+    val answersForEachRoom: List<String>,
+  )
+
+  fun MutableList<Any>.addQuestionsAndAnswers(
+    numberOfRooms: Int = 1,
+    answerOverrides: List<Answers> = emptyList(),
+  ) {
     questions.forEach { question ->
       this.add(question)
-      this.addAll(activeCharacteristics.getOrDefault(question, MutableList(numberOfRooms) { "No" }))
+      val answers = if(answerOverrides.any { it.question == question }) {
+        answerOverrides.first { it.question == question }.answersForEachRoom
+      } else {
+        MutableList(numberOfRooms) { "No" }
+      }
+      this.addAll(answers)
     }
   }
 
@@ -59,7 +72,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
       1,
     )
-    rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf("Yes")))
+    rows.addQuestionsAndAnswers(
+      numberOfRooms = 1,
+      answerOverrides = listOf(Answers("Is this room located on the ground floor?" , listOf("Yes")))
+    )
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -107,7 +123,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
       1.2,
     )
-    rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf("Yes")))
+    rows.addQuestionsAndAnswers(
+      numberOfRooms = 1,
+      answerOverrides = listOf(Answers("Is this room located on the ground floor?" , listOf("Yes")))
+    )
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -159,7 +178,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       1.0,
       1.0,
     )
-    rows.addCharacteristics(3, mapOf("Is this room located on the ground floor?" to listOf("No", "Yes", "No")))
+    rows.addQuestionsAndAnswers(
+      numberOfRooms = 3,
+      answerOverrides = listOf(Answers("Is this room located on the ground floor?" , listOf("No", "Yes", "No")))
+    )
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -230,7 +252,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       1.0,
       2.0,
     )
-    rows.addCharacteristics(2, mapOf("Is this room located on the ground floor?" to listOf("No", "Yes")))
+    rows.addQuestionsAndAnswers(
+      numberOfRooms = 2,
+      answerOverrides = listOf(Answers("Is this room located on the ground floor?" , listOf("No", "Yes")))
+    )
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -275,7 +300,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "1",
       "2",
     )
-    rows.addCharacteristics(3, mapOf("Is this room located on the ground floor?" to listOf("No", "Yes", "Yes")))
+    rows.addQuestionsAndAnswers(
+      numberOfRooms = 3,
+      answerOverrides = listOf(Answers("Is this room located on the ground floor?" , listOf("No", "Yes", "Yes")))
+    )
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -341,7 +369,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
       "1",
     )
-    rows.addCharacteristics(1)
+    rows.addQuestionsAndAnswers(1)
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -392,7 +420,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
       "1",
     )
-    rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf("Yes", "No", "No")))
+    rows.addQuestionsAndAnswers(
+      numberOfRooms = 1,
+      answerOverrides = listOf(Answers("Is this room located on the ground floor?" , listOf("Yes", "No", "No"))),
+    )
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -451,7 +482,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
       "1",
     )
-    rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf("Yes", "No", "No")))
+    rows.addQuestionsAndAnswers(
+      numberOfRooms = 1,
+      answerOverrides = listOf(Answers("Is this room located on the ground floor?" , listOf("Yes", "No", "No"))),
+    )
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -507,7 +541,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "1",
       "1",
     )
-    rows.addCharacteristics(2)
+    rows.addQuestionsAndAnswers(2)
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -559,7 +593,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
       "1",
     )
-    rows.addCharacteristics(1)
+    rows.addQuestionsAndAnswers(1)
 
     val roomsSheet = dataFrameOf(header, rows)
 
@@ -601,7 +635,7 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
       "1",
     )
-    rows.addCharacteristics(1)
+    rows.addQuestionsAndAnswers(1)
     rows.replaceAll { if (it == "Is this room located on the ground floor?") "Bad question" else it }
 
     val roomsSheet = dataFrameOf(header, rows)
@@ -644,7 +678,10 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
       "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
       "1",
     )
-    rows.addCharacteristics(1, mapOf("Is this room located on the ground floor?" to listOf("Yes", "No", "No")))
+    rows.addQuestionsAndAnswers(
+      numberOfRooms = 1,
+      answerOverrides = listOf(Answers("Is this room located on the ground floor?" , listOf("Yes", "No", "No"))),
+    )
     rows.replaceAll { if (it == "Yes") "Bad answer" else it }
 
     val roomsSheet = dataFrameOf(header, rows)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DataFrameUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/DataFrameUtils.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
+import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 
@@ -12,5 +13,12 @@ object DataFrameUtils {
     check(list.size % 2 == 0) { "Should contain an even number of entries" }
 
     return dataFrameOf(list.subList(0, 2), list.subList(2, rows.size))
+  }
+
+  fun dataFrameForHeadersAndRows(headersAndRows: List<List<Any>>): AnyFrame {
+    val headers = headersAndRows[0].map { it.toString() }
+    val rows = headersAndRows.subList(1, headersAndRows.size).flatten()
+
+    return dataFrameOf(headers, rows)
   }
 }


### PR DESCRIPTION

Before this commit site survey imports fails the first time it tries to create a bed when one already exists in a different room. Now it checks all beds before failing, making it easier to find all issues in a single attempt.