### PR TITLE
Booking to Space Booking Non Arrival Code Fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/NonArrivalReasonEntity.kt
@@ -11,6 +11,11 @@ import java.util.UUID
 
 @Repository
 interface NonArrivalReasonRepository : JpaRepository<NonArrivalReasonEntity, UUID> {
+
+  companion object {
+    val NON_ARRIVAL_REASON_CUSTODIAL_DISPOSAL_RIC: UUID = UUID.fromString("9d3b1f8e-9fa6-45b7-84ac-2d5fe34ff935")
+  }
+
   @Query("SELECT r FROM NonArrivalReasonEntity r WHERE r.isActive = true")
   fun findAllActiveReasons(): List<NonArrivalReasonEntity>
   fun findByLegacyDeliusReasonCode(it: String): NonArrivalReasonEntity?

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingManagementInfoServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingManagementInfoServiceTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.seed.cas1
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository.Companion.NON_ARRIVAL_REASON_CUSTODIAL_DISPOSAL_RIC
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingManagementInfoService
+
+@ExtendWith(MockKExtension::class)
+@SuppressWarnings("UnusedPrivateProperty")
+class Cas1BookingManagementInfoServiceTest {
+
+  @MockK
+  private lateinit var departureReasonRepository: DepartureReasonRepository
+
+  @MockK
+  private lateinit var moveOnCategoryRepository: MoveOnCategoryRepository
+
+  @MockK
+  private lateinit var nonArrivalReasonRepository: NonArrivalReasonRepository
+
+  @InjectMockKs
+  private lateinit var service: Cas1BookingManagementInfoService
+
+  @Test
+  fun `use hardcoded non arrival reason for 1H`() {
+    val reason = NonArrivalReasonEntityFactory().produce()
+
+    every { nonArrivalReasonRepository.findByIdOrNull(NON_ARRIVAL_REASON_CUSTODIAL_DISPOSAL_RIC) } returns reason
+
+    val result = service.getNonArrivalReason("1H")
+
+    assertThat(result).isEqualTo(reason)
+  }
+
+  @Test
+  fun `use mapped non arrival reason if not 1H`() {
+    val reason = NonArrivalReasonEntityFactory().produce()
+
+    every { nonArrivalReasonRepository.findByLegacyDeliusReasonCode("NOT1H") } returns reason
+
+    val result = service.getNonArrivalReason("NOT1H")
+
+    assertThat(result).isEqualTo(reason)
+  }
+}


### PR DESCRIPTION
When converting bookings to space bookings we look up the `NonArrivalReason` using the legacy code provided in the delius referral import.

We have recently introduced multiple entries in the `non_arrival_reason_codes` table for delius code ‘1H’. This leads to an error when importing bookings with these non arrival reasons:

`Query did not return a unique result: 2 results were returned`

This commit updates the booking to space bookings code to use a specific reason code when `1H` is encountered, avoiding the aforementioned error