### PR TITLE
APS-2154 Add DomainEventType.emittable config

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/DomainEventUrlConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/DomainEventUrlConfig.kt
@@ -46,7 +46,7 @@ class DomainEventUrlConfig {
       DomainEventType.CAS3_REFERRAL_SUBMITTED -> cas3["referral-submitted-event-detail"]
       DomainEventType.CAS3_PERSON_DEPARTURE_UPDATED -> cas3["person-departure-updated-event-detail"]
       DomainEventType.CAS3_BOOKING_CANCELLED_UPDATED -> cas3["booking-cancelled-updated-event-detail"]
-      else -> throw IllegalArgumentException("Don't emit for $domainEventType")
+      else -> throw IllegalArgumentException("Cannot resolve a domain event URL for $domainEventType")
     } ?: throw IllegalStateException("Missing URL for $domainEventType")
 
     return template.resolve("eventId", eventId.toString())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -211,6 +211,7 @@ enum class DomainEventType(
     Cas1EventType.applicationExpired.value,
     "An Approved Premises application has expired",
     Cas1TimelineEventType.applicationExpired,
+    emittable = false,
   ),
   APPROVED_PREMISES_BOOKING_MADE(
     DomainEventCas.CAS1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -280,6 +280,7 @@ enum class DomainEventType(
     Cas1EventType.bookingKeyWorkerAssigned.value,
     "A keyworker has been assigned to the booking",
     Cas1TimelineEventType.bookingKeyworkerAssigned,
+    emittable = false,
   ),
   APPROVED_PREMISES_APPLICATION_WITHDRAWN(
     DomainEventCas.CAS1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -183,6 +183,12 @@ enum class DomainEventType(
   val typeDescription: String,
   val cas1TimelineEventType: Cas1TimelineEventType? = null,
   val schemaVersions: List<DomainEventSchemaVersion> = listOf(DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION),
+  /**
+   * If this domain event can be considered to be emitted.
+   *
+   * Logic around emitting domain events is different for each CAS. This field is currently only used by CAS1
+   */
+  val emittable: Boolean = true,
 ) {
   APPROVED_PREMISES_APPLICATION_SUBMITTED(
     DomainEventCas.CAS1,
@@ -321,6 +327,7 @@ enum class DomainEventType(
     Cas1EventType.requestForPlacementCreated.value,
     "An Approved Premises Request for Placement has been created",
     Cas1TimelineEventType.requestForPlacementCreated,
+    emittable = false,
   ),
   APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED(
     DomainEventCas.CAS1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -97,7 +97,7 @@ class Cas1AssessmentDomainEventService(
     )
   }
 
-  fun furtherInformationRequested(assessment: AssessmentEntity, clarificationNoteEntity: AssessmentClarificationNoteEntity, emit: Boolean = true) {
+  fun furtherInformationRequested(assessment: AssessmentEntity, clarificationNoteEntity: AssessmentClarificationNoteEntity) {
     val requesterStaffDetails = when (val result = apDeliusContextApiClient.getStaffDetail(clarificationNoteEntity.createdByUser.deliusUsername)) {
       is ClientResult.Success -> result.body
       is ClientResult.Failure -> result.throwException()
@@ -141,7 +141,7 @@ class Cas1AssessmentDomainEventService(
       data = data,
     )
 
-    domainEventService.saveFurtherInformationRequestedEvent(domainEvent, emit)
+    domainEventService.saveFurtherInformationRequestedEvent(domainEvent)
   }
 
   fun assessmentAccepted(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementDomainEventService.kt
@@ -235,7 +235,6 @@ class Cas1SpaceBookingManagementDomainEventService(
     val eventNumber = updatedCas1SpaceBooking.deliusEventNumber!!
 
     domainEventService.saveKeyWorkerAssignedEvent(
-      emit = false,
       domainEvent = DomainEvent(
         id = domainEventId,
         applicationId = applicationId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -305,16 +305,16 @@ class Cas1DomainEventService(
   private fun emit(
     domainEvent: DomainEventEntity,
   ) {
-    if (!emitDomainEventsEnabled) {
-      log.info("Not emitting SNS event for domain event because domain-events.cas1.emit-enabled is not enabled")
-      return
-    }
-
     val eventType = domainEvent.type
     val typeName = eventType.typeName
 
     if (!eventType.emittable) {
       sentryService.captureErrorMessage("An attempt was made to emit domain event ${domainEvent.id} of type $typeName which is not emittable")
+      return
+    }
+
+    if (!emitDomainEventsEnabled) {
+      log.info("Not emitting SNS event for domain event because domain-events.cas1.emit-enabled is not enabled")
       return
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -251,10 +251,9 @@ class Cas1DomainEventService(
   )
 
   @Transactional
-  fun saveKeyWorkerAssignedEvent(domainEvent: DomainEvent<BookingKeyWorkerAssignedEnvelope>, emit: Boolean) = saveAndEmit(
+  fun saveKeyWorkerAssignedEvent(domainEvent: DomainEvent<BookingKeyWorkerAssignedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED,
-    emit = emit,
   )
 
   fun getAllDomainEventsForApplication(applicationId: UUID) = getAllDomainEventsById(applicationId = applicationId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -231,12 +231,10 @@ class Cas1DomainEventService(
   fun saveApplicationExpiredEvent(
     domainEvent: DomainEvent<ApplicationExpiredEnvelope>,
     triggerSource: TriggerSourceType,
-    emit: Boolean,
   ) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED,
     triggerSource = triggerSource,
-    emit = emit,
   )
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -245,10 +245,9 @@ class Cas1DomainEventService(
   )
 
   @Transactional
-  fun saveFurtherInformationRequestedEvent(domainEvent: DomainEvent<FurtherInformationRequestedEnvelope>, emit: Boolean = true) = saveAndEmit(
+  fun saveFurtherInformationRequestedEvent(domainEvent: DomainEvent<FurtherInformationRequestedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
-    emit = emit,
   )
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -89,7 +89,6 @@ class Cas1PlacementApplicationDomainEventService(
           eventDetails = eventDetails,
         ),
       ),
-      emit = false,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
@@ -76,7 +76,6 @@ class Cas1PlacementRequestDomainEventService(
           eventDetails = eventDetails,
         ),
       ),
-      emit = false,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
@@ -68,7 +68,6 @@ class Cas1ExpiredApplicationsScheduledJob(
             ),
           ),
           triggerSource = TriggerSourceType.SYSTEM,
-          emit = false,
         )
         log.info("Domain event id $domainEventId emitted for application $applicationId.")
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/DailyMetricsReportGeneratorTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.DailyMetricsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventMigrationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
@@ -44,6 +45,7 @@ class DailyMetricsReportGeneratorTest {
     false,
     mockk<DomainEventUrlConfig>(),
     mockk<Cas1DomainEventMigrationService>(),
+    mockk<SentryService>(),
   )
 
   private val dates = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -11,9 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.NullSource
-import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedAssessedBy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedEnvelope
@@ -401,10 +398,8 @@ class Cas1AssessmentDomainEventServiceTest {
       clearAllMocks()
     }
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(booleans = [true, false])
-    fun `it raises a Further Information Requested Domain Event`(emit: Boolean?) {
+    @Test
+    fun `it raises a Further Information Requested Domain Event`() {
       val assessment = createAssessment()
       val clarificationNoteEntity = AssessmentClarificationNoteEntityFactory()
         .withAssessment(assessment)
@@ -427,17 +422,8 @@ class Cas1AssessmentDomainEventServiceTest {
         recipientStaffDetails,
       )
 
-      val emitValue: Boolean
-
-      if (emit !== null) {
-        emitValue = emit
-        every { domainEventService.saveFurtherInformationRequestedEvent(any(), emit) } just Runs
-        service.furtherInformationRequested(assessment, clarificationNoteEntity, emit)
-      } else {
-        emitValue = true
-        every { domainEventService.saveFurtherInformationRequestedEvent(any(), true) } just Runs
-        service.furtherInformationRequested(assessment, clarificationNoteEntity)
-      }
+      every { domainEventService.saveFurtherInformationRequestedEvent(any()) } just Runs
+      service.furtherInformationRequested(assessment, clarificationNoteEntity)
 
       verify(exactly = 1) {
         domainEventService.saveFurtherInformationRequestedEvent(
@@ -470,7 +456,6 @@ class Cas1AssessmentDomainEventServiceTest {
 
             rootDomainEventDataMatches && envelopeMatches && eventDetailsMatch && requesterUserDetailsMatch && recipientUserDetailsMatch
           },
-          emitValue,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementDomainEventServiceTest.kt
@@ -426,7 +426,7 @@ class Cas1BookingManagementDomainEventServiceTest {
 
     @BeforeEach
     fun before() {
-      every { domainEventService.saveKeyWorkerAssignedEvent(any(), any()) } just Runs
+      every { domainEventService.saveKeyWorkerAssignedEvent(any()) } just Runs
 
       every { offenderService.getPersonSummaryInfoResults(any(), any()) } returns
         listOf(PersonSummaryInfoResult.Success.Full("THEBOOKINGCRN", caseSummary))
@@ -453,7 +453,6 @@ class Cas1BookingManagementDomainEventServiceTest {
       verify(exactly = 1) {
         domainEventService.saveKeyWorkerAssignedEvent(
           capture(domainEventArgument),
-          emit = false,
         )
       }
 
@@ -485,7 +484,6 @@ class Cas1BookingManagementDomainEventServiceTest {
       verify(exactly = 1) {
         domainEventService.saveKeyWorkerAssignedEvent(
           capture(domainEventArgument),
-          emit = false,
         )
       }
 
@@ -515,7 +513,6 @@ class Cas1BookingManagementDomainEventServiceTest {
       verify(exactly = 1) {
         domainEventService.saveKeyWorkerAssignedEvent(
           capture(domainEventArgument),
-          emit = false,
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -740,9 +740,8 @@ class Cas1DomainEventServiceTest {
       }
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `saveBookingKeyWorkerAssignedEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
+    @Test
+    fun `saveBookingKeyWorkerAssignedEvent sends correct arguments to saveAndEmit`() {
       val id = UUID.randomUUID()
 
       val eventDetails = BookingKeyWorkerAssignedFactory().produce()
@@ -757,13 +756,12 @@ class Cas1DomainEventServiceTest {
 
       every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
-      domainEventServiceSpy.saveKeyWorkerAssignedEvent(domainEvent, emit)
+      domainEventServiceSpy.saveKeyWorkerAssignedEvent(domainEvent)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED,
-          emit,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -812,16 +812,13 @@ class Cas1DomainEventServiceTest {
 
       every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
 
-      val emit = false
-
-      domainEventServiceSpy.saveApplicationExpiredEvent(domainEvent, TriggerSourceType.SYSTEM, emit)
+      domainEventServiceSpy.saveApplicationExpiredEvent(domainEvent, TriggerSourceType.SYSTEM)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED,
           triggerSource = TriggerSourceType.SYSTEM,
-          emit = emit,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -1006,9 +1006,8 @@ class Cas1DomainEventServiceTest {
       }
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `saveFurtherInformationRequestedEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
+    @Test
+    fun `saveFurtherInformationRequestedEvent sends correct arguments to saveAndEmit`() {
       val id = UUID.randomUUID()
 
       val eventDetails = FurtherInformationRequestedFactory().produce()
@@ -1021,15 +1020,14 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
-      domainEventServiceSpy.saveFurtherInformationRequestedEvent(domainEvent, emit)
+      domainEventServiceSpy.saveFurtherInformationRequestedEvent(domainEvent)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
-          emit = emit,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationCas1DomainEventServiceTest.kt
@@ -105,7 +105,7 @@ class Cas1PlacementApplicationCas1DomainEventServiceTest {
       )
 
       val staffMember = staffUserDetails.toStaffMember()
-      every { domainEventService.saveRequestForPlacementCreatedEvent(any(), any()) } returns Unit
+      every { domainEventService.saveRequestForPlacementCreatedEvent(any()) } returns Unit
 
       service.placementApplicationSubmitted(placementApplication, USERNAME)
 
@@ -131,7 +131,6 @@ class Cas1PlacementApplicationCas1DomainEventServiceTest {
             assertThat(eventDetails.duration).isEqualTo(7)
             assertThat(eventDetails.requestForPlacementType).isEqualTo(expectedRequestForPlacementType)
           },
-          emit = false,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestCas1DomainEventServiceTest.kt
@@ -103,7 +103,7 @@ class Cas1PlacementRequestCas1DomainEventServiceTest {
 
     @Test
     fun `if source is application assessment, create a domain event`() {
-      every { domainEventService.saveRequestForPlacementCreatedEvent(any(), any()) } returns Unit
+      every { domainEventService.saveRequestForPlacementCreatedEvent(any()) } returns Unit
 
       service.placementRequestCreated(
         placementRequest = placementRequest,
@@ -132,7 +132,6 @@ class Cas1PlacementRequestCas1DomainEventServiceTest {
             assertThat(eventDetails.duration).isEqualTo(7)
             assertThat(eventDetails.requestForPlacementType).isEqualTo(RequestForPlacementType.initial)
           },
-          emit = false,
         )
       }
     }


### PR DESCRIPTION
This commit adds a new boolean property `DomainEventType.emittable` used to indicate if any domain events of this type are emittable. This is currently only used by CAS1.

This commit updates the logic in `Cas1DomainEventService` to observe this logic and updates `APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED.emittable` to false, to give us a domain event type to use in our tests.

Subsequent commits will set `emittable` to true for all domain event types that are never currently emitted