### PR TITLE
APS-2168 - Add placement_request_id to domain_events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -120,6 +120,8 @@ data class DomainEventEntity(
   val bookingId: UUID?,
   @Column(name = "cas1_space_booking_id")
   val cas1SpaceBookingId: UUID?,
+  @Column(name = "cas1_placement_request_id")
+  val cas1PlacementRequestId: UUID?,
   val crn: String,
   @Enumerated(value = EnumType.STRING)
   val type: DomainEventType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -10,6 +10,7 @@ data class DomainEvent<T>(
   val assessmentId: UUID? = null,
   val bookingId: UUID? = null,
   val cas1SpaceBookingId: UUID? = null,
+  val cas1PlacementRequestId: UUID? = null,
   val crn: String,
   val nomsNumber: String?,
   val occurredAt: Instant,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -136,6 +136,7 @@ class Cas1BookingDomainEventService(
         metadata = mapOfNonNullValues(
           MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequest.id.toString(),
         ),
+        cas1PlacementRequestId = placementRequest.id,
       ),
     )
   }
@@ -384,6 +385,7 @@ class Cas1BookingDomainEventService(
         metadata = mapOfNonNullValues(
           MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequestId?.toString(),
         ),
+        cas1PlacementRequestId = placementRequestId,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -276,6 +276,7 @@ class Cas1DomainEventService(
         assessmentId = domainEvent.assessmentId,
         bookingId = domainEvent.bookingId,
         cas1SpaceBookingId = domainEvent.cas1SpaceBookingId,
+        cas1PlacementRequestId = domainEvent.cas1PlacementRequestId,
         crn = domainEvent.crn,
         type = eventType,
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2DomainEventService.kt
@@ -95,6 +95,7 @@ class Cas2DomainEventService(
         assessmentId = domainEvent.assessmentId,
         bookingId = domainEvent.bookingId,
         cas1SpaceBookingId = domainEvent.cas1SpaceBookingId,
+        cas1PlacementRequestId = domainEvent.cas1PlacementRequestId,
         crn = domainEvent.crn,
         nomsNumber = domainEvent.nomsNumber,
         type = enumTypeFromDataType(domainEvent.data::class),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3DomainEventService.kt
@@ -233,6 +233,7 @@ class Cas3DomainEventService(
         triggerSource = triggerSourceType,
         schemaVersion = domainEvent.schemaVersion,
         cas1SpaceBookingId = domainEvent.cas1SpaceBookingId,
+        cas1PlacementRequestId = domainEvent.cas1PlacementRequestId,
       ),
     )
 

--- a/src/main/resources/db/migration/all/20250328142746__add_cas1_placement_request_id_to_domain_event.sql
+++ b/src/main/resources/db/migration/all/20250328142746__add_cas1_placement_request_id_to_domain_event.sql
@@ -1,0 +1,3 @@
+ALTER TABLE domain_events ADD cas1_placement_request_id UUID NULL;
+ALTER TABLE domain_events ADD FOREIGN KEY (cas1_placement_request_id) REFERENCES placement_requests(id);
+CREATE INDEX domain_events_cas1_placement_request_id_idx ON domain_events (cas1_placement_request_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -21,6 +21,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var assessmentId: Yielded<UUID?> = { null }
   private var bookingId: Yielded<UUID?> = { null }
   private var cas1SpaceBookingId: Yielded<UUID?> = { null }
+  private var cas1PlacementRequestId: Yielded<UUID?> = { null }
   private var crn: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var type: Yielded<DomainEventType> = { DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
   private var occurredAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
@@ -130,5 +131,6 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     metadata = this.metadata(),
     schemaVersion = this.schemaVersion(),
     cas1SpaceBookingId = this.cas1SpaceBookingId(),
+    cas1PlacementRequestId = this.cas1PlacementRequestId(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
@@ -148,6 +148,7 @@ class Cas1BookingCas1DomainEventServiceTest {
       assertThat(domainEvent.crn).isEqualTo("THEBOOKINGCRN")
       assertThat(domainEvent.bookingId).isNull()
       assertThat(domainEvent.cas1SpaceBookingId).isEqualTo(spaceBooking.id)
+      assertThat(domainEvent.cas1PlacementRequestId).isEqualTo(placementRequest.id)
       assertThat(domainEvent.occurredAt).isEqualTo(createdAt.toInstant())
       assertThat(domainEvent.data.eventType).isEqualTo(EventType.bookingMade)
       assertThat(domainEvent.data.timestamp).isEqualTo(createdAt.toInstant())
@@ -266,6 +267,7 @@ class Cas1BookingCas1DomainEventServiceTest {
       assertThat(domainEvent.crn).isEqualTo("THEBOOKINGCRN")
       assertThat(domainEvent.bookingId).isEqualTo(booking.id)
       assertThat(domainEvent.cas1SpaceBookingId).isNull()
+      assertThat(domainEvent.cas1PlacementRequestId).isEqualTo(placementRequest.id)
       assertThat(domainEvent.occurredAt).isEqualTo(createdAt.toInstant())
       assertThat(domainEvent.data.eventType).isEqualTo(EventType.bookingMade)
       assertThat(domainEvent.data.timestamp).isEqualTo(createdAt.toInstant())
@@ -558,6 +560,7 @@ class Cas1BookingCas1DomainEventServiceTest {
       assertThat(domainEvent.applicationId).isEqualTo(application.id)
       assertThat(domainEvent.crn).isEqualTo("Application CRN")
       assertThat(domainEvent.data.eventType).isEqualTo(EventType.bookingNotMade)
+      assertThat(domainEvent.cas1PlacementRequestId).isEqualTo(placementRequest.id)
 
       val data = domainEvent.data.eventDetails
       assertThat(data.applicationId).isEqualTo(application.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -280,6 +280,8 @@ class Cas1DomainEventServiceTest {
       val id = UUID.randomUUID()
       val applicationId = UUID.randomUUID()
       val bookingId = UUID.randomUUID()
+      val cas1SpaceBookingId = UUID.randomUUID()
+      val cas1PlacementRequestId = UUID.randomUUID()
       val crn = "CRN"
       val nomsNumber = "123"
       val occurredAt = Instant.now()
@@ -295,6 +297,8 @@ class Cas1DomainEventServiceTest {
         occurredAt = occurredAt,
         data = domainEventAndJson.envelope,
         bookingId = bookingId,
+        cas1SpaceBookingId = cas1SpaceBookingId,
+        cas1PlacementRequestId = cas1PlacementRequestId,
         schemaVersion = domainEventAndJson.schemaVersion.versionNo,
       )
 
@@ -311,6 +315,8 @@ class Cas1DomainEventServiceTest {
             assertThat(it.data).isEqualTo(domainEventAndJson.persistedJson)
             assertThat(it.triggeredByUserId).isEqualTo(user.id)
             assertThat(it.bookingId).isEqualTo(bookingId)
+            assertThat(it.cas1SpaceBookingId).isEqualTo(cas1SpaceBookingId)
+            assertThat(it.cas1PlacementRequestId).isEqualTo(cas1PlacementRequestId)
           },
         )
       }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-2168

With the introduction of cas1 change requests it’s likely we’ll need a way to group domain events relates to a given placement requuest. We currently use Domain Event Meta data to do this reporting, but it’s not an efficient way to query the data.

This commit adds a new indexed column `domain_events.cas1_placement_requests` to resolve these issues