### PR TITLE
APS-2175 - Add specific log category for site survey changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedPremisesFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedPremisesFromSiteSurveyXlsxJob.kt
@@ -53,6 +53,7 @@ class Cas1SeedPremisesFromSiteSurveyXlsxJob(
   }
 
   private val log = LoggerFactory.getLogger(this::class.java)
+  private val changesLog = LoggerFactory.getLogger("${this::class.java}.changes")
 
   override fun processXlsx(file: File) {
     val siteSurveyPremise = Cas1SiteSurveyPremiseFactory().load(file)
@@ -153,7 +154,7 @@ class Cas1SeedPremisesFromSiteSurveyXlsxJob(
     premisesInfo: PremisesInfo,
   ) {
     val qCode = premisesInfo.siteSurveyPremise.qCode
-    log.info("Creating new premise for qcode $qCode (${premisesInfo.siteSurveyPremise.name})")
+    changesLog.info("Creating new premise for qcode $qCode (${premisesInfo.siteSurveyPremise.name})")
 
     val siteSurvey = premisesInfo.siteSurveyPremise
 
@@ -226,7 +227,7 @@ class Cas1SeedPremisesFromSiteSurveyXlsxJob(
 
     val diff = javers.compare(beforeChange, afterChange)
     if (diff.hasChanges()) {
-      log.info("Changes for import of ${siteSurvey.name} are ${diff.prettyPrint()}")
+      changesLog.info("Changes for import of ${siteSurvey.name} are ${diff.prettyPrint()}")
       premisesRepository.save(existingPremise)
     } else {
       entityManager.clear()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
@@ -43,6 +43,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
   }
 
   private val log = LoggerFactory.getLogger(this::class.java)
+  private val changesLog = LoggerFactory.getLogger("${this::class.java}.changes")
 
   override fun processXlsx(file: File) {
     val qCode = Cas1SiteSurveyPremiseFactory().getQCode(file)
@@ -168,7 +169,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
         beds = mutableListOf(),
       ),
     )
-    log.info("Created new room with code ${room.roomCode} and name ${room.roomName} in premise ${premises.name}.")
+    changesLog.info("Created new room with code ${room.roomCode} and name ${room.roomName} in premise ${premises.name}.")
   }
 
   private data class ApprovedPremisesRoomForComparison(
@@ -198,7 +199,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
 
     val diff = javers.compare(beforeChange, afterChange)
     if (diff.hasChanges()) {
-      log.info("Changes for existing room ${existingRoom.name} with code ${existingRoom.code}: ${diff.prettyPrint()}")
+      changesLog.info("Changes for existing room ${existingRoom.name} with code ${existingRoom.code}: ${diff.prettyPrint()}")
     } else {
       log.info("No changes for existing room ${existingRoom.name} with code ${existingRoom.code}.")
     }
@@ -217,7 +218,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
         createdAt = null,
       ),
     )
-    log.info("Created new bed with code ${bed.bedCode} and name ${bed.bedName} in room code ${bed.roomCode}.")
+    changesLog.info("Created new bed with code ${bed.bedCode} and name ${bed.bedName} in room code ${bed.roomCode}.")
   }
 
   private fun findExistingPremisesByQCodeOrThrow(qCode: String): ApprovedPremisesEntity = approvedPremisesRepository.findByQCode(qCode)


### PR DESCRIPTION
This makes it easier to grep on specific changes that have been made when updating a premises