### PR TITLE
APS-2156 Add day-specific auto alloc config for dev/test

### DIFF
--- a/src/main/resources/db/migration/dev/R__9_cas1_cru_management_areas.sql
+++ b/src/main/resources/db/migration/dev/R__9_cas1_cru_management_areas.sql
@@ -3,3 +3,31 @@
 -- differs in local and dev/test
 
 UPDATE cas1_cru_management_areas SET assessment_auto_allocation_username = 'AP_USER_TEST_1';
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'MONDAY','AP_USER_TEST_1' FROM cas1_cru_management_areas area
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'TUESDAY','AP_USER_TEST_1' FROM cas1_cru_management_areas area
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'WEDNESDAY','AP_USER_TEST_1' FROM cas1_cru_management_areas area
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'THURSDAY','AP_USER_TEST_1' FROM cas1_cru_management_areas area
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'FRIDAY','AP_USER_TEST_1' FROM cas1_cru_management_areas area
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'SATURDAY','AP_USER_TEST_1' FROM cas1_cru_management_areas area
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'SUNDAY','AP_USER_TEST_1' FROM cas1_cru_management_areas area
+ON CONFLICT DO NOTHING;

--- a/src/main/resources/db/migration/local/R__4_cas1_cru_management_areas.sql
+++ b/src/main/resources/db/migration/local/R__4_cas1_cru_management_areas.sql
@@ -3,4 +3,41 @@
 -- differs in local and dev/test
 
 UPDATE cas1_cru_management_areas SET assessment_auto_allocation_username = 'JIMSNOWLDAP';
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'MONDAY','JIMSNOWLDAP' FROM cas1_cru_management_areas area WHERE id != 'bfb04c2a-1954-4512-803d-164f7fcf252c'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'TUESDAY','JIMSNOWLDAP' FROM cas1_cru_management_areas area WHERE id != 'bfb04c2a-1954-4512-803d-164f7fcf252c'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'WEDNESDAY','JIMSNOWLDAP' FROM cas1_cru_management_areas area WHERE id != 'bfb04c2a-1954-4512-803d-164f7fcf252c'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'THURSDAY','JIMSNOWLDAP' FROM cas1_cru_management_areas area WHERE id != 'bfb04c2a-1954-4512-803d-164f7fcf252c'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'FRIDAY','JIMSNOWLDAP' FROM cas1_cru_management_areas area WHERE id != 'bfb04c2a-1954-4512-803d-164f7fcf252c'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'SATURDAY','JIMSNOWLDAP' FROM cas1_cru_management_areas area WHERE id != 'bfb04c2a-1954-4512-803d-164f7fcf252c'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO cas1_cru_management_area_auto_allocations
+SELECT area.id,'SUNDAY','JIMSNOWLDAP' FROM cas1_cru_management_areas area WHERE id != 'bfb04c2a-1954-4512-803d-164f7fcf252c'
+ON CONFLICT DO NOTHING;
+
 UPDATE cas1_cru_management_areas SET assessment_auto_allocation_username = 'CRUWOMENSESTATE' WHERE id = 'bfb04c2a-1954-4512-803d-164f7fcf252c';
+
+-- women's estate
+INSERT INTO cas1_cru_management_area_auto_allocations VALUES('bfb04c2a-1954-4512-803d-164f7fcf252c','MONDAY','JIMSNOWLDAP') ON CONFLICT DO NOTHING;
+INSERT INTO cas1_cru_management_area_auto_allocations VALUES('bfb04c2a-1954-4512-803d-164f7fcf252c','TUESDAY','JIMSNOWLDAP') ON CONFLICT DO NOTHING;
+INSERT INTO cas1_cru_management_area_auto_allocations VALUES('bfb04c2a-1954-4512-803d-164f7fcf252c','WEDNESDAY','JIMSNOWLDAP') ON CONFLICT DO NOTHING;
+INSERT INTO cas1_cru_management_area_auto_allocations VALUES('bfb04c2a-1954-4512-803d-164f7fcf252c','THURSDAY','JIMSNOWLDAP') ON CONFLICT DO NOTHING;
+INSERT INTO cas1_cru_management_area_auto_allocations VALUES('bfb04c2a-1954-4512-803d-164f7fcf252c','FRIDAY','JIMSNOWLDAP') ON CONFLICT DO NOTHING;
+INSERT INTO cas1_cru_management_area_auto_allocations VALUES('bfb04c2a-1954-4512-803d-164f7fcf252c','SATURDAY','JIMSNOWLDAP') ON CONFLICT DO NOTHING;
+INSERT INTO cas1_cru_management_area_auto_allocations VALUES('bfb04c2a-1954-4512-803d-164f7fcf252c','SUNDAY','JIMSNOWLDAP') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
We have recently changed CAS1 assessment auto allocation to be day-specific. This commit adds configuration for the local and dev environment to fix end to end tests.