### PR TITLE
CAS-1501 CAS3 Occupancy report to include bedspaces without created at date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -34,7 +34,7 @@ interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
     WHERE
       p.service = 'temporary-accommodation'
       AND (CAST(:probationRegionId AS UUID) IS NULL OR p.probation_region_id = :probationRegionId)
-      AND (b.created_at <= :endDate AND (b.end_date IS NULL OR b.end_date >= :startDate))
+      AND ((b.created_at IS NULL OR b.created_at <= :endDate) AND (b.end_date IS NULL OR b.end_date >= :startDate))
     ORDER BY b.name      
     """,
     nativeQuery = true,


### PR DESCRIPTION
This [PR CAS-1501](https://dsdmoj.atlassian.net/browse/CAS-1501) is to include the bedspaces without created at date in the occupancy report