### PR TITLE
APS-2154 Simplify CAS1 domain event persistence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -19,4 +19,5 @@ data class DomainEvent<T>(
   val metadata: Map<MetaDataName, String?> = emptyMap(),
   val schemaVersion: Int? = null,
   val triggerSource: TriggerSourceType? = null,
+  val emit: Boolean = true,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEvent.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import java.time.Instant
 import java.util.UUID
 
@@ -17,4 +18,5 @@ data class DomainEvent<T>(
   val data: T,
   val metadata: Map<MetaDataName, String?> = emptyMap(),
   val schemaVersion: Int? = null,
+  val triggerSource: TriggerSourceType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -134,8 +134,8 @@ class Cas1ApplicationDomainEventService(
           eventType = EventType.applicationWithdrawn,
           eventDetails = getApplicationWithdrawn(application, withdrawingUser, eventOccurredAt),
         ),
+        emit = application.isSubmitted(),
       ),
-      emit = application.isSubmitted(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -72,6 +72,7 @@ class Cas1AssessmentDomainEventService(
         crn = assessment.application.crn,
         nomsNumber = assessment.application.nomsNumber,
         occurredAt = occurredAt,
+        triggerSource = triggerSource,
         data = AssessmentAllocatedEnvelope(
           id = id,
           timestamp = occurredAt,
@@ -93,7 +94,6 @@ class Cas1AssessmentDomainEventService(
           ),
         ),
       ),
-      triggerSource,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -228,20 +228,15 @@ class Cas1DomainEventService(
   )
 
   @Transactional
-  fun saveApplicationExpiredEvent(
-    domainEvent: DomainEvent<ApplicationExpiredEnvelope>,
-    triggerSource: TriggerSourceType,
-  ) = saveAndEmit(
+  fun saveApplicationExpiredEvent(domainEvent: DomainEvent<ApplicationExpiredEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED,
-    triggerSource = triggerSource,
   )
 
   @Transactional
-  fun saveAssessmentAllocatedEvent(domainEvent: DomainEvent<AssessmentAllocatedEnvelope>, triggerSource: TriggerSourceType) = saveAndEmit(
+  fun saveAssessmentAllocatedEvent(domainEvent: DomainEvent<AssessmentAllocatedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
-    triggerSource = triggerSource,
   )
 
   @Transactional
@@ -267,7 +262,6 @@ class Cas1DomainEventService(
     domainEvent: DomainEvent<*>,
     eventType: DomainEventType,
     emit: Boolean = true,
-    triggerSource: TriggerSourceType? = null,
   ) {
     val domainEventEntity = domainEventRepository.save(
       DomainEventEntity(
@@ -283,7 +277,7 @@ class Cas1DomainEventService(
         createdAt = OffsetDateTime.now(),
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS1",
-        triggerSource = triggerSource,
+        triggerSource = domainEvent.triggerSource,
         triggeredByUserId = userService.getUserForRequestOrNull()?.id,
         nomsNumber = domainEvent.nomsNumber,
         metadata = domainEvent.metadata,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlCon
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
@@ -185,10 +184,9 @@ class Cas1DomainEventService(
   )
 
   @Transactional
-  fun saveApplicationWithdrawnEvent(domainEvent: DomainEvent<ApplicationWithdrawnEnvelope>, emit: Boolean) = saveAndEmit(
+  fun saveApplicationWithdrawnEvent(domainEvent: DomainEvent<ApplicationWithdrawnEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
-    emit = emit,
   )
 
   @Transactional
@@ -261,7 +259,6 @@ class Cas1DomainEventService(
   fun saveAndEmit(
     domainEvent: DomainEvent<*>,
     eventType: DomainEventType,
-    emit: Boolean = true,
   ) {
     val domainEventEntity = domainEventRepository.save(
       DomainEventEntity(
@@ -285,8 +282,10 @@ class Cas1DomainEventService(
       ),
     )
 
-    if (eventType.emittable && emit) {
+    if (eventType.emittable && domainEvent.emit) {
       emit(domainEventEntity)
+    } else {
+      log.debug("Not emitting domain event of type $eventType. Type emittable? ${eventType.emittable}. Emit? ${domainEvent.emit}")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
@@ -66,8 +66,8 @@ class Cas1ExpiredApplicationsScheduledJob(
               eventType = EventType.applicationExpired,
               eventDetails = applicationExpired,
             ),
+            triggerSource = TriggerSourceType.SYSTEM,
           ),
-          triggerSource = TriggerSourceType.SYSTEM,
         )
         log.info("Domain event id $domainEventId emitted for application $applicationId.")
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
@@ -296,7 +296,7 @@ class Cas1ApplicationCas1DomainEventServiceTest {
     ) {
       val domainEventWithdrawnBy = WithdrawnByFactory().produce()
       every { mockDomainEventTransformer.toWithdrawnBy(user) } returns domainEventWithdrawnBy
-      every { mockDomainEventService.saveApplicationWithdrawnEvent(any(), any()) } just Runs
+      every { mockDomainEventService.saveApplicationWithdrawnEvent(any()) } just Runs
 
       service.applicationWithdrawn(application, user)
 
@@ -305,7 +305,8 @@ class Cas1ApplicationCas1DomainEventServiceTest {
           match {
             val data = it.data.eventDetails
 
-            it.applicationId == application.id &&
+            it.emit == emitted &&
+              it.applicationId == application.id &&
               it.crn == application.crn &&
               it.nomsNumber == application.nomsNumber &&
               data.applicationId == application.id &&
@@ -318,7 +319,6 @@ class Cas1ApplicationCas1DomainEventServiceTest {
               data.withdrawalReason == "alternative_identified_placement_no_longer_required" &&
               data.otherWithdrawalReason == "the other reason"
           },
-          emit = emitted,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -112,7 +112,7 @@ class Cas1AssessmentDomainEventServiceTest {
         allocatingUserStaffDetails,
       )
 
-      every { domainEventService.saveAssessmentAllocatedEvent(any(), any()) } just Runs
+      every { domainEventService.saveAssessmentAllocatedEvent(any()) } just Runs
 
       service.assessmentAllocated(assessment, assigneeUser, allocatingUser)
 
@@ -120,6 +120,8 @@ class Cas1AssessmentDomainEventServiceTest {
         domainEventService.saveAssessmentAllocatedEvent(
           match {
             val envelope = it.data
+            val triggerSourceMatches = it.triggerSource == TriggerSourceType.USER
+
             val eventDetails = envelope.eventDetails
 
             val rootDomainEventDataMatches = (
@@ -145,11 +147,7 @@ class Cas1AssessmentDomainEventServiceTest {
                 allocatedByUserDetailsMatch
               )
 
-            rootDomainEventDataMatches && envelopeMatches && eventDetailsMatch
-          },
-          match {
-            val triggerSource = it
-            triggerSource == TriggerSourceType.USER
+            triggerSourceMatches && rootDomainEventDataMatches && envelopeMatches && eventDetailsMatch
           },
         )
       }
@@ -163,7 +161,7 @@ class Cas1AssessmentDomainEventServiceTest {
         assigneeUserStaffDetails,
       )
 
-      every { domainEventService.saveAssessmentAllocatedEvent(any(), any()) } just Runs
+      every { domainEventService.saveAssessmentAllocatedEvent(any()) } just Runs
 
       service.assessmentAllocated(assessment, assigneeUser, allocatingUser = null)
 
@@ -171,8 +169,8 @@ class Cas1AssessmentDomainEventServiceTest {
         domainEventService.saveAssessmentAllocatedEvent(
           withArg {
             assertThat(it.data.eventDetails.allocatedBy).isNull()
+            assertThat(it.triggerSource).isEqualTo(TriggerSourceType.SYSTEM)
           },
-          TriggerSourceType.SYSTEM,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpiredEnvelope
@@ -236,7 +235,7 @@ class Cas1DomainEventServiceTest {
 
       every { domainEventWorkerMock.emitEvent(any(), any()) } returns Unit
 
-      domainEventService.saveAndEmit(domainEventToSave, type, true)
+      domainEventService.saveAndEmit(domainEventToSave, type)
 
       verify(exactly = 1) {
         domainEventRepositoryMock.save(
@@ -278,7 +277,7 @@ class Cas1DomainEventServiceTest {
 
     @ParameterizedTest
     @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1DomainEventServiceTest#allCas1DomainEventTypes")
-    fun `saveAndEmit persists event and does not emit event if emit is false`(type: DomainEventType) {
+    fun `saveAndEmit persists event and does not emit event if emit on domain event is false`(type: DomainEventType) {
       val id = UUID.randomUUID()
       val applicationId = UUID.randomUUID()
       val bookingId = UUID.randomUUID()
@@ -302,9 +301,10 @@ class Cas1DomainEventServiceTest {
         cas1SpaceBookingId = cas1SpaceBookingId,
         cas1PlacementRequestId = cas1PlacementRequestId,
         schemaVersion = domainEventAndJson.schemaVersion.versionNo,
+        emit = false,
       )
 
-      domainEventService.saveAndEmit(domainEventToSave, type, false)
+      domainEventService.saveAndEmit(domainEventToSave, type)
 
       verify(exactly = 1) {
         domainEventRepositoryMock.save(
@@ -399,7 +399,7 @@ class Cas1DomainEventServiceTest {
       )
 
       try {
-        domainEventService.saveAndEmit(domainEventToSave, type, true)
+        domainEventService.saveAndEmit(domainEventToSave, type)
       } catch (_: Exception) {
       }
 
@@ -527,7 +527,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveApplicationSubmittedDomainEvent(domainEvent)
 
@@ -553,7 +553,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveApplicationAssessedDomainEvent(domainEvent)
 
@@ -579,7 +579,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveBookingMadeDomainEvent(domainEvent)
 
@@ -631,7 +631,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.savePersonNotArrivedEvent(domainEvent)
 
@@ -639,7 +639,6 @@ class Cas1DomainEventServiceTest {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
-          emit = true,
         )
       }
     }
@@ -684,7 +683,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveBookingNotMadeEvent(domainEvent)
 
@@ -710,7 +709,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveBookingCancelledEvent(domainEvent)
 
@@ -736,7 +735,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveBookingChangedEvent(domainEvent)
 
@@ -762,7 +761,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveKeyWorkerAssignedEvent(domainEvent)
 
@@ -774,9 +773,8 @@ class Cas1DomainEventServiceTest {
       }
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `saveApplicationWithdrawnEvent sends correct arguments to saveAndEmit`(emit: Boolean) {
+    @Test
+    fun `saveApplicationWithdrawnEvent sends correct arguments to saveAndEmit`() {
       val id = UUID.randomUUID()
 
       val eventDetails = ApplicationWithdrawnFactory().produce()
@@ -789,15 +787,14 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), emit) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
-      domainEventServiceSpy.saveApplicationWithdrawnEvent(domainEvent, emit)
+      domainEventServiceSpy.saveApplicationWithdrawnEvent(domainEvent)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
-          emit,
         )
       }
     }
@@ -816,7 +813,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveApplicationExpiredEvent(domainEvent)
 
@@ -998,7 +995,7 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any()) } returns Unit
 
       domainEventServiceSpy.saveAssessmentAllocatedEvent(domainEvent)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -231,6 +231,7 @@ class Cas1DomainEventServiceTest {
         bookingId = bookingId,
         metadata = metadata,
         schemaVersion = domainEventAndJson.schemaVersion.versionNo,
+        triggerSource = TriggerSourceType.USER,
       )
 
       every { domainEventWorkerMock.emitEvent(any(), any()) } returns Unit
@@ -249,6 +250,7 @@ class Cas1DomainEventServiceTest {
             assertThat(it.triggeredByUserId).isEqualTo(user.id)
             assertThat(it.bookingId).isEqualTo(bookingId)
             assertThat(it.metadata).isEqualTo(metadata)
+            assertThat(it.triggerSource).isEqualTo(TriggerSourceType.USER)
           },
         )
       }
@@ -814,15 +816,14 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
-      domainEventServiceSpy.saveApplicationExpiredEvent(domainEvent, TriggerSourceType.SYSTEM)
+      domainEventServiceSpy.saveApplicationExpiredEvent(domainEvent)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED,
-          triggerSource = TriggerSourceType.SYSTEM,
         )
       }
     }
@@ -997,15 +998,14 @@ class Cas1DomainEventServiceTest {
 
       val domainEventServiceSpy = spyk(domainEventService)
 
-      every { domainEventServiceSpy.saveAndEmit(any(), any(), any(), any()) } returns Unit
+      every { domainEventServiceSpy.saveAndEmit(any(), any(), any()) } returns Unit
 
-      domainEventServiceSpy.saveAssessmentAllocatedEvent(domainEvent, TriggerSourceType.USER)
+      domainEventServiceSpy.saveAssessmentAllocatedEvent(domainEvent)
 
       verify {
         domainEventServiceSpy.saveAndEmit(
           domainEvent = domainEvent,
           eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
-          triggerSource = TriggerSourceType.USER,
         )
       }
     }


### PR DESCRIPTION
This PR simplifies how domain events are persisted by moving previously bespoke arguments 'trigger source' and 'emit' into the internal `DomainEvent` model, making the 'save domain event' functions take one-and-only-one argument - the internal `DomainEvent` model.