### PR TITLE
Cas 2 Refactor to use CasResult

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -30,7 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockCaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.prisonAPIMockNotFoundInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationRepository
@@ -40,7 +40,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -1517,9 +1517,10 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               .withCurrentRestriction(true)
               .withCurrentExclusion(true).produce()
 
-          val caseDetail = offenderDetails.asCaseSummary()
-          apDeliusContextMockCaseSummary(caseDetail)
-          mockInmateDetailPrisonsApiCall(InmateDetail(caseDetail.nomsId!!, InmateStatus.IN, null))
+          val caseDetail = offenderDetails.asCaseDetail()
+
+          apDeliusContextMockSuccessfulCaseDetailCall(crn, offenderDetails.asCaseDetail())
+          mockInmateDetailPrisonsApiCall(InmateDetail(caseDetail.case.nomsId!!, InmateStatus.IN, null))
 
           cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
             withAddedAt(OffsetDateTime.now())
@@ -1531,7 +1532,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewApplication(
-                crn = caseDetail.crn,
+                crn = caseDetail.case.crn,
               ),
             )
             .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2ApplicationServiceTest.kt
@@ -769,6 +769,7 @@ class Cas2v2ApplicationServiceTest {
 
     @BeforeEach
     fun setup() {
+      every { mockOffenderService.findPrisonCode(any(), any()) } answers { callOriginal() }
       every { mockCas2v2LockableApplicationRepository.acquirePessimisticLock(any()) } returns Cas2v2LockableApplicationEntity(UUID.randomUUID())
       every { mockObjectMapper.writeValueAsString(submitCas2v2Application.translatedDocument) } returns "{}"
       every { mockDomainEventService.saveCas2ApplicationSubmittedDomainEvent(any()) } just Runs
@@ -926,7 +927,7 @@ class Cas2v2ApplicationServiceTest {
       // abort our attempt to submit the application.
       every {
         mockOffenderService.getInmateDetailByNomsNumber(any(), any())
-      } returns AuthorisableActionResult.NotFound()
+      } returns CasResult.NotFound("InmateDetail", offenderDetails.otherIds.nomsNumber!!)
 
       assertGeneralValidationError("Inmate Detail not found")
 
@@ -974,7 +975,7 @@ class Cas2v2ApplicationServiceTest {
       // abort our attempt to submit the application and return a validation message.
       every {
         mockOffenderService.getInmateDetailByNomsNumber(any(), any())
-      } returns AuthorisableActionResult.Success(InmateDetailFactory().produce())
+      } returns CasResult.Success(InmateDetailFactory().produce())
 
       assertGeneralValidationError("No prison code available")
 
@@ -1031,7 +1032,7 @@ class Cas2v2ApplicationServiceTest {
           cas2v2Application.crn,
           cas2v2Application.nomsNumber.toString(),
         )
-      } returns AuthorisableActionResult.Success(inmateDetail)
+      } returns CasResult.Success(inmateDetail)
 
       every { mockNotifyConfig.templates.cas2ApplicationSubmitted } returns "abc123"
       every { mockNotifyConfig.emailAddresses.cas2Assessors } returns "exampleAssessorInbox@example.com"


### PR DESCRIPTION
This refactors code to use CasResult, as well as removing duplicated code, and also removes a use of the deprecated OffenderDetailSummary class.