### PR TITLE
Give all OOSB permissions to Find and Book Beta Role

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -92,8 +92,10 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
     ApprovedPremisesUserRole.cruMemberFindAndBookBeta,
     permissions = commonCruMemberPermissions + listOf(
       UserPermission.CAS1_SPACE_BOOKING_CREATE,
+      UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE,
       UserPermission.CAS1_OUT_OF_SERVICE_BED_CREATE_BED_ON_HOLD,
       UserPermission.CAS1_OUT_OF_SERVICE_BED_CANCEL,
+      UserPermission.CAS1_VIEW_OUT_OF_SERVICE_BEDS,
     ),
   ),
 


### PR DESCRIPTION
This simplifies UI testing and logically any CRU member with access to the find and book beta should also have access to out of service beds. We’ve checked current permissons and all beta users have future manager, which also has this permission.