### PR TITLE
APS-2063 Add CAS1_OUT_OF_SERVICE_BED_CANCEL permission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OutOfServiceBedsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OutOfServiceBedsController.kt
@@ -78,7 +78,7 @@ class Cas1OutOfServiceBedsController(
     outOfServiceBedId: UUID,
     body: Cas1NewOutOfServiceBedCancellation,
   ): ResponseEntity<Cas1OutOfServiceBedCancellation> {
-    userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE)
+    userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_OUT_OF_SERVICE_BED_CANCEL)
 
     val premises = tryGetApprovedPremises(premisesId)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
@@ -23,6 +23,7 @@ enum class UserPermission {
   CAS1_BOOKING_WITHDRAW,
   CAS1_BOOKING_CHANGE_DATES,
   CAS1_OUT_OF_SERVICE_BED_CREATE,
+  CAS1_OUT_OF_SERVICE_BED_CANCEL,
 
   /**
    * If the user can record an appeal against a rejected application

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -89,7 +89,10 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
   CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA(
     ServiceName.approvedPremises,
     ApprovedPremisesUserRole.cruMemberFindAndBookBeta,
-    permissions = commonCruMemberPermissions + listOf(UserPermission.CAS1_SPACE_BOOKING_CREATE),
+    permissions = commonCruMemberPermissions + listOf(
+      UserPermission.CAS1_SPACE_BOOKING_CREATE,
+      UserPermission.CAS1_OUT_OF_SERVICE_BED_CANCEL,
+    ),
   ),
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/UserTransformer.kt
@@ -136,6 +136,7 @@ class UserTransformer(
       UserPermission.CAS1_BOOKING_CHANGE_DATES -> ApiUserPermission.bookingChangeDates
       UserPermission.CAS1_BOOKING_WITHDRAW -> ApiUserPermission.bookingWithdraw
       UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE -> ApiUserPermission.outOfServiceBedCreate
+      UserPermission.CAS1_OUT_OF_SERVICE_BED_CANCEL -> ApiUserPermission.outOfServiceBedCancel
       UserPermission.CAS1_PROCESS_AN_APPEAL -> ApiUserPermission.processAnAppeal
       UserPermission.CAS1_USER_LIST -> ApiUserPermission.userList
       UserPermission.CAS1_USER_MANAGEMENT -> ApiUserPermission.userManagement

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2897,6 +2897,7 @@ components:
         - cas1_booking_change_dates
         - cas1_booking_withdraw
         - cas1_out_of_service_bed_create
+        - cas1_out_of_service_bed_cancel
         - cas1_process_an_appeal
         - cas1_user_list
         - cas1_user_management

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7122,6 +7122,7 @@ components:
         - cas1_booking_change_dates
         - cas1_booking_withdraw
         - cas1_out_of_service_bed_create
+        - cas1_out_of_service_bed_cancel
         - cas1_process_an_appeal
         - cas1_user_list
         - cas1_user_management

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4816,6 +4816,7 @@ components:
         - cas1_booking_change_dates
         - cas1_booking_withdraw
         - cas1_out_of_service_bed_create
+        - cas1_out_of_service_bed_cancel
         - cas1_process_an_appeal
         - cas1_user_list
         - cas1_user_management

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3506,6 +3506,7 @@ components:
         - cas1_booking_change_dates
         - cas1_booking_withdraw
         - cas1_out_of_service_bed_create
+        - cas1_out_of_service_bed_cancel
         - cas1_process_an_appeal
         - cas1_user_list
         - cas1_user_management

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3527,6 +3527,7 @@ components:
         - cas1_booking_change_dates
         - cas1_booking_withdraw
         - cas1_out_of_service_bed_create
+        - cas1_out_of_service_bed_cancel
         - cas1_process_an_appeal
         - cas1_user_list
         - cas1_user_management

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3088,6 +3088,7 @@ components:
         - cas1_booking_change_dates
         - cas1_booking_withdraw
         - cas1_out_of_service_bed_create
+        - cas1_out_of_service_bed_cancel
         - cas1_process_an_appeal
         - cas1_user_list
         - cas1_user_management

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OutOfServiceBedTest.kt
@@ -2091,7 +2091,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Cancel Out-Of-Service Bed for non-existent premises returns 404`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA)) { _, jwt ->
         webTestClient.post()
           .uri("/cas1/premises/9054b6a8-65ad-4d55-91ee-26ba65e05488/out-of-service-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488/cancellations")
           .header("Authorization", "Bearer $jwt")
@@ -2113,7 +2113,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
         withYieldedProbationRegion { givenAProbationRegion() }
       }
 
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
+      givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA)) { _, jwt ->
         webTestClient.post()
           .uri("/cas1/premises/${premises.id}/out-of-service-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488/cancellations")
           .header("Authorization", "Bearer $jwt")
@@ -2154,7 +2154,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(
       value = UserRole::class,
-      names = [ "CAS1_FUTURE_MANAGER", "CAS1_CRU_MEMBER_ENABLE_OUT_OF_SERVICE_BEDS", "CAS1_JANITOR" ],
+      names = [ "CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA", "CAS1_JANITOR" ],
     )
     fun `Cancel Out-Of-Service Bed returns OK with correct body when user has the correct roles`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2063

- Add an CAS1_OUT_OF_SERVICE_BED_CANCEL permission.
- Add this permission to the CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA role
- Update the /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}/cancellations endpoint to require this permission
- Update tests to use CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA instead of CAS1_FUTURE_MANAGER
- Remove CAS1_CRU_MEMBER_ENABLE_OUT_OF_SERVICE_BEDS from cancel bed test