### PR TITLE
Disable spring data redis repositories

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,8 @@ spring:
       timeout: 60000
       ssl:
         enabled: false
+      repositories:
+        enabled: false
 
   security:
     oauth2:


### PR DESCRIPTION
Because we have both spring data redis and spring data jpa installed, we see many of the following warnings on startup:

```
Spring Data Redis - Could not safely identify store assignment for repository candidate interface uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
```

It’s not clear why we’re seeing this, because the repositories its referring to are of type `JpaRepository`.

Regardless, we can stop this warning by disabling repository support for spring data redis, which is fine because we don’t have any spring data redis repostories, as evidenced by this log line:

```
.s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 65 ms. Found 0 Redis repository interfaces.