### PR TITLE
APS-1373 Fix CAS1 deadline time for emergency assessments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskDeadlineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskDeadlineService.kt
@@ -6,9 +6,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DatesConstant
 import java.time.LocalTime
 import java.time.OffsetDateTime
-import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
@@ -68,14 +68,14 @@ class TaskDeadlineService(
   private fun ZonedDateTime.isBeforeSameWorkingDayDeadline() = this.toLocalTime().isBefore(SAME_WORKING_DAY_DEADLINE_TIME)
 
   private fun OffsetDateTime.slewedToWorkingPattern(): OffsetDateTime {
-    val zonedDateTime = this.toZonedDateTime().withZoneSameInstant(GB_LOCAL_TIMEZONE)
+    val zonedDateTime = this.toZonedDateTime().withZoneSameInstant(DatesConstant.DEFAULT_CAS_TIMEZONE)
     return if (zonedDateTime.isWorkingDay() && zonedDateTime.isBeforeSameWorkingDayDeadline()) {
       zonedDateTime.withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
     } else {
       workingDayService
         .nextWorkingDay(zonedDateTime.toLocalDate())
         .atTime(WORKING_DAY_START_TIME)
-        .atZone(GB_LOCAL_TIMEZONE)
+        .atZone(DatesConstant.DEFAULT_CAS_TIMEZONE)
         .withZoneSameInstant(ZoneOffset.UTC)
         .toOffsetDateTime()
     }
@@ -91,7 +91,5 @@ class TaskDeadlineService(
 
     private val SAME_WORKING_DAY_DEADLINE_TIME: LocalTime = LocalTime.of(13, 0)
     private val WORKING_DAY_START_TIME: LocalTime = LocalTime.of(9, 0)
-
-    private val GB_LOCAL_TIMEZONE = ZoneId.of("Europe/London")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentEmailService.kt
@@ -133,6 +133,11 @@ class Cas1AssessmentEmailService(
     }
   }
 
+  /*
+  This is partially duplicating logic from TaskDeadlineService. This service
+  should be told the type of deadline, not try and figure it out given the
+  current date
+   */
   private fun deadlineCopy(deadline: OffsetDateTime?, isEmergency: Boolean): String {
     if (deadline == null) {
       return DEFAULT_DEADLINE_COPY

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Dates.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 import io.netty.util.internal.ThreadLocalRandom
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaZoneId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DatesConstant.DEFAULT_CAS_TIMEZONE
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -85,13 +86,7 @@ fun LocalDateTime.toUiDateTimeFormat(): String = this.format(cas1UiExtendedDateT
 
 fun LocalDate.toCas2UiFormat(): String = this.format(cas2UiExtendedDateFormat)
 
-fun LocalDate.toUtcOffsetDateTime(): OffsetDateTime = OffsetDateTime.of(
-  this,
-  LocalTime.of(0, 0, 0, 0),
-  ZoneOffset.UTC,
-)
-
-fun OffsetDateTime.toUiFormattedHourOfDay(): String = this.format(cas1UiTimeFormat).lowercase()
+fun OffsetDateTime.toUiFormattedHourOfDay(): String = this.atZoneSameInstant(DEFAULT_CAS_TIMEZONE).format(cas1UiTimeFormat).lowercase()
 
 fun OffsetDateTime.toCas2UiFormattedHourOfDay(): String = this.format(cas2UiTimeFormat).lowercase()
 
@@ -152,3 +147,8 @@ fun Instant.minusRandomSeconds(maxOffset: Long): Instant {
 }
 
 fun LocalDateTime.toInstant(): Instant = this.atZone(ZoneId.systemDefault()).toInstant()
+
+@SuppressWarnings("TooManyFunctions")
+object DatesConstant {
+  val DEFAULT_CAS_TIMEZONE: ZoneId = ZoneId.of("Europe/London")
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/DatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/DatesTest.kt
@@ -117,8 +117,22 @@ class DatesTest {
   }
 
   @Test
-  fun `toUiFormattedHourOfDay formats a LocalDate correctly`() {
+  fun `toUiFormattedHourOfDay formats a LocalDate correctly, UTC offset with no DST`() {
     val dateTime = OffsetDateTime.parse("2024-01-01T11:15:00Z")
+
+    assertThat(dateTime.toUiFormattedHourOfDay()).isEqualTo("11am")
+  }
+
+  @Test
+  fun `toUiFormattedHourOfDay formats a LocalDate correctly, UTC offset with DST`() {
+    val dateTime = OffsetDateTime.parse("2024-06-01T13:15:00Z")
+
+    assertThat(dateTime.toUiFormattedHourOfDay()).isEqualTo("2pm")
+  }
+
+  @Test
+  fun `toUiFormattedHourOfDay formats a LocalDate correctly, BST offset`() {
+    val dateTime = OffsetDateTime.parse("2024-05-01T11:15:00+01:00")
 
     assertThat(dateTime.toUiFormattedHourOfDay()).isEqualTo("11am")
   }


### PR DESCRIPTION
See https://dsdmoj.atlassian.net/browse/APS-1373

When we send an email related to an emergency assessment we are showing the deadline time as 10am, despite is being 11am local time. This issue only start happening after the change to british summer time (UTC+1).

We are persisting deadlines correctly in the database, but when we render this time in the assessment allocated email we formatting with specifying any timezone information the offset associated with the deadline is being used (UTC).

This commit changes time in email rendering to use Europe/London.

For consistency the `OffsetDataTime` should probably be created with a Europe/London offset, but equally anything rendering the time shouldn’t assume the given `OffsetDateTime` is in the required timezone.