### PR TITLE
Improve `built-cas1-roles.json` formatting

### DIFF
--- a/src/main/resources/static/codegen/built-cas1-roles.json
+++ b/src/main/resources/static/codegen/built-cas1-roles.json
@@ -1,52 +1,194 @@
-[ {
-  "name" : "assessor",
-  "permissions" : [ "cas1_assess_appealed_application", "cas1_assess_application", "cas1_assess_placement_application", "cas1_view_assigned_assessments" ]
-}, {
-  "name" : "matcher",
-  "permissions" : [ ]
-}, {
-  "name" : "future_manager",
-  "permissions" : [ "cas1_out_of_service_bed_create", "cas1_premises_view", "cas1_premises_manage", "cas1_space_booking_list", "cas1_space_booking_record_arrival", "cas1_space_booking_record_departure", "cas1_space_booking_record_non_arrival", "cas1_space_booking_record_keyworker", "cas1_space_booking_view", "cas1_view_out_of_service_beds" ]
-}, {
-  "name" : "workflow_manager",
-  "permissions" : [ "cas1_adhoc_booking_create", "cas1_application_withdraw_others", "cas1_booking_change_dates", "cas1_booking_withdraw", "cas1_premises_view", "cas1_request_for_placement_withdraw_others", "cas1_user_list", "cas1_view_cru_dashboard", "cas1_view_manage_tasks" ]
-}, {
-  "name" : "cru_member",
-  "permissions" : [ "cas1_adhoc_booking_create", "cas1_application_withdraw_others", "cas1_booking_change_dates", "cas1_booking_withdraw", "cas1_placement_request_record_unable_to_match", "cas1_premises_view", "cas1_request_for_placement_withdraw_others", "cas1_space_booking_list", "cas1_space_booking_view", "cas1_space_booking_withdraw", "cas1_user_list", "cas1_view_cru_dashboard", "cas1_view_manage_tasks", "cas1_booking_create" ]
-}, {
-  "name" : "cru_member_find_and_book_beta",
-  "permissions" : [ "cas1_adhoc_booking_create", "cas1_application_withdraw_others", "cas1_booking_change_dates", "cas1_booking_withdraw", "cas1_placement_request_record_unable_to_match", "cas1_premises_view", "cas1_request_for_placement_withdraw_others", "cas1_space_booking_list", "cas1_space_booking_view", "cas1_space_booking_withdraw", "cas1_user_list", "cas1_view_cru_dashboard", "cas1_view_manage_tasks", "cas1_premises_capacity_report_view", "cas1_space_booking_create", "cas1_out_of_service_bed_create", "cas1_out_of_service_bed_create_bed_on_hold", "cas1_out_of_service_bed_cancel", "cas1_view_out_of_service_beds", "cas1_emergency_transfer_perform" ]
-}, {
-  "name" : "cru_member_enable_out_of_service_beds",
-  "permissions" : [ "cas1_out_of_service_bed_create", "cas1_view_out_of_service_beds" ]
-}, {
-  "name" : "change_request_dev",
-  "permissions" : [ "cas1_change_request_list", "cas1_appeal_create", "cas1_planned_transfer_create", "cas1_appeal_assess", "cas1_planned_transfer_assess" ]
-}, {
-  "name" : "applicant",
-  "permissions" : [ ]
-}, {
-  "name" : "report_viewer",
-  "permissions" : [ "cas1_reports_view" ]
-}, {
-  "name" : "report_viewer_with_pii",
-  "permissions" : [ "cas1_reports_view", "cas1_reports_view_with_pii" ]
-}, {
-  "name" : "excluded_from_assess_allocation",
-  "permissions" : [ ]
-}, {
-  "name" : "excluded_from_match_allocation",
-  "permissions" : [ ]
-}, {
-  "name" : "excluded_from_placement_application_allocation",
-  "permissions" : [ ]
-}, {
-  "name" : "appeals_manager",
-  "permissions" : [ "cas1_assess_appealed_application", "cas1_assess_application", "cas1_process_an_appeal", "cas1_view_assigned_assessments" ]
-}, {
-  "name" : "janitor",
-  "permissions" : [ "cas1_adhoc_booking_create", "cas1_assess_appealed_application", "cas1_assess_application", "cas1_assess_placement_application", "cas1_booking_create", "cas1_booking_withdraw", "cas1_booking_change_dates", "cas1_change_request_list", "cas1_out_of_service_bed_create", "cas1_out_of_service_bed_create_bed_on_hold", "cas1_out_of_service_bed_cancel", "cas1_placement_request_record_unable_to_match", "cas1_process_an_appeal", "cas1_user_list", "cas1_user_management", "cas1_view_assigned_assessments", "cas1_view_cru_dashboard", "cas1_view_manage_tasks", "cas1_view_out_of_service_beds", "cas1_space_booking_create", "cas1_space_booking_list", "cas1_space_booking_record_arrival", "cas1_space_booking_record_departure", "cas1_space_booking_record_non_arrival", "cas1_space_booking_record_keyworker", "cas1_space_booking_view", "cas1_space_booking_withdraw", "cas1_premises_capacity_report_view", "cas1_premises_view", "cas1_premises_manage", "cas1_application_withdraw_others", "cas1_emergency_transfer_perform", "cas1_reports_view", "cas1_reports_view_with_pii", "cas1_request_for_placement_withdraw_others", "cas1_appeal_create", "cas1_planned_transfer_create", "cas1_appeal_assess", "cas1_planned_transfer_assess" ]
-}, {
-  "name" : "user_manager",
-  "permissions" : [ "cas1_user_list", "cas1_user_management" ]
-} ]
+[
+  {
+    "name" : "assessor",
+    "permissions" : [
+      "cas1_assess_appealed_application",
+      "cas1_assess_application",
+      "cas1_assess_placement_application",
+      "cas1_view_assigned_assessments"
+    ]
+  },
+  {
+    "name" : "matcher",
+    "permissions" : [ ]
+  },
+  {
+    "name" : "future_manager",
+    "permissions" : [
+      "cas1_out_of_service_bed_create",
+      "cas1_premises_manage",
+      "cas1_premises_view",
+      "cas1_space_booking_list",
+      "cas1_space_booking_record_arrival",
+      "cas1_space_booking_record_departure",
+      "cas1_space_booking_record_keyworker",
+      "cas1_space_booking_record_non_arrival",
+      "cas1_space_booking_view",
+      "cas1_view_out_of_service_beds"
+    ]
+  },
+  {
+    "name" : "workflow_manager",
+    "permissions" : [
+      "cas1_adhoc_booking_create",
+      "cas1_application_withdraw_others",
+      "cas1_booking_change_dates",
+      "cas1_booking_withdraw",
+      "cas1_premises_view",
+      "cas1_request_for_placement_withdraw_others",
+      "cas1_user_list",
+      "cas1_view_cru_dashboard",
+      "cas1_view_manage_tasks"
+    ]
+  },
+  {
+    "name" : "cru_member",
+    "permissions" : [
+      "cas1_adhoc_booking_create",
+      "cas1_application_withdraw_others",
+      "cas1_booking_change_dates",
+      "cas1_booking_create",
+      "cas1_booking_withdraw",
+      "cas1_placement_request_record_unable_to_match",
+      "cas1_premises_view",
+      "cas1_request_for_placement_withdraw_others",
+      "cas1_space_booking_list",
+      "cas1_space_booking_view",
+      "cas1_space_booking_withdraw",
+      "cas1_user_list",
+      "cas1_view_cru_dashboard",
+      "cas1_view_manage_tasks"
+    ]
+  },
+  {
+    "name" : "cru_member_find_and_book_beta",
+    "permissions" : [
+      "cas1_adhoc_booking_create",
+      "cas1_application_withdraw_others",
+      "cas1_booking_change_dates",
+      "cas1_booking_withdraw",
+      "cas1_emergency_transfer_perform",
+      "cas1_out_of_service_bed_cancel",
+      "cas1_out_of_service_bed_create",
+      "cas1_out_of_service_bed_create_bed_on_hold",
+      "cas1_placement_request_record_unable_to_match",
+      "cas1_premises_capacity_report_view",
+      "cas1_premises_view",
+      "cas1_request_for_placement_withdraw_others",
+      "cas1_space_booking_create",
+      "cas1_space_booking_list",
+      "cas1_space_booking_view",
+      "cas1_space_booking_withdraw",
+      "cas1_user_list",
+      "cas1_view_cru_dashboard",
+      "cas1_view_manage_tasks",
+      "cas1_view_out_of_service_beds"
+    ]
+  },
+  {
+    "name" : "cru_member_enable_out_of_service_beds",
+    "permissions" : [
+      "cas1_out_of_service_bed_create",
+      "cas1_view_out_of_service_beds"
+    ]
+  },
+  {
+    "name" : "change_request_dev",
+    "permissions" : [
+      "cas1_appeal_assess",
+      "cas1_appeal_create",
+      "cas1_change_request_list",
+      "cas1_planned_transfer_assess",
+      "cas1_planned_transfer_create"
+    ]
+  },
+  {
+    "name" : "applicant",
+    "permissions" : [ ]
+  },
+  {
+    "name" : "report_viewer",
+    "permissions" : [
+      "cas1_reports_view"
+    ]
+  },
+  {
+    "name" : "report_viewer_with_pii",
+    "permissions" : [
+      "cas1_reports_view",
+      "cas1_reports_view_with_pii"
+    ]
+  },
+  {
+    "name" : "excluded_from_assess_allocation",
+    "permissions" : [ ]
+  },
+  {
+    "name" : "excluded_from_match_allocation",
+    "permissions" : [ ]
+  },
+  {
+    "name" : "excluded_from_placement_application_allocation",
+    "permissions" : [ ]
+  },
+  {
+    "name" : "appeals_manager",
+    "permissions" : [
+      "cas1_assess_appealed_application",
+      "cas1_assess_application",
+      "cas1_process_an_appeal",
+      "cas1_view_assigned_assessments"
+    ]
+  },
+  {
+    "name" : "janitor",
+    "permissions" : [
+      "cas1_adhoc_booking_create",
+      "cas1_appeal_assess",
+      "cas1_appeal_create",
+      "cas1_application_withdraw_others",
+      "cas1_assess_appealed_application",
+      "cas1_assess_application",
+      "cas1_assess_placement_application",
+      "cas1_booking_change_dates",
+      "cas1_booking_create",
+      "cas1_booking_withdraw",
+      "cas1_change_request_list",
+      "cas1_emergency_transfer_perform",
+      "cas1_out_of_service_bed_cancel",
+      "cas1_out_of_service_bed_create",
+      "cas1_out_of_service_bed_create_bed_on_hold",
+      "cas1_placement_request_record_unable_to_match",
+      "cas1_planned_transfer_assess",
+      "cas1_planned_transfer_create",
+      "cas1_premises_capacity_report_view",
+      "cas1_premises_manage",
+      "cas1_premises_view",
+      "cas1_process_an_appeal",
+      "cas1_reports_view",
+      "cas1_reports_view_with_pii",
+      "cas1_request_for_placement_withdraw_others",
+      "cas1_space_booking_create",
+      "cas1_space_booking_list",
+      "cas1_space_booking_record_arrival",
+      "cas1_space_booking_record_departure",
+      "cas1_space_booking_record_keyworker",
+      "cas1_space_booking_record_non_arrival",
+      "cas1_space_booking_view",
+      "cas1_space_booking_withdraw",
+      "cas1_user_list",
+      "cas1_user_management",
+      "cas1_view_assigned_assessments",
+      "cas1_view_cru_dashboard",
+      "cas1_view_manage_tasks",
+      "cas1_view_out_of_service_beds"
+    ]
+  },
+  {
+    "name" : "user_manager",
+    "permissions" : [
+      "cas1_user_list",
+      "cas1_user_management"
+    ]
+  }
+]


### PR DESCRIPTION
Before this commit the `built-cas1-roles.json` wasn’t putting linebreaks for each entry in the array, leading to merge conflicts for small permission changes.

This commit tweaks the object mapper configuration to add these line breaks, which will hopefully reduce merge conflicts and also make the file more readible. It also sorts permissions alphabetically to further avoid merge issues