### PR TITLE
CAS-1546 - add pom details to Cas2Application 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -104,10 +104,12 @@ data class Cas2ApplicationEntity(
   var telephoneNumber: String? = null,
 ) {
   override fun toString() = "Cas2ApplicationEntity: $id"
-  val currentPrisonCode: String
-    get() = applicationAssignments.first().prisonCode
+  val currentPrisonCode: String?
+    get() = applicationAssignments.firstOrNull()?.prisonCode
   val currentPomUserId: UUID?
-    get() = applicationAssignments.first().allocatedPomUser?.id
+    get() = applicationAssignments.firstOrNull()?.allocatedPomUser?.id
+  val currentAssignmentDate: LocalDate?
+    get() = applicationAssignments.maxByOrNull { it.createdAt }?.createdAt?.toLocalDate()
   val mostRecentPomUserId: UUID
     get() = applicationAssignments.first { it.allocatedPomUser?.id != null }.allocatedPomUser?.id!!
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas2/Cas2StartupScript.kt
@@ -69,7 +69,7 @@ class Cas2StartupScript(
     seedLogger.info("Auto-scripting application for ${applicant.nomisUsername}, in state $state")
     val createdAt = randomDateTime()
     val submittedAt = if (state == "IN_PROGRESS") null else createdAt.plusDays(randomInt(EARLIEST_SUBMISSION, LATEST_SUBMISSION).toLong())
-    val application = applicationRepository.save(
+    val application =
       Cas2ApplicationEntity(
         id = UUID.randomUUID(),
         crn = "X320741",
@@ -81,8 +81,14 @@ class Cas2StartupScript(
         submittedAt = submittedAt,
         schemaVersion = jsonSchemaService.getNewestSchema(Cas2ApplicationJsonSchemaEntity::class.java),
         schemaUpToDate = true,
-      ),
-    )
+        referringPrisonCode = if (submittedAt != null) "MDI" else null,
+      )
+
+    // create application assignments for submitted applications
+    if (submittedAt != null) {
+      application.createApplicationAssignment(prisonCode = "MDI", allocatedPomUser = applicant)
+    }
+    applicationRepository.save(application)
 
     if (listOf("SUBMITTED", "IN_REVIEW").contains(state)) {
       val appWithPromotedProperties = applyFirstClassProperties(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/NomisUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/NomisUserService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEnti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.nomisuserroles.NomisStaffInformation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.nomisuserroles.NomisUserDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import java.util.UUID
 
 @Service
@@ -25,6 +26,8 @@ class NomisUserService(
 
     return getUserForUsername(username, jwt)
   }
+
+  fun getNomisUserById(id: UUID) = userRepository.findById(id).orElseThrow { NotFoundProblem(id, "NomisUser") }
 
   fun getUserByStaffId(staffId: Long): NomisUserEntity {
     val userDetails = userRepository.findByNomisStaffId(staffId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2ApplicationService.kt
@@ -103,9 +103,8 @@ class Cas2ApplicationService(
 
   fun getApplicationForUser(applicationId: UUID, user: NomisUserEntity): CasResult<Cas2ApplicationEntity> {
     val applicationEntity = applicationRepository.findByIdOrNull(applicationId)
-      ?: return CasResult.NotFound("Application", applicationId.toString())
 
-    if (applicationEntity.abandonedAt != null) {
+    if (applicationEntity == null || applicationEntity.abandonedAt != null) {
       return CasResult.NotFound("Application", applicationId.toString())
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2LocationChangedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2LocationChangedService.kt
@@ -38,7 +38,7 @@ class Cas2LocationChangedService(
           is ClientResult.Failure -> throw result.toException()
         }
 
-        if (isNewPrison(application.currentPrisonCode, prisoner.prisonId)) {
+        if (isNewPrison(application.currentPrisonCode!!, prisoner.prisonId)) {
           application.createApplicationAssignment(
             prisonCode = prisoner.prisonId,
             allocatedPomUser = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -6,7 +6,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OffenderManagementUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import java.util.UUID
@@ -19,24 +21,33 @@ class ApplicationsTransformer(
   private val statusUpdateTransformer: StatusUpdateTransformer,
   private val timelineEventsTransformer: TimelineEventsTransformer,
   private val assessmentsTransformer: AssessmentsTransformer,
+  private val nomisUserService: NomisUserService,
+  private val offenderManagementUnitRepository: OffenderManagementUnitRepository,
 ) {
 
-  fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult): Cas2Application = Cas2Application(
-    id = jpa.id,
-    person = personTransformer.transformModelToPersonApi(personInfo),
-    createdBy = nomisUserTransformer.transformJpaToApi(jpa.createdByUser),
-    schemaVersion = jpa.schemaVersion.id,
-    outdatedSchema = !jpa.schemaUpToDate,
-    createdAt = jpa.createdAt.toInstant(),
-    submittedAt = jpa.submittedAt?.toInstant(),
-    data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
-    document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
-    status = getStatus(jpa),
-    type = "CAS2",
-    telephoneNumber = jpa.telephoneNumber,
-    assessment = if (jpa.assessment != null) assessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
-    timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
-  )
+  fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult): Cas2Application {
+    val currentUser = jpa.currentPomUserId?.let { nomisUserService.getNomisUserById(jpa.currentPomUserId!!) }
+    return Cas2Application(
+      id = jpa.id,
+      person = personTransformer.transformModelToPersonApi(personInfo),
+      createdBy = nomisUserTransformer.transformJpaToApi(jpa.createdByUser),
+      schemaVersion = jpa.schemaVersion.id,
+      outdatedSchema = !jpa.schemaUpToDate,
+      createdAt = jpa.createdAt.toInstant(),
+      submittedAt = jpa.submittedAt?.toInstant(),
+      data = if (jpa.data != null) objectMapper.readTree(jpa.data) else null,
+      document = if (jpa.document != null) objectMapper.readTree(jpa.document) else null,
+      status = getStatus(jpa),
+      type = "CAS2",
+      telephoneNumber = jpa.telephoneNumber,
+      assessment = if (jpa.assessment != null) assessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
+      timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
+      allocatedPomName = currentUser?.name,
+      allocatedPomEmailAddress = currentUser?.email,
+      currentPrisonName = jpa.currentPrisonCode?.let { offenderManagementUnitRepository.findByPrisonCode(it)?.prisonName ?: it },
+      assignmentDate = jpa.currentAssignmentDate,
+    )
+  }
 
   fun transformJpaSummaryToSummary(
     jpaSummary: Cas2ApplicationSummaryEntity,

--- a/src/main/resources/static/cas2-schemas.yml
+++ b/src/main/resources/static/cas2-schemas.yml
@@ -56,6 +56,15 @@ components:
               type: array
               items:
                 $ref: '_shared.yml#/components/schemas/Cas2TimelineEvent'
+            allocatedPomName:
+              type: string
+            currentPrisonName:
+              type: string
+            allocatedPomEmailAddress:
+              type: string
+            assignmentDate:
+              type: string
+              format: date
           required:
             - createdBy
             - schemaVersion

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5136,6 +5136,15 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Cas2TimelineEvent'
+            allocatedPomName:
+              type: string
+            currentPrisonName:
+              type: string
+            allocatedPomEmailAddress:
+              type: string
+            assignmentDate:
+              type: string
+              format: date
           required:
             - createdBy
             - schemaVersion

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2ApplicationEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import io.mockk.mockk
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
@@ -108,6 +109,23 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
 
   fun withApplicationAssignments(applicationAssignments: MutableList<Cas2ApplicationAssignmentEntity>) = apply {
     this.applicationAssignments = { applicationAssignments }
+  }
+
+  fun withApplicationAssignments(
+    prisonCode: String = "PRI",
+    user: NomisUserEntity = NomisUserEntityFactory().produce(),
+  ) = apply {
+    this.applicationAssignments = {
+      mutableListOf(
+        Cas2ApplicationAssignmentEntity(
+          id = UUID.randomUUID(),
+          application = mockk(),
+          prisonCode = prisonCode,
+          allocatedPomUser = user,
+          createdAt = OffsetDateTime.now(),
+        ),
+      )
+    }
   }
 
   fun withReferringPrisonCode(referringPrisonCode: String) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.NullNode
 import com.ninjasquad.springmockk.SpykBean
 import io.mockk.clearMocks
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -1272,6 +1273,11 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               withSubmittedAt(OffsetDateTime.now().minusDays(1))
             }
 
+            val omu = offenderManagementUnitEntityFactory.produceAndPersist()
+
+            applicationEntity.createApplicationAssignment(prisonCode = omu.prisonCode, allocatedPomUser = userEntity)
+            cas2ApplicationRepository.save(applicationEntity)
+
             cas2AssessmentEntityFactory.produceAndPersist {
               withApplication(applicationEntity)
             }
@@ -1292,6 +1298,10 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             )
 
             Assertions.assertThat(responseBody.assessment!!.statusUpdates).isEqualTo(emptyList<Cas2StatusUpdate>())
+            assertThat(responseBody.allocatedPomEmailAddress).isEqualTo(userEntity.email)
+            assertThat(responseBody.allocatedPomName).isEqualTo(userEntity.name)
+            assertThat(responseBody.assignmentDate).isEqualTo(applicationEntity.currentAssignmentDate)
+            assertThat(responseBody.currentPrisonName).isEqualTo(omu.prisonName)
 
             Assertions.assertThat(responseBody.timelineEvents!!.map { event -> event.label })
               .isEqualTo(listOf("Application submitted"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/Cas2ApplicationEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/entity/Cas2ApplicationEntityTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.entity
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 
@@ -19,12 +18,5 @@ class Cas2ApplicationEntityTest {
     application.createApplicationAssignment(prisonCode = prisonCode, allocatedPomUser = user)
     assertThat(application.currentPrisonCode).isEqualTo(prisonCode)
     assertThat(application.mostRecentPomUserId).isEqualTo(user.id)
-  }
-
-  @Test
-  fun `should throw error when no assignments exists`() {
-    val application = Cas2ApplicationEntityFactory().withNomsNumber(nomsNumber).withCreatedByUser(user).produce()
-    val exception = assertThrows<NoSuchElementException> { application.currentPrisonCode }
-    assertThat(exception.message).isEqualTo("List is empty.")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/Cas2LocationChangedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/Cas2LocationChangedServiceTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2EmailSe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2LocationChangedService
 import java.time.Instant
 import java.time.ZoneId
-import kotlin.NoSuchElementException
 
 @ExtendWith(MockKExtension::class)
 class Cas2LocationChangedServiceTest {
@@ -108,7 +107,7 @@ class Cas2LocationChangedServiceTest {
     every { applicationService.findMostRecentApplication(eq(nomsNumber)) } returns application
     every { applicationRepository.save(any()) } returns application
 
-    assertThrows<NoSuchElementException> { locationChangedService.process(locationEvent) }
+    assertThrows<NullPointerException> { locationChangedService.process(locationEvent) }
 
     verify(exactly = 1) { prisonerSearchClient.getPrisoner(any()) }
     verify(exactly = 1) { applicationService.findMostRecentApplication(eq(nomsNumber)) }


### PR DESCRIPTION
This PR updates the Cas 2 applications to include POM name, current Prison, and email address with the main application.

It also adds missing data to the start up script, so applications are (more) correctly populated.