### PR TITLE
Pipeline Config for new cas3_e2e_playwright_tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,45 @@ jobs:
       - store_artifacts:
           path: e2e/videos
           destination: videos
+      - slack/notify:
+          event: fail
+          channel: << pipeline.parameters.alerts-slack-channel >>
+          template: basic_fail_1
+  cas3_e2e_playwright_tests:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.40.0-focal
+    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
+    parameters:
+      environment:
+        type: string
+        default: dev
+    steps:
+      - run:
+          name: Clone E2E repo
+          command: |
+            git clone -b feature/CAS-1470_temp_download_logging https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git .
+      - run:
+          name: Update npm
+          command: 'npm install -g npm@10.1.0'
+      - node/install-packages
+      - run:
+          name: Install Playwright
+          command: npx playwright install
+      - run:
+          name: Run E2E tests
+          command: |
+            export ASSESSOR_USERNAME=${CYPRESS_ASSESSOR_USERNAME_<< parameters.environment >>} ASSESSOR_PASSWORD=${CYPRESS_ASSESSOR_PASSWORD_<< parameters.environment >>} REFERRER_USERNAME=${CYPRESS_REFERRER_USERNAME_<< parameters.environment >>} REFERRER_PASSWORD=${CYPRESS_REFERRER_PASSWORD_<< parameters.environment >>} ACTING_USER_PROBATION_REGION_ID=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>} ACTING_USER_PROBATION_REGION_NAME=${ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>} ENVIRONMENT=${CYPRESS_ENVIRONMENT_<< parameters.environment >>} DEV_PLAYWRIGHT_BASE_URL=https://transitional-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
+            npm run test:playwright:e2e:ci
+      - store_artifacts:
+          path: e2e_playwright/playwright-report
+          destination: e2e_playwright/playwright-report
+      - store_artifacts:
+          path: e2e_playwright/test-results
+          destination: e2e_playwright/test-results
+      - slack/notify:
+          event: fail
+          channel: << pipeline.parameters.alerts-slack-channel >>
+          template: basic_fail_1
   trigger_ui_github_action:
     machine:
       image: ubuntu-2204:current
@@ -468,6 +507,12 @@ workflows:
           requires:
             - deploy_dev
       - cas3_e2e_tests:
+          context:
+            - hmpps-common-vars
+            - hmpps-community-accommodation
+          requires:
+            - deploy_dev
+      - cas3_e2e_playwright_tests:
           context:
             - hmpps-common-vars
             - hmpps-community-accommodation


### PR DESCRIPTION
**PR includes**
* Config to run new `cas3_e2e_playwright_tests` job in API pipeline
* This job will run alongside `cas3_e2e_tests` until `cas3_e2e_playwright_tests` has full replaced it - currently the new one covers the reporting e2e tests which have now been removed from the e2e tests run by `cas3_e2e_tests`. 
* This will be the approach going forward (add to one / remove from the other)