### PR TITLE
Suppress hibernate 2nd level cache warning

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,9 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         cache:
           use_second_level_cache: true
+        javax:
+          cache:
+            missing_cache_strategy: 'create'
       jakarta:
         persistence:
           query:


### PR DESCRIPTION
Before this commit we would see the following message several times on startup

```
Missing cache[uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity] was created on-the-fly. The created cache will use a provider-specific default configuration: make sure you defined one. You can disable this warning by setting 'hibernate.javax.cache.missing_cache_strategy' to 'create'. |
```

This commit disables this warning as this is the behaviour we want, and we have set the default cache settings in `hibernate-ehcache.xml`