### PR TITLE
APS-2156 Use day-specific assessment auto allocation config

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1CruManagementAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1CruManagementAreaEntity.kt
@@ -32,6 +32,7 @@ data class Cas1CruManagementAreaEntity(
   var name: String,
   var emailAddress: String?,
   val notifyReplyToEmailId: String?,
+  @Deprecated("We now us assessmentAutoAllocations")
   var assessmentAutoAllocationUsername: String?,
   @ElementCollection(fetch = FetchType.LAZY)
   @CollectionTable(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1CruManagementAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1CruManagementAreaEntityFactory.kt
@@ -32,6 +32,7 @@ class Cas1CruManagementAreaEntityFactory : Factory<Cas1CruManagementAreaEntity> 
     this.notifyReplyToEmailId = { notifyReplyToEmailId }
   }
 
+  @Deprecated("We now use assessmentAutoAllocations")
   fun withAssessmentAutoAllocationUsername(assessmentAutoAllocationUsername: String?) = apply {
     this.assessmentAutoAllocationUsername = { assessmentAutoAllocationUsername }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationTest.kt
@@ -73,6 +73,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AutoAllocationDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
@@ -94,6 +95,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsListOfObjects
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationStatus as ApiApprovedPremisesApplicationStatus
@@ -2185,10 +2187,17 @@ class ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Submit emergency application auto allocates the assessment, sends emails and raises domain events`() {
+      // Thursday
+      clock.setNow(LocalDateTime.parse("2025-03-27T10:15:30"))
+
       val (submittingUser, jwt) = givenAUser(
         probationRegion = givenAProbationRegion(
           apArea = givenAnApArea(
-            defaultCruManagementArea = givenACas1CruManagementArea(assessmentAutoAllocationUsername = "DEFAULT_LONDON_ASSESSOR"),
+            defaultCruManagementArea = givenACas1CruManagementArea(
+              assessmentAutoAllocations = mutableMapOf(
+                AutoAllocationDay.THURSDAY to "DEFAULT_LONDON_ASSESSOR",
+              ),
+            ),
           ),
         ),
       )
@@ -2291,6 +2300,9 @@ class ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Submit short notice application auto allocates the assessment according to overridden ap area, sends emails and raises domain events`() {
+      // Sunday
+      clock.setNow(LocalDateTime.parse("2025-03-30T10:15:30"))
+
       val (submittingUser, jwt) = givenAUser()
 
       val (assessorUser, _) = givenAUser(
@@ -2320,7 +2332,9 @@ class ApplicationTest : IntegrationTestBase() {
       val overriddenApArea = givenAnApArea(
         name = "wales",
         defaultCruManagementArea = givenACas1CruManagementArea(
-          assessmentAutoAllocationUsername = "DEFAULT_WALES_ASSESSOR",
+          assessmentAutoAllocations = mutableMapOf(
+            AutoAllocationDay.SUNDAY to "DEFAULT_WALES_ASSESSOR",
+          ),
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1CruManagementArea.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1CruManagementArea.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AutoAllocationDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 
 fun IntegrationTestBase.givenACas1CruManagementArea(
   assessmentAutoAllocationUsername: String? = null,
+  assessmentAutoAllocations: MutableMap<AutoAllocationDay, String> = mutableMapOf(),
 ): Cas1CruManagementAreaEntity = cas1CruManagementAreaEntityFactory.produceAndPersist {
   withAssessmentAutoAllocationUsername(assessmentAutoAllocationUsername)
+  withAssessmentAutoAllocations(assessmentAutoAllocations)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/MutableClockConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/MutableClockConfiguration.kt
@@ -24,8 +24,8 @@ class MutableClockConfiguration {
     clock.reset()
   }
 
-  class MutableClock : Clock() {
-    var fixedTime: Instant? = null
+  class MutableClock(time: Instant? = null) : Clock() {
+    var fixedTime: Instant? = time
 
     fun reset() = run { fixedTime = null }
 


### PR DESCRIPTION
**Do not merge this until the updated configuration has been applied in production**

This commit changes the emergency and short notice automatic assessment allocation logic to use the day-specific allocation configuration.

This commit deprecates the old allocation configuration. This will be removed once this change has gone live without any issues