### PR TITLE
CBA-411-cas-2-assessor-cannot-view-an-application-submitted-for-a-crn-with-an-exclusion

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2v2/Cas2v2ApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2v2/Cas2v2ApplicationController.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationSummaryEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
@@ -73,14 +72,14 @@ class Cas2v2ApplicationController(
       )
 
     val application = extractEntityFromCasResult(applicationResult)
-    return ResponseEntity.ok(getPersonDetailAndTransform(application, user))
+    return ResponseEntity.ok(getPersonDetailAndTransform(application))
   }
 
   @Transactional
   override fun applicationsPost(body: NewCas2v2Application): ResponseEntity<Application> {
     val user = userService.getUserForRequest()
 
-    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByCrn(body.crn, user)) {
+    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByCrn(body.crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(body.crn, "Offender")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for Prison Number: ${body.crn}")
@@ -129,7 +128,7 @@ class Cas2v2ApplicationController(
     }
 
     val entity = extractEntityFromCasResult(applicationResult)
-    return ResponseEntity.ok(getPersonDetailAndTransform(entity, user))
+    return ResponseEntity.ok(getPersonDetailAndTransform(entity))
   }
 
   @Transactional
@@ -156,9 +155,8 @@ class Cas2v2ApplicationController(
   @SuppressWarnings("ThrowsCount")
   private fun getPersonDetailAndTransform(
     application: Cas2v2ApplicationEntity,
-    user: Cas2v2UserEntity,
   ): Application {
-    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByCrn(application.crn, user)) {
+    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByCrn(application.crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(application.crn, "Offender")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for Prison Number: ${application.crn}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2v2/Cas2v2PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2v2/Cas2v2PeopleController.kt
@@ -9,17 +9,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2v2.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2v2.Cas2v2OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2v2.Cas2v2UserService
 
 @Service("Cas2v2PeopleController")
 class Cas2v2PeopleController(
-  private val cas2v2UserService: Cas2v2UserService,
   private val cas2v2OffenderService: Cas2v2OffenderService,
 ) : PeopleCas2v2Delegate {
 
   override fun searchByCrnGet(crn: String): ResponseEntity<Person> {
-    val user = cas2v2UserService.getUserForRequest()
-    when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByCrn(crn, user)) {
+    when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByCrn(crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(crn, "Offender")
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for CRN: $crn")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
@@ -28,8 +25,7 @@ class Cas2v2PeopleController(
   }
 
   override fun searchByNomisIdGet(nomsNumber: String): ResponseEntity<Person> {
-    val user = cas2v2UserService.getUserForRequest()
-    when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, user)) {
+    when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomsNumber(nomsNumber)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(nomsNumber, "Offender")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for Prison Number: $nomsNumber")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2v2/Cas2v2SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2v2/Cas2v2SubmissionsController.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationSummaryEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -57,7 +56,7 @@ class Cas2v2SubmissionsController(
     val applicationResult = cas2v2ApplicationService.getSubmittedCas2v2ApplicationForAssessor(applicationId)
     val application = extractEntityFromCasResult(applicationResult)
 
-    return ResponseEntity.ok(getPersonDetailAndTransform(application, user))
+    return ResponseEntity.ok(getPersonDetailAndTransform(application))
   }
 
   @Transactional
@@ -86,9 +85,8 @@ class Cas2v2SubmissionsController(
   @SuppressWarnings("ThrowsCount")
   private fun getPersonDetailAndTransform(
     application: Cas2v2ApplicationEntity,
-    user: Cas2v2UserEntity,
   ): Cas2v2SubmittedApplication {
-    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByCrn(application.crn, user)) {
+    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByCrn(application.crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(application.crn, "Offender")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for Prison Number: ${application.crn}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2ApplicationService.kt
@@ -124,7 +124,7 @@ class Cas2v2ApplicationService(
     applicationOrigin: ApplicationOrigin = ApplicationOrigin.homeDetentionCurfew,
     bailHearingDate: LocalDate? = null,
   ) = validated<Cas2v2ApplicationEntity> {
-    val offenderDetailsResult = cas2v2OffenderService.getPersonByCrn(crn, user)
+    val offenderDetailsResult = cas2v2OffenderService.getPersonByCrn(crn)
 
     val offenderDetails = when (offenderDetailsResult) {
       is Cas2v2OffenderSearchResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2ApplicationServiceTest.kt
@@ -308,7 +308,7 @@ class Cas2v2ApplicationServiceTest {
       val crn = "CRN345"
       val username = "SOME_PERSON"
 
-      every { mockCas2v2OffenderService.getPersonByCrn(any(), any()) } returns Cas2v2OffenderSearchResult.NotFound(crn)
+      every { mockCas2v2OffenderService.getPersonByCrn(any()) } returns Cas2v2OffenderSearchResult.NotFound(crn)
 
       val user = userWithUsername(username)
 
@@ -324,7 +324,7 @@ class Cas2v2ApplicationServiceTest {
       val crn = "CRN345"
       val username = "SOME PERSON"
 
-      every { mockCas2v2OffenderService.getPersonByCrn(any(), any()) } returns Cas2v2OffenderSearchResult.Forbidden(crn)
+      every { mockCas2v2OffenderService.getPersonByCrn(any()) } returns Cas2v2OffenderSearchResult.Forbidden(crn)
 
       val user = userWithUsername(username)
 
@@ -345,7 +345,7 @@ class Cas2v2ApplicationServiceTest {
 
       val user = userWithUsername(username)
 
-      every { mockCas2v2OffenderService.getPersonByCrn(crn, user) } returns Cas2v2OffenderSearchResult.Success.Full(
+      every { mockCas2v2OffenderService.getPersonByCrn(crn) } returns Cas2v2OffenderSearchResult.Success.Full(
         crn,
         FullPerson(
           name = "",
@@ -931,7 +931,7 @@ class Cas2v2ApplicationServiceTest {
           as Cas2v2ApplicationEntity
       }
 
-      every { mockCas2v2OffenderService.getPersonByCrn(any(), user) } returns Cas2v2OffenderSearchResult.Success.Full(
+      every { mockCas2v2OffenderService.getPersonByCrn(any()) } returns Cas2v2OffenderSearchResult.Success.Full(
         "crn",
         FullPerson(
           name = "",
@@ -984,7 +984,7 @@ class Cas2v2ApplicationServiceTest {
           as Cas2v2ApplicationEntity
       }
 
-      every { mockCas2v2OffenderService.getPersonByCrn(cas2v2Application.crn, user) } returns Cas2v2OffenderSearchResult.Success.Full(
+      every { mockCas2v2OffenderService.getPersonByCrn(cas2v2Application.crn) } returns Cas2v2OffenderSearchResult.Success.Full(
         cas2v2Application.crn,
         FullPerson(
           name = "",
@@ -1073,7 +1073,7 @@ class Cas2v2ApplicationServiceTest {
           as Cas2v2ApplicationEntity
       }
 
-      every { mockCas2v2OffenderService.getPersonByCrn(cas2v2Application.crn, user) } returns Cas2v2OffenderSearchResult.Success.Full(
+      every { mockCas2v2OffenderService.getPersonByCrn(cas2v2Application.crn) } returns Cas2v2OffenderSearchResult.Success.Full(
         cas2v2Application.crn,
         FullPerson(
           name = "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2v2/Cas2v2OffenderServiceTest.kt
@@ -61,7 +61,7 @@ class Cas2v2OffenderServiceTest {
     fun `returns NotFound result when Probation Offender Search returns 404`() {
       every { mockProbationOffenderSearchClient.searchOffenderByNomsNumber(nomsNumber) } returns StatusCode(HttpMethod.POST, "/search", HttpStatus.NOT_FOUND, null)
 
-      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, nomisUser) is Cas2v2OffenderSearchResult.NotFound).isTrue
+      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber) is Cas2v2OffenderSearchResult.NotFound).isTrue
     }
 
     @Test
@@ -71,7 +71,7 @@ class Cas2v2OffenderServiceTest {
         emptyList(),
       )
 
-      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, nomisUser) is Cas2v2OffenderSearchResult.NotFound).isTrue
+      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber) is Cas2v2OffenderSearchResult.NotFound).isTrue
     }
 
     @Test
@@ -104,14 +104,14 @@ class Cas2v2OffenderServiceTest {
         body = inmateDetail,
       )
 
-      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, nomisUser) is Cas2v2OffenderSearchResult.Success).isTrue
+      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber) is Cas2v2OffenderSearchResult.Success).isTrue
     }
 
     @Test
     fun `returns Unknown if Probation Offender Search responds with a 500`() {
       every { mockProbationOffenderSearchClient.searchOffenderByNomsNumber(nomsNumber) } returns StatusCode(HttpMethod.GET, "/search", HttpStatus.INTERNAL_SERVER_ERROR, null, true)
 
-      val result = cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, nomisUser)
+      val result = cas2v2OffenderService.getPersonByNomsNumber(nomsNumber)
 
       assertThat(result is Cas2v2OffenderSearchResult.Unknown).isTrue
       result as Cas2v2OffenderSearchResult.Unknown
@@ -140,7 +140,7 @@ class Cas2v2OffenderServiceTest {
         null,
       )
 
-      val result = cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, nomisUser)
+      val result = cas2v2OffenderService.getPersonByNomsNumber(nomsNumber)
 
       assertThat(result is Cas2v2OffenderSearchResult.NotFound).isTrue
     }
@@ -175,7 +175,7 @@ class Cas2v2OffenderServiceTest {
         body = inmateDetail,
       )
 
-      val result = cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, nomisUser)
+      val result = cas2v2OffenderService.getPersonByNomsNumber(nomsNumber)
 
       assertThat(result is Cas2v2OffenderSearchResult.Success.Full).isTrue
       result as Cas2v2OffenderSearchResult.Success.Full
@@ -326,23 +326,13 @@ class Cas2v2OffenderServiceTest {
     }
 
     @Test
-    fun `Check a nomis user searching by crn cannot view an offender with a currentRestriction`() {
-      assertThat(cas2v2OffenderService.getPersonByCrn(crn, nomisUser) is Cas2v2OffenderSearchResult.Forbidden).isTrue
+    fun `Check searching by crn cannot view an offender with a currentRestriction`() {
+      assertThat(cas2v2OffenderService.getPersonByCrn(crn) is Cas2v2OffenderSearchResult.Forbidden).isTrue
     }
 
     @Test
-    fun `Check a nomis user searching by nomis cannot view an offender with a currentRestriction`() {
-      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, nomisUser) is Cas2v2OffenderSearchResult.Forbidden).isTrue
-    }
-
-    @Test
-    fun `Check a delius user searching by crn cannot view an offender with a currentRestriction`() {
-      assertThat(cas2v2OffenderService.getPersonByCrn(crn, deliusUser) is Cas2v2OffenderSearchResult.Forbidden).isTrue
-    }
-
-    @Test
-    fun `Check a delius user searching by nomis cannot view an offender with a currentRestriction`() {
-      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, deliusUser) is Cas2v2OffenderSearchResult.Forbidden).isTrue
+    fun `Check searching by nomis cannot view an offender with a currentRestriction`() {
+      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber) is Cas2v2OffenderSearchResult.Forbidden).isTrue
     }
   }
 
@@ -399,23 +389,13 @@ class Cas2v2OffenderServiceTest {
     }
 
     @Test
-    fun `Check a nomis user searching by crn can view an offender with a currentExclusion`() {
-      assertThat(cas2v2OffenderService.getPersonByCrn(crn, nomisUser) is Cas2v2OffenderSearchResult.Success.Full).isTrue
+    fun `Check searching by crn can view an offender with a currentExclusion`() {
+      assertThat(cas2v2OffenderService.getPersonByCrn(crn) is Cas2v2OffenderSearchResult.Success.Full).isTrue
     }
 
     @Test
-    fun `Check a nomis user searching by nomis can view an offender with a currentExclusion`() {
-      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, nomisUser) is Cas2v2OffenderSearchResult.Success.Full).isTrue
-    }
-
-    @Test
-    fun `Check a delius user searching by crn can view an offender with a currentExclusion`() {
-      assertThat(cas2v2OffenderService.getPersonByCrn(crn, deliusUser) is Cas2v2OffenderSearchResult.Success.Full).isTrue
-    }
-
-    @Test
-    fun `Check a delius user searching by nomis can view an offender with a currentExclusion`() {
-      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber, deliusUser) is Cas2v2OffenderSearchResult.Success.Full).isTrue
+    fun `Check searching by nomis can view an offender with a currentExclusion`() {
+      assertThat(cas2v2OffenderService.getPersonByNomsNumber(nomsNumber) is Cas2v2OffenderSearchResult.Success.Full).isTrue
     }
   }
 }


### PR DESCRIPTION
feat: remove exclusion restriction globally in cas2 bail