### PR TITLE
APS-2137 Update space booking amendment validation bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -581,11 +581,11 @@ class Cas1SpaceBookingService(
       previousCharacteristicsIfChanged = previousCharacteristicsIfChanged,
     )
 
-    updatedBooking.application?.let {
-      if (previousArrivalDateIfChanged != null || previousDepartureDateIfChanged != null) {
+    if (previousArrivalDateIfChanged != null || previousDepartureDateIfChanged != null) {
+      updatedBooking.application?.let { application ->
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedBooking,
-          application = updatedBooking.application!!,
+          application = application,
         )
       }
     }
@@ -631,9 +631,10 @@ class Cas1SpaceBookingService(
     val (newArrivalDate, newDepartureDate) = updateSpaceBookingDetails.calculateEffectiveDates(bookingToUpdate)
 
     if (bookingToUpdate.hasArrival()) {
-      updateDepartureDates(bookingToUpdate, newDepartureDate)
+      bookingToUpdate.updateDepartureDates(newDepartureDate)
     } else {
-      updateFullBookingDates(bookingToUpdate, newArrivalDate, newDepartureDate)
+      bookingToUpdate.updateArrivalDates(newArrivalDate)
+      bookingToUpdate.updateDepartureDates(newDepartureDate)
     }
 
     if (updateSpaceBookingDetails.characteristics != null) {
@@ -653,23 +654,14 @@ class Cas1SpaceBookingService(
     }
   }
 
-  private fun updateDepartureDates(booking: Cas1SpaceBookingEntity, newDepartureDate: LocalDate) {
-    booking.expectedDepartureDate = newDepartureDate
-    booking.canonicalDepartureDate = newDepartureDate
+  private fun Cas1SpaceBookingEntity.updateDepartureDates(newDepartureDate: LocalDate) {
+    this.expectedDepartureDate = newDepartureDate
+    this.canonicalDepartureDate = newDepartureDate
   }
 
-  private fun updateArrivalDates(booking: Cas1SpaceBookingEntity, newArrivalDate: LocalDate) {
-    booking.expectedArrivalDate = newArrivalDate
-    booking.canonicalArrivalDate = newArrivalDate
-  }
-
-  private fun updateFullBookingDates(
-    booking: Cas1SpaceBookingEntity,
-    newArrivalDate: LocalDate,
-    newDepartureDate: LocalDate,
-  ) {
-    updateArrivalDates(booking, newArrivalDate)
-    updateDepartureDates(booking, newDepartureDate)
+  private fun Cas1SpaceBookingEntity.updateArrivalDates(newArrivalDate: LocalDate) {
+    this.expectedArrivalDate = newArrivalDate
+    this.canonicalArrivalDate = newArrivalDate
   }
 
   data class UpdateSpaceBookingDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -617,7 +617,12 @@ class Cas1SpaceBookingService(
       "$.premisesId" hasValidationError "premisesMismatch"
     }
 
-    val effectiveArrivalDate = updateSpaceBookingDetails.arrivalDate ?: bookingToUpdate.expectedArrivalDate
+    val effectiveArrivalDate = if (bookingToUpdate.hasArrival()) {
+      bookingToUpdate.actualArrivalDate
+    } else {
+      updateSpaceBookingDetails.arrivalDate ?: bookingToUpdate.expectedArrivalDate
+    }
+
     val effectiveDepartureDate = updateSpaceBookingDetails.departureDate ?: bookingToUpdate.expectedDepartureDate
 
     if (effectiveDepartureDate.isBefore(effectiveArrivalDate)) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -1973,6 +1973,31 @@ class Cas1SpaceBookingServiceTest {
     }
 
     @Test
+    fun `should return validation error after arrival when new departure date is before actual arrival date`() {
+      existingSpaceBooking.expectedArrivalDate = LocalDate.of(2025, 6, 15)
+      existingSpaceBooking.actualArrivalDate = LocalDate.of(2025, 6, 20)
+      existingSpaceBooking.expectedDepartureDate = LocalDate.of(2025, 6, 25)
+
+      every { cas1PremisesService.findPremiseById(any()) } returns premises
+      every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
+
+      val result = service.updateSpaceBooking(
+        UpdateSpaceBookingDetails(
+          bookingId = UUID.randomUUID(),
+          premisesId = UUID.randomUUID(),
+          arrivalDate = null,
+          departureDate = LocalDate.of(2025, 6, 18),
+          updatedBy = user,
+          characteristics = null,
+        ),
+      )
+
+      assertThatCasResult(result)
+        .isFieldValidationError()
+        .hasMessage("$.departureDate", "The departure date is before the arrival date.")
+    }
+
+    @Test
     fun `should update only departure dates when booking status is hasArrival`() {
       existingSpaceBooking.actualArrivalDate = LocalDate.now()
       existingSpaceBooking.expectedDepartureDate = LocalDate.of(2025, 1, 10)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
@@ -144,16 +144,8 @@ class CasResultFieldValidationErrorAssertions<T>(actual: CasResult.FieldValidati
   fun hasMessage(field: String, expectedMessage: String): CasResultFieldValidationErrorAssertions<T> {
     val validationMessages = actual.validationMessages
 
-    if (!validationMessages.containsKey(field)) {
-      failWithMessage("Expected field <%s> not found in validation messages '$validationMessages'", field)
-    } else if (validationMessages[field] != expectedMessage) {
-      failWithMessage(
-        "Expected field <%s> to have message <%s> but was <%s>",
-        field,
-        expectedMessage,
-        validationMessages[field],
-      )
-    }
+    assertThat(validationMessages).containsEntry(field, expectedMessage)
+
     return this
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
@@ -145,7 +145,7 @@ class CasResultFieldValidationErrorAssertions<T>(actual: CasResult.FieldValidati
     val validationMessages = actual.validationMessages
 
     if (!validationMessages.containsKey(field)) {
-      failWithMessage("Expected field <%s> not found in validation messages", field)
+      failWithMessage("Expected field <%s> not found in validation messages '$validationMessages'", field)
     } else if (validationMessages[field] != expectedMessage) {
       failWithMessage(
         "Expected field <%s> to have message <%s> but was <%s>",


### PR DESCRIPTION
Before this PR, when checking if a proposed departure date is after the booking’s arrivals date, we would compare it to the expected arrival date. This is not the correct behaviour if an arrival has occurred. In that case we should compare it to the actual arrival date.

Local testing of this is shown below:

* Create booking 15/1/2030 - 25/1/2030
* Change to 16/1/2030 - 26/1/2030
* Record arrival for 5/1/2025
* Change end date to 6/1/2025

![Screenshot 2025-03-20 at 16 53 18](https://github.com/user-attachments/assets/05da4ecf-1d66-4750-a655-d676b76e9077)
