### PR TITLE
enable the filtering of different application assignment types

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/Cas2ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/Cas2ApplicationsController.kt
@@ -35,6 +35,7 @@ class Cas2ApplicationsController(
     isSubmitted: Boolean?,
     page: Int?,
     prisonCode: String?,
+    assignmentType: String?,
   ): ResponseEntity<List<ModelCas2ApplicationSummary>> {
     val user = userService.getUserForRequest()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -104,6 +104,11 @@ data class Cas2ApplicationEntity(
   var telephoneNumber: String? = null,
 ) {
   override fun toString() = "Cas2ApplicationEntity: $id"
+
+  val allocatedPomUserId: UUID
+    get() = applicationAssignments.firstOrNull()?.allocatedPomUserId ?: createdByUser.id
+
+  fun isSubmitted() = submittedAt != null
 }
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2UserAccessService.kt
@@ -6,17 +6,21 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEnti
 
 @Service
 class Cas2UserAccessService {
-  fun userCanViewApplication(user: NomisUserEntity, application: Cas2ApplicationEntity): Boolean = if (user.id == application.createdByUser.id) {
-    true
-  } else if (application.submittedAt == null) {
-    false
-  } else {
-    offenderIsFromSamePrisonAsUser(application.referringPrisonCode, user.activeCaseloadId)
-  }
+  fun userCanViewApplication(user: NomisUserEntity, application: Cas2ApplicationEntity) = isCreatedByUser(user, application) ||
+    (
+      application.isSubmitted() &&
+        (
+          isAssignedUser(user, application) ||
+            offenderIsFromSamePrisonAsUser(
+              application.referringPrisonCode,
+              user.activeCaseloadId,
+            )
+          )
+      )
 
-  fun offenderIsFromSamePrisonAsUser(referringPrisonCode: String?, activeCaseloadId: String?): Boolean = if (referringPrisonCode !== null && activeCaseloadId !== null) {
-    activeCaseloadId == referringPrisonCode
-  } else {
-    false
-  }
+  fun isCreatedByUser(user: NomisUserEntity, application: Cas2ApplicationEntity): Boolean = user.id == application.createdByUser.id
+
+  fun isAssignedUser(user: NomisUserEntity, application: Cas2ApplicationEntity): Boolean = user.id == application.allocatedPomUserId
+
+  fun offenderIsFromSamePrisonAsUser(referringPrisonCode: String?, activeCaseloadId: String?): Boolean = referringPrisonCode?.let { it == activeCaseloadId } ?: false
 }

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -65,6 +65,11 @@ paths:
           description: Prison code of applications to return.  If blank, returns all results.
           schema:
             type: string
+        - name: assignmentType
+          in: query
+          description: The relationship of the application to the user - created by, allocated to, deallocated from, or prison wide.
+          schema:
+            enum: [CREATED, ALLOCATED, DEALLOCATED, PRISON]
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -67,6 +67,11 @@ paths:
           description: Prison code of applications to return.  If blank, returns all results.
           schema:
             type: string
+        - name: assignmentType
+          in: query
+          description: The relationship of the application to the user - created by, allocated to, deallocated from, or prison wide.
+          schema:
+            enum: [CREATED, ALLOCATED, DEALLOCATED, PRISON]
       responses:
         200:
           description: successful operation


### PR DESCRIPTION
this allows the api to return applications based on POM user assignment, rather than just createdByUser or in the same prison