### PR TITLE
Add a debug profile

### DIFF
--- a/src/main/resources/application-debug.yml
+++ b/src/main/resources/application-debug.yml
@@ -1,0 +1,16 @@
+log-client-credentials-jwt-info: true
+log-request-response: true
+
+logging:
+  level:
+    # Log hibernate queries
+    org.hibernate.SQL: DEBUG
+    # Uncomment the two entries below to see SQL binding
+    #org.hibernate.orm.jdbc.bind: TRACE
+    #org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    # Log jdbc template queries
+    org.springframework.jdbc.core.JdbcTemplate: debug
+    # allows us to see the JWT token to simplify local API invocation
+    uk.gov.justice.digital.hmpps.approvedpremisesapi.config.RequestResponseLoggingFilter: TRACE
+    # allows us to see the request URL and method for upstream requests
+    reactor.netty.http.client.HttpClientConnect: DEBUG


### PR DESCRIPTION
This is temporary additionl whilst we’re making changes to ap-tools. It allows us to simply enable debug logging whilst using profiles other than ‘local’