### PR TITLE
Use latest hmpps.gradle-spring-boot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.apache.commons.io.FileUtils
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.4"
   kotlin("plugin.spring") version "2.1.10"
   kotlin("plugin.jpa") version "2.1.10"
   id("org.openapi.generator") version "7.11.0"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,6 +128,8 @@ spring:
 
 springdoc:
   swagger-ui:
+    # advised by https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/7.x.md (7.1.4)
+    version: 5.20.0
     urls-primary-name: "All CAS"
   remove-broken-reference-definitions: false
   writer-with-order-by-keys: true


### PR DESCRIPTION
We also pin the version of swagger-ui to resolve `CVE-2025-26791` (see https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/7.x.md)