### PR TITLE
APS-2034 modify booking cancellation endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -17,6 +17,7 @@ interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity,
     val CAS1_RELATED_PLACEMENT_REQ_WITHDRAWN_ID: UUID = UUID.fromString("0a115fa4-6fd0-4b23-8e31-e6d1769c3985")
     val CAS1_RELATED_APP_WITHDRAWN_ID: UUID = UUID.fromString("bcb90030-b2d3-47d1-b289-a8b8c8898576")
     val CAS1_RELATED_OTHER_ID: UUID = UUID.fromString("1d6f3c6e-3a86-49b4-bfca-2513a078aba3")
+    val CAS1_BOOKING_SUCCESSFULLY_APPEALED_ID: UUID = UUID.fromString("acba3547-ab22-442d-acec-2652e49895f2")
   }
 
   @Query("SELECT c FROM CancellationReasonEntity c WHERE c.serviceScope = :serviceName OR c.serviceScope = '*' ORDER by c.sortOrder ASC, c.name ASC")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -124,6 +124,7 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_PLANNED_TRANSFER_CREATE,
       UserPermission.CAS1_PLACEMENT_APPEAL_ASSESS,
       UserPermission.CAS1_PLANNED_TRANSFER_ASSESS,
+      UserPermission.CAS1_SPACE_BOOKING_WITHDRAW,
     ),
   ),
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ChangeRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ChangeRequestEntity.kt
@@ -105,7 +105,7 @@ data class Cas1ChangeRequestEntity(
   var rejectionReason: Cas1ChangeRequestRejectionReasonEntity?,
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "decision_made_by_user_id")
-  val decisionMadeByUser: UserEntity?,
+  var decisionMadeByUser: UserEntity?,
   var resolved: Boolean,
   var resolvedAt: OffsetDateTime?,
   val createdAt: OffsetDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1RejectChan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRejectionReasonRepository
@@ -98,6 +99,36 @@ class Cas1ChangeRequestService(
       },
     ),
   )
+
+  @Transactional
+  fun approvePlacementAppeal(changeRequestId: UUID, user: UserEntity, spaceBooking: Cas1SpaceBookingEntity): CasResult<Unit> = validatedCasResult {
+    if (spaceBooking.hasArrival()) {
+      return CasResult.GeneralValidationError("Space booking with ID ${spaceBooking.id} has been marked as arrived")
+    }
+
+    if (spaceBooking.hasNonArrival()) {
+      return CasResult.GeneralValidationError("Space booking with ID ${spaceBooking.id} has been marked as non-arrived")
+    }
+
+    if (spaceBooking.isCancelled()) {
+      return CasResult.GeneralValidationError("Space booking with ID ${spaceBooking.id} has been cancelled")
+    }
+
+    val changeRequest = findChangeRequest(changeRequestId)
+
+    if (changeRequest == null) {
+      return CasResult.NotFound("change request", changeRequestId.toString())
+    } else if (changeRequest.decision == ChangeRequestDecision.APPROVED) {
+      return CasResult.GeneralValidationError("Change request with ID $changeRequestId is already approved")
+    } else {
+      changeRequest.decision = ChangeRequestDecision.APPROVED
+      changeRequest.resolve()
+      changeRequest.decisionMadeByUser = user
+      cas1ChangeRequestRepository.save(changeRequest)
+    }
+
+    return Success(Unit)
+  }
 
   @Transactional
   fun rejectChangeRequest(

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -1345,6 +1345,57 @@ paths:
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
 
+  /premises/{premisesId}/space-bookings/{bookingId}/appeal:
+    post:
+      tags:
+        - space bookings
+      summary: Cancels a space booking and approves the appeal change request
+      operationId: "appeal"
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the space booking is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bookingId
+          in: path
+          description: space booking id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the cancellation
+        content:
+          'application/json':
+            schema:
+              $ref: 'cas1-schemas.yml#/components/schemas/Cas1ApprovedPlacementAppeal'
+        required: true
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+      x-codegen-request-body-name: body
+
   /premises/{premisesId}/day-summary/{date}:
     get:
       tags:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -693,6 +693,20 @@ components:
       required:
         - occurredAt
         - reasonId
+    Cas1ApprovedPlacementAppeal:
+      type: object
+      properties:
+        occurredAt:
+          type: string
+          format: date
+        reasonNotes:
+          type: string
+        placementAppealChangeRequestId:
+          type: string
+          format: uuid
+      required:
+        - occurredAt
+        - placementAppealChangeRequestId
     Cas1PremiseCapacity:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -1347,6 +1347,57 @@ paths:
               schema:
                 $ref: '#/components/schemas/Problem'
 
+  /premises/{premisesId}/space-bookings/{bookingId}/appeal:
+    post:
+      tags:
+        - space bookings
+      summary: Cancels a space booking and approves the appeal change request
+      operationId: "appeal"
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises the space booking is related to
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bookingId
+          in: path
+          description: space booking id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: details of the cancellation
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Cas1ApprovedPlacementAppeal'
+        required: true
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        404:
+          description: invalid premises ID or booking ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+        500:
+          $ref: '#/components/responses/500Response'
+      x-codegen-request-body-name: body
+
   /premises/{premisesId}/day-summary/{date}:
     get:
       tags:
@@ -7254,6 +7305,20 @@ components:
       required:
         - occurredAt
         - reasonId
+    Cas1ApprovedPlacementAppeal:
+      type: object
+      properties:
+        occurredAt:
+          type: string
+          format: date
+        reasonNotes:
+          type: string
+        placementAppealChangeRequestId:
+          type: string
+          format: uuid
+      required:
+        - occurredAt
+        - placementAppealChangeRequestId
     Cas1PremiseCapacity:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-roles.json
+++ b/src/main/resources/static/codegen/built-cas1-roles.json
@@ -100,7 +100,8 @@
       "cas1_placement_appeal_assess",
       "cas1_placement_appeal_create",
       "cas1_planned_transfer_assess",
-      "cas1_planned_transfer_create"
+      "cas1_planned_transfer_create",
+      "cas1_space_booking_withdraw"
     ]
   },
   {


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2034

Following a discussion with @davidatkinsuk on 23/04/25 and based on some of the comments during review it was agreed to change some of the controller logic related to this PR.  The changes were essentially to add the approve appeal logic as a separate space booking appeal endpoint:

- Add new end point /cas1/premises/{premisesId}/space-bookings/{bookingId}/appeal
- Add new type Cas1ApprovedPlacementAppeal which is same as Cas1NewSpaceBookingCancellation but with a mandatory placementAppealChangeRequestId
- Create new controller function appeal() (which cancels space booking and approves change request), similar to cancelSpaceBooking()
- Make new controller function transactional.

---------------------

The original requirements were:

**Desired Outcome**

- Extend the current booking cancellation endpoint to have an optional parameter of change_request_id
- If the change_request_id is defined, the user must have the permission CAS1_CHANGE_REQUEST_ASSESS (for now add this to the user CAS1_CHANGE_REQUEST_DEV)
- Ensure that the booking has not been marked as either arrived or non arrived before cancelling (these checks are already carried out, non arrival was recently added)
- Where there is a change request id defined in the cancel booking flow, add logic to automatically update the change request to 'approved'
- Where there is a change request id defined included in the cancel booking flow, use cancellation reason acba3547-ab22-442d-acec-2652e49895f2 (Booking successfully appealed)
- Change the cancellation_reason parameter to be optional, as if a change_request_id is is supplied, a cancellation reason is not needed. Add a check to ensure it is provided and return a useful error when change_request_id is not provided, as this is no longer managed at the API level