### PR TITLE
Block withdrawal for non-arrived space bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -476,11 +476,13 @@ class Cas1SpaceBookingService(
   )
 
   fun getWithdrawableState(spaceBooking: Cas1SpaceBookingEntity, user: UserEntity): WithdrawableState = WithdrawableState(
-    withdrawable = !spaceBooking.isCancelled() && !spaceBooking.hasArrival(),
+    withdrawable = !spaceBooking.isCancelled() && !spaceBooking.hasArrival() && !spaceBooking.hasNonArrival(),
     withdrawn = spaceBooking.isCancelled(),
     userMayDirectlyWithdraw = user.hasPermission(UserPermission.CAS1_SPACE_BOOKING_WITHDRAW),
     blockingReason = if (spaceBooking.hasArrival()) {
       BlockingReason.ArrivalRecordedInCas1
+    } else if (spaceBooking.hasNonArrival()) {
+      BlockingReason.NonArrivalRecordedInCas1
     } else {
       null
     },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -312,4 +312,5 @@ data class WithdrawableDatePeriod(
 enum class BlockingReason {
   ArrivalRecordedInCas1,
   ArrivalRecordedInDelius,
+  NonArrivalRecordedInCas1,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -142,6 +142,10 @@ data class WithdrawableTree(
       notes.add("1 or more placements cannot be withdrawn as they have an arrival")
     }
 
+    if (blockedReasons.contains(BlockingReason.NonArrivalRecordedInCas1)) {
+      notes.add("1 or more placements cannot be withdrawn as they have a non-arrival")
+    }
+
     if (blockedReasons.contains(BlockingReason.ArrivalRecordedInDelius)) {
       notes.add("1 or more placements cannot be withdrawn as they have an arrival recorded in Delius")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -345,12 +345,12 @@ class WithdrawalTest : IntegrationTestBase() {
      * | ---> Match request 2             | -            |
      * | -> Request for placement 2       | YES          |
      * | -> Match request 3               | BLOCKED      |
-     * | ---> Booking 2 has arrival       | BLOCKING     |
+     * | ---> Space Booking 2 has arrival | BLOCKING     |
      * | -> Adhoc Booking                 | YES          |
      * ```
      */
     @Test
-    fun `Returns all possible types when a user can manage bookings, with booking arrivals in CAS1 blocking bookings`() {
+    fun `Returns all possible types when a user can manage bookings, with space booking arrivals in CAS1 blocking bookings`() {
       givenAUser { applicant, _ ->
         givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
           givenAUser { requestForPlacementAssessor, _ ->
@@ -385,7 +385,15 @@ class WithdrawalTest : IntegrationTestBase() {
                 startDate = LocalDate.now(),
                 endDate = nowPlusDays(1),
               )
-              addBookingToPlacementRequest(placementRequest3, booking2HasArrival)
+              // spaceBooking2HasNonArrival
+              givenACas1SpaceBooking(
+                crn = application.crn,
+                expectedArrivalDate = LocalDate.now(),
+                expectedDepartureDate = nowPlusDays(1),
+                actualArrivalDate = LocalDate.now(),
+                nonArrivalConfirmedAt = null,
+                placementRequest = placementRequest3,
+              )
 
               val adhocBooking = createBooking(
                 application = application,
@@ -458,7 +466,7 @@ class WithdrawalTest : IntegrationTestBase() {
      * | -> Request for placement 2        | YES          |
      * | -> Match request 3                | BLOCKED      |
      * | ---> Space Booking 2 non arrival  | BLOCKING     |
-     * | -> Adhoc Booking                 | YES          |
+     * | -> Adhoc Booking                  | YES          |
      * ```
      */
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawables
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1CruManagementArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
@@ -39,6 +40,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.jsonForObject
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -411,6 +413,119 @@ class WithdrawalTest : IntegrationTestBase() {
 
               val expected = Withdrawables(
                 notes = listOf("1 or more placements cannot be withdrawn as they have an arrival"),
+                withdrawables = listOf(
+                  toWithdrawable(placementApplication1),
+                  toWithdrawable(booking1NoArrival),
+                  toWithdrawable(placementApplication2),
+                  toWithdrawable(adhocBooking),
+                ),
+              )
+
+              webTestClient.get()
+                .uri("/applications/${application.id}/withdrawables")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonForObject(expected.withdrawables)
+
+              webTestClient.get()
+                .uri("/applications/${application.id}/withdrawablesWithNotes")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonForObject(expected)
+            }
+          }
+        }
+      }
+    }
+
+    /**
+     * ```
+     * | Entities                          | Withdrawable |
+     * | --------------------------------- | ------------ |
+     * | Application                       | BLOCKED      |
+     * | -> Request for placement 1        | YES          |
+     * | ---> Match request 1              | -            |
+     * | -----> Booking 1 arrival pending  | YES          |
+     * | ---> Match request 2              | -            |
+     * | -> Request for placement 2        | YES          |
+     * | -> Match request 3                | BLOCKED      |
+     * | ---> Space Booking 2 non arrival  | BLOCKING     |
+     * | -> Adhoc Booking                 | YES          |
+     * ```
+     */
+    @Test
+    fun `Returns all possible types when a user can manage bookings, with space booking non arrivals blocking bookings`() {
+      givenAUser { applicant, _ ->
+        givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
+          givenAUser { requestForPlacementAssessor, _ ->
+            givenAnOffender { offenderDetails, _ ->
+              val (application, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
+              val (otherApplication, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
+
+              val placementApplication1 = createPlacementApplication(application, DateSpan(now(), duration = 2))
+              val placementRequest1 = createPlacementRequest(application, placementApplication = placementApplication1)
+              val booking1NoArrival = createBooking(
+                application = application,
+                hasArrivalInCas1 = false,
+                hasArrivalInDelius = false,
+                adhoc = false,
+                startDate = nowPlusDays(1),
+                endDate = nowPlusDays(6),
+              )
+              addBookingToPlacementRequest(placementRequest1, booking1NoArrival)
+
+              createPlacementRequest(application, placementApplication = placementApplication1)
+
+              val placementApplication2 = createPlacementApplication(
+                application,
+                DateSpan(now(), duration = 2),
+                allocatedTo = requestForPlacementAssessor,
+              )
+
+              val placementRequest3 = createPlacementRequest(application)
+              // spaceBooking2HasNonArrival
+              givenACas1SpaceBooking(
+                crn = application.crn,
+                expectedArrivalDate = LocalDate.now(),
+                expectedDepartureDate = nowPlusDays(1),
+                nonArrivalConfirmedAt = Instant.now(),
+                placementRequest = placementRequest3,
+              )
+
+              val adhocBooking = createBooking(
+                application = application,
+                adhoc = true,
+                hasArrivalInCas1 = false,
+                hasArrivalInDelius = false,
+                startDate = nowPlusDays(20),
+                endDate = nowPlusDays(26),
+              )
+
+              createBooking(
+                application = otherApplication,
+                adhoc = true,
+                hasArrivalInCas1 = false,
+                startDate = nowPlusDays(20),
+                endDate = nowPlusDays(26),
+              )
+              createBooking(
+                application = otherApplication,
+                adhoc = null,
+                hasArrivalInCas1 = false,
+                startDate = nowPlusDays(20),
+                endDate = nowPlusDays(26),
+              )
+
+              val expected = Withdrawables(
+                notes = listOf("1 or more placements cannot be withdrawn as they have a non-arrival"),
                 withdrawables = listOf(
                   toWithdrawable(placementApplication1),
                   toWithdrawable(booking1NoArrival),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
@@ -24,6 +24,7 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
   expectedDepartureDate: LocalDate = LocalDate.now(),
   nonArrivalConfirmedAt: Instant? = null,
   cancellationOccurredAt: LocalDate? = null,
+  actualArrivalDate: LocalDate? = null,
 ): Cas1SpaceBookingEntity {
   val (user) = givenAUser()
   val placementRequestToUse = placementRequest ?: if (offlineApplication == null) {
@@ -40,6 +41,7 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
   return cas1SpaceBookingEntityFactory.produceAndPersist {
     withCrn(crn)
     withExpectedArrivalDate(expectedArrivalDate)
+    withActualArrivalDate(actualArrivalDate)
     withCanonicalArrivalDate(canonicalArrivalDate)
     withExpectedDepartureDate(expectedDepartureDate)
     withCanonicalDepartureDate(expectedDepartureDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -1484,6 +1484,7 @@ class Cas1SpaceBookingServiceTest {
         Cas1SpaceBookingEntityFactory()
           .withActualArrivalDate(null)
           .withCancellationOccurredAt(null)
+          .withNonArrivalConfirmedAt(null)
           .produce(),
         UserEntityFactory().withDefaults().produce(),
       )
@@ -1499,6 +1500,7 @@ class Cas1SpaceBookingServiceTest {
         Cas1SpaceBookingEntityFactory()
           .withActualArrivalDate(LocalDate.now())
           .withCancellationOccurredAt(null)
+          .withNonArrivalConfirmedAt(null)
           .produce(),
         UserEntityFactory().withDefaults().produce(),
       )
@@ -1509,11 +1511,28 @@ class Cas1SpaceBookingServiceTest {
     }
 
     @Test
+    fun `is not withdrawable if has a non-arrival`() {
+      val result = service.getWithdrawableState(
+        Cas1SpaceBookingEntityFactory()
+          .withActualArrivalDate(null)
+          .withCancellationOccurredAt(null)
+          .withNonArrivalConfirmedAt(Instant.now())
+          .produce(),
+        UserEntityFactory().withDefaults().produce(),
+      )
+
+      assertThat(result.withdrawable).isEqualTo(false)
+      assertThat(result.withdrawn).isEqualTo(false)
+      assertThat(result.blockingReason).isEqualTo(BlockingReason.NonArrivalRecordedInCas1)
+    }
+
+    @Test
     fun `is not withdrawable if already cancelled`() {
       val result = service.getWithdrawableState(
         Cas1SpaceBookingEntityFactory()
           .withActualArrivalDate(null)
           .withCancellationOccurredAt(LocalDate.now())
+          .withNonArrivalConfirmedAt(null)
           .produce(),
         UserEntityFactory().withDefaults().produce(),
       )


### PR DESCRIPTION
If a space booking has a non arrival recorded it shouldn’t be possible to withdraw/cancel it. Furthermore, any related placement request or application should not be withdrawable (as per the current behaviour for space bookings with an arrival)