### PR TITLE
Remove use of deprecate code in isLao

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -307,14 +307,9 @@ class OffenderService(
     return AuthorisableActionResult.Success(offender)
   }
 
-  /*
-   * This should call apDeliusContextApiClient.getSummariesForCrns(crns) directly
-   */
   fun isLao(crn: String): Boolean {
-    val offenderResponse = offenderDetailsDataSource.getOffenderDetailSummary(crn)
-
-    val offender = when (offenderResponse) {
-      is ClientResult.Success -> offenderResponse.body
+    val offender = when (val offenderResponse = apDeliusContextApiClient.getSummariesForCrns(listOf(crn))) {
+      is ClientResult.Success -> offenderResponse.body.cases.first()
       is ClientResult.Failure -> offenderResponse.throwException()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -814,47 +814,53 @@ class OffenderServiceTest {
 
     @Test
     fun `returns true for Offender with current restriction`() {
-      val offenderDetails = OffenderDetailsSummaryFactory()
-        .withCurrentRestriction(true)
-        .withCurrentExclusion(false)
-        .produce()
-
-      every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
+      every { mockApDeliusContextApiClient.getSummariesForCrns(listOf("CRN123")) } returns ClientResult.Success(
         HttpStatus.OK,
-        offenderDetails,
+        CaseSummaries(
+          listOf(
+            CaseSummaryFactory()
+              .withCurrentRestriction(true)
+              .withCurrentExclusion(false)
+              .produce(),
+          ),
+        ),
       )
 
-      assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isTrue
+      assertThat(offenderService.isLao("CRN123")).isTrue
     }
 
     @Test
     fun `returns true for Offender with current exclusion`() {
-      val offenderDetails = OffenderDetailsSummaryFactory()
-        .withCurrentRestriction(false)
-        .withCurrentExclusion(true)
-        .produce()
-
-      every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
+      every { mockApDeliusContextApiClient.getSummariesForCrns(listOf("CRN123")) } returns ClientResult.Success(
         HttpStatus.OK,
-        offenderDetails,
+        CaseSummaries(
+          listOf(
+            CaseSummaryFactory()
+              .withCurrentRestriction(false)
+              .withCurrentExclusion(true)
+              .produce(),
+          ),
+        ),
       )
 
-      assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isTrue
+      assertThat(offenderService.isLao("CRN123")).isTrue
     }
 
     @Test
     fun `returns false for Offender without current exclusion or restriction`() {
-      val offenderDetails = OffenderDetailsSummaryFactory()
-        .withCurrentRestriction(false)
-        .withCurrentExclusion(false)
-        .produce()
-
-      every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
+      every { mockApDeliusContextApiClient.getSummariesForCrns(listOf("CRN123")) } returns ClientResult.Success(
         HttpStatus.OK,
-        offenderDetails,
+        CaseSummaries(
+          listOf(
+            CaseSummaryFactory()
+              .withCurrentRestriction(false)
+              .withCurrentExclusion(false)
+              .produce(),
+          ),
+        ),
       )
 
-      assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isFalse
+      assertThat(offenderService.isLao("CRN123")).isFalse
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -809,49 +809,53 @@ class OffenderServiceTest {
     )
   }
 
-  @Test
-  fun `isLao returns true for Offender with current restriction`() {
-    val offenderDetails = OffenderDetailsSummaryFactory()
-      .withCurrentRestriction(true)
-      .withCurrentExclusion(false)
-      .produce()
+  @Nested
+  inner class IsLao {
 
-    every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
-      HttpStatus.OK,
-      offenderDetails,
-    )
+    @Test
+    fun `returns true for Offender with current restriction`() {
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCurrentRestriction(true)
+        .withCurrentExclusion(false)
+        .produce()
 
-    assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isTrue
-  }
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
+        HttpStatus.OK,
+        offenderDetails,
+      )
 
-  @Test
-  fun `isLao returns true for Offender with current exclusion`() {
-    val offenderDetails = OffenderDetailsSummaryFactory()
-      .withCurrentRestriction(false)
-      .withCurrentExclusion(true)
-      .produce()
+      assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isTrue
+    }
 
-    every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
-      HttpStatus.OK,
-      offenderDetails,
-    )
+    @Test
+    fun `returns true for Offender with current exclusion`() {
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCurrentRestriction(false)
+        .withCurrentExclusion(true)
+        .produce()
 
-    assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isTrue
-  }
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
+        HttpStatus.OK,
+        offenderDetails,
+      )
 
-  @Test
-  fun `isLao returns false for Offender without current exclusion or restriction`() {
-    val offenderDetails = OffenderDetailsSummaryFactory()
-      .withCurrentRestriction(false)
-      .withCurrentExclusion(false)
-      .produce()
+      assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isTrue
+    }
 
-    every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
-      HttpStatus.OK,
-      offenderDetails,
-    )
+    @Test
+    fun `returns false for Offender without current exclusion or restriction`() {
+      val offenderDetails = OffenderDetailsSummaryFactory()
+        .withCurrentRestriction(false)
+        .withCurrentExclusion(false)
+        .produce()
 
-    assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isFalse
+      every { mockOffenderDetailsDataSource.getOffenderDetailSummary(offenderDetails.otherIds.crn) } returns ClientResult.Success(
+        HttpStatus.OK,
+        offenderDetails,
+      )
+
+      assertThat(offenderService.isLao(offenderDetails.otherIds.crn)).isFalse
+    }
   }
 
   @Nested


### PR DESCRIPTION
This commit updates the `offenderService.isLao` function to use `apDeliusContextApiClient` client directly instead of via the now deprecated `offenderDetailsDataSource`