### PR TITLE
Make truncation optional for dev profile

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,7 +32,7 @@ generic-service:
     SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL: https://www.gov.uk
     SERVICES_MANAGE-POM-CASES_BASE-URL: https://dev.moic.service.justice.gov.uk
     SERVICES_PRISONER-SEARCH_BASE-URL: https://prisoner-search-dev.prison.service.justice.gov.uk
-    SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev+test,classpath:db/migration/dev,classpath:db/migration/all-except-integration
+    SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/local+dev+test,classpath:db/migration/dev-truncate,classpath:db/migration/dev,classpath:db/migration/all-except-integration
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
     ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: dev

--- a/src/main/resources/db/migration/dev-truncate/R__1_truncate_cas2.sql
+++ b/src/main/resources/db/migration/dev-truncate/R__1_truncate_cas2.sql
@@ -1,0 +1,6 @@
+-- ${flyway:timestamp}
+TRUNCATE TABLE cas_2_applications CASCADE;
+
+DELETE FROM domain_events WHERE domain_events.type in (
+   'CAS2_APPLICATION_STATUS_UPDATED', 'CAS2_APPLICATION_SUBMITTED'
+);

--- a/src/main/resources/db/migration/dev-truncate/R__2_truncate_cas3.sql
+++ b/src/main/resources/db/migration/dev-truncate/R__2_truncate_cas3.sql
@@ -1,4 +1,8 @@
 -- ${flyway:timestamp}
+TRUNCATE TABLE premises CASCADE;
 
 TRUNCATE TABLE applications CASCADE;
 TRUNCATE table assessments CASCADE;
+
+TRUNCATE TABLE rooms CASCADE;
+TRUNCATE TABLE beds CASCADE;

--- a/src/main/resources/db/migration/dev/R__1_create_premises.sql
+++ b/src/main/resources/db/migration/dev/R__1_create_premises.sql
@@ -2,8 +2,6 @@
 -- ideally this would only be managed via the seed CSV files but removing the contents of this file breaks R__5_create_bookings_for_cas3 as they require the beds
 -- to exist at that point in time. The correct solution is to move this logic into the SeedOnStartupService
 
-TRUNCATE TABLE premises CASCADE;
-
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status") values ('Address 1', 'd33006b7-55d9-4a8e-b722-5e18093dbcdf', 'd75ce5b8-fc07-494b-8950-a46a63ac377e', 'Something House', NULL, 'LA9 1DS', 'a02b7727-63aa-46f2-80f1-e0b05b31903c', 'temporary-accommodation', 'active') ON CONFLICT (id) DO NOTHING;
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status") values ('Address 2', 'ada106c7-e1fb-409a-a38e-0002ea8e7e45', '89faa462-7ea6-45ba-b169-93d947d20cae', 'Something Court', NULL, 'EC1 3XZ', '6b4a1308-17af-4c1a-a330-6005bec9e27b', 'temporary-accommodation', 'active') ON CONFLICT (id) DO NOTHING;
 insert into "premises" ("address_line1", "id", "local_authority_area_id", "name", "notes", "postcode", "probation_region_id", "service", "status") values ('Address 3', '36c7b1f2-5a4b-467b-838c-2970c9c253cf', '7baa6fa4-d029-4be5-a5a9-d87f9bd35ce5', 'Something Place', NULL, 'SA1 1AF', 'afee0696-8df3-4d9f-9d0c-268f17772e2c', 'temporary-accommodation', 'active') ON CONFLICT (id) DO NOTHING;

--- a/src/main/resources/db/migration/dev/R__4_create_rooms_and_beds.sql
+++ b/src/main/resources/db/migration/dev/R__4_create_rooms_and_beds.sql
@@ -2,9 +2,6 @@
 -- ideally this would only be managed via the seed CSV files but removing the contents of this file breaks R__5_create_bookings_for_cas3 as they require the beds
 -- to exist at that point in time. The correct solution is to move this logic into the SeedOnStartupService
 
-TRUNCATE TABLE rooms CASCADE;
-TRUNCATE TABLE beds CASCADE;
-
 -- CAS3 beds for Kent, Surrey & Sussex
 
 -- Premises 1 (2x rooms, 1x bed each)
@@ -16,7 +13,7 @@ values
         'ROOM1',
         NULL,
         'd6447105-4bfe-4f1e-add7-4668e1ca28b0'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 insert into
     beds ("id", "name", "room_id")
@@ -25,7 +22,7 @@ values
         'e8887df9-b31b-4e9c-931a-e063d778ab0d',
         'BED1',
         '14c0911e-6296-4b3f-ad00-5a2cf6f23a08'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 insert into
     rooms ("id", "name", "notes", "premises_id")
@@ -35,7 +32,7 @@ values
         'ROOM2',
         NULL,
         'd6447105-4bfe-4f1e-add7-4668e1ca28b0'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 insert into
     beds ("id", "name", "room_id")
 values
@@ -43,7 +40,7 @@ values
         '135812b4-e6c0-4ccf-9502-4bfea66f3bd3',
         'BED1',
         'fe86a602-6873-49d3-ac3a-3dfef743ae03'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 -- Premises 2 (1x room, 1x bed)
 insert into
@@ -54,7 +51,7 @@ values
         'ROOM1',
         NULL,
         'e2543d2f-33a9-454b-ae15-03ca0475faa3'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 insert into
     beds ("id", "name", "room_id")
 values
@@ -62,7 +59,7 @@ values
         '6d6d4c56-9989-4fb5-a486-d32f525748e6',
         'BED1',
         '2d87a9a2-1f94-45ec-9790-eb8732a4ba6f'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 -- Premises 3 (1x room, 1x bed)
 insert into
@@ -73,7 +70,7 @@ values
         'ROOM1',
         NULL,
         '0ad5999f-a07c-4605-b875-81d7a17e9f70'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 insert into
     beds ("id", "name", "room_id")
 values
@@ -81,7 +78,7 @@ values
         '8be1ed0e-dae7-42d2-97e0-95c95fdb4c50',
         'BED1',
         '135812b4-e6c0-4ccf-9502-4bfea66f3bd3'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 -- CAS3 beds for East of England
 
@@ -94,7 +91,7 @@ values
         'EOFE-1',
         NULL,
         '70a6046c-23fc-4a30-b151-582ffd509e6a'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 insert into
     beds ("id", "name", "room_id")
@@ -103,7 +100,7 @@ values
         '38e6b775-88c5-4571-8b6e-da3711aeaca6',
         'BED1',
         '4d27144d-1c3d-4785-9fbd-879d8b0b5b41'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 insert into
     rooms ("id", "name", "notes", "premises_id")
@@ -113,7 +110,7 @@ values
         'EOFE-2',
         NULL,
         '70a6046c-23fc-4a30-b151-582ffd509e6a'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 insert into
     beds ("id", "name", "room_id")
@@ -122,7 +119,7 @@ values
         'fd1c7078-43c8-41f5-8e57-a4d59f3c831a',
         'BED1',
         '94c58e72-d31a-49c3-8569-fc341e46ba6a'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 -- Premises 2 (1x room, 1x bed)
 insert into
@@ -133,7 +130,7 @@ values
         'A1',
         NULL,
         '6aa177cb-617f-4abb-be46-056ea7e4a59d'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 insert into
     beds ("id", "name", "room_id")
 values
@@ -141,7 +138,7 @@ values
         '64fd8f3d-1fb6-4346-a190-65588b998301',
         'BED1',
         '82ff4d7f-13c2-4827-8957-c38ad4750c53'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 
 -- Premises 2 (1x room, 1x bed)
 insert into
@@ -152,7 +149,7 @@ values
         'A1',
         NULL,
         '773431cd-f560-4be8-9e6f-b582a4ebf204'
-    );
+    ) ON CONFLICT (id) DO NOTHING;
 insert into
     beds ("id", "name", "room_id")
 values
@@ -160,4 +157,4 @@ values
         '8ecef9a5-268c-4595-9fd0-042fed3d4882',
         'BED1',
         '02e1c7a3-47e7-4845-95f5-98aeed0ef81b'
-    );
+    ) ON CONFLICT (id) DO NOTHING;

--- a/src/main/resources/db/migration/dev/R__6_clear_cas2_applications.sql
+++ b/src/main/resources/db/migration/dev/R__6_clear_cas2_applications.sql
@@ -1,3 +1,0 @@
--- ${flyway:timestamp}
-
-TRUNCATE TABLE cas_2_applications CASCADE;

--- a/src/main/resources/db/migration/dev/R__7_clear_cas2_domain_events.sql
+++ b/src/main/resources/db/migration/dev/R__7_clear_cas2_domain_events.sql
@@ -1,5 +1,0 @@
--- ${flyway:timestamp}
-
-DELETE FROM domain_events WHERE domain_events.type in (
-    'CAS2_APPLICATION_STATUS_UPDATED', 'CAS2_APPLICATION_SUBMITTED'
-);


### PR DESCRIPTION
Before this commit any environment using the `dev` profile would truncate various tables truncated whenever the API starts.

This commit moves the truncation SQL into a new folder and old applies that folder for deployments to the ‘dev’ environment on the MOJ cloud platform. Any local deployments using the `dev` profile wll no longer truncate tables on startup.

This will break any deployments using the `dev` profile. To fix this, run the following:

```
delete from flyway_migrations where script = 'R__3_clear_applications.sql';
delete from flyway_migrations where script = 'R__6_clear_cas2_applications.sql';
delete from flyway_migrations where script = 'R__7_clear_cas2_domain_events.sql';
```