### PR TITLE
CBA-434-implement-new-status-details-content-in-assessor-view

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2v2/Cas2v2ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2v2/Cas2v2ReferenceDataController.kt
@@ -5,13 +5,13 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2v2.ReferenceDataCas2v2Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2v2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationStatusTransformer
 
 @Service
 class Cas2v2ReferenceDataController(
   private val statusTransformer: ApplicationStatusTransformer,
-  private val statusFinder: Cas2PersistedApplicationStatusFinder,
+  private val statusFinder: Cas2v2PersistedApplicationStatusFinder,
 ) : ReferenceDataCas2v2Delegate {
   override fun referenceDataApplicationStatusGet(): ResponseEntity<List<Cas2v2ApplicationStatus>> = ResponseEntity.ok(transformToApi(statusFinder.active()))
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import java.util.UUID
 
 object Cas2ApplicationStatusSeeding {
 
-  @SuppressWarnings("LongMethod")
-  fun statusList(): List<Cas2PersistedApplicationStatus> = listOf(
+  val statuses = listOf(
     Cas2PersistedApplicationStatus(
       id = UUID.fromString("f5cd423b-08eb-4efb-96ff-5cc6bb073905"),
       name = "moreInfoRequested",
@@ -16,6 +16,49 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("fabbb8c0-344e-4a9d-a964-7987b22d09c6"),
           name = "personalInformation",
           label = "Personal information",
+          applicableToServices = listOf(ServiceName.cas2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("3df29b1b-e2fc-4df7-b4b8-0527cd9e3a6f"),
+          name = "applicantDetails",
+          label = "Applicant details",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("28926b7b-2056-478c-95fe-a611967b8fab"),
+          name = "concernsToOthers",
+          label = "Concerns to others",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("76be117e-c496-489c-a69d-ef26a05a6f64"),
+          name = "concernsToTheApplicant",
+          label = "Concerns to the applicant",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("03718bee-a0f1-4a5d-b095-e23c2b1211ab"),
+          name = "currentAllegedOffences",
+          label = "Current alleged offences",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("53f17f5b-c3bb-4bd2-9ccb-b5f0664aa104"),
+          name = "previousUnspentConvictions",
+          label = "Previous unspent convictions",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("4c8e39ea-0f8b-4131-a781-cac706f38914"),
+          name = "probationAndOASys",
+          label = "Probation & OASys",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("0e78cbc4-4139-4402-8a8a-763d9ca5d93b"),
+          name = "fundingAndID",
+          label = "Funding & ID",
+          applicableToServices = listOf(ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("05669c8a-d65c-48d2-a5e4-0c3f6fc8977b"),
@@ -31,26 +74,31 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("7ba5cd7d-8ae3-4fe5-bb27-9367197ea160"),
           name = "riskToSelf",
           label = "Risk to self",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("8641d719-7356-42d3-8363-e323bf76caec"),
           name = "riskOfSeriousHarm",
           label = "Risk of serious harm",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("90f075ae-0b9f-445b-a9b5-1095abca87dc"),
           name = "currentOffences",
           label = "Current offences",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("8ce77ea1-324e-4ac8-be8c-33d6d4d927f8"),
           name = "offendingHistory",
           label = "Offending history",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("d2c44705-2795-4610-9879-dcf26940e121"),
           name = "hdcAndCpp",
           label = "HDC licence and CPP details",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("94631a70-6c51-43d6-9112-2b6d042b5aa0"),
@@ -137,6 +185,25 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("ed5d529c-d7d1-4f29-a0c0-89fd104cc320"),
           name = "rehousedByAnotherLandlord",
           label = "Rehoused by another landlord",
+          applicableToServices = listOf(ServiceName.cas2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("37aa6cab-1ef7-497e-8a8c-624c9ab69f5a"),
+          name = "applicantBailedToNonCAS2Accommodation",
+          label = "Applicant bailed to non CAS2 accommodation",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("566f7a9e-00c4-431d-9b3c-af87ff78379d"),
+          name = "applicantRemandedInCustody",
+          label = "Applicant remanded in custody",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("74397513-72f8-4efc-9ecf-32adf8c1db8a"),
+          name = "applicantUnableToAffordRent",
+          label = "Applicant unable to afford rent",
+          applicableToServices = listOf(ServiceName.cas2v2),
         ),
       ),
     ),
@@ -150,21 +217,25 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("e4a2391e-e847-427a-a913-51e0b0ad9f52"),
           name = "hdcNoLongerEligible",
           label = "HDC - no longer eligible",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("c5dce0d2-fc05-4a07-8157-25b8821cdb06"),
           name = "governorDecidedUnsuitable",
           label = "Governor - decided unsuitable",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("3fb37f85-be88-4eee-812d-af122e268eef"),
           name = "governorChosenAlternative",
           label = "Governor - chosen alternative accommodation",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("8a857a7d-94f9-43ec-963c-2a2528e88a6e"),
           name = "governorOther",
           label = "Governor - other",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("d3c789b8-947d-4e24-9cef-335545d85abe"),
@@ -175,6 +246,53 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("6fc8d3b7-eb53-479d-8903-3880a9ed563f"),
           name = "personTransferredToAnotherPrisonWithdrawal",
           label = "Person transferred to another prison",
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("3acf6010-820a-458d-ae8d-1d8a937af890"),
+          name = "changeOfCircumstances",
+          label = "Change of circumstances",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("cc5e63f7-c37a-46f5-a83a-5953e40881c6"),
+          name = "sentencingHearingBooked",
+          label = "Sentencing hearing booked",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("766a1675-b917-4532-8485-6ec0380f4f4c"),
+          name = "applicantTransferredToAnotherPrisonWithdrawal",
+          label = "Applicant transferred to another prison",
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("c985337e-b9a7-4609-ac9b-fb8b5ec4a48a"),
+          name = "applicantBailedToNonCAS2Accommodation",
+          label = "Applicant bailed to non CAS2 accommodation",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("170787fa-8474-40e7-bdf7-c9f072ce06ef"),
+          name = "applicantGivenCommunitySentence",
+          label = "Applicant given community sentence",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("fec969b5-6cab-459e-a595-8337e43b34a8"),
+          name = "applicantGivenCustodialSentence",
+          label = "Applicant given custodial sentence",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("3440c6c1-b5ff-4b76-ae48-ecf80a3cec49"),
+          name = "applicantGivenCustodialSentence",
+          label = "Other sentence",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("cf339ef6-bcd7-47ae-8f54-b0011a46a3c8"),
+          name = "applicantRemandedInCustody",
+          label = "Applicant remanded in custody",
+          applicableToServices = listOf(ServiceName.cas2v2),
         ),
       ),
     ),
@@ -233,11 +351,13 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("f38f55c0-fda6-44f8-a3b1-a7c0a990bc51"),
           name = "hdcNotEligible",
           label = "HDC not eligible",
+          applicableToServices = listOf(ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("4f1033ab-2dea-47ce-8a86-7c47b3ccadd8"),
           name = "personTransferredToAnotherPrison",
           label = "Person transferred to another prison",
+          applicableToServices = listOf(ServiceName.cas2v2),
         ),
       ),
     ),
@@ -248,4 +368,25 @@ object Cas2ApplicationStatusSeeding {
       description = "The accommodation is arranged for the agreed dates.",
     ),
   )
+
+  @SuppressWarnings("LongMethod")
+  fun statusList(
+    services: List<ServiceName> = listOf(
+      ServiceName.cas2,
+      ServiceName.cas2v2,
+    ),
+  ): List<Cas2PersistedApplicationStatus> {
+    val filteredStatuses = mutableListOf<Cas2PersistedApplicationStatus>()
+    for (status in statuses) {
+      val cas2PersistedApplicationStatus = Cas2PersistedApplicationStatus(
+        id = status.id,
+        name = status.name,
+        label = status.label,
+        description = status.description,
+        statusDetails = status.statusDetails?.filter { detail -> detail.applicableToServices.any { service -> service in services } },
+      )
+      filteredStatuses.add(cas2PersistedApplicationStatus)
+    }
+    return filteredStatuses
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt
@@ -64,11 +64,13 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("05669c8a-d65c-48d2-a5e4-0c3f6fc8977b"),
           name = "exclusionZonesAndAreas",
           label = "Exclusion zones and preferred areas",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("831c241d-63f3-4d17-b969-b8154d7e4902"),
           name = "healthNeeds",
           label = "Health needs",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("7ba5cd7d-8ae3-4fe5-bb27-9367197ea160"),
@@ -104,6 +106,7 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("94631a70-6c51-43d6-9112-2b6d042b5aa0"),
           name = "other",
           label = "Other",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
       ),
     ),
@@ -155,31 +158,37 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("62645779-242d-4601-a8f8-d2cbf1d41dfa"),
           name = "areaUnsuitable",
           label = "Area unsuitable",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("fc38f750-e9d2-4270-b542-d38286b9855c"),
           name = "changeOfCircumstances",
           label = "Change of circumstances",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("31122b89-e087-4b5f-b59a-f7ffa0dd3e0c"),
           name = "noResponse",
           label = "No response",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("32e62af3-6ea5-4496-a82c-b7bad67080a5"),
           name = "offerWithdrawnByNacro",
           label = "Offer withdrawn by Nacro",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("b5bfbff4-aaa6-4fb0-ba36-5bca58927dc5"),
           name = "propertyUnsuitable",
           label = "Property unsuitable for needs",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("f58267b8-f91b-4a4f-9aa2-80089ba111e4"),
           name = "withdrawnByReferrer",
           label = "Withdrawn by referrer",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("ed5d529c-d7d1-4f29-a0c0-89fd104cc320"),
@@ -241,11 +250,13 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("d3c789b8-947d-4e24-9cef-335545d85abe"),
           name = "withdrewOrDeclinedOffer",
           label = "Withdrew or declined offer",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("6fc8d3b7-eb53-479d-8903-3880a9ed563f"),
           name = "personTransferredToAnotherPrisonWithdrawal",
           label = "Person transferred to another prison",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("3acf6010-820a-458d-ae8d-1d8a937af890"),
@@ -263,6 +274,7 @@ object Cas2ApplicationStatusSeeding {
           id = UUID.fromString("766a1675-b917-4532-8485-6ec0380f4f4c"),
           name = "applicantTransferredToAnotherPrisonWithdrawal",
           label = "Applicant transferred to another prison",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("c985337e-b9a7-4609-ac9b-fb8b5ec4a48a"),
@@ -303,61 +315,76 @@ object Cas2ApplicationStatusSeeding {
       description = "The application has been cancelled.",
       statusDetails = listOf(
         Cas2PersistedApplicationStatusDetail(
+          id = UUID.fromString("ba46bbe0-8fb6-4539-cccc-5586e6bfe8b6"),
+          name = "nacroAssessedAsHighRisk",
+          label = "NACRO assessed as high risk",
+          applicableToServices = listOf(ServiceName.cas2v2),
+        ),
+        Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("ba46bbe0-8fb6-4539-895d-5586e6bfe8b6"),
           name = "assessedAsHighRisk",
           label = "Assessed as high risk",
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("522bb736-aeb6-480f-a51a-2bf3dcfcd482"),
           name = "notEligible",
           label = "Not eligible",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("ccf43af1-359b-4a14-8941-85eefa88f016"),
           name = "noRecourseToPublicFunds",
           label = "No recourse to public funds",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("c149a14d-ba06-420a-b844-5edfc02da6b1"),
           name = "noPropertyAvailable",
           label = "No property available",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("3fbdccc9-4858-4ae4-abb5-bd2b90d96d96"),
           name = "noFemalePropertyAvailable",
           label = "No female property available",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("bc539d6d-c353-49fa-847f-6967a148c527"),
           name = "noAdaptedPropertyAvailable",
           label = "No adapted property available",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("78636840-0155-45d4-971e-fe8d2d6c660c"),
           name = "noSuitablePropertyAvailable",
           label = "No suitable property available",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("7e8749c9-5254-4dae-90ed-590cf9f59847"),
           name = "incompleteReferral",
           label = "Incomplete referral",
+          applicableToServices = listOf(ServiceName.cas2, ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("d1d96185-d92a-450b-b47f-bcce50356eed"),
           name = "createdInError",
           label = "Created in error",
+          applicableToServices = listOf(ServiceName.cas2v2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("f38f55c0-fda6-44f8-a3b1-a7c0a990bc51"),
           name = "hdcNotEligible",
           label = "HDC not eligible",
-          applicableToServices = listOf(ServiceName.cas2v2),
+          applicableToServices = listOf(ServiceName.cas2),
         ),
         Cas2PersistedApplicationStatusDetail(
           id = UUID.fromString("4f1033ab-2dea-47ce-8a86-7c47b3ccadd8"),
           name = "personTransferredToAnotherPrison",
           label = "Person transferred to another prison",
-          applicableToServices = listOf(ServiceName.cas2v2),
+          applicableToServices = listOf(ServiceName.cas2),
         ),
       ),
     ),
@@ -368,25 +395,17 @@ object Cas2ApplicationStatusSeeding {
       description = "The accommodation is arranged for the agreed dates.",
     ),
   )
+  fun statusList(service: ServiceName): List<Cas2PersistedApplicationStatus> = statuses
+    .mapNotNull { status ->
+      when {
+        status.statusDetails.isNullOrEmpty() -> status
+        else -> {
+          val filteredDetails = status.statusDetails!!
+            .filter { it.applicableToServices.contains(service) }
+            .takeIf { it.isNotEmpty() }
 
-  @SuppressWarnings("LongMethod")
-  fun statusList(
-    services: List<ServiceName> = listOf(
-      ServiceName.cas2,
-      ServiceName.cas2v2,
-    ),
-  ): List<Cas2PersistedApplicationStatus> {
-    val filteredStatuses = mutableListOf<Cas2PersistedApplicationStatus>()
-    for (status in statuses) {
-      val cas2PersistedApplicationStatus = Cas2PersistedApplicationStatus(
-        id = status.id,
-        name = status.name,
-        label = status.label,
-        description = status.description,
-        statusDetails = status.statusDetails?.filter { detail -> detail.applicableToServices.any { service -> service in services } },
-      )
-      filteredStatuses.add(cas2PersistedApplicationStatus)
+          filteredDetails?.let { status.copy(statusDetails = it) }
+        }
+      }
     }
-    return filteredStatuses
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatus.kt
@@ -7,7 +7,7 @@ data class Cas2PersistedApplicationStatus(
   val name: String,
   val label: String,
   val description: String,
-  val statusDetails: List<Cas2PersistedApplicationStatusDetail>? = emptyList(),
+  val statusDetails: List<Cas2PersistedApplicationStatusDetail>? = null,
   val isActive: Boolean = true,
 ) {
   fun findStatusDetailOnStatus(detailName: String) = statusDetails?.find { detail -> detail.name == detailName }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatusDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatusDetail.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import java.util.UUID
 
 data class Cas2PersistedApplicationStatusDetail(
@@ -7,4 +8,5 @@ data class Cas2PersistedApplicationStatusDetail(
   val name: String,
   val label: String,
   val isActive: Boolean = true,
+  val applicableToServices: List<ServiceName> = listOf(ServiceName.cas2, ServiceName.cas2v2),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatusFinder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2PersistedApplicationStatusFinder.kt
@@ -1,11 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import java.util.UUID
 
 @Component
 class Cas2PersistedApplicationStatusFinder(
-  private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(),
+  private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2),
 ) {
   fun all(): List<Cas2PersistedApplicationStatus> = statusList
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2v2PersistedApplicationStatusFinder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2v2PersistedApplicationStatusFinder.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 
 @Component
 class Cas2v2PersistedApplicationStatusFinder(
-  private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(listOf(ServiceName.cas2v2)),
+  private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2v2),
 ) {
   fun all(): List<Cas2PersistedApplicationStatus> = statusList
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2v2PersistedApplicationStatusFinder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2v2PersistedApplicationStatusFinder.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import java.util.UUID
+
+@Component
+class Cas2v2PersistedApplicationStatusFinder(
+  private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(listOf(ServiceName.cas2v2)),
+) {
+  fun all(): List<Cas2PersistedApplicationStatus> = statusList
+
+  fun active(): List<Cas2PersistedApplicationStatus> = statusList.filter { it.isActive }
+
+  fun getById(id: UUID): Cas2PersistedApplicationStatus = statusList.find { status -> status.id == id }
+    ?: error("Status with id $id not found")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2StatusUpdateService.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2v2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2DomainEventService
@@ -45,15 +45,13 @@ class Cas2v2StatusUpdateService(
   private val domainEventService: Cas2DomainEventService,
   private val emailNotificationService: EmailNotificationService,
   private val notifyConfig: NotifyConfig,
-  private val statusFinder: Cas2PersistedApplicationStatusFinder,
+  private val cas2v2PersistedApplicationStatusFinder: Cas2v2PersistedApplicationStatusFinder,
   private val statusTransformer: ApplicationStatusTransformer,
   @Value("\${url-templates.frontend.cas2v2.application}") private val applicationUrlTemplate: String,
   @Value("\${url-templates.frontend.cas2v2.application-overview}") private val applicationOverviewUrlTemplate: String,
 ) {
 
   private val log = LoggerFactory.getLogger(this::class.java)
-
-  fun isValidStatus(statusUpdate: Cas2v2AssessmentStatusUpdate): Boolean = findActiveStatusByName(statusUpdate.newStatus) != null
 
   @Transactional
   @SuppressWarnings("ReturnCount")
@@ -113,7 +111,7 @@ class Cas2v2StatusUpdateService(
     return CasResult.Success(createdStatusUpdate)
   }
 
-  private fun findActiveStatusByName(statusName: String): Cas2PersistedApplicationStatus? = statusFinder.active()
+  private fun findActiveStatusByName(statusName: String): Cas2PersistedApplicationStatus? = cas2v2PersistedApplicationStatusFinder.active()
     .find { status -> status.name == statusName }
 
   fun createStatusUpdatedDomainEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2StatusUpdateEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
@@ -17,7 +18,7 @@ class Cas2StatusUpdateEntityFactory : Factory<Cas2StatusUpdateEntity> {
   private var assessor: Yielded<ExternalUserEntity> = { ExternalUserEntityFactory().produce() }
   private var assessment: Yielded<Cas2AssessmentEntity?> = { null }
   private var application: Yielded<Cas2ApplicationEntity>? = null
-  private var statusId: Yielded<UUID> = { Cas2ApplicationStatusSeeding.statusList().random().id }
+  private var statusId: Yielded<UUID> = { Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2).random().id }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var label: Yielded<String> = { "More information requested" }
   private var description: Yielded<String> = { "More information about the application has been requested" }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2StatusUpdateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2v2/Cas2v2StatusUpdateEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2StatusUpdateDetailEntity
@@ -17,7 +18,7 @@ class Cas2v2StatusUpdateEntityFactory : Factory<Cas2v2StatusUpdateEntity> {
   private var assessor: Yielded<Cas2v2UserEntity> = { Cas2v2UserEntityFactory().produce() }
   private var assessment: Yielded<Cas2v2AssessmentEntity?> = { null }
   private var application: Yielded<Cas2v2ApplicationEntity>? = null
-  private var statusId: Yielded<UUID> = { Cas2ApplicationStatusSeeding.statusList().random().id }
+  private var statusId: Yielded<UUID> = { Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2).random().id }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
   private var label: Yielded<String> = { "More information requested" }
   private var description: Yielded<String> = { "More information about the application has been requested" }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2StatusUpdateTest.kt
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2Assessor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
@@ -113,7 +114,7 @@ class Cas2StatusUpdateTest(
           val persistedStatusUpdate = realStatusUpdateRepository.findFirstByApplicationIdOrderByCreatedAtDesc(application.id)
           assertThat(persistedStatusUpdate!!.assessment!!.id).isEqualTo(assessmentId)
 
-          val appliedStatus = Cas2ApplicationStatusSeeding.statusList()
+          val appliedStatus = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2)
             .find { status ->
               status.id == persistedStatusUpdate.statusId
             }
@@ -231,7 +232,7 @@ class Cas2StatusUpdateTest(
                 realStatusUpdateDetailRepository.findFirstByStatusUpdateIdOrderByCreatedAtDesc(persistedStatusUpdate!!.id)
               assertThat(persistedStatusDetailUpdate).isNotNull
 
-              val appliedStatus = Cas2ApplicationStatusSeeding.statusList()
+              val appliedStatus = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2)
                 .find { status ->
                   status.id == persistedStatusUpdate.statusId
                 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2ReferenceDataTest.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2v2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationStatusTransformer
+
+class Cas2v2ReferenceDataTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var statusTransformer: ApplicationStatusTransformer
+
+  @Autowired
+  lateinit var cas2v2statusFinder: Cas2v2PersistedApplicationStatusFinder
+
+  @Autowired
+  lateinit var cas2statusFinder: Cas2PersistedApplicationStatusFinder
+
+  @Test
+  fun `All available application status options are returned`() {
+    val expectedStatusOptions = objectMapper.writeValueAsString(
+      cas2v2statusFinder.active().map { status -> statusTransformer.transformModelToApi(status) },
+    )
+
+    val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt()
+
+    webTestClient.get()
+      .uri("/cas2v2/reference-data/application-status")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(expectedStatusOptions)
+  }
+
+  @Test
+  fun `Ensure CAS2 and CAS2V2 lists are different`() {
+    val expectedCas2StatusOptions = objectMapper.writeValueAsString(
+      cas2statusFinder.active().map { status -> statusTransformer.transformModelToApi(status) },
+    )
+
+    val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt()
+
+    webTestClient.get()
+      .uri("/cas2v2/reference-data/application-status")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(String::class.java)
+      .consumeWith { result ->
+        val responseJson = result.responseBody
+        assertThat(responseJson).isNotEqualTo(expectedCas2StatusOptions)
+      }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2StatusUpdateTest.kt
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2AssessmentStatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.Cas2v2IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2Assessor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2PomUser
@@ -113,7 +114,7 @@ class Cas2v2StatusUpdateTest(
           val persistedStatusUpdate = realCas2v2StatusUpdateRepository.findFirstByApplicationIdOrderByCreatedAtDesc(application.id)
           assertThat(persistedStatusUpdate!!.assessment!!.id).isEqualTo(assessmentId)
 
-          val appliedStatus = Cas2ApplicationStatusSeeding.statusList()
+          val appliedStatus = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2)
             .find { status ->
               status.id == persistedStatusUpdate.statusId
             }
@@ -231,7 +232,7 @@ class Cas2v2StatusUpdateTest(
                 realCas2v2StatusUpdateDetailRepository.findFirstByStatusUpdateIdOrderByCreatedAtDesc(persistedStatusUpdate.id)
               assertThat(persistedStatusDetailUpdate).isNotNull
 
-              val appliedStatus = Cas2ApplicationStatusSeeding.statusList()
+              val appliedStatus = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2)
                 .find { status ->
                   status.id == persistedStatusUpdate.statusId
                 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/reference/Cas2PersistedApplicationStatusFinderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/reference/Cas2PersistedApplicationStatusFinderTest.kt
@@ -1,9 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.model.reference
 
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2ApplicationStatusSeeding
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.reference.Cas2PersistedApplicationStatusFinder
 import java.util.UUID
@@ -71,6 +77,95 @@ class Cas2PersistedApplicationStatusFinderTest {
       Assertions.assertThat(exception.message).isEqualTo(
         "Status with id 9887f81e-1a81-49b8-b0a6-5a17b3c9d7d1 not found",
       )
+    }
+  }
+
+  @Nested
+  inner class ServiceDifferentiation {
+    @Test
+    fun `Requests for CAS2 service returns only CAS2 detail updates`() {
+      val statusList = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2)
+      val finder = Cas2PersistedApplicationStatusFinder(statusList)
+
+      val statuses = finder.all()
+
+      assertEquals(11, statuses.size, "Should return exactly 11 status updates")
+
+      val expectedDetailsSizes = mapOf(
+        0 to 9,
+        7 to 7,
+        8 to 7,
+        9 to 10,
+      )
+
+      statuses.forEachIndexed { index, status ->
+        if (index in expectedDetailsSizes.keys) {
+          assertNotNull(status.statusDetails, "Status at index $index should have details")
+          assertEquals(
+            expectedDetailsSizes[index],
+            status.statusDetails?.size,
+            "Unexpected details size at index $index",
+          )
+        } else {
+          assertNull(
+            status.statusDetails,
+            "Status at index $index should not have details",
+          )
+        }
+      }
+
+      // Verify all details are applicable to CAS2 service
+      statuses
+        .flatMap { it.statusDetails.orEmpty() }
+        .forEach { detail ->
+          assertTrue(
+            detail.applicableToServices.contains(ServiceName.cas2),
+            "All details should be applicable to CAS2 service",
+          )
+        }
+    }
+
+    @Test
+    fun `Requests for CAS2v2 service returns only CAS2v2 detail updates`() {
+      val statusList = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2v2)
+      val finder = Cas2PersistedApplicationStatusFinder(statusList)
+
+      val statuses = finder.all()
+
+      assertEquals(11, statuses.size, "Should return exactly 11 status updates")
+
+      val expectedDetailsSizes = mapOf(
+        0 to 10,
+        7 to 9,
+        8 to 10,
+        9 to 9,
+      )
+
+      statuses.forEachIndexed { index, status ->
+        if (index in expectedDetailsSizes.keys) {
+          assertNotNull(status.statusDetails, "Status at index $index should have details")
+          assertEquals(
+            expectedDetailsSizes[index],
+            status.statusDetails?.size,
+            "Unexpected details size at index $index",
+          )
+        } else {
+          assertNull(
+            status.statusDetails,
+            "Status at index $index should not have details",
+          )
+        }
+      }
+
+      // Verify all details are applicable to CAS2 service
+      statuses
+        .flatMap { it.statusDetails.orEmpty() }
+        .forEach { detail ->
+          assertTrue(
+            detail.applicableToServices.contains(ServiceName.cas2v2),
+            "All details should be applicable to CAS2 service",
+          )
+        }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/StatusUpdateTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/StatusUpdateTransformerTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ExternalUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
@@ -33,7 +34,7 @@ class StatusUpdateTransformerTest {
 
   @Test
   fun `transforms JPA Cas2StatusUpdate db entity to API representation`() {
-    val status = Cas2ApplicationStatusSeeding.statusList().random()
+    val status = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2).random()
 
     val jpaEntity = Cas2StatusUpdateEntityFactory()
       .withStatusId(status.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2StatusUpdateTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2StatusUpdateTransformerTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2v2.Cas2v2UserEntityFactory
@@ -33,7 +34,7 @@ class Cas2v2StatusUpdateTransformerTest {
 
   @Test
   fun `transforms JPA Cas2v2StatusUpdate db entity to API representation`() {
-    val status = Cas2ApplicationStatusSeeding.statusList().random()
+    val status = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2).random()
 
     val jpaEntity = Cas2v2StatusUpdateEntityFactory()
       .withStatusId(status.id)


### PR DESCRIPTION
In the Bail UI we inherit the status updates from CAS2. These are defined in code [here](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/reference/Cas2ApplicationStatusSeeding.kt)

This list needs to be changed as set out in [this ticket](https://dsdmoj.atlassian.net/browse/CBA-434). Since some fields don't make sense for the different services, e.g. HDC licence and CPP details (CAS2) or  Previous unspent convictions (Bail), we need to differentiate the updates. The updates are referenced by UUID in other areas of the code, e.g. the [live applications SQL for the application repository](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/resources/db/migration/all/20250107134233__application_controller_and_linked_services_in_cas2v2.sql#L161) which creates a worrying number of unknown unknowns.

To solve this issue we will add a service `enum` to the `Cas2PersistedApplicationStatus` in the seeder mentioned above.  This will default to CAS1, CAS2, CAS3 on all the existing updates, and then we can add our new statuses for Bail as CAS2V2 and exclude those from existing services while including the the ones we need from the existing services.

The status updates are pulled by the UI via `/reference/status-updates`. In the all the services that use that (those) end points we need to add code to include/exclude the Bail status updates from that returned list.


## Plan

 * Add a ServiceName enum to the Status update data class
 * Modify the find to filter on service name
 * Update the reference end points to pass service name
 * if no service is passed default to existing list
 * Update tests

