### PR TITLE
Run prod to preprod restore earlier in the day

### DIFF
--- a/helm_deploy/hmpps-approved-premises-api/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -58,7 +58,7 @@ kind: CronJob
 metadata:
   name: db-refresh-job
 spec:
-  schedule: "0 8 * * 1"
+  schedule: "0 7 * * 1"
   concurrencyPolicy: "Forbid"
   jobTemplate:
     spec:


### PR DESCRIPTION
The job currently runs at 9am british summer time. It’s more helpful to have this job run before devs start work (e.g. before 9am) as it temporarily makes pre-prod unavailable. It also means if the job fails to run an alert will be available for us to respond to when we start work.