### PR TITLE
Use internal enum for PlacementRequest Ap Type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
@@ -26,7 +26,8 @@ data class PlacementRequirementsEntity(
   @Id
   val id: UUID,
   val gender: Gender,
-  val apType: ApType,
+
+  val apType: JpaApType,
 
   @ManyToOne
   @JoinColumn(name = "postcode_district_id")
@@ -60,3 +61,19 @@ data class PlacementRequirementsEntity(
 
   val createdAt: OffsetDateTime,
 )
+
+// Do not re-order these elements as we currently use ordinal enum mapping in hibernate
+// (i.e. they're persisted as index numbers, not enum name strings)
+enum class JpaApType(val apiType: ApType) {
+  NORMAL(ApType.normal),
+  PIPE(ApType.pipe),
+  ESAP(ApType.esap),
+  RFAP(ApType.rfap),
+  MHAP_ST_JOSEPHS(ApType.mhapStJosephs),
+  MHAP_ELLIOT_HOUSE(ApType.mhapElliottHouse),
+  ;
+
+  companion object {
+    fun fromApiType(apiType: ApType) = entries.first { it.apiType == apiType }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
@@ -25,8 +25,7 @@ interface PlacementRequirementsRepository : JpaRepository<PlacementRequirementsE
 data class PlacementRequirementsEntity(
   @Id
   val id: UUID,
-  val gender: Gender,
-
+  val gender: JpaGender,
   val apType: JpaApType,
 
   @ManyToOne
@@ -75,5 +74,17 @@ enum class JpaApType(val apiType: ApType) {
 
   companion object {
     fun fromApiType(apiType: ApType) = entries.first { it.apiType == apiType }
+  }
+}
+
+// Do not re-order these elements as we currently use ordinal enum mapping in hibernate
+// (i.e. they're persisted as index numbers, not enum name strings)
+enum class JpaGender(val apiType: Gender) {
+  MALE(Gender.male),
+  FEMALE(Gender.female),
+  ;
+
+  companion object {
+    fun fromApiType(apiType: Gender) = entries.first { it.apiType == apiType }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequirementsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequirementsService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostcodeDistrictRepository
@@ -40,7 +41,7 @@ class Cas1PlacementRequirementsService(
     val placementRequirementsEntity = placementRequirementsRepository.save(
       PlacementRequirementsEntity(
         id = UUID.randomUUID(),
-        apType = requirements.type,
+        apType = JpaApType.fromApiType(requirements.type),
         gender = requirements.gender,
         postcodeDistrict = postcodeDistrict,
         radius = requirements.radius,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequirementsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequirementsService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostcodeDistrictRepository
@@ -42,7 +43,7 @@ class Cas1PlacementRequirementsService(
       PlacementRequirementsEntity(
         id = UUID.randomUUID(),
         apType = JpaApType.fromApiType(requirements.type),
-        gender = requirements.gender,
+        gender = JpaGender.fromApiType(requirements.gender),
         postcodeDistrict = postcodeDistrict,
         radius = requirements.radius,
         desirableCriteria = desirableCriteria,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -32,7 +32,7 @@ class PlacementRequestTransformer(
 
   fun transformJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult): PlacementRequest = PlacementRequest(
     id = jpa.id,
-    gender = jpa.placementRequirements.gender,
+    gender = jpa.placementRequirements.gender.apiType,
     type = jpa.placementRequirements.apType.apiType,
     expectedArrival = jpa.expectedArrival,
     duration = jpa.duration,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -33,7 +33,7 @@ class PlacementRequestTransformer(
   fun transformJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult): PlacementRequest = PlacementRequest(
     id = jpa.id,
     gender = jpa.placementRequirements.gender,
-    type = jpa.placementRequirements.apType,
+    type = jpa.placementRequirements.apType.apiType,
     expectedArrival = jpa.expectedArrival,
     duration = jpa.duration,
     location = jpa.placementRequirements.postcodeDistrict.outcode,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
@@ -2,11 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistrictEntity
 import java.time.OffsetDateTime
@@ -16,7 +16,7 @@ class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> 
 
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var gender: Yielded<Gender> = { Gender.male }
-  private var apType: Yielded<ApType> = { ApType.normal }
+  private var apType: Yielded<JpaApType> = { JpaApType.NORMAL }
   private var postcodeDistrict: Yielded<PostCodeDistrictEntity> = { PostCodeDistrictEntityFactory().produce() }
   private var application: Yielded<ApprovedPremisesApplicationEntity>? = null
   private var assessment: Yielded<ApprovedPremisesAssessmentEntity>? = null
@@ -38,7 +38,7 @@ class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> 
     this.application = { application }
   }
 
-  fun withApType(apType: ApType) = apply {
+  fun withApType(apType: JpaApType) = apply {
     this.apType = { apType }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
@@ -2,11 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistrictEntity
 import java.time.OffsetDateTime
@@ -15,7 +15,7 @@ import java.util.UUID
 class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> {
 
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var gender: Yielded<Gender> = { Gender.male }
+  private var gender: Yielded<JpaGender> = { JpaGender.MALE }
   private var apType: Yielded<JpaApType> = { JpaApType.NORMAL }
   private var postcodeDistrict: Yielded<PostCodeDistrictEntity> = { PostCodeDistrictEntityFactory().produce() }
   private var application: Yielded<ApprovedPremisesApplicationEntity>? = null
@@ -64,6 +64,10 @@ class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> 
 
   fun withCreatedAt(createdAt: OffsetDateTime) = apply {
     this.createdAt = { createdAt }
+  }
+
+  fun withGender(gender: JpaGender) = apply {
+    this.gender = { gender }
   }
 
   override fun produce(): PlacementRequirementsEntity = PlacementRequirementsEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -64,6 +64,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus.NOT_STARTED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
@@ -2101,7 +2102,7 @@ class AssessmentTest : IntegrationTestBase() {
               )
 
               val placementRequirements = PlacementRequirements(
-                gender = Gender.male,
+                gender = Gender.female,
                 type = ApType.normal,
                 location = postcodeDistrict.outcode,
                 radius = 50,
@@ -2167,7 +2168,7 @@ class AssessmentTest : IntegrationTestBase() {
               val persistedPlacementRequirements = persistedPlacementRequest.placementRequirements
 
               assertThat(persistedPlacementRequirements.apType).isEqualTo(JpaApType.NORMAL)
-              assertThat(persistedPlacementRequirements.gender).isEqualTo(placementRequirements.gender)
+              assertThat(persistedPlacementRequirements.gender).isEqualTo(JpaGender.FEMALE)
               assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)
               assertThat(persistedPlacementRequirements.radius).isEqualTo(placementRequirements.radius)
 
@@ -2279,7 +2280,7 @@ class AssessmentTest : IntegrationTestBase() {
                 placementRequirementsRepository.findTopByApplicationOrderByCreatedAtDesc(application)!!
 
               assertThat(persistedPlacementRequirements.apType).isEqualTo(JpaApType.NORMAL)
-              assertThat(persistedPlacementRequirements.gender).isEqualTo(placementRequirements.gender)
+              assertThat(persistedPlacementRequirements.gender).isEqualTo(JpaGender.MALE)
               assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)
               assertThat(persistedPlacementRequirements.radius).isEqualTo(placementRequirements.radius)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -63,6 +63,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus.IN_PROGRESS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus.NOT_STARTED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
@@ -2165,7 +2166,7 @@ class AssessmentTest : IntegrationTestBase() {
 
               val persistedPlacementRequirements = persistedPlacementRequest.placementRequirements
 
-              assertThat(persistedPlacementRequirements.apType).isEqualTo(placementRequirements.type)
+              assertThat(persistedPlacementRequirements.apType).isEqualTo(JpaApType.NORMAL)
               assertThat(persistedPlacementRequirements.gender).isEqualTo(placementRequirements.gender)
               assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)
               assertThat(persistedPlacementRequirements.radius).isEqualTo(placementRequirements.radius)
@@ -2277,7 +2278,7 @@ class AssessmentTest : IntegrationTestBase() {
               val persistedPlacementRequirements =
                 placementRequirementsRepository.findTopByApplicationOrderByCreatedAtDesc(application)!!
 
-              assertThat(persistedPlacementRequirements.apType).isEqualTo(placementRequirements.type)
+              assertThat(persistedPlacementRequirements.apType).isEqualTo(JpaApType.NORMAL)
               assertThat(persistedPlacementRequirements.gender).isEqualTo(placementRequirements.gender)
               assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)
               assertThat(persistedPlacementRequirements.radius).isEqualTo(placementRequirements.radius)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS1SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS1SubjectAccessRequestServiceTest.kt
@@ -747,7 +747,7 @@ class CAS1SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
         "application_id": "${placementRequirement.application.id}",
         "assessment_id": "${placementRequirement.assessment.id}",
         "placement_requirements_id": "${placementRequirement.id}",
-        "gender": "${placementRequirement.gender.value.uppercase()}",
+        "gender": "${placementRequirement.gender.name}",
         "ap_type": "${placementRequirement.apType.name}",
         "outcode": "${placementRequirement.postcodeDistrict.outcode}",
         "radius": ${placementRequirement.radius},

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS1SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS1SubjectAccessRequestServiceTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Characteristic
@@ -21,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
@@ -748,7 +748,7 @@ class CAS1SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
         "assessment_id": "${placementRequirement.assessment.id}",
         "placement_requirements_id": "${placementRequirement.id}",
         "gender": "${placementRequirement.gender.value.uppercase()}",
-        "ap_type": "${placementRequirement.apType.value.uppercase()}",
+        "ap_type": "${placementRequirement.apType.name}",
         "outcode": "${placementRequirement.postcodeDistrict.outcode}",
         "radius": ${placementRequirement.radius},
         "created_at": "$CREATED_AT"
@@ -1001,7 +1001,7 @@ class CAS1SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     withApplication(application)
     withAssessment(assessment)
     withCreatedAt(OffsetDateTime.parse(CREATED_AT))
-    withApType(ApType.normal)
+    withApType(JpaApType.NORMAL)
     withDesirableCriteria(listOf(characteristicEntity()))
     withEssentialCriteria(listOf(characteristicEntity()))
     withPostcodeDistrict(postCodeDistrictFactory.produceAndPersist())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
@@ -41,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequire
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
@@ -153,6 +155,7 @@ class PlacementRequestTransformerTest {
           ),
         )
         .withApType(JpaApType.ESAP)
+        .withGender(JpaGender.MALE)
         .produce()
 
       val placementRequestEntity = placementRequestFactory
@@ -168,8 +171,8 @@ class PlacementRequestTransformerTest {
       assertThat(result).isEqualTo(
         PlacementRequest(
           id = placementRequestEntity.id,
-          gender = placementRequirementsEntity.gender,
           type = ApType.esap,
+          gender = Gender.male,
           expectedArrival = placementRequestEntity.expectedArrival,
           duration = placementRequestEntity.duration,
           location = placementRequirementsEntity.postcodeDistrict.outcode,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
@@ -39,6 +40,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
@@ -150,6 +152,7 @@ class PlacementRequestTransformerTest {
             CharacteristicEntityFactory().withPropertyName("somethingElse").produce(),
           ),
         )
+        .withApType(JpaApType.ESAP)
         .produce()
 
       val placementRequestEntity = placementRequestFactory
@@ -166,7 +169,7 @@ class PlacementRequestTransformerTest {
         PlacementRequest(
           id = placementRequestEntity.id,
           gender = placementRequirementsEntity.gender,
-          type = placementRequirementsEntity.apType,
+          type = ApType.esap,
           expectedArrival = placementRequestEntity.expectedArrival,
           duration = placementRequestEntity.duration,
           location = placementRequirementsEntity.postcodeDistrict.outcode,


### PR DESCRIPTION
Before this PR we were using an enum generated from API specs to map `ApType` and `Gender` on `PlacementRequirement`. This is a problem because we’re also using ordinal based mapping in the database, instead of name based mappings. This means if the ordering of the generated enum changes, then subsequent retrievals from the database could be wrong.

This commit doesn’t fix the ordinal mapping issue, but does introduce internal manually created enums with a warning comment making it less likely for the ordering of the enum to be changed.