### PR TITLE
APS-1877 Add missing delius reason codes for CAS1

### DIFF
--- a/src/main/resources/db/migration/all/20250312105010__update_cas1_delius_reason_codes.sql
+++ b/src/main/resources/db/migration/all/20250312105010__update_cas1_delius_reason_codes.sql
@@ -1,0 +1,10 @@
+UPDATE non_arrival_reasons SET legacy_delius_reason_code = '1H' WHERE name = 'Arrested / In custody / Recalled';
+UPDATE non_arrival_reasons SET legacy_delius_reason_code = 'H' WHERE name = 'Admitted to hospital';
+
+UPDATE move_on_categories SET legacy_delius_category_code = 'CAS2' WHERE service_scope = 'approved-premises' AND name = 'CAS2';
+UPDATE move_on_categories SET legacy_delius_category_code = 'CAS3' WHERE service_scope = 'approved-premises' AND name = 'CAS3';
+
+UPDATE departure_reasons SET legacy_delius_reason_code = 'PAT' WHERE service_scope = 'approved-premises' AND name = 'Positive alcohol test / use';
+
+DELETE from departure_reasons WHERE service_scope = 'approved-premises' AND name = 'Behaviour / increasing risk in AP';
+UPDATE departure_reasons SET name = 'Behaviour / increasing risk in AP' WHERE  service_scope = 'approved-premises' AND name = 'Behaviour / increasing risk';


### PR DESCRIPTION
# Non Arrival

Arrested / In custody / Recalled - Code ‘1H’. (there are other entries with 1H, leave as is)

Admitted to hospital - Code 'H'

# Move On

CAS2 - Code ‘CAS2’
CAS3 - Code ‘CAS3’

# Departure Reasons

Positive alcohol test/ use (Breach / Recall) - Code ‘PAT’

Behaviour/ increasing risk in AP (Breach / Recall) - Code 'D' (we have an existing entry 'Behaviour / increasing risk'. Relabel and revive this entry)