### PR TITLE
APS-2097 simplify seed tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCharacteristicsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SeedCharacteristicsTest.kt
@@ -17,14 +17,12 @@ class SeedCharacteristicsTest : SeedTestBase() {
 
   @Test
   fun `Attempting to seed characteristic with missing characteristic_name field fails and logs error`() {
-    withCsv(
-      "invalid-characteristics-missing-name",
+    seed(
+      SeedFileType.characteristics,
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
         "hasWideDoor,Is the door to this room at least 900mm wide?,approved-premises,room\n" +
         "hasWideDoor,,temporary-accommodation,room\n",
     )
-
-    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-missing-name.csv")
 
     assertThat(characteristicRepository.count()).isEqualTo(0)
 
@@ -38,14 +36,12 @@ class SeedCharacteristicsTest : SeedTestBase() {
 
   @Test
   fun `Attempting to seed characteristic with unknown scope field fails and logs error`() {
-    withCsv(
-      "invalid-characteristics-unknown-scope",
+    seed(
+      SeedFileType.characteristics,
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
         "hasWideDoor,Is the door to this room at least 900mm wide?,foo,room\n" +
         "hasWideDoor,Is the entrance wide?,temporary-accommodation,bar\n",
     )
-
-    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-unknown-scope.csv")
 
     assertThat(characteristicRepository.count()).isEqualTo(0)
 
@@ -59,14 +55,12 @@ class SeedCharacteristicsTest : SeedTestBase() {
 
   @Test
   fun `Attempting to seed characteristic missing either scope field fails and logs error`() {
-    withCsv(
-      "invalid-characteristics-missing-scope",
+    seed(
+      SeedFileType.characteristics,
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
         "hasWideDoor,Is the door to this room at least 900mm wide?,,room\n" +
         "hasWideDoor,Is the entrance wide?,temporary-accommodation,\n",
     )
-
-    seedService.seedData(SeedFileType.characteristics, "invalid-characteristics-missing-scope.csv")
 
     assertThat(characteristicRepository.count()).isEqualTo(0)
 
@@ -80,16 +74,13 @@ class SeedCharacteristicsTest : SeedTestBase() {
 
   @Test
   fun `Seeding new characteristics twice (unique propertyName, serviceScope and modelScope) succeeds without dupes`() {
-    withCsv(
-      "valid-characteristics",
-      "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
-        "hasWideDoor,Is the door to this room at least 900mm wide?,approved-premises,room\n" +
-        "hasWideDoor,Is the room entrance wide?,temporary-accommodation,room\n" +
-        "isIap,Is this an IAP?,approved-premises,premises\n",
-    )
+    val csv = "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
+      "hasWideDoor,Is the door to this room at least 900mm wide?,approved-premises,room\n" +
+      "hasWideDoor,Is the room entrance wide?,temporary-accommodation,room\n" +
+      "isIap,Is this an IAP?,approved-premises,premises\n"
 
-    seedService.seedData(SeedFileType.characteristics, "valid-characteristics.csv")
-    seedService.seedData(SeedFileType.characteristics, "valid-characteristics.csv")
+    seed(SeedFileType.characteristics, csv)
+    seed(SeedFileType.characteristics, csv)
 
     val apWideDoorRoom = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "hasWideDoor",
@@ -132,13 +123,11 @@ class SeedCharacteristicsTest : SeedTestBase() {
     assertThat(characteristicRepository.count()).isEqualTo(1)
     assertThat(characteristic!!.name).isEqualTo("Is the door wide?")
 
-    withCsv(
-      "valid-characteristics-update",
+    seed(
+      SeedFileType.characteristics,
       "characteristic_property_name,characteristic_name,service_scope,model_scope\n" +
         "hasWideDoor,Is the DOOR wide?,approved-premises,room\n",
     )
-
-    seedService.seedData(SeedFileType.characteristics, "valid-characteristics-update.csv")
 
     val updatedCharacteristic = characteristicRepository.findByPropertyNameAndScopes(
       propertyName = "hasWideDoor",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1RedactAssessmentDetailsTest.kt
@@ -31,8 +31,8 @@ class Cas1RedactAssessmentDetailsTest : SeedTestBase() {
     val assessment2HasJson = createAssessment(data = sampleJson)
     val assessment3Unmodified = createAssessment(data = sampleJson)
 
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesRedactAssessmentDetails,
       rowsToCsv(
         listOf(
           Cas1RemoveAssessmentDetailsSeedCsvRow(assessment1NoJson.id.toString()),
@@ -40,8 +40,6 @@ class Cas1RedactAssessmentDetailsTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesRedactAssessmentDetails, "valid-csv.csv")
 
     val expectedJson = """{"sufficient-information":{"sufficient-information":{"sufficientInformation":"yes","query":""}}}"""
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedAssessmentMoreInfoBugFixTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedAssessmentMoreInfoBugFixTest.kt
@@ -33,8 +33,8 @@ class SeedAssessmentMoreInfoBugFixTest : SeedTestBase() {
     val assessment3Unmodified = createAssessment(data = sampleJson)
     val assessment4FlatJson = createAssessment(data = removeLineBreaks(sampleJson))
 
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesAssessmentMoreInfoBugFix,
       rowsToCsv(
         listOf(
           Cas1FurtherInfoBugFixSeedCsvRow(assessment1NoJson.id.toString()),
@@ -43,8 +43,6 @@ class SeedAssessmentMoreInfoBugFixTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesAssessmentMoreInfoBugFix, "valid-csv.csv")
 
     val expectedJson = """{
       "sufficient-information-confirm":{"confirm":"yes"},

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest.kt
@@ -172,12 +172,10 @@ class SeedCas1BackfillActiveSpaceBookingsCreatedInDeliusTest : SeedTestBase() {
       ),
     )
 
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesBackfillActiveSpaceBookingsCreatedInDelius,
       rowsToCsv(listOf(Cas1CreateMissingReferralsSeedCsvRow(premises.qCode))),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesBackfillActiveSpaceBookingsCreatedInDelius, "valid-csv.csv")
 
     val premiseSpaceBookings = cas1SpaceBookingTestRepository.findByPremisesId(premises.id)
     assertThat(premiseSpaceBookings).hasSize(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
@@ -316,12 +316,10 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       departureDate = LocalDate.of(2025, 8, 5),
     )
 
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesBookingToSpaceBooking,
       rowsToCsv(listOf(Cas1BookingToSpaceBookingSeedCsvRow(premises.qCode))),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesBookingToSpaceBooking, "valid-csv.csv")
 
     val premiseSpaceBookings = cas1SpaceBookingTestRepository.findByPremisesId(premises.id)
     assertThat(premiseSpaceBookings).hasSize(5)
@@ -612,12 +610,10 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       placementRequest2,
     )
 
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesBookingToSpaceBooking,
       rowsToCsv(listOf(Cas1BookingToSpaceBookingSeedCsvRow(premises.qCode))),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesBookingToSpaceBooking, "valid-csv.csv")
 
     val bookingCreatedDomainEvents = domainEventRepository.findByApplicationId(application1.id)
     assertThat(bookingCreatedDomainEvents).hasSize(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CreateTestApplicationSeedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CreateTestApplicationSeedTest.kt
@@ -34,8 +34,8 @@ class SeedCas1CreateTestApplicationSeedTest : SeedTestBase() {
 
     postCodeDistrictFactory.produceAndPersist()
 
-    withCsv(
-      csvName = "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesCreateTestApplications,
       contents = listOf(
         Cas1CreateTestApplicationsSeedCsvRow(
           creatorUsername = user.deliusUsername,
@@ -46,8 +46,6 @@ class SeedCas1CreateTestApplicationSeedTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesCreateTestApplications, "valid-csv.csv")
 
     val applications = approvedPremisesApplicationRepository.findAll()
     assertThat(applications).hasSize(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CruManagementAreaTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CruManagementAreaTest.kt
@@ -32,8 +32,9 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
   @Test
   fun `Attempting to seed using an invalid id logs an error`() {
     val invalidId = UUID.randomUUID()
-    withCsv(
-      csvName = "invalid-id",
+
+    seed(
+      SeedFileType.approvedPremisesCruManagementAreas,
       contents = listOf(
         CruManagementAreaSeedCsvRow(
           id = invalidId,
@@ -43,8 +44,6 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesCruManagementAreas, "invalid-id.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -58,8 +57,8 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
 
   @Test
   fun `Attempting to seed using an invalid name logs an error`() {
-    withCsv(
-      csvName = "invalid-name",
+    seed(
+      SeedFileType.approvedPremisesCruManagementAreas,
       contents = listOf(
         CruManagementAreaSeedCsvRow(
           id = areaId,
@@ -69,8 +68,6 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesCruManagementAreas, "invalid-name.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -84,8 +81,8 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
 
   @Test
   fun `Updating cru management area persists correctly`() {
-    withCsv(
-      csvName = "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesCruManagementAreas,
       contents = listOf(
         CruManagementAreaSeedCsvRow(
           id = areaId,
@@ -96,8 +93,6 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
       ).toCsv(),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesCruManagementAreas, "valid-csv.csv")
-
     val updatedArea = cas1CruManagementAreaRepository.findByIdOrNull(areaId)!!
 
     assertThat(updatedArea.emailAddress).isEqualTo("updated@test.com")
@@ -106,8 +101,8 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
 
   @Test
   fun `Updating cru management area with null values correctly`() {
-    withCsv(
-      csvName = "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesCruManagementAreas,
       contents = listOf(
         CruManagementAreaSeedCsvRow(
           id = areaId,
@@ -117,8 +112,6 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesCruManagementAreas, "valid-csv.csv")
 
     val updatedArea = cas1CruManagementAreaRepository.findByIdOrNull(areaId)!!
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DomainEventReplayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DomainEventReplayTest.kt
@@ -27,8 +27,8 @@ class SeedCas1DomainEventReplayTest : SeedTestBase() {
         .produce(),
     )
 
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesReplayDomainEvents,
       rowsToCsv(
         listOf(
           Cas1DomainEventReplaySeedCsvRow(
@@ -37,8 +37,6 @@ class SeedCas1DomainEventReplayTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesReplayDomainEvents, "valid-csv.csv")
 
     val message = snsDomainEventListener.blockForMessage(DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1DuplicateApplicationTest.kt
@@ -56,8 +56,8 @@ class SeedCas1DuplicateApplicationTest : SeedTestBase() {
           NeedsDetailsFactory().produce(),
         )
 
-        withCsv(
-          "valid-csv",
+        seed(
+          SeedFileType.approvedPremisesDuplicateApplication,
           rowsToCsv(
             listOf(
               Cas1DuplicateApplicationSeedCsvRow(
@@ -66,8 +66,6 @@ class SeedCas1DuplicateApplicationTest : SeedTestBase() {
             ),
           ),
         )
-
-        seedService.seedData(SeedFileType.approvedPremisesDuplicateApplication, "valid-csv.csv")
 
         val newApplication = approvedPremisesApplicationRepository.findAll()
           .filter { it.crn == sourceApplication.crn }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusReferralsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1ImportDeliusReferralsTest.kt
@@ -20,8 +20,8 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
 
   @Test
   fun `Row with no expected arrival date is ignored`() {
-    withCsv(
-      csvName = "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesImportDeliusReferrals,
       contents = listOf(
         Cas1DeliusImportDeliusReferralRowRaw(
           crn = "CRN1",
@@ -31,15 +31,13 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
       ).toCsv(),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesImportDeliusReferrals, "valid-csv.csv")
-
     assertThat(cas1DeliusBookingImportRepository.findAll()).isEmpty()
   }
 
   @Test
   fun `Row with only mandatory fields can be processed`() {
-    withCsv(
-      csvName = "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesImportDeliusReferrals,
       contents = listOf(
         Cas1DeliusImportDeliusReferralRowRaw(
           crn = "CRN1",
@@ -52,8 +50,6 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesImportDeliusReferrals, "valid-csv.csv")
 
     val bookingImport = cas1DeliusBookingImportRepository.findAll()[0]
 
@@ -84,8 +80,8 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
   fun `Row with all available fields can be processed`() {
     val bookingId = UUID.randomUUID()
 
-    withCsv(
-      csvName = "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesImportDeliusReferrals,
       contents = listOf(
         Cas1DeliusImportDeliusReferralRowRaw(
           bookingId = bookingId.toString(),
@@ -115,8 +111,6 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesImportDeliusReferrals, "valid-csv.csv")
 
     val bookingImport = cas1DeliusBookingImportRepository.findAll()[0]
 
@@ -151,8 +145,8 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
       "DP", "DR", "IR", "2", "3", "1", "8", "RJ", "9", "4", "6", "7", "5",
     )
 
-    withCsv(
-      csvName = "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesImportDeliusReferrals,
       contents =
       allDecisionCodes.map { decisionCode ->
         Cas1DeliusImportDeliusReferralRowRaw(
@@ -167,8 +161,6 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
       }.toCsv(),
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesImportDeliusReferrals, "valid-csv.csv")
-
     val bookingImport = cas1DeliusBookingImportRepository.findAll()
 
     assertThat(bookingImport.map { it.crn }).containsExactlyInAnyOrder("AD", "ADA1", "ASA2", "ADA3", "AI", "A10", "AR")
@@ -178,8 +170,8 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
   fun `Fields containing data known to be unusable are set to null`() {
     val bookingId = UUID.randomUUID()
 
-    withCsv(
-      csvName = "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesImportDeliusReferrals,
       contents = listOf(
         Cas1DeliusImportDeliusReferralRowRaw(
           bookingId = bookingId.toString(),
@@ -200,8 +192,6 @@ class SeedCas1ImportDeliusReferralsTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesImportDeliusReferrals, "valid-csv.csv")
 
     val bookingImport = cas1DeliusBookingImportRepository.findAll()[0]
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
@@ -40,8 +40,8 @@ class SeedCas1LinkBookingToPlacementRequestTest : SeedTestBase() {
     val placementRequest = createPlacementRequest(application, user)
     val booking = createBooking(application)
 
-    generateCsvFile(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesLinkBookingToPlacementRequest,
       CsvBuilder()
         .withUnquotedFields("booking_id")
         .withUnquotedFields("placement_request_id")
@@ -51,8 +51,6 @@ class SeedCas1LinkBookingToPlacementRequestTest : SeedTestBase() {
         .newRow()
         .build(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesLinkBookingToPlacementRequest, "valid-csv.csv")
 
     val updatedPlacementRequest = placementRequestRepository.findByIdOrNull(placementRequest.id)!!
     assertThat(updatedPlacementRequest.booking!!.id).isEqualTo(booking.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 class SeedCas1OutOfServiceBedTest : SeedTestBase() {
   @Test
   fun `Logs an error if the premises ID is not provided`() {
-    seedWithCsv("no-premises-id") {
+    seedWithCsv {
       withRow(
         bedId = UUID.randomUUID(),
         startDate = LocalDate.now(),
@@ -43,7 +43,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
   fun `Logs an error if no premises exists with the given ID`() {
     val row = Cas1OutOfServiceBedSeedCsvRowFactory().produce()
 
-    seedWithCsv("no-premises") {
+    seedWithCsv {
       withRow(row)
     }
 
@@ -57,7 +57,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
 
   @Test
   fun `Logs an error if the bed ID is not provided`() {
-    seedWithCsv("no-bed-id") {
+    seedWithCsv {
       withRow(
         premisesId = UUID.randomUUID(),
         startDate = LocalDate.now(),
@@ -92,7 +92,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
       .withReasonId(reason.id)
       .produce()
 
-    seedWithCsv("no-bed") {
+    seedWithCsv {
       withRow(row)
     }
 
@@ -106,7 +106,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
 
   @Test
   fun `Logs an error if the start date is not provided`() {
-    seedWithCsv("no-start-date") {
+    seedWithCsv {
       withRow(
         premisesId = UUID.randomUUID(),
         bedId = UUID.randomUUID(),
@@ -127,7 +127,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
 
   @Test
   fun `Logs an error if the end date is not provided`() {
-    seedWithCsv("no-end-date") {
+    seedWithCsv {
       withRow(
         premisesId = UUID.randomUUID(),
         bedId = UUID.randomUUID(),
@@ -148,7 +148,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
 
   @Test
   fun `Logs an error if the reason ID is not provided`() {
-    seedWithCsv("no-reason-id") {
+    seedWithCsv {
       withRow(
         premisesId = UUID.randomUUID(),
         bedId = UUID.randomUUID(),
@@ -175,7 +175,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
         .withBedId(bed.id)
         .produce()
 
-      seedWithCsv("no-reason") {
+      seedWithCsv {
         withRow(row)
       }
 
@@ -205,7 +205,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
         .withCancellationNotes(null)
         .produce()
 
-      seedWithCsv("valid-out-of-service-bed") {
+      seedWithCsv {
         withRow(row)
       }
 
@@ -243,7 +243,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
         .withCancellationNotes("Some cancellation notes")
         .produce()
 
-      seedWithCsv("cancelled-out-of-service-bed") {
+      seedWithCsv {
         withRow(row)
       }
 
@@ -289,7 +289,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
         .withNotes("Updated notes")
         .produce()
 
-      seedWithCsv("updated-out-of-service-bed") {
+      seedWithCsv {
         withRow(firstRow)
         withRow(secondRow)
       }
@@ -349,7 +349,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
           .withCancellationNotes("Some cancellation notes")
           .produce()
 
-        seedWithCsv("multiple-out-of-service-beds") {
+        seedWithCsv {
           withRow(firstRow)
           withRow(secondRow)
           withRow(thirdRow)
@@ -385,14 +385,11 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
     }
   }
 
-  private fun seedWithCsv(name: String? = null, config: CsvBuilder.() -> Unit) {
-    val fileName = (name ?: randomStringMultiCaseWithNumbers(64))
-    generateCsvFile(
-      fileName,
+  private fun seedWithCsv(config: CsvBuilder.() -> Unit) {
+    seed(
+      SeedFileType.approvedPremisesOutOfServiceBeds,
       csv(config),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesOutOfServiceBeds, fileName + ".csv")
   }
 
   private fun csv(config: CsvBuilder.() -> Unit) = CsvBuilder()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromCsvTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromCsvTest.kt
@@ -30,8 +30,8 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create an Approved Premises with an invalid Probation Region logs an error`() {
-    withCsv(
-      "invalid-probation",
+    seed(
+      SeedFileType.approvedPremises,
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
@@ -40,8 +40,6 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-probation.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -57,8 +55,8 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
   fun `Attempting to create an Approved Premises with an invalid Local Authority Area logs an error`() {
     val probationRegion = givenAProbationRegion()
 
-    withCsv(
-      "invalid-local-authority",
+    seed(
+      SeedFileType.approvedPremises,
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
@@ -68,8 +66,6 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-local-authority.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -94,8 +90,8 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
       withServiceScope("temporary-accommodation")
     }
 
-    withCsv(
-      "invalid-service-scope",
+    seed(
+      SeedFileType.approvedPremises,
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
@@ -106,8 +102,6 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-service-scope.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -132,8 +126,8 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
       withModelScope("room")
     }
 
-    withCsv(
-      "invalid-model-scope",
+    seed(
+      SeedFileType.approvedPremises,
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesSeedCsvRowFactory()
@@ -144,8 +138,6 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremises, "invalid-model-scope.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -163,16 +155,14 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
       .withIsCatered("Catered")
       .produce()
 
-    withCsv(
-      "new-ap-invalid-boolean",
+    seed(
+      SeedFileType.approvedPremises,
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           csvRow,
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremises, "new-ap-invalid-boolean.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -186,13 +176,11 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create an Approved Premises missing required headers lists missing fields`() {
-    withCsv(
-      "new-ap-missing-headers",
+    seed(
+      SeedFileType.approvedPremises,
       "name,apCode,qCode,apArea,pdu,probationRegion,localAuthorityArea,town,addressLine1\n" +
         "HOPE,Q00,North East,Leeds,Yorkshire & The Humber,Leeds,Leeds,1 The Street, Leeds",
     )
-
-    seedService.seedData(SeedFileType.approvedPremises, "new-ap-missing-headers.csv")
 
     val expectedErrorMessage = "The headers provided: " +
       "[name, apCode, qCode, apArea, pdu, probationRegion, localAuthorityArea, town, addressLine1] " +
@@ -246,16 +234,14 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
       .withManagerDetails("manager details")
       .produce()
 
-    withCsv(
-      "new-ap",
+    seed(
+      SeedFileType.approvedPremises,
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           csvRow,
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremises, "new-ap.csv")
 
     val persistedApprovedPremises = approvedPremisesRepository.findByApCode(csvRow.apCode)
     assertThat(persistedApprovedPremises).isNotNull
@@ -304,16 +290,14 @@ class Cas1SeedPremisesFromCsvTest : SeedTestBase() {
       .withSupportsSpaceBookings("no")
       .produce()
 
-    withCsv(
-      "update-ap",
+    seed(
+      SeedFileType.approvedPremises,
       approvedPremisesSeedCsvRowsToCsv(
         listOf(
           csvRow,
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremises, "update-ap.csv")
 
     val persistedApprovedPremises = approvedPremisesRepository.findByApCode(csvRow.apCode)
     assertThat(persistedApprovedPremises).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromCsvTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromCsvTest.kt
@@ -38,8 +38,8 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       withServiceScope("temporary-accommodation")
     }
 
-    withCsv(
-      "invalid-ap-rooms-service-scope",
+    seed(
+      SeedFileType.approvedPremisesRooms,
       approvedPremisesRoomsSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesRoomsSeedCsvRowFactory()
@@ -49,8 +49,6 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-service-scope.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -77,8 +75,8 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       withServiceScope("approved-premises")
     }
 
-    withCsv(
-      "invalid-ap-rooms-model-scope",
+    seed(
+      SeedFileType.approvedPremisesRooms,
       approvedPremisesRoomsSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesRoomsSeedCsvRowFactory()
@@ -88,8 +86,6 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-model-scope.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -103,8 +99,8 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create an AP room without an associated premises logs an error`() {
-    withCsv(
-      "invalid-ap-rooms-missing-premises",
+    seed(
+      SeedFileType.approvedPremisesRooms,
       approvedPremisesRoomsSeedCsvRowsToCsv(
         listOf(
           ApprovedPremisesRoomsSeedCsvRowFactory()
@@ -113,8 +109,6 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "invalid-ap-rooms-missing-premises.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -135,16 +129,14 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       .withIsArsonSuitable("false")
       .produce()
 
-    withCsv(
-      "new-ap-room-invalid-boolean",
+    seed(
+      SeedFileType.approvedPremisesRooms,
       approvedPremisesRoomsSeedCsvRowsToCsv(
         listOf(
           csvRow,
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-room-invalid-boolean.csv")
 
     assertThat(logEntries)
       .withFailMessage("-> logEntries actually contains: $logEntries")
@@ -158,13 +150,11 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
 
   @Test
   fun `Attempting to create an AP Room missing required headers lists missing fields`() {
-    withCsv(
-      "new-ap-room-missing-headers",
+    seed(
+      SeedFileType.approvedPremisesRooms,
       "apCode,bedCode,roomNumber,bedCount,isSingle,isGroundFloor,isFullyFm,hasCrib7Bedding\n" +
         "HOPE,NESPU01,1,1,yes,yes,no,no",
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-room-missing-headers.csv")
 
     val expectedErrorMessage = "The headers provided: " +
       "[apCode, bedCode, roomNumber, bedCount, isSingle, isGroundFloor, isFullyFm, hasCrib7Bedding] " +
@@ -219,8 +209,8 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       .withNotes("This room is very small")
       .produce()
 
-    withCsv(
-      "new-ap-rooms",
+    seed(
+      SeedFileType.approvedPremisesRooms,
       approvedPremisesRoomsSeedCsvRowsToCsv(
         listOf(
           rowRoom4A,
@@ -229,8 +219,6 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "new-ap-rooms.csv")
 
     val persistedRoom5 = roomRepository.findByCode("NEABC-5")
     val persistedRoom4 = roomRepository.findByCode("NEABC-4")
@@ -312,8 +300,8 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
       .withNotes("This is large")
       .produce()
 
-    withCsv(
-      "updated-ap-rooms",
+    seed(
+      SeedFileType.approvedPremisesRooms,
       approvedPremisesRoomsSeedCsvRowsToCsv(
         listOf(
           rowRoom4A,
@@ -321,8 +309,6 @@ class SeedApprovedPremisesRoomsTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesRooms, "updated-ap-rooms.csv")
 
     val updatedRoom = roomRepository.findByCode("NEABC-4")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1SoftDeleteApplicationTimelineNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1SoftDeleteApplicationTimelineNotesTest.kt
@@ -22,8 +22,8 @@ class SeedCas1SoftDeleteApplicationTimelineNotesTest : SeedTestBase() {
       withApplicationId(application.id)
     }.map { it.id }
 
-    withCsv(
-      csvName = "timeline_notes",
+    seed(
+      SeedFileType.approvedPremisesDeleteApplicationTimelineNotes,
       contents = listOf(
         ApprovedPremisesApplicationIdNoteIdCsvRow(
           applicationId = application.id.toString(),
@@ -35,8 +35,6 @@ class SeedCas1SoftDeleteApplicationTimelineNotesTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesDeleteApplicationTimelineNotes, "timeline_notes.csv")
 
     assertThat(applicationTimelineNoteRepository.getReferenceById(noteIds[0]).deletedAt).isNull()
     assertThat(applicationTimelineNoteRepository.getReferenceById(noteIds[1]).deletedAt).isNotNull()
@@ -54,8 +52,8 @@ class SeedCas1SoftDeleteApplicationTimelineNotesTest : SeedTestBase() {
       withApplicationId(application.id)
     }.id
 
-    withCsv(
-      csvName = "timeline_notes",
+    seed(
+      SeedFileType.approvedPremisesDeleteApplicationTimelineNotes,
       contents = listOf(
         ApprovedPremisesApplicationIdNoteIdCsvRow(
           applicationId = application.id.toString(),
@@ -67,8 +65,6 @@ class SeedCas1SoftDeleteApplicationTimelineNotesTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesDeleteApplicationTimelineNotes, "timeline_notes.csv")
 
     assertThat(logEntries)
       .anyMatch {
@@ -98,8 +94,8 @@ class SeedCas1SoftDeleteApplicationTimelineNotesTest : SeedTestBase() {
       withApplicationId(anotherApplication.id)
     }.id
 
-    withCsv(
-      csvName = "timeline_notes",
+    seed(
+      SeedFileType.approvedPremisesDeleteApplicationTimelineNotes,
       contents = listOf(
         ApprovedPremisesApplicationIdNoteIdCsvRow(
           applicationId = application.id.toString(),
@@ -111,8 +107,6 @@ class SeedCas1SoftDeleteApplicationTimelineNotesTest : SeedTestBase() {
         ),
       ).toCsv(),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesDeleteApplicationTimelineNotes, "timeline_notes.csv")
 
     assertThat(logEntries)
       .anyMatch {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1UpdateSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1UpdateSpaceBookingTest.kt
@@ -25,8 +25,8 @@ class SeedCas1UpdateSpaceBookingTest : SeedTestBase() {
       ),
     )
 
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesUpdateSpaceBooking,
       rowsToCsv(
         listOf(
           Cas1UpdateSpaceBookingSeedJobCsvRow(
@@ -42,8 +42,6 @@ class SeedCas1UpdateSpaceBookingTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesUpdateSpaceBooking, "valid-csv.csv")
 
     val updatedSpaceBooking = cas1SpaceBookingRepository.findById(spaceBooking.id).get()
     assertThat(updatedSpaceBooking.deliusEventNumber).isEqualTo("999")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
 
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -39,8 +38,9 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
         val (application, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
         val placementRequest = createPlacementRequest(application)
-        withCsv(
-          "valid-csv",
+
+        seed(
+          SeedFileType.approvedPremisesWithdrawPlacementRequest,
           rowsToCsv(
             listOf(
               Cas1WithdrawPlacementRequestSeedSeedCsvRow(
@@ -50,8 +50,6 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
             ),
           ),
         )
-
-        seedService.seedData(SeedFileType.approvedPremisesWithdrawPlacementRequest, "valid-csv.csv")
 
         assertThat(logEntries).anyMatch {
           it.level == "error" &&
@@ -83,8 +81,8 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
           withPlacementApplication(placementApplication)
         }
 
-        withCsv(
-          "valid-csv",
+        seed(
+          SeedFileType.approvedPremisesWithdrawPlacementRequest,
           rowsToCsv(
             listOf(
               Cas1WithdrawPlacementRequestSeedSeedCsvRow(
@@ -98,8 +96,6 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
             ),
           ),
         )
-
-        seedService.seedData(SeedFileType.approvedPremisesWithdrawPlacementRequest, "valid-csv.csv")
 
         assertPlacementApplicationNotWithdrawn(placementApplication)
 
@@ -138,19 +134,19 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
 
   private fun assertPlacementApplicationNotWithdrawn(placementApplication: PlacementApplicationEntity) {
     val updatedPlacementApplication = placementApplicationRepository.findByIdOrNull(placementApplication.id)!!
-    Assertions.assertThat(updatedPlacementApplication.isWithdrawn).isFalse()
-    Assertions.assertThat(updatedPlacementApplication.withdrawalReason).isNull()
+    assertThat(updatedPlacementApplication.isWithdrawn).isFalse()
+    assertThat(updatedPlacementApplication.withdrawalReason).isNull()
   }
 
   private fun assertPlacementRequestWithdrawn(placementRequest: PlacementRequestEntity, reason: PlacementRequestWithdrawalReason) {
     val updatedPlacementRequest = placementRequestRepository.findByIdOrNull(placementRequest.id)!!
-    Assertions.assertThat(updatedPlacementRequest.isWithdrawn).isEqualTo(true)
-    Assertions.assertThat(updatedPlacementRequest.withdrawalReason).isEqualTo(reason)
+    assertThat(updatedPlacementRequest.isWithdrawn).isEqualTo(true)
+    assertThat(updatedPlacementRequest.withdrawalReason).isEqualTo(reason)
   }
 
   private fun assertPlacementRequestNotWithdrawn(placementRequest: PlacementRequestEntity) {
     val updatedPlacementRequest = placementRequestRepository.findByIdOrNull(placementRequest.id)!!
-    Assertions.assertThat(updatedPlacementRequest.isWithdrawn).isEqualTo(false)
+    assertThat(updatedPlacementRequest.isWithdrawn).isEqualTo(false)
   }
 
   @SuppressWarnings("LongParameterList")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
@@ -277,8 +277,8 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
   }
 
   private fun callSeedJob(application: ApprovedPremisesApplicationEntity) {
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.approvedPremisesUpdateEventNumber,
       rowsToCsv(
         listOf(
           Cas1UpdateEventNumberSeedJobCsvRow(
@@ -290,8 +290,6 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.approvedPremisesUpdateEventNumber, "valid-csv.csv")
   }
 
   private fun createApplication(): Pair<ApprovedPremisesApplicationEntity, OffenderDetailSummary> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/UsersBasicSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/UsersBasicSeedJobTest.kt
@@ -25,8 +25,8 @@ class UsersBasicSeedJobTest : SeedTestBase() {
   fun `Seeding a non existent user logs an error`() {
     apDeliusContextMockNotFoundStaffDetailCall("INVALID-USER")
 
-    withCsv(
-      "invalid-user",
+    seed(
+      SeedFileType.usersBasic,
       apStaffUserSeedCsvRowsToCsv(
         listOf(
           ApStaffUserSeedCsvRowFactory()
@@ -35,8 +35,6 @@ class UsersBasicSeedJobTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.usersBasic, "invalid-user.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -65,8 +63,8 @@ class UsersBasicSeedJobTest : SeedTestBase() {
       ),
     )
 
-    withCsv(
-      "unknown-user",
+    seed(
+      SeedFileType.usersBasic,
       apStaffUserSeedCsvRowsToCsv(
         listOf(
           ApStaffUserSeedCsvRowFactory()
@@ -75,8 +73,6 @@ class UsersBasicSeedJobTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.usersBasic, "unknown-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("UNKNOWN-USER")
 
@@ -111,8 +107,8 @@ class UsersBasicSeedJobTest : SeedTestBase() {
     }
     user.qualifications.addAll(qualificationEntities)
 
-    withCsv(
-      "pre-existing-user",
+    seed(
+      SeedFileType.usersBasic,
       apStaffUserSeedCsvRowsToCsv(
         listOf(
           ApStaffUserSeedCsvRowFactory()
@@ -121,8 +117,6 @@ class UsersBasicSeedJobTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.usersBasic, "pre-existing-user.csv")
 
     val persistedUser = userRepository.findByDeliusUsername("PRE-EXISTING-USER")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/SeedCas2ApplicationTest.kt
@@ -30,8 +30,8 @@ class SeedCas2ApplicationTest : SeedTestBase() {
     val applicationId = "6a1551ea-cdb7-4f5e-beac-aee9ad73339c"
     val creationTimestamp = OffsetDateTime.parse("2022-12-13T15:00:00+01:00")
 
-    withCsv(
-      "unknown-cas2-application",
+    seed(
+      SeedFileType.cas2Applications,
       cas2ApplicationSeedCsvRowsToCsv(
         listOf(
           Cas2ApplicationSeedCsvRowFactory()
@@ -48,8 +48,6 @@ class SeedCas2ApplicationTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.cas2Applications, "unknown-cas2-application.csv")
 
     val persistedApplication = cas2ApplicationRepository.getReferenceById(UUID.fromString(applicationId))
 
@@ -72,8 +70,8 @@ class SeedCas2ApplicationTest : SeedTestBase() {
     val applicationId = "6a1551ea-cdb7-4f5e-beac-aee9ad73339c"
     val creationTimestamp = OffsetDateTime.parse("2022-12-13T15:00:00+01:00")
 
-    withCsv(
-      "in-progress-cas2-application",
+    seed(
+      SeedFileType.cas2Applications,
       cas2ApplicationSeedCsvRowsToCsv(
         listOf(
           Cas2ApplicationSeedCsvRowFactory()
@@ -90,8 +88,6 @@ class SeedCas2ApplicationTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.cas2Applications, "in-progress-cas2-application.csv")
 
     val persistedApplication = cas2ApplicationRepository.getReferenceById(UUID.fromString(applicationId))
 
@@ -121,8 +117,8 @@ class SeedCas2ApplicationTest : SeedTestBase() {
     val creationTimestamp = OffsetDateTime.parse("2022-12-13T15:00:00+01:00")
     val submissionTimestamp = OffsetDateTime.parse("2022-12-15T12:00:00+01:00")
 
-    withCsv(
-      "submitted-cas2-application",
+    seed(
+      SeedFileType.cas2Applications,
       cas2ApplicationSeedCsvRowsToCsv(
         listOf(
           Cas2ApplicationSeedCsvRowFactory()
@@ -140,8 +136,6 @@ class SeedCas2ApplicationTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.cas2Applications, "submitted-cas2-application.csv")
 
     val persistedApplication = cas2ApplicationRepository.getReferenceById(UUID.fromString(applicationId))
 
@@ -173,8 +167,8 @@ class SeedCas2ApplicationTest : SeedTestBase() {
     val creationTimestamp = OffsetDateTime.parse("2022-12-13T15:00:00+01:00")
     val submissionTimestamp = OffsetDateTime.parse("2022-12-15T12:00:00+01:00")
 
-    withCsv(
-      "in-review-cas2-application",
+    seed(
+      SeedFileType.cas2Applications,
       cas2ApplicationSeedCsvRowsToCsv(
         listOf(
           Cas2ApplicationSeedCsvRowFactory()
@@ -191,8 +185,6 @@ class SeedCas2ApplicationTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.cas2Applications, "in-review-cas2-application.csv")
 
     val persistedApplication = cas2ApplicationRepository.getReferenceById(UUID.fromString(applicationId))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedExternalUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedExternalUsersTest.kt
@@ -15,8 +15,8 @@ class SeedExternalUsersTest : SeedTestBase() {
   fun `Attempting to seed a fake currently unknown user succeeds`() {
     externalUserRepository.deleteAll()
 
-    withCsv(
-      "unknown-external-user",
+    seed(
+      SeedFileType.externalUsers,
       externalUserSeedCsvRowsToCsv(
         listOf(
           ExternalUsersSeedCsvRowFactory()
@@ -27,8 +27,6 @@ class SeedExternalUsersTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.externalUsers, "unknown-external-user.csv")
 
     val persistedUser = externalUserRepository.findByUsername("CAS2_ASSESSOR_FAKE")
 
@@ -47,8 +45,8 @@ class SeedExternalUsersTest : SeedTestBase() {
       withEmail("chas.ash@example.com")
     }
 
-    withCsv(
-      "existing-external-user",
+    seed(
+      SeedFileType.externalUsers,
       externalUserSeedCsvRowsToCsv(
         listOf(
           ExternalUsersSeedCsvRowFactory()
@@ -59,8 +57,6 @@ class SeedExternalUsersTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.externalUsers, "existing-external-user.csv")
 
     val persistedUser = externalUserRepository.findByUsername("CAS2_ASSESSOR_FAKE")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedNomisUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedNomisUsersTest.kt
@@ -15,8 +15,8 @@ class SeedNomisUsersTest : SeedTestBase() {
   fun `Attempting to seed a fake currently unknown user succeeds`() {
     nomisUserRepository.deleteAll()
 
-    withCsv(
-      "unknown-nomis-user",
+    seed(
+      SeedFileType.nomisUsers,
       nomisUserSeedCsvRowsToCsv(
         listOf(
           NomisUsersSeedCsvRowFactory()
@@ -27,8 +27,6 @@ class SeedNomisUsersTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.nomisUsers, "unknown-nomis-user.csv")
 
     val persistedUser = nomisUserRepository.findByNomisUsername("ROGER_SMITH_FAKE")
 
@@ -47,8 +45,8 @@ class SeedNomisUsersTest : SeedTestBase() {
       withEmail("roger.smith@example.com")
     }
 
-    withCsv(
-      "existing-nomis-user",
+    seed(
+      SeedFileType.nomisUsers,
       nomisUserSeedCsvRowsToCsv(
         listOf(
           NomisUsersSeedCsvRowFactory()
@@ -59,8 +57,6 @@ class SeedNomisUsersTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.nomisUsers, "existing-nomis-user.csv")
 
     val persistedUser = nomisUserRepository.findByNomisUsername("ROGER_SMITH_FAKE")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedScaffoldingTest.kt
@@ -67,16 +67,14 @@ class SeedScaffoldingTest : SeedTestBase() {
 
   @Test
   fun `Attempting to process a malformed file logs an error`() {
-    withCsv(
-      "malformed",
+    seed(
+      SeedFileType.user,
       """
 delius_username,roles,qualifications,remove_existing_roles_and_qualifications
 RogerSmith,CAS1_FUTURE_MANAGER,,false
 ,
       """.trimIndent(),
     )
-
-    seedService.seedData(SeedFileType.user, "malformed.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationBedspaceTest.kt
@@ -15,8 +15,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
   @Test
   fun `Attempting to create a Temporary Accommodation Bedspace with an invalid premises logs an error`() {
-    withCsv(
-      "invalid-ta-bedspace-premises-name",
+    seed(
+      SeedFileType.temporaryAccommodationBedspace,
       temporaryAccommodationBedspaceSeedCsvRowsToCsv(
         listOf(
           TemporaryAccommodationBedspaceSeedCsvRowFactory()
@@ -25,8 +25,6 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "invalid-ta-bedspace-premises-name.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -52,16 +50,14 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
       .withCharacteristics(listOf("Shared bathroom", "Shared kitchen"))
       .produce()
 
-    withCsv(
-      "new-ta-bedspace",
+    seed(
+      SeedFileType.temporaryAccommodationBedspace,
       temporaryAccommodationBedspaceSeedCsvRowsToCsv(
         listOf(
           csvRow,
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "new-ta-bedspace.csv")
 
     val persistedPremises = temporaryAccommodationPremisesRepository.findByName(premises.name)
     assertThat(persistedPremises).isNotNull
@@ -100,16 +96,14 @@ class SeedTemporaryAccommodationBedspaceTest : SeedTestBase() {
       .withCharacteristics(listOf("Shared kitchen"))
       .produce()
 
-    withCsv(
-      "update-ta-bedspace",
+    seed(
+      SeedFileType.temporaryAccommodationBedspace,
       temporaryAccommodationBedspaceSeedCsvRowsToCsv(
         listOf(
           csvRow,
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "update-ta-bedspace.csv")
 
     val persistedPremises = temporaryAccommodationPremisesRepository.findByName(premises.name)
     assertThat(persistedPremises).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationPremisesTest.kt
@@ -15,8 +15,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
   @Test
   fun `Attempting to create a Temporary Accommodation Premises with an invalid Probation Region logs an error`() {
-    withCsv(
-      "invalid-probation-ta",
+    seed(
+      SeedFileType.temporaryAccommodationPremises,
       temporaryAccommodationPremisesSeedCsvRowsToCsv(
         listOf(
           TemporaryAccommodationPremisesSeedCsvRowFactory()
@@ -25,8 +25,6 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "invalid-probation-ta.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -40,8 +38,8 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
   fun `Attempting to create a Temporary Accommodation Premises with an invalid Local Authority Area logs an error`() {
     val probationRegion = givenAProbationRegion()
 
-    withCsv(
-      "invalid-local-authority-ta",
+    seed(
+      SeedFileType.temporaryAccommodationPremises,
       temporaryAccommodationPremisesSeedCsvRowsToCsv(
         listOf(
           TemporaryAccommodationPremisesSeedCsvRowFactory()
@@ -51,8 +49,6 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "invalid-local-authority-ta.csv")
 
     assertThat(logEntries).anyMatch {
       it.level == "error" &&
@@ -79,16 +75,14 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
       .withCharacteristics(listOf("Park nearby", "Pub nearby"))
       .produce()
 
-    withCsv(
-      "new-ta-premises",
+    seed(
+      SeedFileType.temporaryAccommodationPremises,
       temporaryAccommodationPremisesSeedCsvRowsToCsv(
         listOf(
           csvRow,
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "new-ta-premises.csv")
 
     val persistedPremises = temporaryAccommodationPremisesRepository.findByName(csvRow.name)
     assertThat(persistedPremises).isNotNull
@@ -136,16 +130,14 @@ class SeedTemporaryAccommodationPremisesTest : SeedTestBase() {
       .withCharacteristics(listOf("Park nearby"))
       .produce()
 
-    withCsv(
-      "update-ta-premises",
+    seed(
+      SeedFileType.temporaryAccommodationPremises,
       temporaryAccommodationPremisesSeedCsvRowsToCsv(
         listOf(
           csvRow,
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "update-ta-premises.csv")
 
     val persistedPremises = temporaryAccommodationPremisesRepository.findByName(csvRow.name)
     assertThat(persistedPremises).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTemporaryAccommodationSmokeTest.kt
@@ -9,8 +9,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 class SeedTemporaryAccommodationSmokeTest : SeedTestBase() {
   @Test
   fun `Temporary Accommodation premises and bedspaces can be seeded using realistic data`() {
-    withCsv(
-      "ta-smoketest-premises",
+    seed(
+      SeedFileType.temporaryAccommodationPremises,
       "Property reference,Address Line 1,Address Line 2 (optional),City/Town,Postcode,Region,Local authority / Borough,Probation delivery unit (PDU),Floor level access?,Wheelchair accessible?,Pub nearby?,Park nearby?,School nearby?,Women only?,Men only?,Not suitable for RSO?,Not suitable for arson offenders?,Optional notes,Email Address\n" +
         "WED,1 Wednesday Street,,Westminster,SE19 4EP,London,Lewisham,Lewisham and Bromley,TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,\"Property is located in a block of flats. Bedspace is accessible for wheelchair users, as has ground floor access and a lift up to the property. Cleaning turn around is 7 days.\",wed@emailaddress.com\n" +
         "CHE,1 CherryTree Lane,,Sheffield,SH7 4PB,Yorkshire and the Humber,Sheffield,Sheffield,FALSE,FALSE,FALSE,TRUE,TRUE,FALSE,TRUE,TRUE,FALSE,\"Property is located on the same road as a primary school and a park.\",che@emailaddress.com\n" +
@@ -19,8 +19,8 @@ class SeedTemporaryAccommodationSmokeTest : SeedTestBase() {
         "APP,78 Applemill Court,Pudding Lane,Hereford,HR6 7ZP,West Midlands,Herefordshire,\"Herefordshire, Shropshire and Telford\",TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,app@emailaddress.com",
     )
 
-    withCsv(
-      "ta-smoketest-bedspace",
+    seed(
+      SeedFileType.temporaryAccommodationBedspace,
       "Property reference,Bedspace reference,Single bed?,Double bed?,Shared kitchen?,Floor level access?,Lift access?,Wheelchair accessible?,Not suitable for RSO?,Not suitable for arson offenders?,Optional notes about the bedspace,Email address\n" +
         "WED,WED-1,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,FALSE,FALSE,\"Bedspace is accessible for wheelchair users, as has ground floor access and a lift up to the property.\",wed@email.com\n" +
         "WED,WED-2,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,FALSE,FALSE,\"Bedspace is accessible for wheelchair users, as has ground floor access and a lift up to the property.\",wed@email.com\n" +
@@ -32,9 +32,6 @@ class SeedTemporaryAccommodationSmokeTest : SeedTestBase() {
         "APP,APP-1,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,app@email.com\n" +
         "APP,APP-2,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,app@email.com",
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationPremises, "ta-smoketest-premises.csv")
-    seedService.seedData(SeedFileType.temporaryAccommodationBedspace, "ta-smoketest-bedspace.csv")
 
     assertThat(logEntries).noneMatch {
       it.level == "error"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedTestBase.kt
@@ -71,7 +71,7 @@ abstract class SeedTestBase : IntegrationTestBase() {
       contents,
     )
 
-    seedService.seedData(SeedFileType.approvedPremisesRemapBedCodes, "$fileName.csv")
+    seedService.seedData(seedFileType, "$fileName.csv")
   }
 
   protected fun generateCsvFile(fileName: String, contents: String) {
@@ -82,11 +82,6 @@ abstract class SeedTestBase : IntegrationTestBase() {
       Path("$seedFilePrefix/$fileName.csv"),
       contents,
     )
-  }
-
-  @Deprecated(message = "Use generateCsvFile", replaceWith = ReplaceWith("[createCsv]"))
-  protected fun withCsv(csvName: String, contents: String) {
-    generateCsvFile(csvName, contents)
   }
 
   protected fun createXlsxForSeeding(fileName: String, sheets: Map<String, DataFrame<*>>) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
@@ -96,8 +96,8 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
       withNomsNumber(OTHER_NOMS)
     }
 
-    withCsv(
-      "valid-csv",
+    seed(
+      SeedFileType.updateNomsNumber,
       rowsToCsv(
         listOf(
           UpdateNomsNumberSeedRow(
@@ -108,8 +108,6 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
         ),
       ),
     )
-
-    seedService.seedData(SeedFileType.updateNomsNumber, "valid-csv.csv")
 
     val updatedApplication = approvedPremisesApplicationRepository.findByIdOrNull(application.id)
     assertThat(updatedApplication!!.nomsNumber).isEqualTo(NEW_NOMS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateUsersFromApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateUsersFromApiTest.kt
@@ -29,20 +29,19 @@ class SeedUpdateUsersFromApiTest : SeedTestBase() {
 
     apDeliusContextAddStaffDetailResponse(staffUserDetails)
 
-    val csv = CsvBuilder()
-      .withUnquotedFields(
-        "delius_username",
-        "service_name",
-      )
-      .newRow()
-      .withQuotedField(USERNAME)
-      .withQuotedField(ServiceName.approvedPremises)
-      .newRow()
-      .build()
-
-    withCsv("known-user-csv", csv)
-
-    seedService.seedData(SeedFileType.updateUsersFromApi, "known-user-csv.csv")
+    seed(
+      SeedFileType.updateUsersFromApi,
+      CsvBuilder()
+        .withUnquotedFields(
+          "delius_username",
+          "service_name",
+        )
+        .newRow()
+        .withQuotedField(USERNAME)
+        .withQuotedField(ServiceName.approvedPremises)
+        .newRow()
+        .build(),
+    )
 
     val persistedUser = userRepository.findByDeliusUsername(USERNAME)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUsersTest.kt
@@ -28,8 +28,8 @@ class SeedUsersTest : SeedTestBase() {
 
     @Test
     fun `Seeding a user who doesn't exist in delius errors`() {
-      withCsv(
-        "invalid-user",
+      seed(
+        SeedFileType.user,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -38,8 +38,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.user, "invalid-user.csv")
 
       assertThat(logEntries).anyMatch {
         it.level == "error" &&
@@ -70,8 +68,8 @@ class SeedUsersTest : SeedTestBase() {
 
       )
 
-      withCsv(
-        "unknown-user",
+      seed(
+        SeedFileType.user,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -83,8 +81,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.user, "unknown-user.csv")
 
       val persistedUser = userRepository.findByDeliusUsername("UNKNOWN-USER")
 
@@ -105,8 +101,8 @@ class SeedUsersTest : SeedTestBase() {
         roles = emptyList(),
       )
 
-      withCsv(
-        "known-user",
+      seed(
+        SeedFileType.user,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -118,8 +114,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.user, "known-user.csv")
 
       val persistedUser = userRepository.findByDeliusUsername("KNOWN-USER")
 
@@ -141,8 +135,8 @@ class SeedUsersTest : SeedTestBase() {
         qualifications = listOf(UserQualification.EMERGENCY),
       )
 
-      withCsv(
-        "known-user",
+      seed(
+        SeedFileType.user,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -154,8 +148,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.user, "known-user.csv")
 
       val persistedUser = userRepository.findByDeliusUsername("KNOWN-USER")
 
@@ -179,8 +171,8 @@ class SeedUsersTest : SeedTestBase() {
         qualifications = listOf(UserQualification.EMERGENCY),
       )
 
-      withCsv(
-        "known-user",
+      seed(
+        SeedFileType.user,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -192,8 +184,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.user, "known-user.csv")
 
       val persistedUser = userRepository.findByDeliusUsername("KNOWN-USER")
 
@@ -214,8 +204,8 @@ class SeedUsersTest : SeedTestBase() {
         roles = emptyList(),
       )
 
-      withCsv(
-        "unknown-role",
+      seed(
+        SeedFileType.user,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -227,8 +217,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.user, "unknown-role.csv")
 
       assertThat(logEntries).anyMatch {
         it.level == "error" &&
@@ -246,8 +234,8 @@ class SeedUsersTest : SeedTestBase() {
         roles = emptyList(),
       )
 
-      withCsv(
-        "unknown-qualification",
+      seed(
+        SeedFileType.user,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -258,8 +246,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.user, "unknown-qualification.csv")
 
       assertThat(logEntries).anyMatch {
         it.level == "error" &&
@@ -329,23 +315,19 @@ class SeedUsersTest : SeedTestBase() {
         )
       }
 
-      withCsv(
-        "users-many-times-base-job",
-        usersSeedRowToCsv(
-          seedInfos.map {
-            UserRoleAssignmentsSeedCsvRowFactory()
-              .withDeliusUsername(it.staffUserDetails.username!!)
-              .withRoles(it.roles.map { it.name })
-              .withQualifications(it.qualifications.map { it.name })
-              .withRemoveExistingRowsAndQualifications(true)
-              .produce()
-          },
-        ),
+      val csv = usersSeedRowToCsv(
+        seedInfos.map {
+          UserRoleAssignmentsSeedCsvRowFactory()
+            .withDeliusUsername(it.staffUserDetails.username!!)
+            .withRoles(it.roles.map { it.name })
+            .withQualifications(it.qualifications.map { it.name })
+            .withRemoveExistingRowsAndQualifications(true)
+            .produce()
+        },
       )
-
       var iteration = 1
       repeat(20) {
-        seedService.seedData(SeedFileType.user, "users-many-times-base-job.csv")
+        seed(SeedFileType.user, csv)
 
         seedInfos.forEach {
           val persistedUser = userRepository.findByDeliusUsername(it.staffUserDetails.username!!.uppercase())!!
@@ -425,23 +407,20 @@ class SeedUsersTest : SeedTestBase() {
         )
       }
 
-      withCsv(
-        "users-many-times-ap-job",
-        usersSeedRowToCsv(
-          seedInfos.map {
-            UserRoleAssignmentsSeedCsvRowFactory()
-              .withDeliusUsername(it.staffUserDetails.username!!)
-              .withRoles(it.roles.map { it.name })
-              .withQualifications(it.qualifications.map { it.name })
-              .withRemoveExistingRowsAndQualifications(true)
-              .produce()
-          },
-        ),
+      val csv = usersSeedRowToCsv(
+        seedInfos.map {
+          UserRoleAssignmentsSeedCsvRowFactory()
+            .withDeliusUsername(it.staffUserDetails.username!!)
+            .withRoles(it.roles.map { it.name })
+            .withQualifications(it.qualifications.map { it.name })
+            .withRemoveExistingRowsAndQualifications(true)
+            .produce()
+        },
       )
 
       var iteration = 1
       repeat(20) {
-        seedService.seedData(SeedFileType.approvedPremisesUsers, "users-many-times-ap-job.csv")
+        seed(SeedFileType.approvedPremisesUsers, csv)
 
         seedInfos.forEach {
           val persistedUser = userRepository.findByDeliusUsername(it.staffUserDetails.username!!.uppercase())!!
@@ -480,8 +459,8 @@ class SeedUsersTest : SeedTestBase() {
         roles = emptyList(),
       )
 
-      withCsv(
-        "known-user",
+      seed(
+        SeedFileType.user,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -493,8 +472,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.user, "known-user.csv")
 
       val persistedUser = userRepository.findByDeliusUsername("KNOWN-USER")
 
@@ -518,8 +495,8 @@ class SeedUsersTest : SeedTestBase() {
         roles = listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS3_ASSESSOR),
       )
 
-      withCsv(
-        "multi-service-user",
+      seed(
+        SeedFileType.approvedPremisesUsers,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -530,8 +507,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.approvedPremisesUsers, "multi-service-user.csv")
 
       val persistedUser = userRepository.findByDeliusUsername("MULTI-SERVICE-USER")
 
@@ -553,8 +528,8 @@ class SeedUsersTest : SeedTestBase() {
         roles = listOf(UserRole.CAS1_ASSESSOR, UserRole.CAS3_REPORTER, UserRole.CAS3_ASSESSOR),
       )
 
-      withCsv(
-        "multi-service-user",
+      seed(
+        SeedFileType.temporaryAccommodationUsers,
         usersSeedRowToCsv(
           listOf(
             UserRoleAssignmentsSeedCsvRowFactory()
@@ -565,8 +540,6 @@ class SeedUsersTest : SeedTestBase() {
           ),
         ),
       )
-
-      seedService.seedData(SeedFileType.temporaryAccommodationUsers, "multi-service-user.csv")
 
       val persistedUser = userRepository.findByDeliusUsername("MULTI-SERVICE-USER")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas3/Cas3ReferralRejectionSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/cas3/Cas3ReferralRejectionSeedJobTest.kt
@@ -41,12 +41,10 @@ class Cas3ReferralRejectionSeedJobTest : SeedTestBase() {
     val rejectedReason = "Another reason (please add)"
     val rejectedReasonDetail = randomStringLowerCase(30)
 
-    withCsv(
-      "cas3-referral-rejection-csv",
+    seed(
+      SeedFileType.temporaryAccommodationReferralRejection,
       rowsToCsv(listOf(Cas3ReferralRejectionSeedCsvRow(assessment.id, rejectedReason, rejectedReasonDetail, false, user.deliusUsername))),
     )
-
-    seedService.seedData(SeedFileType.temporaryAccommodationReferralRejection, "cas3-referral-rejection-csv.csv")
 
     val persistedAssessment = temporaryAccommodationAssessmentRepository.findByIdOrNull(assessment.id)!!
     assertThat(persistedAssessment).isNotNull


### PR DESCRIPTION
Update all seed tests to use a test function that creates a CSV on disk and then invokes the seed service for this CSV