### PR TITLE
APS-2156 Add day specific assessment auto allocation configuration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1CruManagementAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1CruManagementAreaEntity.kt
@@ -1,7 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapKeyColumn
+import jakarta.persistence.MapKeyEnumerated
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
@@ -25,8 +33,32 @@ data class Cas1CruManagementAreaEntity(
   var emailAddress: String?,
   val notifyReplyToEmailId: String?,
   var assessmentAutoAllocationUsername: String?,
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+    name = "cas1_cru_management_area_auto_allocations",
+    joinColumns = [JoinColumn(name = "cas1_cru_management_area_id")],
+  )
+  /**
+   * The delius username that should be used for assessment
+   * auto allocation on a given day. If a day isn't defined,
+   * an assessment cannot be auto allocated
+   */
+  @MapKeyEnumerated(EnumType.STRING)
+  @MapKeyColumn(name = "day")
+  @Column(name = "delius_username")
+  var assessmentAutoAllocations: MutableMap<AutoAllocationDay, String>,
 ) {
   companion object {
     val WOMENS_ESTATE_ID = UUID.fromString("bfb04c2a-1954-4512-803d-164f7fcf252c")
   }
+}
+
+enum class AutoAllocationDay {
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY,
+  SUNDAY,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1CruManagementAreaSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1CruManagementAreaSeedJob.kt
@@ -3,10 +3,37 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AutoAllocationDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedColumns
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapOfNonNullValues
 import java.util.UUID
 
+/*
+To generate a baseline CSV for this seed job, use the following and export it as CSV
+
+select
+cru.id as id,
+cru.name as current_name,
+cru.email_address as email_address,
+cru.assessment_auto_allocation_username   as assessment_auto_allocation_username,
+mon.delius_username as assessment_auto_allocation_monday,
+tue.delius_username as assessment_auto_allocation_tuesday,
+wed.delius_username as assessment_auto_allocation_wednesday,
+thu.delius_username as assessment_auto_allocation_thursday,
+fri.delius_username as assessment_auto_allocation_friday,
+sat.delius_username as assessment_auto_allocation_saturday,
+sun.delius_username as assessment_auto_allocation_sunday
+from cas1_cru_management_areas cru
+left outer join cas1_cru_management_area_auto_allocations mon on mon.cas1_cru_management_area_id = cru.id and mon."day" = 'MONDAY'
+left outer join cas1_cru_management_area_auto_allocations tue on tue.cas1_cru_management_area_id = cru.id and tue."day" = 'TUESDAY'
+left outer join cas1_cru_management_area_auto_allocations wed on wed.cas1_cru_management_area_id = cru.id and wed."day" = 'WEDNESDAY'
+left outer join cas1_cru_management_area_auto_allocations thu on thu.cas1_cru_management_area_id = cru.id and thu."day" = 'THURSDAY'
+left outer join cas1_cru_management_area_auto_allocations fri on fri.cas1_cru_management_area_id = cru.id and fri."day" = 'FRIDAY'
+left outer join cas1_cru_management_area_auto_allocations sat on sat.cas1_cru_management_area_id = cru.id and sat."day" = 'SATURDAY'
+left outer join cas1_cru_management_area_auto_allocations sun on sun.cas1_cru_management_area_id = cru.id and sun."day" = 'SUNDAY'
+ */
 @Component
 class Cas1CruManagementAreaSeedJob(
   private val cas1CruManagementAreaRepository: Cas1CruManagementAreaRepository,
@@ -16,16 +43,34 @@ class Cas1CruManagementAreaSeedJob(
     "current_name",
     "email_address",
     "assessment_auto_allocation_username",
+    "assessment_auto_allocation_monday",
+    "assessment_auto_allocation_tuesday",
+    "assessment_auto_allocation_wednesday",
+    "assessment_auto_allocation_thursday",
+    "assessment_auto_allocation_friday",
+    "assessment_auto_allocation_saturday",
+    "assessment_auto_allocation_sunday",
   ),
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun deserializeRow(columns: Map<String, String>) = CruManagementAreaSeedCsvRow(
-    id = UUID.fromString(columns["id"]!!.trim()),
-    currentName = columns["current_name"]!!.trim(),
-    emailAddress = columns["email_address"]!!.trim(),
-    assessmentAutoAllocationUsername = columns["assessment_auto_allocation_username"]!!.trim(),
-  )
+  override fun deserializeRow(columns: Map<String, String>): CruManagementAreaSeedCsvRow {
+    val seedColumns = SeedColumns(columns)
+
+    return CruManagementAreaSeedCsvRow(
+      id = seedColumns.getUuidOrNull("id")!!,
+      currentName = seedColumns.getStringOrNull("current_name")!!,
+      emailAddress = seedColumns.getStringOrNull("email_address"),
+      assessmentAutoAllocationUsername = seedColumns.getStringOrNull("assessment_auto_allocation_username"),
+      assessmentAutoAllocationMonday = seedColumns.getStringOrNull("assessment_auto_allocation_monday"),
+      assessmentAutoAllocationTuesday = seedColumns.getStringOrNull("assessment_auto_allocation_tuesday"),
+      assessmentAutoAllocationWednesday = seedColumns.getStringOrNull("assessment_auto_allocation_wednesday"),
+      assessmentAutoAllocationThursday = seedColumns.getStringOrNull("assessment_auto_allocation_thursday"),
+      assessmentAutoAllocationFriday = seedColumns.getStringOrNull("assessment_auto_allocation_friday"),
+      assessmentAutoAllocationSaturday = seedColumns.getStringOrNull("assessment_auto_allocation_saturday"),
+      assessmentAutoAllocationSunday = seedColumns.getStringOrNull("assessment_auto_allocation_sunday"),
+    )
+  }
 
   override fun processRow(row: CruManagementAreaSeedCsvRow) {
     val id = row.id
@@ -37,13 +82,27 @@ class Cas1CruManagementAreaSeedJob(
       error("Not updating entry for '$id' as current name '$currentName' in seed file doesn't match actual name '${managementArea.name}'")
     }
 
-    val emailAddress = row.emailAddress.ifBlank { null }
-    val autoAlloc = row.assessmentAutoAllocationUsername.ifBlank { null }
+    val emailAddress = row.emailAddress?.ifBlank { null }
+    val autoAlloc = row.assessmentAutoAllocationUsername?.ifBlank { null }
 
     val before = managementArea.copy()
 
     managementArea.emailAddress = emailAddress
     managementArea.assessmentAutoAllocationUsername = autoAlloc
+
+    managementArea.assessmentAutoAllocations.clear()
+    managementArea.assessmentAutoAllocations.putAll(
+      mapOfNonNullValues(
+        AutoAllocationDay.MONDAY to row.assessmentAutoAllocationMonday,
+        AutoAllocationDay.TUESDAY to row.assessmentAutoAllocationTuesday,
+        AutoAllocationDay.WEDNESDAY to row.assessmentAutoAllocationWednesday,
+        AutoAllocationDay.THURSDAY to row.assessmentAutoAllocationThursday,
+        AutoAllocationDay.FRIDAY to row.assessmentAutoAllocationFriday,
+        AutoAllocationDay.SATURDAY to row.assessmentAutoAllocationSaturday,
+        AutoAllocationDay.SUNDAY to row.assessmentAutoAllocationSunday,
+      ) as Map<AutoAllocationDay, String>,
+    )
+
     cas1CruManagementAreaRepository.save(managementArea)
 
     log.info("Management are was $before, is now $managementArea")
@@ -53,6 +112,13 @@ class Cas1CruManagementAreaSeedJob(
 data class CruManagementAreaSeedCsvRow(
   val id: UUID,
   val currentName: String,
-  val emailAddress: String,
-  val assessmentAutoAllocationUsername: String,
+  val emailAddress: String?,
+  val assessmentAutoAllocationUsername: String?,
+  val assessmentAutoAllocationMonday: String?,
+  val assessmentAutoAllocationTuesday: String?,
+  val assessmentAutoAllocationWednesday: String?,
+  val assessmentAutoAllocationThursday: String?,
+  val assessmentAutoAllocationFriday: String?,
+  val assessmentAutoAllocationSaturday: String?,
+  val assessmentAutoAllocationSunday: String?,
 )

--- a/src/main/resources/db/migration/all/20250327095253__add_cas1_cru_management_area_auto_allocation.sql
+++ b/src/main/resources/db/migration/all/20250327095253__add_cas1_cru_management_area_auto_allocation.sql
@@ -1,0 +1,9 @@
+CREATE TABLE cas1_cru_management_area_auto_allocations (
+    cas1_cru_management_area_id uuid NOT NULL,
+    "day" text NOT NULL,
+    delius_username text NOT NULL,
+    CONSTRAINT cas1_cru_management_area_auto_allocations_pk PRIMARY KEY (cas1_cru_management_area_id, "day"),
+    CONSTRAINT cas1_cru_management_area_auto_allocations_unique UNIQUE (cas1_cru_management_area_id,"day"),
+    CONSTRAINT cas1_cru_management_area_auto_allocations_check CHECK (day = 'MONDAY' OR day = 'TUESDAY' OR day = 'WEDNESDAY' OR day = 'THURSDAY' OR day = 'FRIDAY' OR day = 'SATURDAY' OR day = 'SUNDAY'),
+	CONSTRAINT cas1_cru_management_area_auto_allocations_cas1_cru_management_areas_fk FOREIGN KEY (cas1_cru_management_area_id) REFERENCES cas1_cru_management_areas(id)
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1CruManagementAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1CruManagementAreaEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AutoAllocationDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
@@ -13,6 +14,7 @@ class Cas1CruManagementAreaEntityFactory : Factory<Cas1CruManagementAreaEntity> 
   private var emailAddress: Yielded<String?> = { randomStringUpperCase(10) }
   private var notifyReplyToEmailId: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var assessmentAutoAllocationUsername: Yielded<String?> = { null }
+  private var assessmentAutoAllocations: Yielded<MutableMap<AutoAllocationDay, String>> = { mutableMapOf() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -34,11 +36,16 @@ class Cas1CruManagementAreaEntityFactory : Factory<Cas1CruManagementAreaEntity> 
     this.assessmentAutoAllocationUsername = { assessmentAutoAllocationUsername }
   }
 
+  fun withAssessmentAutoAllocations(assessmentAutoAllocations: MutableMap<AutoAllocationDay, String>) = apply {
+    this.assessmentAutoAllocations = { assessmentAutoAllocations }
+  }
+
   override fun produce() = Cas1CruManagementAreaEntity(
     id = this.id(),
     name = this.name(),
     emailAddress = this.emailAddress(),
     notifyReplyToEmailId = this.notifyReplyToEmailId(),
     assessmentAutoAllocationUsername = this.assessmentAutoAllocationUsername(),
+    assessmentAutoAllocations = this.assessmentAutoAllocations(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CruManagementAreaTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1CruManagementAreaTest.kt
@@ -8,6 +8,7 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AutoAllocationDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.CruManagementAreaSeedCsvRow
 import java.util.UUID
@@ -25,6 +26,17 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
         .withName("Existing Name")
         .withEmailAddress("exisdtingEmail@here.com")
         .withAssessmentAutoAllocationUsername("existingUserName")
+        .withAssessmentAutoAllocations(
+          mutableMapOf(
+            AutoAllocationDay.MONDAY to "old monday",
+            AutoAllocationDay.TUESDAY to "old tuesday",
+            AutoAllocationDay.WEDNESDAY to "old wednesday",
+            AutoAllocationDay.THURSDAY to "old thursday",
+            AutoAllocationDay.FRIDAY to "old friday",
+            AutoAllocationDay.SATURDAY to "old saturday",
+            AutoAllocationDay.SUNDAY to "old sunday",
+          ),
+        )
         .produce(),
     ).id
   }
@@ -41,6 +53,13 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
           currentName = "doesnt matter",
           emailAddress = "doesnt matter",
           assessmentAutoAllocationUsername = "doesnt matter",
+          assessmentAutoAllocationMonday = "doesnt matter",
+          assessmentAutoAllocationTuesday = "doesnt matter",
+          assessmentAutoAllocationWednesday = "doesnt matter",
+          assessmentAutoAllocationThursday = "doesnt matter",
+          assessmentAutoAllocationFriday = "doesnt matter",
+          assessmentAutoAllocationSaturday = "doesnt matter",
+          assessmentAutoAllocationSunday = "doesnt matter",
         ),
       ).toCsv(),
     )
@@ -65,6 +84,13 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
           currentName = "Wrong Name",
           emailAddress = "doesnt matter",
           assessmentAutoAllocationUsername = "doesnt matter",
+          assessmentAutoAllocationMonday = "doesnt matter",
+          assessmentAutoAllocationTuesday = "doesnt matter",
+          assessmentAutoAllocationWednesday = "doesnt matter",
+          assessmentAutoAllocationThursday = "doesnt matter",
+          assessmentAutoAllocationFriday = "doesnt matter",
+          assessmentAutoAllocationSaturday = "doesnt matter",
+          assessmentAutoAllocationSunday = "doesnt matter",
         ),
       ).toCsv(),
     )
@@ -89,6 +115,13 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
           currentName = "Existing Name",
           emailAddress = "updated@test.com",
           assessmentAutoAllocationUsername = "updated delius username",
+          assessmentAutoAllocationMonday = "username mon",
+          assessmentAutoAllocationTuesday = "username tue",
+          assessmentAutoAllocationWednesday = "username wed",
+          assessmentAutoAllocationThursday = "username thu",
+          assessmentAutoAllocationFriday = "username fri",
+          assessmentAutoAllocationSaturday = "username sat",
+          assessmentAutoAllocationSunday = "username sun",
         ),
       ).toCsv(),
     )
@@ -97,10 +130,22 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
 
     assertThat(updatedArea.emailAddress).isEqualTo("updated@test.com")
     assertThat(updatedArea.assessmentAutoAllocationUsername).isEqualTo("updated delius username")
+
+    assertThat(updatedArea.assessmentAutoAllocations).isEqualTo(
+      mapOf(
+        AutoAllocationDay.MONDAY to "username mon",
+        AutoAllocationDay.TUESDAY to "username tue",
+        AutoAllocationDay.WEDNESDAY to "username wed",
+        AutoAllocationDay.THURSDAY to "username thu",
+        AutoAllocationDay.FRIDAY to "username fri",
+        AutoAllocationDay.SATURDAY to "username sat",
+        AutoAllocationDay.SUNDAY to "username sun",
+      ),
+    )
   }
 
   @Test
-  fun `Updating cru management area with null values correctly`() {
+  fun `Updating cru management area with null values removes configuration`() {
     seed(
       SeedFileType.approvedPremisesCruManagementAreas,
       contents = listOf(
@@ -109,6 +154,13 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
           currentName = "Existing Name",
           emailAddress = "   ",
           assessmentAutoAllocationUsername = "  ",
+          assessmentAutoAllocationMonday = "",
+          assessmentAutoAllocationTuesday = "still something here",
+          assessmentAutoAllocationWednesday = " ",
+          assessmentAutoAllocationThursday = "",
+          assessmentAutoAllocationFriday = "and here",
+          assessmentAutoAllocationSaturday = "",
+          assessmentAutoAllocationSunday = "",
         ),
       ).toCsv(),
     )
@@ -117,6 +169,12 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
 
     assertThat(updatedArea.emailAddress).isNull()
     assertThat(updatedArea.assessmentAutoAllocationUsername).isNull()
+    assertThat(updatedArea.assessmentAutoAllocations).isEqualTo(
+      mapOf(
+        AutoAllocationDay.TUESDAY to "still something here",
+        AutoAllocationDay.FRIDAY to "and here",
+      ),
+    )
   }
 
   private fun List<CruManagementAreaSeedCsvRow>.toCsv(): String {
@@ -126,6 +184,13 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
         "current_name",
         "email_address",
         "assessment_auto_allocation_username",
+        "assessment_auto_allocation_monday",
+        "assessment_auto_allocation_tuesday",
+        "assessment_auto_allocation_wednesday",
+        "assessment_auto_allocation_thursday",
+        "assessment_auto_allocation_friday",
+        "assessment_auto_allocation_saturday",
+        "assessment_auto_allocation_sunday",
       )
       .newRow()
 
@@ -133,8 +198,15 @@ class SeedCas1CruManagementAreaTest : SeedTestBase() {
       builder
         .withQuotedField(it.id)
         .withQuotedField(it.currentName)
-        .withQuotedField(it.emailAddress)
-        .withQuotedField(it.assessmentAutoAllocationUsername)
+        .withQuotedField(it.emailAddress ?: "")
+        .withQuotedField(it.assessmentAutoAllocationUsername ?: "")
+        .withQuotedField(it.assessmentAutoAllocationMonday ?: "")
+        .withQuotedField(it.assessmentAutoAllocationTuesday ?: "")
+        .withQuotedField(it.assessmentAutoAllocationWednesday ?: "")
+        .withQuotedField(it.assessmentAutoAllocationThursday ?: "")
+        .withQuotedField(it.assessmentAutoAllocationFriday ?: "")
+        .withQuotedField(it.assessmentAutoAllocationSaturday ?: "")
+        .withQuotedField(it.assessmentAutoAllocationSunday ?: "")
         .newRow()
     }
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-2156

This commit updates the `Cas1CruManagementAreaEntity` to include day specific assessment allocation configuration. This is not currently used by code.

Once these allocations are used by the code, the existing `assessment_auto_allocation_username` value will be removed.