### PR TITLE
Cba 431 create a sar endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2SubjectAccessRequestRepository.kt
@@ -1,0 +1,229 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.SubjectAccessRequestRepositoryBase
+import java.time.LocalDateTime
+
+@Repository
+class Cas2v2SubjectAccessRequestRepository(
+  jdbcTemplate: NamedParameterJdbcTemplate,
+) : SubjectAccessRequestRepositoryBase(jdbcTemplate) {
+
+  fun getApplicationsJson(
+    crn: String?,
+    nomsNumber: String?,
+    startDate: LocalDateTime?,
+    endDate: LocalDateTime?,
+  ): String {
+    val result = jdbcTemplate.queryForMap(
+      """
+      select json_agg(applications) as json
+      from ( 
+        select
+          ca.id,
+        	ca.crn,
+        	ca.noms_number,
+        	ca."data",
+        	ca."document",
+        	nu."name" as created_by_user,
+        	ca.created_at,
+        	ca.submitted_at,
+        	ca.referring_prison_code,
+        	ca.preferred_areas,
+        	ca.telephone_number,
+        	ca.hdc_eligibility_date,
+        	ca.conditional_release_date,
+        	ca.abandoned_at,
+          ca.application_origin,
+          CAST( ca.bail_hearing_date as DATE) 
+        from
+        	cas_2_v2_applications ca
+        inner join cas_2_v2_users nu on
+        	nu.id = ca.created_by_user_id
+        where 
+        	(ca.crn = :crn
+        		or ca.noms_number = :noms_number ) 
+        	and (:start_date::date is null or ca.created_at >= :start_date) 
+        	and (:end_date::date is null or ca.created_at <= :end_date)
+      ) applications
+      """.trimIndent(),
+      MapSqlParameterSource()
+        .addSarParameters(crn, nomsNumber, startDate, endDate),
+    )
+    return toJsonString(result)
+  }
+
+  fun getAssessments(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String {
+    val result = jdbcTemplate.queryForMap(
+      """
+      select json_agg(assessments) as json
+      from(
+          select
+          	caa.id,
+          	ca.crn,
+          	ca.noms_number,
+          	ca.id as application_id,
+          	caa.created_at,
+          	caa.assessor_name,
+          	caa.nacro_referral_id
+          from
+          	cas_2_v2_assessments caa
+          inner join public.cas_2_v2_applications ca 
+          on
+          	ca.id = caa.application_id
+          where 
+          	(ca.crn = :crn
+          		or ca.noms_number = :noms_number )
+          and (:start_date::date is null or ca.created_at >= :start_date) 
+          and (:end_date::date is null or ca.created_at <= :end_date)
+      ) assessments
+      """.trimIndent(),
+      MapSqlParameterSource().addSarParameters(crn, nomsNumber, startDate, endDate),
+    )
+
+    return toJsonString(result)
+  }
+
+  fun getApplicationNotes(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String {
+    val result = jdbcTemplate.queryForMap(
+      """
+      select json_agg(cas_2_v2_application_notes) as json 
+      from (
+          select
+          	can.id,
+          	ca.crn,
+          	ca.noms_number,
+          	can.application_id,
+          	can.assessment_id, 
+          	cu."name" as created_by_user,
+            cu.user_type as created_by_user_type,
+            can.body
+          from cas_2_v2_application_notes can 
+          inner join cas_2_v2_applications ca on
+          	ca.id  = can.application_id 
+          left join cas_2_v2_users cu on 
+            cu.id = ca.created_by_user_id
+          where 
+          	(ca.crn = :crn
+          		or ca.noms_number = :noms_number )
+          and (:start_date::date is null or ca.created_at >= :start_date) 
+          and (:end_date::date is null or ca.created_at <= :end_date)
+      ) cas_2_v2_application_notes
+      """.trimIndent(),
+      MapSqlParameterSource().addSarParameters(crn, nomsNumber, startDate, endDate),
+    )
+    return toJsonString(result)
+  }
+
+  fun getStatusUpdates(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String {
+    val result = jdbcTemplate.queryForMap(
+      """
+      select json_agg(cas_2_v2_application_status_updates) as json 
+      from (
+          select
+              csu.id,
+              ca.crn,
+              ca.noms_number, 
+              csu.application_id,
+              csu.assessment_id,
+              eu."name" as assessor_name,
+              to_char(csu.created_at,'YYYY-MM-DD HH24:MI:SS')  as created_at,
+              csu.description ,
+              csu."label"
+          from cas_2_v2_status_updates csu 
+          inner join cas_2_v2_applications ca
+              on ca.id =csu.application_id
+          inner join cas_2_v2_users eu 
+              on eu.id = csu.assessor_id
+          where 
+          	(ca.crn = :crn
+          		or ca.noms_number = :noms_number )
+          and (:start_date::date is null or ca.created_at >= :start_date) 
+          and (:end_date::date is null or ca.created_at <= :end_date)
+      ) cas_2_v2_application_status_updates
+      """.trimIndent(),
+      MapSqlParameterSource()
+        .addSarParameters(crn, nomsNumber, startDate, endDate),
+    )
+    return toJsonString(result)
+  }
+
+  fun getStatusUpdateDetails(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String {
+    val result = jdbcTemplate.queryForMap(
+      """
+      select json_agg(cas_2_v2_application_status_update_details) as json 
+      from (
+        select
+        	ca. crn,
+        	ca. noms_number, 
+        	csud.status_update_id,
+        	csu.application_id,
+        	csu.assessment_id,
+        	csu."label" as status_label,
+        	csud."label" as detail_label,
+        	to_char(csud.created_at , 'YYYY-MM-DD HH24:MI:SS') as created_at 
+        from cas_2_v2_status_updates csu 
+        inner join cas_2_v2_status_update_details csud  
+        	on csu.id  = csud.status_update_id 
+        inner join cas_2_v2_applications ca
+        	on ca.id =csu.application_id
+        inner join cas_2_v2_users eu 
+        	on eu.id = csu.assessor_id 
+        where 
+        	(ca.crn = :crn
+        		or ca.noms_number = :noms_number )
+        and (:start_date::date is null or ca.created_at >= :start_date) 
+        and (:end_date::date is null or ca.created_at <= :end_date)
+        ) cas_2_v2_application_status_update_details
+      """.trimIndent(),
+      MapSqlParameterSource()
+        .addSarParameters(crn, nomsNumber, startDate, endDate),
+    )
+    return toJsonString(result)
+  }
+
+  override fun domainEvents(
+    crn: String?,
+    nomsNumber: String?,
+    startDate: LocalDateTime?,
+    endDate: LocalDateTime?,
+    serviceName: String,
+  ): String {
+    val result = jdbcTemplate.queryForMap(
+      """
+           select json_agg(domain_events) as json from ( 
+               select 
+                 de.id,
+                 de.application_id,
+                 de.crn,
+                 de."type",
+                 de.occurred_at,
+                 de.created_at,
+                 de."data",
+                 de.booking_id,
+                 de.service,
+                 de.assessment_id,
+                 u."name" as triggered_by_user,
+                 de.noms_number,
+                 de.trigger_source
+               from
+                     domain_events de 
+               left join cas_2_v2_users u on 
+                     u.id = de.triggered_by_user_id
+               where
+                  de.service = :service_name and
+                  (de.crn = :crn
+                        or de.noms_number = :noms_number )
+               and (:start_date::date is null or de.created_at >= :start_date)
+               and (:end_date::date is null or de.created_at <= :end_date) 
+           ) domain_events
+      """.trimIndent(),
+      MapSqlParameterSource()
+        .addSarParameters(crn, nomsNumber, startDate, endDate)
+        .addValue("service_name", serviceName),
+    )
+    return toJsonString(result)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2ApplicationEntityFactory.kt
@@ -42,6 +42,7 @@ class Cas2v2ApplicationEntityFactory : Factory<Cas2v2ApplicationEntity> {
   private var hdcEligibilityDate: Yielded<LocalDate?> = { null }
   private var conditionalReleaseDate: Yielded<LocalDate?> = { null }
   private var applicationOrigin: Yielded<ApplicationOrigin> = { ApplicationOrigin.homeDetentionCurfew }
+  private var bailHearingDate: Yielded<LocalDate?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -131,6 +132,10 @@ class Cas2v2ApplicationEntityFactory : Factory<Cas2v2ApplicationEntity> {
     this.applicationOrigin = { applicationOrigin }
   }
 
+  fun withBailHearingDate(bailHearingDate: LocalDate) = apply {
+    this.bailHearingDate = { bailHearingDate }
+  }
+
   @SuppressWarnings("TooGenericExceptionThrown")
   override fun produce(): Cas2v2ApplicationEntity {
     val entity = Cas2v2ApplicationEntity(
@@ -154,6 +159,7 @@ class Cas2v2ApplicationEntityFactory : Factory<Cas2v2ApplicationEntity> {
       conditionalReleaseDate = this.conditionalReleaseDate(),
       preferredAreas = this.preferredAreas(),
       applicationOrigin = this.applicationOrigin(),
+      bailHearingDate = this.bailHearingDate(),
     )
 
     return entity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2NoteEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2NoteEntityFactory.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2v2NoteEntityFactory : Factory<Cas2v2ApplicationNoteEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var createdByUser: Yielded<Cas2v2UserEntity> = { Cas2v2UserEntityFactory().produce() }
+  private var application: Yielded<Cas2v2ApplicationEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var body: Yielded<String> = { "Note body" }
+  private var assessment: Yielded<Cas2v2AssessmentEntity?> = { null }
+
+  fun withApplication(application: Cas2v2ApplicationEntity) = apply {
+    this.application = { application }
+  }
+
+  fun withAssessment(assessment: Cas2v2AssessmentEntity) = apply {
+    this.assessment = { assessment }
+  }
+
+  fun withCreatedByUser(createdByUser: Cas2v2UserEntity) = apply {
+    this.createdByUser = { createdByUser }
+  }
+
+  fun withBody(body: String) = apply {
+    this.body = { body }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  override fun produce(): Cas2v2ApplicationNoteEntity = Cas2v2ApplicationNoteEntity(
+    id = this.id(),
+    createdByUser = this.createdByUser(),
+    application = this.application?.invoke() ?: error("Must provide an application."),
+    createdAt = this.createdAt(),
+    body = this.body(),
+    assessment = this.assessment(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2StatusUpdateDetailEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2StatusUpdateDetailEntityFactory.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2v2StatusUpdateDetailEntityFactory : Factory<Cas2v2StatusUpdateDetailEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var statusDetailId: Yielded<UUID> = { UUID.randomUUID() }
+  private var statusUpdate: Yielded<Cas2v2StatusUpdateEntity>? = null
+  private var label: Yielded<String> = { "More Detail Required" }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+  fun withStatusDetailId(statusDetailId: UUID) = apply {
+    this.statusDetailId = { statusDetailId }
+  }
+
+  fun withStatusUpdate(statusUpdate: Cas2v2StatusUpdateEntity) = apply {
+    this.statusUpdate = { statusUpdate }
+  }
+
+  fun withLabel(label: String) = apply {
+    this.label = { label }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  override fun produce(): Cas2v2StatusUpdateDetailEntity = Cas2v2StatusUpdateDetailEntity(
+    id = this.id(),
+    statusDetailId = this.statusDetailId(),
+    statusUpdate = this.statusUpdate?.invoke() ?: error("Must provide a status update"),
+    label = this.label(),
+    createdAt = this.createdAt(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS2SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS2SubjectAccessRequestServiceTest.kt
@@ -42,7 +42,6 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     )
   }
 
-  // not originally called
   @Test
   fun `Get CAS2 Information - null date Check`() {
     val (offenderDetails, _) = givenAnOffender()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas2v2IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas2v2IntegrationTestBase.kt
@@ -11,14 +11,20 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2v2Applicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2AssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2NoteEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2StatusUpdateDetailEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.IntegrationTestDbManager
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.TestPropertiesInitializer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2v2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserRepository
@@ -47,12 +53,20 @@ abstract class Cas2v2IntegrationTestBase : IntegrationTestBase() {
   lateinit var cas2v2UserRepository: Cas2v2UserRepository
 
   @Autowired
+  lateinit var cas2v2NoteRepository: Cas2v2ApplicationNoteRepository
+
+  @Autowired
   lateinit var cas2v2ApplicationJsonSchemaRepository: Cas2v2ApplicationJsonSchemaTestRepository
+
+  @Autowired
+  lateinit var cas2v2StatusUpdateDetailEntityRepository: Cas2v2StatusUpdateDetailRepository
 
   lateinit var cas2v2ApplicationEntityFactory: PersistedFactory<Cas2v2ApplicationEntity, UUID, Cas2v2ApplicationEntityFactory>
   lateinit var cas2v2AssessmentEntityFactory: PersistedFactory<Cas2v2AssessmentEntity, UUID, Cas2v2AssessmentEntityFactory>
   lateinit var cas2v2StatusUpdateEntityFactory: PersistedFactory<Cas2v2StatusUpdateEntity, UUID, Cas2v2StatusUpdateEntityFactory>
   lateinit var cas2v2UserEntityFactory: PersistedFactory<Cas2v2UserEntity, UUID, Cas2v2UserEntityFactory>
+  lateinit var cas2v2NoteEntityFactory: PersistedFactory<Cas2v2ApplicationNoteEntity, UUID, Cas2v2NoteEntityFactory>
+  lateinit var cas2v2StatusUpdateDetailEntityFactory: PersistedFactory<Cas2v2StatusUpdateDetailEntity, UUID, Cas2v2StatusUpdateDetailEntityFactory>
   lateinit var cas2v2ApplicationJsonSchemaEntityFactory: PersistedFactory<Cas2v2ApplicationJsonSchemaEntity, UUID, Cas2v2ApplicationJsonSchemaEntityFactory>
 
   override fun setupFactories() {
@@ -64,5 +78,7 @@ abstract class Cas2v2IntegrationTestBase : IntegrationTestBase() {
     cas2v2UserEntityFactory = PersistedFactory({ Cas2v2UserEntityFactory() }, cas2v2UserRepository)
     cas2v2ApplicationJsonSchemaEntityFactory =
       PersistedFactory({ Cas2v2ApplicationJsonSchemaEntityFactory() }, cas2v2ApplicationJsonSchemaRepository)
+    cas2v2NoteEntityFactory = PersistedFactory({ Cas2v2NoteEntityFactory() }, cas2v2NoteRepository)
+    cas2v2StatusUpdateDetailEntityFactory = PersistedFactory({ Cas2v2StatusUpdateDetailEntityFactory() }, cas2v2StatusUpdateDetailEntityRepository)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
@@ -40,7 +40,7 @@ import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
-open class SubjectAccessRequestServiceTestBase : IntegrationTestBase() {
+open class SubjectAccessRequestServiceTestBase : Cas2v2IntegrationTestBase() {
   @Autowired
   lateinit var sarService: SubjectAccessRequestService
   lateinit var premises: ApprovedPremisesEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2SubjectAccessRequestServiceTest.kt
@@ -1,15 +1,16 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2v2
 
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SubjectAccessRequestServiceTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2UserType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.assertJsonEquals
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomEmailAddress
@@ -19,13 +20,18 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase() {
+class Cas2v2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase() {
 
   @Test
-  fun `Get CAS2 Information - No Results`() {
+  fun `Get CAS2 v2 Information - No Results`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS2Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      sarService.getCAS2v2Result(
+        offenderDetails.otherIds.crn,
+        offenderDetails.otherIds.nomsNumber,
+        START_DATE,
+        END_DATE,
+      )
     assertJsonEquals(
       """ 
       {
@@ -42,9 +48,8 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     )
   }
 
-  // not originally called
   @Test
-  fun `Get CAS2 Information - null date Check`() {
+  fun `Get CAS2 v2 Information - null date Check`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
       sarService.getCAS2Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
@@ -65,13 +70,13 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
   }
 
   @Test
-  fun `Get CAS2 Information - Applications`() {
+  fun `Get CAS2 v2 Information - Applications`() {
     val (offenderDetails, _) = givenAnOffender()
     val user = nomisUserEntity()
 
-    val application = cas2ApplicationEntity(offenderDetails, user)
+    val application = cas2v2ApplicationEntity(offenderDetails, user)
 
-    val result = sarService.getCAS2Result(
+    val result = sarService.getCAS2v2Result(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -80,7 +85,7 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
 
     val expectedJson = """
    {
-      "Applications": [${cas2ApplicationsJson(application)}],
+      "Applications": [${cas2v2ApplicationsJson(application)}],
       "ApplicationNotes": [ ],
       "Assessments": [ ],
       "StatusUpdates": [ ],
@@ -93,14 +98,14 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
   }
 
   @Test
-  fun `Get CAS2 Information - Application with assessment`() {
+  fun `Get CAS2 v2 Information - Application with assessment`() {
     val (offenderDetails, _) = givenAnOffender()
     val user = nomisUserEntity()
 
-    val application = cas2ApplicationEntity(offenderDetails, user)
-    val assessment = cas2AssessmentEntity(application)
+    val application = cas2v2ApplicationEntity(offenderDetails, user)
+    val assessment = cas2v2AssessmentEntity(application)
 
-    val result = sarService.getCAS2Result(
+    val result = sarService.getCAS2v2Result(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -109,9 +114,9 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
 
     val expectedJson = """
    {
-      "Applications": [${cas2ApplicationsJson(application)}],
+      "Applications": [${cas2v2ApplicationsJson(application)}],
       "ApplicationNotes": [ ],
-      "Assessments": [${cas2AssessmentsJson(assessment)}],
+      "Assessments": [${cas2v2AssessmentsJson(assessment)}],
       "StatusUpdates": [ ],
       "StatusUpdateDetails": [ ],
       "DomainEvents":  [ ],
@@ -122,16 +127,16 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
   }
 
   @Test
-  fun `Get CAS2 Information - Application with Note`() {
+  fun `Get CAS2 v2 Information - Application with Note`() {
     val (offenderDetails, _) = givenAnOffender()
     val user = nomisUserEntity()
 
-    val application = cas2ApplicationEntity(offenderDetails, user)
-    val assessment = cas2AssessmentEntity(application)
+    val application = cas2v2ApplicationEntity(offenderDetails, user)
+    val assessment = cas2v2AssessmentEntity(application)
 
-    val applicationNotes = cas2ApplicationNoteEntity(application, assessment, user)
+    val applicationNotes = cas2v2ApplicationNoteEntity(application, assessment, user)
 
-    val result = sarService.getCAS2Result(
+    val result = sarService.getCAS2v2Result(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -140,9 +145,9 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
 
     val expectedJson = """
    {
-      "Applications": [${cas2ApplicationsJson(application)}],
-      "ApplicationNotes": [${cas2ApplicationNotesJson(applicationNotes)}],
-      "Assessments": [${cas2AssessmentsJson(assessment)}],
+      "Applications": [${cas2v2ApplicationsJson(application)}],
+      "ApplicationNotes": [${cas2v2ApplicationNotesJson(applicationNotes)}],
+      "Assessments": [${cas2v2AssessmentsJson(assessment)}],
       "StatusUpdates": [ ],
       "StatusUpdateDetails": [ ],
       "DomainEvents":  [ ],
@@ -154,18 +159,18 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
   }
 
   @Test
-  fun `Get CAS2 Information - Application with Note and Status update`() {
+  fun `Get CAS2 v2 Information - Application with Note and Status update`() {
     val (offenderDetails, _) = givenAnOffender()
     val user = nomisUserEntity()
-    val externalAssessor = externalUserEntity()
-    val application = cas2ApplicationEntity(offenderDetails, user)
-    val assessment = cas2AssessmentEntity(application)
+    val application = cas2v2ApplicationEntity(offenderDetails, user)
+    val assessment = cas2v2AssessmentEntity(application)
 
-    val applicationNotes = cas2ApplicationNoteEntity(application, assessment, user)
-    val statusUpdate = cas2StatusUpdateEntity(application, assessment, externalAssessor)
+    val applicationNotes = cas2v2ApplicationNoteEntity(application, assessment, user)
+
+    val statusUpdate = cas2v2StatusUpdateEntity(application, assessment, user)
     val statusUpdateDetail = cas2StatusUpdateDetailEntity(statusUpdate)
 
-    val result = sarService.getCAS2Result(
+    val result = sarService.getCAS2v2Result(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -174,11 +179,11 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
 
     val expectedJson = """
    {
-      "Applications": [${cas2ApplicationsJson(application)}],
-      "ApplicationNotes": [${cas2ApplicationNotesJson(applicationNotes)}],
-      "Assessments": [${cas2AssessmentsJson(assessment)}],
-      "StatusUpdates": [${cas2StatusUpdatesJson(statusUpdate)}],
-      "StatusUpdateDetails": [${cas2StatusUpdateDetails(statusUpdateDetail)}],
+      "Applications": [${cas2v2ApplicationsJson(application)}],
+      "ApplicationNotes": [${cas2v2ApplicationNotesJson(applicationNotes)}],
+      "Assessments": [${cas2v2AssessmentsJson(assessment)}],
+      "StatusUpdates": [${cas2v2StatusUpdatesJson(statusUpdate)}],
+      "StatusUpdateDetails": [${cas2v2StatusUpdateDetails(statusUpdateDetail)}],
       "DomainEvents":  [ ],
       "DomainEventsMetadata": [ ]
       
@@ -188,19 +193,18 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
   }
 
   @Test
-  fun `Get CAS2 Information - Domain Events`() {
+  fun `Get CAS2 v2 Information - Domain Events`() {
     val (offenderDetails, _) = givenAnOffender()
     val user = nomisUserEntity()
-    val externalAssessor = externalUserEntity()
-    val application = cas2ApplicationEntity(offenderDetails, user)
-    val assessment = cas2AssessmentEntity(application)
+    val application = cas2v2ApplicationEntity(offenderDetails, user)
+    val assessment = cas2v2AssessmentEntity(application)
 
-    val applicationNotes = cas2ApplicationNoteEntity(application, assessment, user)
-    val statusUpdate = cas2StatusUpdateEntity(application, assessment, externalAssessor)
+    val applicationNotes = cas2v2ApplicationNoteEntity(application, assessment, user)
+    val statusUpdate = cas2v2StatusUpdateEntity(application, assessment, user)
     val statusUpdateDetail = cas2StatusUpdateDetailEntity(statusUpdate)
-    val domainEvent = domainEventEntity(offenderDetails, application.id, assessment.id, null, ServiceName.cas2)
+    val domainEvent = domainEventEntity(offenderDetails, application.id, assessment.id, null, ServiceName.cas2v2)
 
-    val result = sarService.getCAS2Result(
+    val result = sarService.getCAS2v2Result(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -209,11 +213,11 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
 
     val expectedJson = """
    {
-      "Applications": [${cas2ApplicationsJson(application)}],
-      "ApplicationNotes": [${cas2ApplicationNotesJson(applicationNotes)}],
-      "Assessments": [${cas2AssessmentsJson(assessment)}],
-      "StatusUpdates": [${cas2StatusUpdatesJson(statusUpdate)}],
-      "StatusUpdateDetails": [${cas2StatusUpdateDetails(statusUpdateDetail)}],
+      "Applications": [${cas2v2ApplicationsJson(application)}],
+      "ApplicationNotes": [${cas2v2ApplicationNotesJson(applicationNotes)}],
+      "Assessments": [${cas2v2AssessmentsJson(assessment)}],
+      "StatusUpdates": [${cas2v2StatusUpdatesJson(statusUpdate)}],
+      "StatusUpdateDetails": [${cas2v2StatusUpdateDetails(statusUpdateDetail)}],
       "DomainEvents": [${domainEventJson(domainEvent,null)}],
       "DomainEventsMetadata": [${domainEventsMetadataJson(domainEvent)}]
    }
@@ -221,7 +225,7 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     assertJsonEquals(expectedJson, result)
   }
 
-  private fun cas2StatusUpdateDetails(statusUpdateDetail: Cas2StatusUpdateDetailEntity): String = """
+  private fun cas2v2StatusUpdateDetails(statusUpdateDetail: Cas2v2StatusUpdateDetailEntity): String = """
     {
         "crn": "${statusUpdateDetail.statusUpdate.application.crn}",
         "noms_number": "${statusUpdateDetail.statusUpdate.application.nomsNumber}", 
@@ -234,7 +238,7 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     }
   """.trimIndent()
 
-  private fun cas2StatusUpdatesJson(statusUpdate: Cas2StatusUpdateEntity): String = """
+  private fun cas2v2StatusUpdatesJson(statusUpdate: Cas2v2StatusUpdateEntity): String = """
     {
       	"id": "${statusUpdate.id}",
       	"crn": "${statusUpdate.application.crn}",
@@ -242,14 +246,13 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
       	"application_id": "${statusUpdate.application.id}",
       	"assessment_id": "${statusUpdate.assessment!!.id}",
       	"assessor_name": "${statusUpdate.assessor.name}",
-        "assessor_origin": "${statusUpdate.assessor.origin}",
       	"created_at": "${statusUpdate.createdAt.toStandardisedFormat()}",
         "description": "${statusUpdate.description}",
         "label": "${statusUpdate.label}"
     }    
   """.trimIndent()
 
-  private fun cas2ApplicationNotesJson(applicationNotes: Cas2ApplicationNoteEntity): String = """
+  private fun cas2v2ApplicationNotesJson(applicationNotes: Cas2v2ApplicationNoteEntity): String = """
   {
       "id": "${applicationNotes.id}",
       "crn": "${applicationNotes.application.crn}",
@@ -257,12 +260,12 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
       "application_id": "${applicationNotes.application.id}",
       "assessment_id": "${applicationNotes.assessment!!.id}",
       "created_by_user": "${applicationNotes.getUser().name}",
-      "created_by_user_type": "nomis",
+      "created_by_user_type": "NOMIS",
       "body": "${applicationNotes.body}"
   }
   """.trimIndent()
 
-  private fun cas2AssessmentsJson(assessment: Cas2AssessmentEntity): String = """
+  private fun cas2v2AssessmentsJson(assessment: Cas2v2AssessmentEntity): String = """
     {
         "id": "${assessment.id}",
         "crn": "${assessment.application.crn}",
@@ -274,7 +277,7 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     }
   """.trimIndent()
 
-  private fun cas2ApplicationsJson(application: Cas2ApplicationEntity): String = """
+  private fun cas2v2ApplicationsJson(application: Cas2v2ApplicationEntity): String = """
     {
       "id": "${application.id}",
       "crn": "${application.crn}",
@@ -289,15 +292,17 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
       "telephone_number": "${application.telephoneNumber}",
       "hdc_eligibility_date": "$arrivedAtDateOnly",
       "conditional_release_date": "$arrivedAtDateOnly",
-      "abandoned_at": null
+      "abandoned_at": null,
+      "application_origin": "${application.applicationOrigin}",
+      "bail_hearing_date": "${application.bailHearingDate}",
     }
   """.trimIndent()
 
-  private fun cas2ApplicationNoteEntity(
-    application: Cas2ApplicationEntity,
-    assessment: Cas2AssessmentEntity,
-    user: NomisUserEntity,
-  ) = cas2NoteEntityFactory.produceAndPersist {
+  private fun cas2v2ApplicationNoteEntity(
+    application: Cas2v2ApplicationEntity,
+    assessment: Cas2v2AssessmentEntity,
+    user: Cas2v2UserEntity,
+  ) = cas2v2NoteEntityFactory.produceAndPersist {
     withApplication(application)
     withAssessment(assessment)
     withCreatedByUser(user)
@@ -305,11 +310,11 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     withCreatedAt(OffsetDateTime.parse(CREATED_AT))
   }
 
-  private fun cas2StatusUpdateEntity(
-    application: Cas2ApplicationEntity,
-    assessment: Cas2AssessmentEntity,
-    externalAssessor: ExternalUserEntity,
-  ): Cas2StatusUpdateEntity = cas2StatusUpdateEntityFactory.produceAndPersist {
+  private fun cas2v2StatusUpdateEntity(
+    application: Cas2v2ApplicationEntity,
+    assessment: Cas2v2AssessmentEntity,
+    externalAssessor: Cas2v2UserEntity,
+  ): Cas2v2StatusUpdateEntity = cas2v2StatusUpdateEntityFactory.produceAndPersist {
     withApplication(application)
     withAssessment(assessment)
     withStatusId(UUID.randomUUID())
@@ -318,30 +323,24 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     withDescription("Some Description")
   }
 
-  private fun cas2StatusUpdateDetailEntity(statusUpdate: Cas2StatusUpdateEntity): Cas2StatusUpdateDetailEntity = cas2StatusUpdateDetailEntityFactory.produceAndPersist {
+  private fun cas2StatusUpdateDetailEntity(statusUpdate: Cas2v2StatusUpdateEntity): Cas2v2StatusUpdateDetailEntity = cas2v2StatusUpdateDetailEntityFactory.produceAndPersist {
     withStatusUpdate(statusUpdate)
     withLabel("Some detailed label")
     withStatusDetailId(UUID.randomUUID())
+    withCreatedAt(OffsetDateTime.parse(CREATED_AT))
   }
 
-  private fun externalUserEntity() = externalUserEntityFactory.produceAndPersist {
-    withName(randomStringMultiCaseWithNumbers(12))
-    withEmail(randomEmailAddress())
-    withOrigin("NACRO")
-    withUsername(randomStringMultiCaseWithNumbers(10))
-  }
-
-  private fun cas2AssessmentEntity(application: Cas2ApplicationEntity) = cas2AssessmentEntityFactory.produceAndPersist {
+  private fun cas2v2AssessmentEntity(application: Cas2v2ApplicationEntity) = cas2v2AssessmentEntityFactory.produceAndPersist {
     withApplication(application)
     withAssessorName(randomStringMultiCaseWithNumbers(10))
     withNacroReferralId(randomNumberChars(10))
     withCreatedAt(OffsetDateTime.parse(CREATED_AT))
   }
 
-  private fun cas2ApplicationEntity(
+  private fun cas2v2ApplicationEntity(
     offenderDetails: OffenderDetailSummary,
-    user: NomisUserEntity,
-  ) = cas2ApplicationEntityFactory.produceAndPersist {
+    user: Cas2v2UserEntity,
+  ): Cas2v2ApplicationEntity = cas2v2ApplicationEntityFactory.produceAndPersist {
     withCrn(offenderDetails.otherIds.crn)
     withNomsNumber(offenderDetails.otherIds.nomsNumber!!)
     withCreatedByUser(user)
@@ -359,14 +358,16 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
 
     withConditionalReleaseDate(LocalDate.parse(arrivedAtDateOnly))
     withHdcEligibilityDate(LocalDate.parse(arrivedAtDateOnly))
+    withBailHearingDate(LocalDate.parse(arrivedAtDateOnly))
     withPreferredAreas("some areas")
   }
 
-  private fun nomisUserEntity() = nomisUserEntityFactory.produceAndPersist {
+  private fun nomisUserEntity() = cas2v2UserEntityFactory.produceAndPersist {
     withName(randomStringMultiCaseWithNumbers(12))
     withEmail(randomEmailAddress())
-    withNomisUsername(randomStringMultiCaseWithNumbers(7))
-    withActiveCaseloadId(randomStringMultiCaseWithNumbers(3))
+    withUserType(Cas2v2UserType.NOMIS)
+//    withNomisUsername(randomStringMultiCaseWithNumbers(7))
+//    withActiveCaseloadId(randomStringMultiCaseWithNumbers(3))
     withNomisStaffCode(9L)
     withNomisStaffIdentifier(90L)
   }


### PR DESCRIPTION
The SubjectAccessRequestService has an existing function getSarResult. That calls three other functions:

getCAS1Result
getCAS2Result
getCAS3Result


Each one calls a different repository to load data about applications for the respective service.

We have added getCAS2v2Result. Following the existing pattern this new function calls a specific Cas2v2SubjectAccessRequestRepository. Here we search for applications, assesments, notes, status updates using cas_2_v2_applications and cas_2_v2_users.

We have extended the existing Cas2v2ApplicationEntityFactory and created two new factories - Cas2v2NoteEntityFactory, Cas2v2StatusUpdateDetailFactory.


We found a test in CAS2SubjectAccessRequestServiceTest which had no annotation so wasn't being run. We've annotated it.

We extended the Cas2v2IntegrationTestBase. SubjectAccessRequestServiceTestBase now inherits from Cas2v2IntegrationTestBase rather than IntegrationTestBase.

We added the test class Cas2v2SubjectAccessRequestServiceTest