### PR TITLE
Firebreak Move turnaround to CAS3 namespace

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -83,8 +83,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RoomTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TurnaroundTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3PremisesSummaryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspaceCancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspacesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromAuthorisableActionResult
@@ -120,7 +120,7 @@ class PremisesController(
   private val roomService: RoomService,
   private val roomTransformer: RoomTransformer,
   private val cas3VoidBedspaceCancellationTransformer: Cas3VoidBedspaceCancellationTransformer,
-  private val turnaroundTransformer: TurnaroundTransformer,
+  private val cas3TurnaroundTransformer: Cas3TurnaroundTransformer,
   private val bedSummaryTransformer: BedSummaryTransformer,
   private val bedDetailTransformer: BedDetailTransformer,
   private val dateChangeTransformer: DateChangeTransformer,
@@ -917,7 +917,7 @@ class PremisesController(
         val result = cas3BookingService.createTurnaround(booking, body.workingDays)
         val turnaround = extractResultEntityOrThrow(result)
 
-        return ResponseEntity.ok(turnaroundTransformer.transformJpaToApi(turnaround))
+        return ResponseEntity.ok(cas3TurnaroundTransformer.transformJpaToApi(turnaround))
       }
 
       else -> error("This endpoint does not support create turnarounds for bookings with premise type: ${booking.premises::class.qualifiedName}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -20,8 +20,8 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingSummaryForAvailability
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -322,7 +322,7 @@ data class BookingEntity(
   var originalDepartureDate: LocalDate,
   val createdAt: OffsetDateTime,
   @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY)
-  var turnarounds: MutableList<TurnaroundEntity>,
+  var turnarounds: MutableList<Cas3TurnaroundEntity>,
   var nomsNumber: String?,
   @OneToOne(mappedBy = "booking")
   var placementRequest: PlacementRequestEntity?,
@@ -338,7 +338,7 @@ data class BookingEntity(
   val cancellation: CancellationEntity?
     get() = cancellations.maxByOrNull { it.createdAt }
 
-  val turnaround: TurnaroundEntity?
+  val turnaround: Cas3TurnaroundEntity?
     get() = turnarounds.maxByOrNull { it.createdAt }
 
   val isCancelled: Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingGapReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingGapReportRepository.kt
@@ -27,12 +27,12 @@ with bedspaces as (select
                       arrival_date,
                       departure_date,
                       (select working_day_count
-                       from turnarounds
-                       where turnarounds.id = (
+                       from cas3_turnarounds
+                       where cas3_turnarounds.id = (
                            select id
-                           from turnarounds
-                           where  turnarounds.booking_id = bookings.id
-                           order by turnarounds.created_at desc
+                           from cas3_turnarounds
+                           where  cas3_turnarounds.booking_id = bookings.id
+                           order by cas3_turnarounds.created_at desc
                            limit 1)) turnaround_days
                   from bookings
                   left join cancellations on  cancellations.booking_id = bookings.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3TurnaroundEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3TurnaroundEntity.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
 
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
@@ -7,15 +7,16 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import java.time.OffsetDateTime
 import java.util.UUID
 
 @Repository
-interface TurnaroundRepository : JpaRepository<TurnaroundEntity, UUID>
+interface Cas3TurnaroundRepository : JpaRepository<Cas3TurnaroundEntity, UUID>
 
 @Entity
-@Table(name = "turnarounds")
-data class TurnaroundEntity(
+@Table(name = "cas3_turnarounds")
+data class Cas3TurnaroundEntity(
   @Id
   val id: UUID,
   val workingDayCount: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -99,7 +99,7 @@ interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
       CAST(booking.id AS VARCHAR) AS bookingId,
       turnaround.created_at AS CreatedAt,
       working_day_count AS workingDayCount
-    From turnarounds turnaround
+    From cas3_turnarounds turnaround
     INNER JOIN bookings booking ON booking.id = turnaround.booking_id
     INNER JOIN beds bed ON bed.id = booking.bed_id
     INNER JOIN premises premises ON booking.premises_id = premises.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingService.kt
@@ -27,9 +27,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionRepo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.serviceScopeMatches
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
@@ -65,7 +65,7 @@ class Cas3BookingService(
   private val cancellationRepository: CancellationRepository,
   private val cancellationReasonRepository: CancellationReasonRepository,
   private val cas3VoidBedspacesRepository: Cas3VoidBedspacesRepository,
-  private val turnaroundRepository: TurnaroundRepository,
+  private val cas3TurnaroundRepository: Cas3TurnaroundRepository,
   private val extensionRepository: ExtensionRepository,
   private val cas3PremisesService: Cas3PremisesService,
   private val assessmentService: AssessmentService,
@@ -165,8 +165,8 @@ class Cas3BookingService(
         ),
       )
 
-      val turnaround = turnaroundRepository.save(
-        TurnaroundEntity(
+      val turnaround = cas3TurnaroundRepository.save(
+        Cas3TurnaroundEntity(
           id = UUID.randomUUID(),
           workingDayCount = when (enableTurnarounds) {
             true -> premises.turnaroundWorkingDayCount
@@ -257,8 +257,8 @@ class Cas3BookingService(
       return fieldValidationError
     }
 
-    val turnaround = turnaroundRepository.save(
-      TurnaroundEntity(
+    val turnaround = cas3TurnaroundRepository.save(
+      Cas3TurnaroundEntity(
         id = UUID.randomUUID(),
         workingDayCount = workingDays,
         createdAt = OffsetDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
 import java.time.LocalDate
 
 @Component
@@ -25,7 +26,7 @@ class BookingTransformer(
   private val confirmationTransformer: ConfirmationTransformer,
   private val extensionTransformer: ExtensionTransformer,
   private val bedTransformer: BedTransformer,
-  private val turnaroundTransformer: TurnaroundTransformer,
+  private val cas3TurnaroundTransformer: Cas3TurnaroundTransformer,
   private val enumConverterFactory: EnumConverterFactory,
   private val workingDayService: WorkingDayService,
 ) {
@@ -54,8 +55,8 @@ class BookingTransformer(
       originalArrivalDate = jpa.originalArrivalDate,
       originalDepartureDate = jpa.originalDepartureDate,
       createdAt = jpa.createdAt.toInstant(),
-      turnaround = jpa.turnaround?.let(turnaroundTransformer::transformJpaToApi),
-      turnarounds = jpa.turnarounds.map(turnaroundTransformer::transformJpaToApi),
+      turnaround = jpa.turnaround?.let(cas3TurnaroundTransformer::transformJpaToApi),
+      turnarounds = jpa.turnarounds.map(cas3TurnaroundTransformer::transformJpaToApi),
       turnaroundStartDate = if (hasNonZeroDayTurnaround) workingDayService.addWorkingDays(jpa.departureDate, 1) else null,
       effectiveEndDate = if (hasNonZeroDayTurnaround) workingDayService.addWorkingDays(jpa.departureDate, jpa.turnaround!!.workingDayCount) else jpa.departureDate,
       applicationId = jpa.application?.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3TurnaroundTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3TurnaroundTransformer.kt
@@ -1,12 +1,12 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Turnaround
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 
 @Component
-class TurnaroundTransformer {
-  fun transformJpaToApi(jpa: TurnaroundEntity) = Turnaround(
+class Cas3TurnaroundTransformer {
+  fun transformJpaToApi(jpa: Cas3TurnaroundEntity) = Turnaround(
     id = jpa.id,
     bookingId = jpa.booking.id,
     workingDays = jpa.workingDayCount,

--- a/src/main/resources/db/migration/all/20250408132209__add_prefix_cas3_to_turnarounds_table.sql
+++ b/src/main/resources/db/migration/all/20250408132209__add_prefix_cas3_to_turnarounds_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE turnarounds RENAME TO cas3_turnarounds;

--- a/src/main/resources/db/migration/dev/R__5_create_bookings_for_cas3_eofe.sql
+++ b/src/main/resources/db/migration/dev/R__5_create_bookings_for_cas3_eofe.sql
@@ -37,7 +37,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -87,7 +87,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -155,7 +155,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -250,7 +250,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -320,7 +320,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -390,7 +390,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",

--- a/src/main/resources/db/migration/dev/R__5_create_bookings_for_cas3_kss.sql
+++ b/src/main/resources/db/migration/dev/R__5_create_bookings_for_cas3_kss.sql
@@ -37,7 +37,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -85,7 +85,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -151,7 +151,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -245,7 +245,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -313,7 +313,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -381,7 +381,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -455,7 +455,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -529,7 +529,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -603,7 +603,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -677,7 +677,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -751,7 +751,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -825,7 +825,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -899,7 +899,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -973,7 +973,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -1047,7 +1047,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -1121,7 +1121,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",
@@ -1195,7 +1195,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  turnarounds (
+  cas3_turnarounds (
     "id",
     "booking_id",
     "working_day_count",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -48,7 +48,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
   private var application: Yielded<ApplicationEntity?> = { null }
   private var offlineApplication: Yielded<OfflineApplicationEntity?> = { null }
-  private var turnarounds: Yielded<MutableList<TurnaroundEntity>>? = null
+  private var turnarounds: Yielded<MutableList<Cas3TurnaroundEntity>>? = null
   private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var placementRequest: Yielded<PlacementRequestEntity?> = { null }
   private var status: Yielded<BookingStatus?> = { null }
@@ -177,11 +177,11 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.offlineApplication = { offlineApplication }
   }
 
-  fun withYieldedTurnarounds(turnarounds: Yielded<MutableList<TurnaroundEntity>>) = apply {
+  fun withYieldedTurnarounds(turnarounds: Yielded<MutableList<Cas3TurnaroundEntity>>) = apply {
     this.turnarounds = turnarounds
   }
 
-  fun withTurnarounds(turnarounds: MutableList<TurnaroundEntity>) = apply {
+  fun withTurnarounds(turnarounds: MutableList<Cas3TurnaroundEntity>) = apply {
     this.turnarounds = { turnarounds }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3TurnaroundEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3TurnaroundEntityFactory.kt
@@ -1,15 +1,15 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class TurnaroundEntityFactory : Factory<TurnaroundEntity> {
+class Cas3TurnaroundEntityFactory : Factory<Cas3TurnaroundEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var workingDayCount: Yielded<Int> = { randomInt(0, 14) }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
@@ -35,7 +35,8 @@ class TurnaroundEntityFactory : Factory<TurnaroundEntity> {
     this.booking = booking
   }
 
-  override fun produce() = TurnaroundEntity(
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce() = Cas3TurnaroundEntity(
     id = this.id(),
     workingDayCount = this.workingDayCount(),
     createdAt = this.createdAt(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1496,7 +1496,7 @@ class BookingTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.parse("2022-08-15"))
         }
 
-        val existingTurnarounds = turnaroundFactory.produceAndPersistMultiple(1) {
+        val existingTurnarounds = cas3TurnaroundFactory.produceAndPersistMultiple(1) {
           withWorkingDayCount(5)
           withCreatedAt(existingBooking.createdAt)
           withBooking(existingBooking)
@@ -3180,7 +3180,7 @@ class BookingTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2022-07-12"))
           }
 
-          val turnarounds = turnaroundFactory.produceAndPersistMultiple(1) {
+          val turnarounds = cas3TurnaroundFactory.produceAndPersistMultiple(1) {
             withWorkingDayCount(2)
             withCreatedAt(booking.createdAt)
             withBooking(booking)
@@ -3310,7 +3310,7 @@ class BookingTest : IntegrationTestBase() {
             withDepartureDate(LocalDate.parse("2022-07-12"))
           }
 
-          val turnarounds = turnaroundFactory.produceAndPersistMultiple(1) {
+          val turnarounds = cas3TurnaroundFactory.produceAndPersistMultiple(1) {
             withWorkingDayCount(2)
             withCreatedAt(booking.createdAt)
             withBooking(booking)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -94,7 +94,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
@@ -102,6 +101,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestRejectionReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
@@ -195,7 +195,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
@@ -206,6 +205,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Chan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonEntity
@@ -237,6 +237,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2StatusUpdateTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3TurnaroundTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspacesTestRepository
@@ -265,7 +266,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationAssessmentJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationAssessmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TemporaryAccommodationPremisesTestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.TurnaroundTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserQualificationAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserRoleAssignmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.UserTestRepository
@@ -497,7 +497,7 @@ abstract class IntegrationTestBase {
   lateinit var probationDeliveryUnitRepository: ProbationDeliveryUnitTestRepository
 
   @Autowired
-  lateinit var turnaroundRepository: TurnaroundTestRepository
+  lateinit var turnaroundRepository: Cas3TurnaroundTestRepository
 
   @Autowired
   lateinit var probationAreaProbationRegionMappingRepository: ProbationAreaProbationRegionMappingTestRepository
@@ -627,7 +627,7 @@ abstract class IntegrationTestBase {
   lateinit var bookingNotMadeFactory: PersistedFactory<BookingNotMadeEntity, UUID, BookingNotMadeEntityFactory>
   lateinit var probationDeliveryUnitFactory: PersistedFactory<ProbationDeliveryUnitEntity, UUID, ProbationDeliveryUnitEntityFactory>
   lateinit var applicationTeamCodeFactory: PersistedFactory<ApplicationTeamCodeEntity, UUID, ApplicationTeamCodeEntityFactory>
-  lateinit var turnaroundFactory: PersistedFactory<TurnaroundEntity, UUID, TurnaroundEntityFactory>
+  lateinit var cas3TurnaroundFactory: PersistedFactory<Cas3TurnaroundEntity, UUID, Cas3TurnaroundEntityFactory>
   lateinit var placementApplicationFactory: PersistedFactory<PlacementApplicationEntity, UUID, PlacementApplicationEntityFactory>
   lateinit var placementDateFactory: PersistedFactory<PlacementDateEntity, UUID, PlacementDateEntityFactory>
   lateinit var probationAreaProbationRegionMappingFactory: PersistedFactory<ProbationAreaProbationRegionMappingEntity, UUID, ProbationAreaProbationRegionMappingEntityFactory>
@@ -742,7 +742,7 @@ abstract class IntegrationTestBase {
     bookingNotMadeFactory = PersistedFactory({ BookingNotMadeEntityFactory() }, bookingNotMadeRepository)
     probationDeliveryUnitFactory = PersistedFactory({ ProbationDeliveryUnitEntityFactory() }, probationDeliveryUnitRepository)
     applicationTeamCodeFactory = PersistedFactory({ ApplicationTeamCodeEntityFactory() }, applicationTeamCodeRepository)
-    turnaroundFactory = PersistedFactory({ TurnaroundEntityFactory() }, turnaroundRepository)
+    cas3TurnaroundFactory = PersistedFactory({ Cas3TurnaroundEntityFactory() }, turnaroundRepository)
     placementApplicationFactory = PersistedFactory({ PlacementApplicationEntityFactory() }, placementApplicationRepository)
     placementDateFactory = PersistedFactory({ PlacementDateEntityFactory() }, placementDateRepository)
     probationAreaProbationRegionMappingFactory = PersistedFactory({ ProbationAreaProbationRegionMappingEntityFactory() }, probationAreaProbationRegionMappingRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3BedspaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3BedspaceSearchTest.kt
@@ -183,7 +183,7 @@ class Cas3BedspaceSearchTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.parse("2023-03-21"))
         }
 
-        val turnaround = turnaroundFactory.produceAndPersist {
+        val turnaround = cas3TurnaroundFactory.produceAndPersist {
           withBooking(booking)
           withWorkingDayCount(2)
         }
@@ -237,7 +237,7 @@ class Cas3BedspaceSearchTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.parse("2023-03-21"))
         }
 
-        val turnaround = turnaroundFactory.produceAndPersist {
+        val turnaround = cas3TurnaroundFactory.produceAndPersist {
           withBooking(booking)
           withWorkingDayCount(2)
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -2415,27 +2415,27 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking1)
             withWorkingDayCount(2)
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking1)
             withWorkingDayCount(5)
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking1)
             withWorkingDayCount(2)
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking2)
             withWorkingDayCount(2)
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking3)
             withWorkingDayCount(2)
           }
@@ -2548,13 +2548,13 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withExpectedDepartureDate(LocalDate.parse("2023-04-05"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking1)
             withCreatedAt(OffsetDateTime.parse("2023-02-25T16:00:00+01:00"))
             withWorkingDayCount(2)
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking1)
             withCreatedAt(OffsetDateTime.parse("2023-02-12T17:00:00+01:00"))
             withWorkingDayCount(5)
@@ -2662,7 +2662,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withCreatedAt(OffsetDateTime.parse("2024-04-06T09:53:17.789Z"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking)
             withCreatedAt(OffsetDateTime.parse("2024-03-28T17:00:00+01:00"))
             withWorkingDayCount(7)
@@ -2812,7 +2812,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             LocalDate.parse("2023-04-21"),
           )
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking)
             withWorkingDayCount(5)
           }
@@ -2887,7 +2887,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             LocalDate.parse("2023-04-17"),
           )
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking)
             withWorkingDayCount(5)
           }
@@ -3023,49 +3023,49 @@ class Cas3ReportsTest : IntegrationTestBase() {
             withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking5)
             withWorkingDayCount(7)
             withCreatedAt(OffsetDateTime.parse("2024-03-06T10:45:00+01:00"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking4)
             withWorkingDayCount(7)
             withCreatedAt(OffsetDateTime.parse("2024-03-13T09:34:00+01:00"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking2)
             withWorkingDayCount(7)
             withCreatedAt(OffsetDateTime.parse("2024-03-13T14:13:00+01:00"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking3)
             withWorkingDayCount(7)
             withCreatedAt(OffsetDateTime.parse("2024-03-13T16:43:00+01:00"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking3)
             withWorkingDayCount(8)
             withCreatedAt(OffsetDateTime.parse("2024-06-13T09:23:00+01:00"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking1)
             withWorkingDayCount(7)
             withCreatedAt(OffsetDateTime.parse("2024-06-17T13:55:00+01:00"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking3)
             withWorkingDayCount(5)
             withCreatedAt(OffsetDateTime.parse("2024-06-18T09:42:27+01:00"))
           }
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking3)
             withWorkingDayCount(3)
             withCreatedAt(OffsetDateTime.parse("2024-06-18T09:42:37+01:00"))
@@ -3219,7 +3219,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             LocalDate.parse("2023-04-04"),
           )
 
-          turnaroundFactory.produceAndPersist {
+          cas3TurnaroundFactory.produceAndPersist {
             withBooking(booking)
             withWorkingDayCount(5)
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3TurnaroundTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3TurnaroundTestRepository.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import java.util.UUID
 
 @Repository
-interface TurnaroundTestRepository : JpaRepository<TurnaroundEntity, UUID>
+interface Cas3TurnaroundTestRepository : JpaRepository<Cas3TurnaroundEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUsageReportGeneratorTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliver
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
@@ -571,7 +571,7 @@ class BedUsageReportGeneratorTest {
       .withPremises(temporaryAccommodationPremises)
       .produce()
 
-    val turnaround = TurnaroundEntityFactory()
+    val turnaround = Cas3TurnaroundEntityFactory()
       .withBooking(temporaryAccommodationBooking)
       .withWorkingDayCount(2)
       .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BedUtilisationReportGenerator
@@ -465,7 +465,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingStartOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2023-03-28"))
         .withDepartureDate(LocalDate.parse("2023-04-04")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(5).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(5).produce()
         }
 
     every {
@@ -485,7 +485,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingEndOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2023-04-25"))
         .withDepartureDate(LocalDate.parse("2023-04-27")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
         }
 
     every {
@@ -546,7 +546,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingStartOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2023-03-28"))
         .withDepartureDate(LocalDate.parse("2023-04-04")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(5).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(5).produce()
         }
 
     every {
@@ -566,7 +566,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingEndOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2023-04-25"))
         .withDepartureDate(LocalDate.parse("2023-04-27")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
         }
 
     every {
@@ -678,7 +678,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingStartOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2023-03-28"))
         .withDepartureDate(LocalDate.parse("2023-04-04")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(5).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(5).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2023-03-28")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2023-04-04T12:00:00.000Z")).withReason(departureReason)
@@ -702,7 +702,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingEndOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2023-04-25"))
         .withDepartureDate(LocalDate.parse("2023-04-27")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(4).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(4).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2023-04-25")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2023-04-27T12:00:00.000Z")).withReason(departureReason)
@@ -937,7 +937,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingStartOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2024-02-07"))
         .withDepartureDate(LocalDate.parse("2024-02-12")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-07")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2024-02-12T12:00:00.000Z")).withReason(departureReason)
@@ -961,7 +961,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingEndOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2024-02-16"))
         .withDepartureDate(LocalDate.parse("2024-02-22")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-16")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2024-02-22T12:00:00.000Z")).withReason(departureReason)
@@ -1032,7 +1032,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingStartOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2024-02-07"))
         .withDepartureDate(LocalDate.parse("2024-02-12")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-07")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2024-02-12T12:00:00.000Z")).withReason(departureReason)
@@ -1056,7 +1056,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingEndOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2024-02-16"))
         .withDepartureDate(LocalDate.parse("2024-02-22")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-16")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2024-02-22T12:00:00.000Z")).withReason(departureReason)
@@ -1127,7 +1127,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingStartOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2024-02-02"))
         .withDepartureDate(LocalDate.parse("2024-02-07")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-02")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2024-02-07T12:00:00.000Z")).withReason(departureReason)
@@ -1151,7 +1151,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingEndOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2024-02-10"))
         .withDepartureDate(LocalDate.parse("2024-02-15")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-10")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2024-02-15T12:00:00.000Z")).withReason(departureReason)
@@ -1222,7 +1222,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingStartOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2024-02-02"))
         .withDepartureDate(LocalDate.parse("2024-02-07")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-02")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2024-02-07T12:00:00.000Z")).withReason(departureReason)
@@ -1246,7 +1246,7 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingEndOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2024-02-10"))
         .withDepartureDate(LocalDate.parse("2024-02-15")).produce().apply {
-          turnarounds += TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          turnarounds += Cas3TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
           arrivals += ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-10")).produce()
           departures += DepartureEntityFactory().withBooking(this)
             .withDateTime(OffsetDateTime.parse("2024-02-15T12:00:00.000Z")).withReason(departureReason)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
@@ -12,8 +12,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OverlapBookingsSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
@@ -358,7 +358,7 @@ class Cas3BedSearchServiceTest {
       .withBed(expectedResultBed)
       .produce()
 
-    val expectedTurnaround = TurnaroundEntityFactory()
+    val expectedTurnaround = Cas3TurnaroundEntityFactory()
       .withBooking(expectedResultBooking)
       .withWorkingDayCount(2)
       .produce()
@@ -391,7 +391,7 @@ class Cas3BedSearchServiceTest {
       .withBed(unexpectedResultBed)
       .produce()
 
-    val unexpectedTurnaround = TurnaroundEntityFactory()
+    val unexpectedTurnaround = Cas3TurnaroundEntityFactory()
       .withBooking(unexpectedResultBooking)
       .withWorkingDayCount(2)
       .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
@@ -61,9 +61,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -104,7 +104,7 @@ class Cas3BookingServiceTest {
   private val mockCancellationReasonRepository = mockk<CancellationReasonRepository>()
   private val mockBedRepository = mockk<BedRepository>()
   private val mockCas3VoidBedspacesRepository = mockk<Cas3VoidBedspacesRepository>()
-  private val mockTurnaroundRepository = mockk<TurnaroundRepository>()
+  private val mockCas3TurnaroundRepository = mockk<Cas3TurnaroundRepository>()
   private val mockAssessmentRepository = mockk<AssessmentRepository>()
   private val mockUserAccessService = mockk<UserAccessService>()
   private val mockAssessmentService = mockk<AssessmentService>()
@@ -122,7 +122,7 @@ class Cas3BookingServiceTest {
     cancellationRepository = mockCancellationRepository,
     cancellationReasonRepository = mockCancellationReasonRepository,
     cas3VoidBedspacesRepository = mockCas3VoidBedspacesRepository,
-    turnaroundRepository = mockTurnaroundRepository,
+    cas3TurnaroundRepository = mockCas3TurnaroundRepository,
     extensionRepository = mockExtensionRepository,
     cas3PremisesService = mockCas3PremisesService,
     assessmentService = mockAssessmentService,
@@ -1811,7 +1811,7 @@ class Cas3BookingServiceTest {
         )
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(assessmentId) } returns null
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -1882,7 +1882,7 @@ class Cas3BookingServiceTest {
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(application.id) } returns assessment
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -1967,7 +1967,7 @@ class Cas3BookingServiceTest {
         )
       } returns listOf()
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2057,7 +2057,7 @@ class Cas3BookingServiceTest {
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(application.id) } returns assessment
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2093,7 +2093,7 @@ class Cas3BookingServiceTest {
       }
 
       verify(exactly = 1) {
-        mockTurnaroundRepository.save(
+        mockCas3TurnaroundRepository.save(
           match {
             it.booking == bookingSlot.captured &&
               it.workingDayCount == 0
@@ -2150,7 +2150,7 @@ class Cas3BookingServiceTest {
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(application.id) } returns assessment
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2186,7 +2186,7 @@ class Cas3BookingServiceTest {
       }
 
       verify(exactly = 1) {
-        mockTurnaroundRepository.save(
+        mockCas3TurnaroundRepository.save(
           match {
             it.booking == bookingSlot.captured &&
               it.workingDayCount == premises.turnaroundWorkingDayCount
@@ -2241,7 +2241,7 @@ class Cas3BookingServiceTest {
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(application.id) } returns assessment
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2339,7 +2339,7 @@ class Cas3BookingServiceTest {
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(application.id) } returns assessment
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2434,7 +2434,7 @@ class Cas3BookingServiceTest {
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(application.id) } returns assessment
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2520,7 +2520,7 @@ class Cas3BookingServiceTest {
         )
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(assessmentId) } returns null
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2591,7 +2591,7 @@ class Cas3BookingServiceTest {
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(application.id) } returns assessment
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2686,7 +2686,7 @@ class Cas3BookingServiceTest {
       } returns listOf()
       every { mockAssessmentRepository.findByIdOrNull(application.id) } returns assessment
 
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
 
@@ -2779,7 +2779,7 @@ class Cas3BookingServiceTest {
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(any(), any(), any()) } returns listOf()
       every { mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(any(), any(), any(), any()) } returns listOf()
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       val negativeDaysResult = cas3BookingService.createTurnaround(booking, -1)
 
@@ -2822,7 +2822,7 @@ class Cas3BookingServiceTest {
       every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
       every { mockBookingRepository.findByBedIdAndArrivingBeforeDate(any(), any(), any()) } returns listOf()
       every { mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDate(any(), any(), any(), any()) } returns listOf()
-      every { mockTurnaroundRepository.save(any()) } answers { it.invocation.args[0] as TurnaroundEntity }
+      every { mockCas3TurnaroundRepository.save(any()) } answers { it.invocation.args[0] as Cas3TurnaroundEntity }
 
       val result = cas3BookingService.createTurnaround(booking, 2)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -51,7 +51,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
@@ -63,7 +63,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TurnaroundTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -78,7 +78,7 @@ class BookingTransformerTest {
   private val mockDepartureTransformer = mockk<DepartureTransformer>()
   private val mockExtensionTransformer = mockk<ExtensionTransformer>()
   private val mockBedTransformer = mockk<BedTransformer>()
-  private val mockTurnaroundTransformer = mockk<TurnaroundTransformer>()
+  private val mockCas3TurnaroundTransformer = mockk<Cas3TurnaroundTransformer>()
   private val enumConverterFactory = EnumConverterFactory()
   private val mockWorkingDayService = mockk<WorkingDayService>()
 
@@ -91,7 +91,7 @@ class BookingTransformerTest {
     mockConfirmationTransformer,
     mockExtensionTransformer,
     mockBedTransformer,
-    mockTurnaroundTransformer,
+    mockCas3TurnaroundTransformer,
     enumConverterFactory,
     mockWorkingDayService,
   )
@@ -923,7 +923,7 @@ class BookingTransformerTest {
         ),
       )
 
-      turnarounds += TurnaroundEntity(
+      turnarounds += Cas3TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 0,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
@@ -965,7 +965,7 @@ class BookingTransformerTest {
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    every { mockTurnaroundTransformer.transformJpaToApi(departedBooking.turnaround!!) } returns Turnaround(
+    every { mockCas3TurnaroundTransformer.transformJpaToApi(departedBooking.turnaround!!) } returns Turnaround(
       id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
       workingDays = 0,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1134,7 +1134,7 @@ class BookingTransformerTest {
         ),
       )
 
-      turnarounds += TurnaroundEntity(
+      turnarounds += Cas3TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 2,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
@@ -1176,7 +1176,7 @@ class BookingTransformerTest {
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    every { mockTurnaroundTransformer.transformJpaToApi(departedBooking.turnaround!!) } returns Turnaround(
+    every { mockCas3TurnaroundTransformer.transformJpaToApi(departedBooking.turnaround!!) } returns Turnaround(
       id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
       workingDays = 2,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1349,7 +1349,7 @@ class BookingTransformerTest {
         ),
       )
 
-      turnarounds += TurnaroundEntity(
+      turnarounds += Cas3TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 2,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
@@ -1391,7 +1391,7 @@ class BookingTransformerTest {
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    every { mockTurnaroundTransformer.transformJpaToApi(departedBooking.turnaround!!) } returns Turnaround(
+    every { mockCas3TurnaroundTransformer.transformJpaToApi(departedBooking.turnaround!!) } returns Turnaround(
       id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
       workingDays = 2,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -1847,19 +1847,19 @@ class BookingTransformerTest {
       turnarounds = mutableListOf(),
     )
 
-    val turnaround1 = TurnaroundEntity(
+    val turnaround1 = Cas3TurnaroundEntity(
       id = UUID.fromString("34ae3124-cf7a-47d5-86c1-ef9ab4255e30"),
       workingDayCount = 2,
       createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       booking = awaitingArrivalBooking,
     )
-    val turnaround2 = TurnaroundEntity(
+    val turnaround2 = Cas3TurnaroundEntity(
       id = UUID.fromString("b2af671a-997d-443e-906d-3a1a28c71416"),
       workingDayCount = 3,
       createdAt = OffsetDateTime.parse("2022-07-02T10:11:12.345Z"),
       booking = awaitingArrivalBooking,
     )
-    val turnaround3 = TurnaroundEntity(
+    val turnaround3 = Cas3TurnaroundEntity(
       id = UUID.fromString("146d05f8-ba83-42ae-a6d7-807a16b7946d"),
       workingDayCount = 4,
       createdAt = OffsetDateTime.parse("2022-07-03T09:08:07.654Z"),
@@ -1868,21 +1868,21 @@ class BookingTransformerTest {
 
     awaitingArrivalBooking.turnarounds += listOf(turnaround1, turnaround2, turnaround3)
 
-    every { mockTurnaroundTransformer.transformJpaToApi(turnaround1) } returns Turnaround(
+    every { mockCas3TurnaroundTransformer.transformJpaToApi(turnaround1) } returns Turnaround(
       id = UUID.fromString("34ae3124-cf7a-47d5-86c1-ef9ab4255e30"),
       bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
       workingDays = 2,
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    every { mockTurnaroundTransformer.transformJpaToApi(turnaround2) } returns Turnaround(
+    every { mockCas3TurnaroundTransformer.transformJpaToApi(turnaround2) } returns Turnaround(
       id = UUID.fromString("b2af671a-997d-443e-906d-3a1a28c71416"),
       bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
       workingDays = 3,
       createdAt = Instant.parse("2022-07-02T10:11:12.345Z"),
     )
 
-    every { mockTurnaroundTransformer.transformJpaToApi(turnaround3) } returns Turnaround(
+    every { mockCas3TurnaroundTransformer.transformJpaToApi(turnaround3) } returns Turnaround(
       id = UUID.fromString("146d05f8-ba83-42ae-a6d7-807a16b7946d"),
       bookingId = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
       workingDays = 4,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3TurnaroundTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3TurnaroundTransformerTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Turnaround
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3TurnaroundTransformerTest {
+  private val cas3TurnaroundTransformer = Cas3TurnaroundTransformer()
+
+  @Test
+  fun `transformJpaToApi transforms the Cas3TurnaroundEntity into a Turnaround`() {
+    val booking = BookingEntityFactory()
+      .withPremises(
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+          .produce(),
+      )
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .produce()
+
+    val turnaroundId = UUID.randomUUID()
+    val cas3TurnaroundEntity = Cas3TurnaroundEntity(
+      id = turnaroundId,
+      createdAt = OffsetDateTime.parse("2025-04-08T00:00:00Z"),
+      booking = booking,
+      workingDayCount = 5,
+    )
+
+    val result = cas3TurnaroundTransformer.transformJpaToApi(cas3TurnaroundEntity)
+
+    assertThat(result).isEqualTo(
+      Turnaround(
+        id = turnaroundId,
+        bookingId = booking.id,
+        workingDays = 5,
+        createdAt = OffsetDateTime.parse("2025-04-08T00:00:00Z").toInstant(),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
Move turnaround to CAS3 namespace and rename table and entity