### PR TITLE
APS-2061 - Optimise OOSB Bed Report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -58,16 +58,6 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
   @Modifying
   @Query("UPDATE BedEntity b SET b.code = :code WHERE b.id = :id")
   fun updateCode(id: UUID, code: String)
-
-  @Query(
-    """
-      SELECT b.id FROM beds b
-      INNER JOIN rooms r ON r.id = b.room_id
-      INNER JOIN approved_premises p ON r.premises_id = p.premises_id
-    """,
-    nativeQuery = true,
-  )
-  fun allCas1BedIds(): List<UUID>
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -58,13 +58,22 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
   @Modifying
   @Query("UPDATE BedEntity b SET b.code = :code WHERE b.id = :id")
   fun updateCode(id: UUID, code: String)
+
+  @Query(
+    """
+      SELECT b.id FROM beds b
+      INNER JOIN rooms r ON r.id = b.room_id
+      INNER JOIN approved_premises p ON r.premises_id = p.premises_id
+    """,
+    nativeQuery = true,
+  )
+  fun allCas1BedIds(): List<UUID>
 }
 
 @Repository
 class Cas1BedsRepository(
   private val jdbcTemplate: NamedParameterJdbcTemplate,
 ) {
-
   fun bedSummary(premisesId: UUID): List<Cas1PlanningBedSummary> {
     val params = mutableMapOf<String, Any>(
       "premisesId" to premisesId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -80,9 +80,6 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
     pageable: Pageable?,
   ): Page<String>
 
-  @Query("SELECT oosb FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE c is NULL")
-  fun findAllActive(): List<Cas1OutOfServiceBedEntity>
-
   @Query("SELECT oosb FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE oosb.premises.id = :premisesId AND c is NULL")
   fun findAllActiveForPremisesId(premisesId: UUID): List<Cas1OutOfServiceBedEntity>
 
@@ -115,6 +112,12 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
     nativeQuery = true,
   )
   fun findByBedIdAndOverlappingDate(bedId: UUID, startDate: LocalDate, endDate: LocalDate, thisEntityId: UUID?): List<String>
+
+  @Query(
+    "SELECT bed_id FROM cas1_out_of_service_beds GROUP by bed_id",
+    nativeQuery = true,
+  )
+  fun findBedIdsWithAtLeastOneOutOfServiceBedRecord(): List<UUID>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/Cas1OutOfServiceBedsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/Cas1OutOfServiceBedsReportGenerator.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas1OutOfServiceBedReportRow
@@ -14,14 +12,14 @@ import java.util.UUID
 
 class Cas1OutOfServiceBedsReportGenerator(
   private val outOfServiceBedRepository: Cas1OutOfServiceBedRepository,
-) : ReportGenerator<BedEntity, Cas1OutOfServiceBedReportRow, Cas1ReportService.MonthSpecificReportParams>(
+) : ReportGenerator<Cas1OutOfServiceBedsReportGenerator.Cas1BedIdentifier, Cas1OutOfServiceBedReportRow, Cas1ReportService.MonthSpecificReportParams>(
   Cas1OutOfServiceBedReportRow::class,
 ) {
-  override fun filter(properties: Cas1ReportService.MonthSpecificReportParams): (BedEntity) -> Boolean = {
-    checkServiceType(ServiceName.approvedPremises, it.room.premises)
+  override fun filter(properties: Cas1ReportService.MonthSpecificReportParams): (Cas1BedIdentifier) -> Boolean = {
+    true
   }
 
-  override val convert: BedEntity.(properties: Cas1ReportService.MonthSpecificReportParams) -> List<Cas1OutOfServiceBedReportRow> = { properties ->
+  override val convert: Cas1BedIdentifier.(properties: Cas1ReportService.MonthSpecificReportParams) -> List<Cas1OutOfServiceBedReportRow> = { properties ->
     val startOfMonth = LocalDate.of(properties.year, properties.month, 1)
     val endOfMonth = LocalDate.of(properties.year, properties.month, startOfMonth.month.length(startOfMonth.isLeapYear))
 
@@ -48,4 +46,6 @@ class Cas1OutOfServiceBedsReportGenerator(
       )
     }
   }
+
+  data class Cas1BedIdentifier(val id: UUID)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
@@ -5,7 +5,6 @@ import org.jetbrains.kotlinx.dataframe.io.writeExcel
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntityReportRowRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntityReportRowRepository
@@ -32,7 +31,6 @@ import java.time.temporal.TemporalAdjusters
 class Cas1ReportService(
   private val applicationRepository: ApplicationRepository,
   private val applicationEntityReportRowRepository: ApplicationEntityReportRowRepository,
-  private val bedRepository: BedRepository,
   private val cas1PlacementMatchingOutcomesReportRepository: Cas1PlacementMatchingOutcomesReportRepository,
   private val cas1PlacementMatchingOutcomesV2ReportRepository: Cas1PlacementMatchingOutcomesV2ReportRepository,
   private val cas1ApplicationV2ReportRepository: Cas1ApplicationV2ReportRepository,
@@ -114,7 +112,7 @@ class Cas1ReportService(
 
   fun createOutOfServiceBedReport(properties: MonthSpecificReportParams, outputStream: OutputStream) {
     Cas1OutOfServiceBedsReportGenerator(cas1OutOfServiceBedRepository)
-      .createReport(bedRepository.allCas1BedIds().map { Cas1BedIdentifier(it) }, properties)
+      .createReport(cas1OutOfServiceBedRepository.findBedIdsWithAtLeastOneOutOfServiceBedRecord().map { Cas1BedIdentifier(it) }, properties)
       .writeExcel(
         outputStream = outputStream,
         factory = WorkbookFactory.create(true),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Plac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1RequestForPlacementReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.ApplicationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator.Cas1BedIdentifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.DailyMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.PlacementApplicationReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
@@ -113,7 +114,7 @@ class Cas1ReportService(
 
   fun createOutOfServiceBedReport(properties: MonthSpecificReportParams, outputStream: OutputStream) {
     Cas1OutOfServiceBedsReportGenerator(cas1OutOfServiceBedRepository)
-      .createReport(bedRepository.findAll(), properties)
+      .createReport(bedRepository.allCas1BedIds().map { Cas1BedIdentifier(it) }, properties)
       .writeExcel(
         outputStream = outputStream,
         factory = WorkbookFactory.create(true),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1OutOfServiceBedsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1OutOfServiceBedsReportTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
 import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.api.sortBy
 import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,32 +40,40 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
         }
 
         val bed1 = bedEntityFactory.produceAndPersist {
+          withName("bed1")
           withRoom(
             roomEntityFactory.produceAndPersist {
+              withName("room1")
               withPremises(premises)
             },
           )
         }
 
         val bed2 = bedEntityFactory.produceAndPersist {
+          withName("bed2")
           withRoom(
             roomEntityFactory.produceAndPersist {
+              withName("room2")
               withPremises(premises)
             },
           )
         }
 
         val bed3 = bedEntityFactory.produceAndPersist {
+          withName("bed3")
           withRoom(
             roomEntityFactory.produceAndPersist {
+              withName("room3")
               withPremises(premises)
             },
           )
         }
 
         val bed4 = bedEntityFactory.produceAndPersist {
+          withName("bed4")
           withRoom(
             roomEntityFactory.produceAndPersist {
+              withName("room4")
               withPremises(premises)
             },
           )
@@ -149,7 +158,7 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
           .createReport(
             listOf(Cas1BedIdentifier(bed1.id), Cas1BedIdentifier(bed2.id)),
             Cas1ReportService.MonthSpecificReportParams(2023, 4),
-          )
+          ).sortBy { row -> row["bedName"] }
 
         webTestClient.get()
           .uri("$outOfServiceBedsEndpoint?year=2023&month=4")
@@ -163,6 +172,8 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
             val actual = DataFrame
               .readExcel(it.responseBody!!.inputStream())
               .convertTo<Cas1OutOfServiceBedReportRow>(ExcessiveColumns.Remove)
+              .sortBy { row -> row["bedName"] }
+
             Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
           }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1OutOfServiceBedsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1OutOfServiceBedsReportTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_REPORT_VIEWER
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator.Cas1BedIdentifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas1OutOfServiceBedReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
@@ -136,9 +137,17 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
           }
         }
 
+        /*
+        Note - this test is mostly redundant because it calls the report generator directly to determine
+        what the endpoint should be returning. So it's only checking that the controller is calling
+        the report generator, not that it returns an expected result
+
+        This is better tested by [Cas1OutOfServiceBedReportGeneratorTest] which could be merged
+        with this test
+         */
         val expectedDataFrame = Cas1OutOfServiceBedsReportGenerator(realOutOfServiceBedRepository)
           .createReport(
-            listOf(bed1, bed2),
+            listOf(Cas1BedIdentifier(bed1.id), Cas1BedIdentifier(bed2.id)),
             Cas1ReportService.MonthSpecificReportParams(2023, 4),
           )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/Cas1OutOfServiceBedReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/Cas1OutOfServiceBedReportGeneratorTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator.Cas1BedIdentifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas1OutOfServiceBedReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService
 import java.time.LocalDate
@@ -118,7 +119,7 @@ class Cas1OutOfServiceBedReportGeneratorTest {
     } returns listOf(outOfServiceBedOutsideProbationArea)
 
     val result = reportGenerator.createReport(
-      listOf(bedInProbationRegion, bedOutsideProbationRegion),
+      listOf(Cas1BedIdentifier(bedInProbationRegion.id), Cas1BedIdentifier(bedOutsideProbationRegion.id)),
       Cas1ReportService.MonthSpecificReportParams(2023, 4),
     )
 
@@ -166,7 +167,7 @@ class Cas1OutOfServiceBedReportGeneratorTest {
     } returns listOf(outOfServiceBed)
 
     val result = reportGenerator.createReport(
-      listOf(bed),
+      listOf(Cas1BedIdentifier(bed.id)),
       Cas1ReportService.MonthSpecificReportParams(2023, 4),
     )
 
@@ -222,7 +223,7 @@ class Cas1OutOfServiceBedReportGeneratorTest {
     } returns listOf(outOfServiceBed)
 
     val result = reportGenerator.createReport(
-      listOf(bed),
+      listOf(Cas1BedIdentifier(bed.id)),
       Cas1ReportService.MonthSpecificReportParams(2023, 4),
     )
 


### PR DESCRIPTION
Before this PR the complete list of Beds across all CASs was passed to the `Cas1OutOfServiceBedReportGenerator` for consideration. This PR only passes Beds to the `Cas1OutOfServiceBedReportGenerator` where they have an associated out of service bed entity. This should considerably speed up the report generation time

This considerably decreases the size of the input to the report. The report itself is still inefficient and would be better implemented via SQL that only considers records within the given time frame, instead of starting with a large set of beds and then checking each one to see if there’s an OOSB within the given time frame