### PR TITLE
Prison transfers - assign application if no status update linked

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -127,7 +127,7 @@ data class Cas2ApplicationEntity(
 
   fun isMostRecentStatusUpdateANonAssignableStatus() = statusUpdates?.firstOrNull()
     ?.let { mostRecent -> mostRecent.label in Cas2StatusUpdateNonAssignable.entries.map { it.label } }
-    ?: true
+    ?: false
 }
 
 /**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -1801,7 +1801,7 @@ class Cas1SpaceBookingServiceTest {
   inner class UpdateSpaceBooking {
 
     private val newArrivalDate = LocalDate.of(2025, 1, 2)
-    private val newDepartureDate = LocalDate.of(2025, 4, 5)
+    private val newDepartureDate = LocalDate.now().plusMonths(1)
 
     private val user = UserEntityFactory()
       .withDefaults()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/Cas2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/Cas2ApplicationServiceTest.kt
@@ -117,7 +117,7 @@ class Cas2ApplicationServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
-    fun `does not find assignable application as the latest application's status-update list is empty or null`(statusUpdatesListNull: Boolean) {
+    fun `finds assignable application as the latest application's status-update list is empty or null`(statusUpdatesListNull: Boolean) {
       val application = Cas2ApplicationEntityFactory()
         .withApplicationSchema(newestSchema)
         .withCreatedByUser(user)
@@ -132,7 +132,7 @@ class Cas2ApplicationServiceTest {
       every {
         mockApplicationRepository.findFirstByNomsNumberAndSubmittedAtIsNotNullOrderBySubmittedAtDesc(application.nomsNumber!!)
       } returns application
-      assertThat(applicationService.findApplicationToAssign(nomsNumber)).isNull()
+      assertThat(applicationService.findApplicationToAssign(nomsNumber)).isEqualTo(application)
     }
 
     private fun createApplicationWithStatusUpdateEntity(statusUpdateEntityLabel: String): Cas2ApplicationEntity {


### PR DESCRIPTION
**PR summary**
* There are cases we have found where an application has no status updates linked to it. 
* Under these circumstances we now assign the application and send the required emails

