### PR TITLE
APS-2064 & APS-2065 Add bed on hold

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -57,6 +57,7 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
       (FALSE = :excludeFuture OR dd.start_date <= :date) AND 
       (oosb_cancellations IS NULL)
     """
+    val BED_ON_HOLD_CANCELLATION_REASON_ID: UUID = UUID.fromString("199bef2d-0839-40c0-85e2-00b84fde7fde")
   }
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/Cas1OutOfServiceBedsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/Cas1OutOfServiceBedsReportGenerator.kt
@@ -26,7 +26,7 @@ class Cas1OutOfServiceBedsReportGenerator(
 
     val outOfServiceBedIds = outOfServiceBedRepository.findByBedIdAndOverlappingDate(this.id, startOfMonth, endOfMonth, null)
 
-    val outOfServiceBeds = outOfServiceBedRepository.findAllById(outOfServiceBedIds.map(UUID::fromString))
+    val outOfServiceBeds = outOfServiceBedRepository.findAllById(outOfServiceBedIds.map(UUID::fromString)).filter { it.reason.id != Cas1OutOfServiceBedRepository.BED_ON_HOLD_CANCELLATION_REASON_ID }
 
     outOfServiceBeds.map {
       val bed = it.bed

--- a/src/main/resources/db/migration/all/20250310140644__add_bed_on_hold_to_out_of_service_beds_reasons.sql
+++ b/src/main/resources/db/migration/all/20250310140644__add_bed_on_hold_to_out_of_service_beds_reasons.sql
@@ -1,0 +1,3 @@
+INSERT INTO cas1_out_of_service_bed_reasons(id, created_at, name, is_active)
+SELECT '199bef2d-0839-40c0-85e2-00b84fde7fde',now(),'Bed on hold',true
+WHERE NOT EXISTS ( SELECT id FROM cas1_out_of_service_bed_reasons WHERE id = '199bef2d-0839-40c0-85e2-00b84fde7fde');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1OutOfServiceBedsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1OutOfServiceBedsReportTest.kt
@@ -60,6 +60,14 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
           )
         }
 
+        val bed4 = bedEntityFactory.produceAndPersist {
+          withRoom(
+            roomEntityFactory.produceAndPersist {
+              withPremises(premises)
+            },
+          )
+        }
+
         cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
           withBed(bed1)
@@ -104,6 +112,20 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
             withEndDate(LocalDate.of(2023, 7, 5))
             withYieldedReason {
               cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
+            }
+          }
+
+          cas1OutOfServiceBedEntityFactory.produceAndPersist {
+            withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+            withBed(bed4)
+          }.apply {
+            this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+              withCreatedBy(userEntity)
+              withOutOfServiceBed(this@apply)
+              withStartDate(LocalDate.of(2023, 4, 1))
+              withEndDate(LocalDate.of(2023, 7, 5))
+              withReason(cas1OutOfServiceBedReasonTestRepository.getReferenceById(Cas1OutOfServiceBedRepository.BED_ON_HOLD_CANCELLATION_REASON_ID))
             }
           }
 


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2064
Ref: https://dsdmoj.atlassian.net/browse/APS-2065

- Add a new entry to `cas1_out_of_service_bed_reasons` with the name ‘Bed on hold’
- Update the out of service bed report (`Cas1OutOfServiceBedsReportGenerator`) to exclude any entries where the reason for the bed being out of service is ‘Bed on hold’. To do this hardcode the ‘Bed on hold’ ID in the code.

'Bed on Hold' appears as a reason in the UI automatically when creating an out of service bed:

![image](https://github.com/user-attachments/assets/775aa1a7-f3cb-4d09-92d9-c3e6e15bc9c2)

The 'Bed on hold' reason is also shown when viewing the list of out of service beds:

![image](https://github.com/user-attachments/assets/d3936c4c-5ada-40d8-b4cc-14dbbed5d965)

'Bed on hold' is also shown as the reason when viewing the out of service bed record itself:

![image](https://github.com/user-attachments/assets/25802e5c-53ce-4c6f-b4ef-066aed7d52a9)


