### PR TITLE
APS-2178 - Check application status when creating an appeal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -411,6 +411,10 @@ class ApplicationsController(
     val application =
       extractEntityFromCasResult(applicationService.getApplicationForUsername(applicationId, user.deliusUsername))
 
+    if (application !is ApprovedPremisesApplicationEntity) {
+      throw ConflictProblem(applicationId, "Only CAS1 applications are supported")
+    }
+
     val assessment = application.getLatestAssessment()
       ?: throw ConflictProblem(
         applicationId,
@@ -431,7 +435,7 @@ class ApplicationsController(
 
     return ResponseEntity
       .created(URI.create("/applications/${application.id}/appeals/${appeal.id}"))
-      .body(appealTransformer.transformJpaToApi(extractEntityFromCasResult(createAppealResult)))
+      .body(appealTransformer.transformJpaToApi(appeal))
   }
 
   override fun applicationsApplicationIdAssessmentGet(applicationId: UUID): ResponseEntity<Assessment> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -427,23 +427,11 @@ class ApplicationsController(
       createdBy = user,
     )
 
-    val validationResult = when (createAppealResult) {
-      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(applicationId, "Application")
-      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
-      is AuthorisableActionResult.Success -> createAppealResult.entity
-    }
-
-    val appeal = when (validationResult) {
-      is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = validationResult.message)
-      is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = validationResult.validationMessages)
-      is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message)
-
-      is ValidatableActionResult.Success -> validationResult.entity
-    }
+    val appeal = extractEntityFromCasResult(createAppealResult)
 
     return ResponseEntity
       .created(URI.create("/applications/${application.id}/appeals/${appeal.id}"))
-      .body(appealTransformer.transformJpaToApi(appeal))
+      .body(appealTransformer.transformJpaToApi(extractEntityFromCasResult(createAppealResult)))
   }
 
   override fun applicationsApplicationIdAssessmentGet(applicationId: UUID): ResponseEntity<Assessment> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
@@ -42,13 +43,17 @@ class AppealService(
     appealDetail: String,
     decision: AppealDecision,
     decisionDetail: String,
-    application: ApplicationEntity,
+    application: ApprovedPremisesApplicationEntity,
     assessment: AssessmentEntity,
     createdBy: UserEntity,
   ): CasResult<AppealEntity> {
     if (!createdBy.hasRole(UserRole.CAS1_APPEALS_MANAGER)) return CasResult.Unauthorised()
 
     return validatedCasResult {
+      if (application.status != ApprovedPremisesApplicationStatus.REJECTED) {
+        return generalError("Appeals can only be created for rejected applications")
+      }
+
       if (appealDate.isAfter(LocalDate.now())) {
         "$.appealDate" hasValidationError "mustNotBeFuture"
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AppealService.kt
@@ -11,9 +11,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealEmailService
 import java.time.LocalDate
@@ -45,55 +45,53 @@ class AppealService(
     application: ApplicationEntity,
     assessment: AssessmentEntity,
     createdBy: UserEntity,
-  ): AuthorisableActionResult<ValidatableActionResult<AppealEntity>> {
-    if (!createdBy.hasRole(UserRole.CAS1_APPEALS_MANAGER)) return AuthorisableActionResult.Unauthorised()
+  ): CasResult<AppealEntity> {
+    if (!createdBy.hasRole(UserRole.CAS1_APPEALS_MANAGER)) return CasResult.Unauthorised()
 
-    return AuthorisableActionResult.Success(
-      validated {
-        if (appealDate.isAfter(LocalDate.now())) {
-          "$.appealDate" hasValidationError "mustNotBeFuture"
+    return validatedCasResult {
+      if (appealDate.isAfter(LocalDate.now())) {
+        "$.appealDate" hasValidationError "mustNotBeFuture"
+      }
+
+      if (appealDetail.isBlank()) {
+        "$.appealDetail" hasValidationError "empty"
+      }
+
+      if (decisionDetail.isBlank()) {
+        "$.decisionDetail" hasValidationError "empty"
+      }
+
+      if (validationErrors.any()) {
+        return@validatedCasResult fieldValidationError
+      }
+
+      val appeal = appealRepository.save(
+        AppealEntity(
+          id = UUID.randomUUID(),
+          appealDate = appealDate,
+          appealDetail = appealDetail,
+          decision = decision.value,
+          decisionDetail = decisionDetail,
+          createdAt = OffsetDateTime.now(),
+          application = application,
+          assessment = assessment,
+          createdBy = createdBy,
+        ),
+      )
+
+      cas1AppealDomainEventService.appealRecordCreated(appeal)
+
+      when (decision) {
+        AppealDecision.accepted -> {
+          assessmentService.createApprovedPremisesAssessment(application as ApprovedPremisesApplicationEntity, createdFromAppeal = true)
+          cas1AppealEmailService.appealSuccess(application, appeal)
         }
-
-        if (appealDetail.isBlank()) {
-          "$.appealDetail" hasValidationError "empty"
+        AppealDecision.rejected -> {
+          cas1AppealEmailService.appealFailed(application as ApprovedPremisesApplicationEntity)
         }
+      }
 
-        if (decisionDetail.isBlank()) {
-          "$.decisionDetail" hasValidationError "empty"
-        }
-
-        if (validationErrors.any()) {
-          return@validated fieldValidationError
-        }
-
-        val appeal = appealRepository.save(
-          AppealEntity(
-            id = UUID.randomUUID(),
-            appealDate = appealDate,
-            appealDetail = appealDetail,
-            decision = decision.value,
-            decisionDetail = decisionDetail,
-            createdAt = OffsetDateTime.now(),
-            application = application,
-            assessment = assessment,
-            createdBy = createdBy,
-          ),
-        )
-
-        cas1AppealDomainEventService.appealRecordCreated(appeal)
-
-        when (decision) {
-          AppealDecision.accepted -> {
-            assessmentService.createApprovedPremisesAssessment(application as ApprovedPremisesApplicationEntity, createdFromAppeal = true)
-            cas1AppealEmailService.appealSuccess(application, appeal)
-          }
-          AppealDecision.rejected -> {
-            cas1AppealEmailService.appealFailed(application as ApprovedPremisesApplicationEntity)
-          }
-        }
-
-        success(appeal)
-      },
-    )
+      success(appeal)
+    }
   }
 }


### PR DESCRIPTION
This PR ensures that the application has a status of ‘rejected’ when creating an appeal. This fixes a bug we have observed where multiple users can create an appeal for the same application if they don’t navigate away from the application page.

This PR also removes deprecated code and replaces it with `CasResult`