### PR TITLE
Remove use of deprecated function in cas3 booking search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingSearchService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadataWithSize
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import java.time.LocalDate
@@ -60,10 +61,9 @@ class Cas3BookingSearchService(
     bookingSearchResultDtos: List<BookingSearchResultDto>,
     user: UserEntity,
   ): List<BookingSearchResultDto> {
-    val offenderSummaries = offenderService.getOffenderSummariesByCrns(
+    val offenderSummaries = offenderService.getPersonSummaryInfoResults(
       bookingSearchResultDtos.map { it.personCrn }.toSet(),
-      user.deliusUsername,
-      ignoreLaoRestrictions = false,
+      user.cas3LaoStrategy(),
     )
 
     return bookingSearchResultDtos

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseAccessFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseAccessFactory.kt
@@ -15,6 +15,10 @@ class CaseAccessFactory : Factory<CaseAccess> {
   fun withCrn(crn: String) = apply {
     this.crn = { crn }
   }
+  fun withAccess() = apply {
+    withUserExcluded(false)
+    withUserRestricted(false)
+  }
   fun withUserExcluded(userExcluded: Boolean) = apply {
     this.userExcluded = { userExcluded }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDetailFactory.kt
@@ -140,7 +140,10 @@ class CaseSummaryFactory : Factory<CaseSummary> {
   var manager: Yielded<Manager> = { ManagerFactory().produce() }
   var currentExclusion: Yielded<Boolean> = { false }
   var currentRestriction: Yielded<Boolean> = { false }
-
+  fun withNoLimitedAccess() = apply {
+    withCurrentExclusion(false)
+    withCurrentRestriction(false)
+  }
   fun withCrn(crn: String) = apply {
     this.crn = { crn }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -209,13 +209,14 @@ fun IntegrationTestBase.apDeliusContextAddSingleCaseSummaryToBulkResponse(caseSu
   }
 }
 
-fun IntegrationTestBase.apDeliusContextAddListCaseSummaryToBulkResponse(casesSummary: List<CaseSummary>) {
+fun IntegrationTestBase.apDeliusContextAddListCaseSummaryToBulkResponse(
+  casesSummary: List<CaseSummary>,
+  crns: List<String> = casesSummary.map { it.crn },
+) {
   mockSuccessfulGetCallWithBodyAndJsonResponse(
     url = "/probation-cases/summaries",
     requestBody = WireMock.equalToJson(
-      objectMapper.writeValueAsString(
-        casesSummary.map { it.crn },
-      ),
+      objectMapper.writeValueAsString(crns),
       true,
       false,
     ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas3BookingSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas3BookingSearchServiceTest.kt
@@ -66,7 +66,7 @@ class Cas3BookingSearchServiceTest {
       crns.map { TestBookingSearchResult().withPersonCrn(it) },
     )
 
-    every { mockOffenderService.getOffenderSummariesByCrns(crns, any(), any()) } returns
+    every { mockOffenderService.getPersonSummaryInfoResults(crns, any()) } returns
       crns.map { PersonSummaryInfoResult.Success.Full(it, CaseSummaryFactory().produce()) }
 
     val (results, metaData) = cas3BookingSearchService.findBookings(
@@ -108,7 +108,7 @@ class Cas3BookingSearchServiceTest {
           .withBookingCreatedAt(OffsetDateTime.now().minusDays(1)),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().withName(NameFactory().withForename("Gregor").withSurname("Samsa").produce()).produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().withName(NameFactory().withForename("Franz").withSurname("Kafka").produce()).produce()),
@@ -156,7 +156,7 @@ class Cas3BookingSearchServiceTest {
           .withBookingCreatedAt(OffsetDateTime.now().minusDays(1)),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -212,7 +212,7 @@ class Cas3BookingSearchServiceTest {
         TestBookingSearchResult().withPersonCrn("crn3"),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -264,7 +264,7 @@ class Cas3BookingSearchServiceTest {
         TestBookingSearchResult().withPersonCrn("crn3"),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -316,7 +316,7 @@ class Cas3BookingSearchServiceTest {
         TestBookingSearchResult().withPersonCrn("crn3"),
       ),
     )
-    every { mockOffenderService.getOffenderSummariesByCrns(setOf("crn1", "crn2", "crn3"), any(), any()) } returns
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
       listOf(
         PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
@@ -350,7 +350,7 @@ class Cas3BookingSearchServiceTest {
       }
       .produce()
     every { mockBookingRepository.findTemporaryAccommodationBookings(any(), any(), any(), any()) } returns PageImpl(emptyList())
-    every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any()) } returns emptyList()
+    every { mockOffenderService.getPersonSummaryInfoResults(emptySet(), any()) } returns emptyList()
 
     val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
@@ -379,7 +379,7 @@ class Cas3BookingSearchServiceTest {
       }
       .produce()
     every { mockBookingRepository.findTemporaryAccommodationBookings(any(), any(), any(), any()) } returns PageImpl(emptyList())
-    every { mockOffenderService.getOffenderSummariesByCrns(emptySet(), any(), any()) } returns emptyList()
+    every { mockOffenderService.getPersonSummaryInfoResults(emptySet(), any()) } returns emptyList()
 
     val (results, metaData) = cas3BookingSearchService.findBookings(
       null,


### PR DESCRIPTION
note that the integration test `Searching for Temporary Accommodation bookings correctly filtered single booking for a specific crn` expected no offender or permission information to be returned for the offender. This is because the two ap-and-delius mocks were not setup to respond to the given CRN and the deprecated function incorrectly interpreted the 404 as 'offender not found' instead of returning a general error

The new code does return a general error in this case so i've had to explicitly configure the mocks in the test to return an 'offender not found' response (i.e. the absence of results for a requested CRN)