### PR TITLE
APS-2149 Add specific validation logic and tests for appeals and planned transfers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -31,7 +30,6 @@ class Cas1ChangeRequestService(
   private val cas1ChangeRequestRepository: Cas1ChangeRequestRepository,
   private val placementRequestRepository: PlacementRequestRepository,
   private val cas1ChangeRequestReasonRepository: Cas1ChangeRequestReasonRepository,
-  private val objectMapper: ObjectMapper,
   private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
   private val lockableCas1ChangeRequestEntityRepository: LockableCas1ChangeRequestRepository,
   private val cas1ChangeRequestRejectionReasonRepository: Cas1ChangeRequestRejectionReasonRepository,
@@ -70,7 +68,7 @@ class Cas1ChangeRequestService(
         placementRequest = placementRequest,
         spaceBooking = spaceBooking,
         type = ChangeRequestType.valueOf(cas1NewChangeRequest.type.name),
-        requestJson = objectMapper.writeValueAsString(cas1NewChangeRequest.requestJson),
+        requestJson = cas1NewChangeRequest.requestJson.toString(),
         requestReason = requestReason,
         decisionJson = null,
         decision = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
@@ -50,7 +50,16 @@ class Cas1ChangeRequestService(
     if (!placementRequest.spaceBookings.contains(spaceBooking)) return CasResult.NotFound("Placement Request with Space Booking", spaceBooking.id.toString())
 
     if (cas1NewChangeRequest.type == Cas1ChangeRequestType.PLANNED_TRANSFER) {
-      spaceBooking.actualArrivalDate ?: return CasResult.GeneralValidationError("Associated space booking does not have an actual arrival date")
+      if (!spaceBooking.hasArrival()) return CasResult.GeneralValidationError("Associated space booking has not been marked as arrived")
+      if (spaceBooking.hasNonArrival()) return CasResult.GeneralValidationError("Associated space booking has been marked as non arrived")
+      if (spaceBooking.hasDeparted()) return CasResult.GeneralValidationError("Associated space booking has been marked as departed")
+      if (spaceBooking.isCancelled()) return CasResult.GeneralValidationError("Associated space booking has been cancelled")
+    }
+
+    if (cas1NewChangeRequest.type == Cas1ChangeRequestType.PLACEMENT_APPEAL) {
+      if (spaceBooking.hasArrival()) return CasResult.GeneralValidationError("Associated space booking has been marked as arrived")
+      if (spaceBooking.hasNonArrival()) return CasResult.GeneralValidationError("Associated space booking has been marked as non arrived")
+      if (spaceBooking.isCancelled()) return CasResult.GeneralValidationError("Associated space booking has been cancelled")
     }
 
     val now = OffsetDateTime.now()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
@@ -160,7 +160,7 @@ class Cas1ChangeRequestTest {
             .bodyValue(
               Cas1NewChangeRequest(
                 type = Cas1ChangeRequestType.PLACEMENT_APPEAL,
-                requestJson = "{test: 1}",
+                requestJson = "{}",
                 reasonId = changeRequestReason.id,
                 spaceBookingId = spaceBooking.id,
               ),
@@ -171,7 +171,7 @@ class Cas1ChangeRequestTest {
 
           val persistedChangeRequest = cas1ChangeRequestRepository.findAll()[0]
           assertThat(persistedChangeRequest.type).isEqualTo(ChangeRequestType.PLACEMENT_APPEAL)
-          assertThat(persistedChangeRequest.requestJson).isEqualTo("\"{test: 1}\"")
+          assertThat(persistedChangeRequest.requestJson).isEqualTo("{}")
           assertThat(persistedChangeRequest.requestReason).isEqualTo(changeRequestReason)
           assertThat(persistedChangeRequest.spaceBooking.id).isEqualTo(spaceBooking.id)
         }
@@ -200,7 +200,7 @@ class Cas1ChangeRequestTest {
             .bodyValue(
               Cas1NewChangeRequest(
                 type = Cas1ChangeRequestType.PLANNED_TRANSFER,
-                requestJson = "{test: 1}",
+                requestJson = "{}",
                 reasonId = changeRequestReason.id,
                 spaceBookingId = spaceBooking.id,
               ),
@@ -211,7 +211,7 @@ class Cas1ChangeRequestTest {
 
           val persistedChangeRequest = cas1ChangeRequestRepository.findAll()[0]
           assertThat(persistedChangeRequest.type).isEqualTo(ChangeRequestType.PLANNED_TRANSFER)
-          assertThat(persistedChangeRequest.requestJson).isEqualTo("\"{test: 1}\"")
+          assertThat(persistedChangeRequest.requestJson).isEqualTo("{}")
           assertThat(persistedChangeRequest.requestReason).isEqualTo(changeRequestReason)
           assertThat(persistedChangeRequest.spaceBooking.id).isEqualTo(spaceBooking.id)
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestServiceTest.kt
@@ -45,7 +45,6 @@ class Cas1ChangeRequestServiceTest {
     cas1ChangeRequestRepository,
     placementRequestRepository,
     cas1ChangeRequestReasonRepository,
-    objectMapper,
     cas1SpaceBookingRepository,
     lockableCas1ChangeRequestEntityRepository,
     cas1ChangeRequestRejectionReasonRepository,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Lockable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class Cas1ChangeRequestServiceTest {
@@ -192,7 +193,7 @@ class Cas1ChangeRequestServiceTest {
     }
 
     @Test
-    fun `throws general validation error when space booking has null actual arrival date`() {
+    fun `throws general validation error when space booking has null actual arrival date for planned transfer`() {
       val cas1SpaceBooking = Cas1SpaceBookingEntityFactory().produce()
       val placementRequest = PlacementRequestEntityFactory()
         .withDefaults()
@@ -214,8 +215,179 @@ class Cas1ChangeRequestServiceTest {
 
       val result = service.createChangeRequest(placementRequest.id, cas1NewChangeRequest)
 
-      assertThatCasResult(result).isGeneralValidationError("Associated space booking does not have an actual arrival date")
+      assertThatCasResult(result).isGeneralValidationError("Associated space booking has not been marked as arrived")
     }
+  }
+
+  @Test
+  fun `throws general validation error when space booking has non null non_arrival_confirmed_at for planned transfer`() {
+    val cas1SpaceBooking = Cas1SpaceBookingEntityFactory()
+      .withActualArrivalDate(LocalDate.now())
+      .withNonArrivalConfirmedAt(OffsetDateTime.now().toInstant())
+      .produce()
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .withSpaceBookings(mutableListOf(cas1SpaceBooking))
+      .produce()
+    val cas1ChangeRequestReason = Cas1ChangeRequestReasonEntityFactory().produce()
+
+    val cas1NewChangeRequest = Cas1NewChangeRequestFactory()
+      .withType(Cas1ChangeRequestType.PLANNED_TRANSFER)
+      .withReasonId(cas1ChangeRequestReason.id)
+      .withSpaceBookingId(cas1SpaceBooking.id)
+      .produce()
+
+    every { placementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
+    every { cas1ChangeRequestReasonRepository.findByIdOrNull(cas1ChangeRequestReason.id) } returns cas1ChangeRequestReason
+    every { cas1SpaceBookingRepository.findByIdOrNull(cas1SpaceBooking.id) } returns cas1SpaceBooking
+    every { objectMapper.writeValueAsString(cas1NewChangeRequest.requestJson) } returns "{test: 1}"
+    every { cas1ChangeRequestRepository.save(any()) } returns null
+
+    val result = service.createChangeRequest(placementRequest.id, cas1NewChangeRequest)
+
+    assertThatCasResult(result).isGeneralValidationError("Associated space booking has been marked as non arrived")
+  }
+
+  @Test
+  fun `throws general validation error when space booking has non null actual_departure_date for planned transfer`() {
+    val cas1SpaceBooking = Cas1SpaceBookingEntityFactory()
+      .withActualArrivalDate(LocalDate.now())
+      .withActualDepartureDate(LocalDate.now())
+      .produce()
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .withSpaceBookings(mutableListOf(cas1SpaceBooking))
+      .produce()
+    val cas1ChangeRequestReason = Cas1ChangeRequestReasonEntityFactory().produce()
+
+    val cas1NewChangeRequest = Cas1NewChangeRequestFactory()
+      .withType(Cas1ChangeRequestType.PLANNED_TRANSFER)
+      .withReasonId(cas1ChangeRequestReason.id)
+      .withSpaceBookingId(cas1SpaceBooking.id)
+      .produce()
+
+    every { placementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
+    every { cas1ChangeRequestReasonRepository.findByIdOrNull(cas1ChangeRequestReason.id) } returns cas1ChangeRequestReason
+    every { cas1SpaceBookingRepository.findByIdOrNull(cas1SpaceBooking.id) } returns cas1SpaceBooking
+    every { objectMapper.writeValueAsString(cas1NewChangeRequest.requestJson) } returns "{test: 1}"
+    every { cas1ChangeRequestRepository.save(any()) } returns null
+
+    val result = service.createChangeRequest(placementRequest.id, cas1NewChangeRequest)
+
+    assertThatCasResult(result).isGeneralValidationError("Associated space booking has been marked as departed")
+  }
+
+  @Test
+  fun `throws general validation error when space booking has non null cancellation_occurred_at for planned transfer`() {
+    val cas1SpaceBooking = Cas1SpaceBookingEntityFactory()
+      .withActualArrivalDate(LocalDate.now())
+      .withCancellationOccurredAt(LocalDate.now())
+      .produce()
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .withSpaceBookings(mutableListOf(cas1SpaceBooking))
+      .produce()
+    val cas1ChangeRequestReason = Cas1ChangeRequestReasonEntityFactory().produce()
+
+    val cas1NewChangeRequest = Cas1NewChangeRequestFactory()
+      .withType(Cas1ChangeRequestType.PLANNED_TRANSFER)
+      .withReasonId(cas1ChangeRequestReason.id)
+      .withSpaceBookingId(cas1SpaceBooking.id)
+      .produce()
+
+    every { placementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
+    every { cas1ChangeRequestReasonRepository.findByIdOrNull(cas1ChangeRequestReason.id) } returns cas1ChangeRequestReason
+    every { cas1SpaceBookingRepository.findByIdOrNull(cas1SpaceBooking.id) } returns cas1SpaceBooking
+    every { objectMapper.writeValueAsString(cas1NewChangeRequest.requestJson) } returns "{test: 1}"
+    every { cas1ChangeRequestRepository.save(any()) } returns null
+
+    val result = service.createChangeRequest(placementRequest.id, cas1NewChangeRequest)
+
+    assertThatCasResult(result).isGeneralValidationError("Associated space booking has been cancelled")
+  }
+
+  @Test
+  fun `throws general validation error when space booking has non null actual arrival date for appeal`() {
+    val cas1SpaceBooking = Cas1SpaceBookingEntityFactory()
+      .withActualArrivalDate(LocalDate.now())
+      .produce()
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .withSpaceBookings(mutableListOf(cas1SpaceBooking))
+      .produce()
+    val cas1ChangeRequestReason = Cas1ChangeRequestReasonEntityFactory().produce()
+
+    val cas1NewChangeRequest = Cas1NewChangeRequestFactory()
+      .withType(Cas1ChangeRequestType.PLACEMENT_APPEAL)
+      .withReasonId(cas1ChangeRequestReason.id)
+      .withSpaceBookingId(cas1SpaceBooking.id)
+      .produce()
+
+    every { placementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
+    every { cas1ChangeRequestReasonRepository.findByIdOrNull(cas1ChangeRequestReason.id) } returns cas1ChangeRequestReason
+    every { cas1SpaceBookingRepository.findByIdOrNull(cas1SpaceBooking.id) } returns cas1SpaceBooking
+    every { objectMapper.writeValueAsString(cas1NewChangeRequest.requestJson) } returns "{test: 1}"
+    every { cas1ChangeRequestRepository.save(any()) } returns null
+
+    val result = service.createChangeRequest(placementRequest.id, cas1NewChangeRequest)
+
+    assertThatCasResult(result).isGeneralValidationError("Associated space booking has been marked as arrived")
+  }
+
+  @Test
+  fun `throws general validation error when space booking has non null non_arrival_confirmed_at for appeal`() {
+    val cas1SpaceBooking = Cas1SpaceBookingEntityFactory()
+      .withNonArrivalConfirmedAt(OffsetDateTime.now().toInstant())
+      .produce()
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .withSpaceBookings(mutableListOf(cas1SpaceBooking))
+      .produce()
+    val cas1ChangeRequestReason = Cas1ChangeRequestReasonEntityFactory().produce()
+
+    val cas1NewChangeRequest = Cas1NewChangeRequestFactory()
+      .withType(Cas1ChangeRequestType.PLACEMENT_APPEAL)
+      .withReasonId(cas1ChangeRequestReason.id)
+      .withSpaceBookingId(cas1SpaceBooking.id)
+      .produce()
+
+    every { placementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
+    every { cas1ChangeRequestReasonRepository.findByIdOrNull(cas1ChangeRequestReason.id) } returns cas1ChangeRequestReason
+    every { cas1SpaceBookingRepository.findByIdOrNull(cas1SpaceBooking.id) } returns cas1SpaceBooking
+    every { objectMapper.writeValueAsString(cas1NewChangeRequest.requestJson) } returns "{test: 1}"
+    every { cas1ChangeRequestRepository.save(any()) } returns null
+
+    val result = service.createChangeRequest(placementRequest.id, cas1NewChangeRequest)
+
+    assertThatCasResult(result).isGeneralValidationError("Associated space booking has been marked as non arrived")
+  }
+
+  @Test
+  fun `throws general validation error when space booking has non null cancellation_occurred_at for appeal`() {
+    val cas1SpaceBooking = Cas1SpaceBookingEntityFactory()
+      .withCancellationOccurredAt(LocalDate.now())
+      .produce()
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .withSpaceBookings(mutableListOf(cas1SpaceBooking))
+      .produce()
+    val cas1ChangeRequestReason = Cas1ChangeRequestReasonEntityFactory().produce()
+
+    val cas1NewChangeRequest = Cas1NewChangeRequestFactory()
+      .withType(Cas1ChangeRequestType.PLACEMENT_APPEAL)
+      .withReasonId(cas1ChangeRequestReason.id)
+      .withSpaceBookingId(cas1SpaceBooking.id)
+      .produce()
+
+    every { placementRequestRepository.findByIdOrNull(placementRequest.id) } returns placementRequest
+    every { cas1ChangeRequestReasonRepository.findByIdOrNull(cas1ChangeRequestReason.id) } returns cas1ChangeRequestReason
+    every { cas1SpaceBookingRepository.findByIdOrNull(cas1SpaceBooking.id) } returns cas1SpaceBooking
+    every { objectMapper.writeValueAsString(cas1NewChangeRequest.requestJson) } returns "{test: 1}"
+    every { cas1ChangeRequestRepository.save(any()) } returns null
+
+    val result = service.createChangeRequest(placementRequest.id, cas1NewChangeRequest)
+
+    assertThatCasResult(result).isGeneralValidationError("Associated space booking has been cancelled")
   }
 
   @Nested


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2149

**Planned transfer specific logic:**

A planned transfer cannot be created (and must return an error) in the following scenarios:

- booking has not been marked as arrived
- booking has been marked as non arrived
- booking has been marked as departed
- booking has been cancelled

**Appeal specific logic:**

An appeal cannot be created and must return an error in the following scenarios:

- booking has been marked as arrived
- booking has been marked as non arrived
- booking has been cancelled