### PR TITLE
Firebreak move confirmations to Cas3 namespace

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -76,13 +76,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedDetailTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedSummaryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DateChangeTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PremisesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RoomTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.StaffMemberTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3PremisesSummaryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspaceCancellationTransformer
@@ -112,7 +112,7 @@ class PremisesController(
   private val cas3VoidBedspacesTransformer: Cas3VoidBedspacesTransformer,
   private val arrivalTransformer: ArrivalTransformer,
   private val cancellationTransformer: CancellationTransformer,
-  private val confirmationTransformer: ConfirmationTransformer,
+  private val cas3ConfirmationTransformer: Cas3ConfirmationTransformer,
   private val departureTransformer: DepartureTransformer,
   private val extensionTransformer: ExtensionTransformer,
   private val staffMemberTransformer: StaffMemberTransformer,
@@ -571,7 +571,7 @@ class PremisesController(
       }
     val confirmation = extractResultEntityOrThrow(result)
 
-    return ResponseEntity.ok(confirmationTransformer.transformJpaToApi(confirmation))
+    return ResponseEntity.ok(cas3ConfirmationTransformer.transformJpaToApi(confirmation))
   }
 
   override fun premisesPremisesIdBookingsBookingIdDeparturesPost(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -21,6 +21,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import java.time.Instant
 import java.time.LocalDate
@@ -300,7 +301,7 @@ data class BookingEntity(
   @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
   var cancellations: MutableList<CancellationEntity>,
   @OneToOne(mappedBy = "booking")
-  var confirmation: ConfirmationEntity?,
+  var confirmation: Cas3ConfirmationEntity?,
   @OneToOne
   @JoinColumn(name = "application_id")
   var application: ApplicationEntity?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3ConfirmationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3ConfirmationEntity.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
 
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
@@ -7,16 +7,17 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 
 @Repository
-interface ConfirmationRepository : JpaRepository<ConfirmationEntity, UUID>
+interface Cas3ConfirmationRepository : JpaRepository<Cas3ConfirmationEntity, UUID>
 
 @Entity
-@Table(name = "confirmations")
-data class ConfirmationEntity(
+@Table(name = "cas3_confirmations")
+data class Cas3ConfirmationEntity(
   @Id
   val id: UUID,
   val dateTime: OffsetDateTime,
@@ -28,7 +29,7 @@ data class ConfirmationEntity(
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is ConfirmationEntity) return false
+    if (other !is Cas3ConfirmationEntity) return false
 
     if (id != other.id) return false
     if (dateTime != other.dateTime) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3FutureBookingsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3FutureBookingsReportRepository.kt
@@ -43,7 +43,7 @@ interface Cas3FutureBookingsReportRepository : JpaRepository<BookingEntity, UUID
     LEFT JOIN temporary_accommodation_applications cas3_app ON booking.application_id = cas3_app.id
     LEFT JOIN assessments assessment ON app.id = assessment.application_id
     LEFT JOIN temporary_accommodation_assessments cas3_assessment on cas3_assessment.assessment_id = assessment.id
-    LEFT JOIN confirmations confirmation ON confirmation.booking_id = booking.id
+    LEFT JOIN cas3_confirmations confirmation ON confirmation.booking_id = booking.id
     LEFT JOIN cancellations cancellation ON cancellation.booking_id = booking.id
     LEFT JOIN arrivals arrival ON arrival.booking_id = booking.id
     INNER JOIN temporary_accommodation_premises cas3_premises ON cas3_premises.premises_id = premises.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BedUtilisationReportRepository.kt
@@ -60,7 +60,7 @@ interface BedUtilisationReportRepository : JpaRepository<BedEntity, UUID> {
     INNER JOIN premises premises ON booking.premises_id = premises.id
     INNER JOIN probation_regions probation_region ON probation_region.id = premises.probation_region_id
     LEFT JOIN arrivals arrival ON booking.id = arrival.booking_id
-    LEFT JOIN confirmations confirmation ON booking.id = confirmation.booking_id
+    LEFT JOIN cas3_confirmations confirmation ON booking.id = confirmation.booking_id
     WHERE
         premises.service = 'temporary-accommodation'
       AND (CAST(:probationRegionId AS UUID) IS NULL OR premises.probation_region_id = :probationRegionId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/BookingsReportRepository.kt
@@ -52,7 +52,7 @@ interface BookingsReportRepository : JpaRepository<BookingEntity, UUID> {
     LEFT JOIN
       temporary_accommodation_applications cas3_app ON booking.application_id = cas3_app.id
     LEFT JOIN
-      confirmations confirmation ON confirmation.booking_id = booking.id
+      cas3_confirmations confirmation ON confirmation.booking_id = booking.id
     LEFT JOIN
       departures departure ON departure.booking_id = booking.id AND departure.created_at = (SELECT max(d.created_at) FROM departures d WHERE d.booking_id=booking.id)
     LEFT JOIN

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -20,8 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository.Constants.CAS1_RELATED_PLACEMENT_APP_WITHDRAWN_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository.Constants.CAS1_RELATED_PLACEMENT_REQ_WITHDRAWN_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
@@ -31,6 +29,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.serviceScopeMatches
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -62,7 +62,7 @@ class BookingService(
   private val bookingRepository: BookingRepository,
   private val arrivalRepository: ArrivalRepository,
   private val cancellationRepository: CancellationRepository,
-  private val confirmationRepository: ConfirmationRepository,
+  private val cas3ConfirmationRepository: Cas3ConfirmationRepository,
   private val dateChangeRepository: DateChangeRepository,
   private val cancellationReasonRepository: CancellationReasonRepository,
   private val bedRepository: BedRepository,
@@ -391,13 +391,13 @@ class BookingService(
     booking: BookingEntity,
     dateTime: OffsetDateTime,
     notes: String?,
-  ) = validated<ConfirmationEntity> {
+  ) = validated<Cas3ConfirmationEntity> {
     if (booking.confirmation != null) {
       return generalError("This Booking already has a Confirmation set")
     }
 
-    val confirmationEntity = confirmationRepository.save(
-      ConfirmationEntity(
+    val cas3ConfirmationEntity = cas3ConfirmationRepository.save(
+      Cas3ConfirmationEntity(
         id = UUID.randomUUID(),
         dateTime = dateTime,
         notes = notes,
@@ -407,9 +407,9 @@ class BookingService(
     )
     booking.status = BookingStatus.confirmed
     updateBooking(booking)
-    booking.confirmation = confirmationEntity
+    booking.confirmation = cas3ConfirmationEntity
 
-    return success(confirmationEntity)
+    return success(cas3ConfirmationEntity)
   }
 
   private fun shouldCreateDomainEventForBooking(booking: BookingEntity, user: UserEntity?): Boolean = booking.service == ServiceName.approvedPremises.value &&

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/BookingTransformer.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
 import java.time.LocalDate
 
@@ -23,7 +24,7 @@ class BookingTransformer(
   private val departureTransformer: DepartureTransformer,
   private val nonArrivalTransformer: NonArrivalTransformer,
   private val cancellationTransformer: CancellationTransformer,
-  private val confirmationTransformer: ConfirmationTransformer,
+  private val cas3ConfirmationTransformer: Cas3ConfirmationTransformer,
   private val extensionTransformer: ExtensionTransformer,
   private val bedTransformer: BedTransformer,
   private val cas3TurnaroundTransformer: Cas3TurnaroundTransformer,
@@ -49,7 +50,7 @@ class BookingTransformer(
       nonArrival = nonArrivalTransformer.transformJpaToApi(jpa.nonArrival),
       cancellation = cancellationTransformer.transformJpaToApi(jpa.cancellation),
       cancellations = jpa.cancellations.map { cancellationTransformer.transformJpaToApi(it)!! },
-      confirmation = confirmationTransformer.transformJpaToApi(jpa.confirmation),
+      confirmation = cas3ConfirmationTransformer.transformJpaToApi(jpa.confirmation),
       extensions = jpa.extensions.map(extensionTransformer::transformJpaToApi),
       bed = jpa.bed?.let { bedTransformer.transformJpaToApi(it) },
       originalArrivalDate = jpa.originalArrivalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ConfirmationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ConfirmationTransformer.kt
@@ -1,12 +1,12 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
 
 @Component
-class ConfirmationTransformer {
-  fun transformJpaToApi(jpa: ConfirmationEntity?): Confirmation? = jpa?.let {
+class Cas3ConfirmationTransformer {
+  fun transformJpaToApi(jpa: Cas3ConfirmationEntity?): Confirmation? = jpa?.let {
     Confirmation(
       id = it.id,
       bookingId = it.booking.id,

--- a/src/main/resources/db/migration/all/20250408161202__add_prefix_cas3_to_confirmations_table.sql
+++ b/src/main/resources/db/migration/all/20250408161202__add_prefix_cas3_to_confirmations_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE confirmations RENAME TO cas3_confirmations;

--- a/src/main/resources/db/migration/dev/R__5_create_bookings_for_cas3_eofe.sql
+++ b/src/main/resources/db/migration/dev/R__5_create_bookings_for_cas3_eofe.sql
@@ -103,7 +103,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  confirmations (
+  cas3_confirmations (
     "id",
     "booking_id",
     "date_time",

--- a/src/main/resources/db/migration/dev/R__5_create_bookings_for_cas3_kss.sql
+++ b/src/main/resources/db/migration/dev/R__5_create_bookings_for_cas3_kss.sql
@@ -101,7 +101,7 @@ VALUES
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO
-  confirmations (
+  cas3_confirmations (
     "id",
     "booking_id",
     "date_time",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
@@ -17,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
@@ -39,7 +39,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var departures: Yielded<MutableList<DepartureEntity>>? = null
   private var nonArrival: Yielded<NonArrivalEntity>? = null
   private var cancellations: Yielded<MutableList<CancellationEntity>>? = null
-  private var confirmation: Yielded<ConfirmationEntity>? = null
+  private var confirmation: Yielded<Cas3ConfirmationEntity>? = null
   private var extensions: Yielded<MutableList<ExtensionEntity>>? = null
   private var dateChanges: Yielded<MutableList<DateChangeEntity>>? = null
   private var premises: Yielded<PremisesEntity>? = null
@@ -114,11 +114,11 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.cancellations = { cancellations }
   }
 
-  fun withYieldedConfirmation(confirmation: Yielded<ConfirmationEntity>) = apply {
+  fun withYieldedConfirmation(confirmation: Yielded<Cas3ConfirmationEntity>) = apply {
     this.confirmation = confirmation
   }
 
-  fun withConfirmation(confirmation: ConfirmationEntity) = apply {
+  fun withConfirmation(confirmation: Cas3ConfirmationEntity) = apply {
     this.confirmation = { confirmation }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ConfirmationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ConfirmationEntityFactory.kt
@@ -1,15 +1,15 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class ConfirmationEntityFactory : Factory<ConfirmationEntity> {
+class Cas3ConfirmationEntityFactory : Factory<Cas3ConfirmationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(14) }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
@@ -40,7 +40,8 @@ class ConfirmationEntityFactory : Factory<ConfirmationEntity> {
     this.createdAt = { createdAt }
   }
 
-  override fun produce(): ConfirmationEntity = ConfirmationEntity(
+  @Suppress("TooGenericExceptionThrown")
+  override fun produce(): Cas3ConfirmationEntity = Cas3ConfirmationEntity(
     id = this.id(),
     notes = this.notes(),
     dateTime = this.dateTime(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingSearchTest.kt
@@ -266,7 +266,7 @@ class BookingSearchTest : IntegrationTestBase() {
                 withStatus(BookingStatus.confirmed)
                 withServiceName(ServiceName.temporaryAccommodation)
               }
-              val confirmation = confirmationEntityFactory.produceAndPersist {
+              val confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
                 withBooking(booking)
               }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -63,7 +63,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2NoteEntityFa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateDetailEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DateChangeEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
@@ -101,6 +100,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestRejectionReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
@@ -157,7 +157,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpd
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
@@ -205,6 +204,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Chan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
@@ -237,11 +237,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2StatusUpdateTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3ConfirmationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3TurnaroundTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspacesTestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.ConfirmationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationProviderTestRepository
@@ -344,7 +344,7 @@ abstract class IntegrationTestBase {
   lateinit var arrivalRepository: ArrivalTestRepository
 
   @Autowired
-  lateinit var confirmationRepository: ConfirmationTestRepository
+  lateinit var confirmationRepository: Cas3ConfirmationTestRepository
 
   @Autowired
   lateinit var departureRepository: DepartureTestRepository
@@ -579,7 +579,7 @@ abstract class IntegrationTestBase {
   lateinit var temporaryAccommodationPremisesEntityFactory: PersistedFactory<TemporaryAccommodationPremisesEntity, UUID, TemporaryAccommodationPremisesEntityFactory>
   lateinit var bookingEntityFactory: PersistedFactory<BookingEntity, UUID, BookingEntityFactory>
   lateinit var arrivalEntityFactory: PersistedFactory<ArrivalEntity, UUID, ArrivalEntityFactory>
-  lateinit var confirmationEntityFactory: PersistedFactory<ConfirmationEntity, UUID, ConfirmationEntityFactory>
+  lateinit var cas3ConfirmationEntityFactory: PersistedFactory<Cas3ConfirmationEntity, UUID, Cas3ConfirmationEntityFactory>
   lateinit var departureEntityFactory: PersistedFactory<DepartureEntity, UUID, DepartureEntityFactory>
   lateinit var destinationProviderEntityFactory: PersistedFactory<DestinationProviderEntity, UUID, DestinationProviderEntityFactory>
   lateinit var departureReasonEntityFactory: PersistedFactory<DepartureReasonEntity, UUID, DepartureReasonEntityFactory>
@@ -694,7 +694,7 @@ abstract class IntegrationTestBase {
     temporaryAccommodationPremisesEntityFactory = PersistedFactory({ TemporaryAccommodationPremisesEntityFactory() }, temporaryAccommodationPremisesRepository)
     bookingEntityFactory = PersistedFactory({ BookingEntityFactory() }, bookingRepository)
     arrivalEntityFactory = PersistedFactory({ ArrivalEntityFactory() }, arrivalRepository)
-    confirmationEntityFactory = PersistedFactory({ ConfirmationEntityFactory() }, confirmationRepository)
+    cas3ConfirmationEntityFactory = PersistedFactory({ Cas3ConfirmationEntityFactory() }, confirmationRepository)
     departureEntityFactory = PersistedFactory({ DepartureEntityFactory() }, departureRepository)
     destinationProviderEntityFactory = PersistedFactory({ DestinationProviderEntityFactory() }, destinationProviderRepository)
     departureReasonEntityFactory = PersistedFactory({ DepartureReasonEntityFactory() }, departureReasonRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3PremisesTest.kt
@@ -145,7 +145,7 @@ class Cas3PremisesTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.now().plusDays(43))
         }
 
-        confirmedBooking.confirmation = confirmationEntityFactory.produceAndPersist {
+        confirmedBooking.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
           withBooking(confirmedBooking)
         }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -2738,7 +2738,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             LocalDate.parse("2023-04-10"),
           )
 
-          confirmationEntityFactory.produceAndPersist {
+          cas3ConfirmationEntityFactory.produceAndPersist {
             withBooking(booking)
           }
 
@@ -3315,7 +3315,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             LocalDate.of(2024, 4, 12),
           )
 
-          confirmationEntityFactory.produceAndPersist {
+          cas3ConfirmationEntityFactory.produceAndPersist {
             withBooking(booking1)
           }
 
@@ -3329,7 +3329,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             LocalDate.of(2024, 4, 21),
           )
 
-          confirmationEntityFactory.produceAndPersist {
+          cas3ConfirmationEntityFactory.produceAndPersist {
             withBooking(booking2)
           }
 
@@ -3634,7 +3634,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             reportEndDate.randomDateAfter(20),
           )
           bookingFour.let {
-            it.confirmation = confirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -3662,7 +3662,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             reportEndDate.randomDateAfter(40),
           )
           bookingFive.let {
-            it.confirmation = confirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -3684,7 +3684,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             reportEndDate.plusDays(90),
             reportEndDate.plusDays(120),
           ).let {
-            it.confirmation = confirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -3696,7 +3696,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             reportEndDate.plusDays(70),
             reportEndDate.plusDays(85),
           ).let {
-            it.confirmation = confirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -3917,7 +3917,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             reportEndDate.randomDateAfter(20),
           )
           bookingFour.let {
-            it.confirmation = confirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -3945,7 +3945,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             reportEndDate.randomDateAfter(40),
           )
           bookingFive.let {
-            it.confirmation = confirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -3967,7 +3967,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             reportEndDate.plusDays(90),
             reportEndDate.plusDays(120),
           ).let {
-            it.confirmation = confirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -3979,7 +3979,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             reportEndDate.plusDays(70),
             reportEndDate.plusDays(85),
           ).let {
-            it.confirmation = confirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/MigrateBookingStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/MigrateBookingStatusTest.kt
@@ -255,7 +255,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
 
   private fun createCAS3ConfirmedBooking(userEntity: UserEntity): BookingEntity {
     val booking = createTemporaryAccommodationBooking(userEntity, null)
-    booking.confirmation = confirmationEntityFactory.produceAndPersist {
+    booking.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
       withBooking(booking)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3ConfirmationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3ConfirmationTestRepository.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
 import java.util.UUID
 
 @Repository
-interface ConfirmationTestRepository : JpaRepository<ConfirmationEntity, UUID>
+interface Cas3ConfirmationTestRepository : JpaRepository<Cas3ConfirmationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BedUtilisationReportGeneratorTest.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
@@ -19,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
@@ -416,13 +416,13 @@ class BedUtilisationReportGeneratorTest {
     val relevantBookingStraddlingStartOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2023-03-28"))
         .withDepartureDate(LocalDate.parse("2023-04-04")).produce().apply {
-          confirmation = ConfirmationEntityFactory().withBooking(this).produce()
+          confirmation = Cas3ConfirmationEntityFactory().withBooking(this).produce()
         }
 
     val relevantBookingStraddlingEndOfMonth =
       BookingEntityFactory().withBed(bed).withPremises(premises).withArrivalDate(LocalDate.parse("2023-04-28"))
         .withDepartureDate(LocalDate.parse("2023-05-04")).produce().apply {
-          confirmation = ConfirmationEntityFactory().withBooking(this).produce()
+          confirmation = Cas3ConfirmationEntityFactory().withBooking(this).produce()
         }
 
     val bedUtilisationBedspaceReportData = convertToCas3BedUtilisationBedspaceReportData(bed)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
@@ -23,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProfileFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.BookingsReportGenerator
@@ -109,7 +109,7 @@ class BookingsReportGeneratorTest {
       }
       .produce()
 
-    booking.confirmation = ConfirmationEntityFactory()
+    booking.confirmation = Cas3ConfirmationEntityFactory()
       .withBooking(booking)
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -31,7 +31,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
@@ -45,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -58,8 +58,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingReposi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
@@ -67,6 +65,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
@@ -102,7 +102,7 @@ class BookingServiceTest {
   private val mockBookingRepository = mockk<BookingRepository>()
   private val mockArrivalRepository = mockk<ArrivalRepository>()
   private val mockCancellationRepository = mockk<CancellationRepository>()
-  private val mockConfirmationRepository = mockk<ConfirmationRepository>()
+  private val mockCas3ConfirmationRepository = mockk<Cas3ConfirmationRepository>()
   private val mockDateChangeRepository = mockk<DateChangeRepository>()
   private val mockCancellationReasonRepository = mockk<CancellationReasonRepository>()
   private val mockBedRepository = mockk<BedRepository>()
@@ -124,7 +124,7 @@ class BookingServiceTest {
     bookingRepository = mockBookingRepository,
     arrivalRepository = mockArrivalRepository,
     cancellationRepository = mockCancellationRepository,
-    confirmationRepository = mockConfirmationRepository,
+    cas3ConfirmationRepository = mockCas3ConfirmationRepository,
     dateChangeRepository = mockDateChangeRepository,
     cancellationReasonRepository = mockCancellationReasonRepository,
     bedRepository = mockBedRepository,
@@ -891,7 +891,7 @@ class BookingServiceTest {
       }
       .produce()
 
-    val confirmationEntity = ConfirmationEntityFactory()
+    val confirmationEntity = Cas3ConfirmationEntityFactory()
       .withBooking(bookingEntity)
       .produce()
 
@@ -914,7 +914,7 @@ class BookingServiceTest {
       .produce()
     val bookingEntity = createApprovedPremisesAccommodationBooking(application)
 
-    every { mockConfirmationRepository.save(any()) } answers { it.invocation.args[0] as ConfirmationEntity }
+    every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
     every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
     every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(), user) } just Runs
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
@@ -40,6 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
@@ -49,8 +49,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingReposi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureRepository
@@ -62,6 +60,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
@@ -95,7 +95,7 @@ class Cas3BookingServiceTest {
   private val mockBookingRepository = mockk<BookingRepository>()
   private val mockArrivalRepository = mockk<ArrivalRepository>()
   private val mockCancellationRepository = mockk<CancellationRepository>()
-  private val mockConfirmationRepository = mockk<ConfirmationRepository>()
+  private val mockCas3ConfirmationRepository = mockk<Cas3ConfirmationRepository>()
   private val mockExtensionRepository = mockk<ExtensionRepository>()
   private val mockDepartureRepository = mockk<DepartureRepository>()
   private val mockDepartureReasonRepository = mockk<DepartureReasonRepository>()
@@ -113,7 +113,7 @@ class Cas3BookingServiceTest {
   fun createCas3BookingService(): Cas3BookingService = Cas3BookingService(
     bookingRepository = mockBookingRepository,
     bedRepository = mockBedRepository,
-    confirmationRepository = mockConfirmationRepository,
+    cas3ConfirmationRepository = mockCas3ConfirmationRepository,
     assessmentRepository = mockAssessmentRepository,
     arrivalRepository = mockArrivalRepository,
     departureRepository = mockDepartureRepository,
@@ -1387,7 +1387,7 @@ class Cas3BookingServiceTest {
         }
         .produce()
 
-      val confirmationEntity = ConfirmationEntityFactory()
+      val confirmationEntity = Cas3ConfirmationEntityFactory()
         .withBooking(bookingEntity)
         .produce()
 
@@ -1408,7 +1408,7 @@ class Cas3BookingServiceTest {
     fun `createConfirmation returns Success with correct result when validation passed and emits domain event`() {
       val bookingEntity = createBooking(null)
 
-      every { mockConfirmationRepository.save(any()) } answers { it.invocation.args[0] as ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
 
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(), user) } just Runs
@@ -1439,7 +1439,7 @@ class Cas3BookingServiceTest {
     fun `createConfirmation returns Success with correct result and not closing the referral when booking is done without application`() {
       val bookingEntity = createBooking(null)
 
-      every { mockConfirmationRepository.save(any()) } answers { it.invocation.args[0] as ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
 
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(), user) } just Runs
@@ -1485,7 +1485,7 @@ class Cas3BookingServiceTest {
 
       val bookingEntity = createBooking(application)
 
-      every { mockConfirmationRepository.save(any()) } answers { it.invocation.args[0] as ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
 
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(), user) } just Runs
@@ -1532,7 +1532,7 @@ class Cas3BookingServiceTest {
         .produce()
       val bookingEntity = createBooking(application)
 
-      every { mockConfirmationRepository.save(any()) } answers { it.invocation.args[0] as ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(), user) } just Runs
       every { mockAssessmentRepository.findByApplicationIdAndReallocatedAtNull(bookingEntity.application!!.id) } returns null
@@ -1578,7 +1578,7 @@ class Cas3BookingServiceTest {
 
       val bookingEntity = createBooking(application)
 
-      every { mockConfirmationRepository.save(any()) } answers { it.invocation.args[0] as ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(), user) } just Runs
       every { mockAssessmentRepository.findByApplicationIdAndReallocatedAtNull(bookingEntity.application!!.id) } returns assessment

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -41,7 +41,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
@@ -51,6 +50,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEnt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
@@ -58,11 +58,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTrans
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
 import java.time.Instant
 import java.time.LocalDate
@@ -74,7 +74,7 @@ class BookingTransformerTest {
   private val mockArrivalTransformer = mockk<ArrivalTransformer>()
   private val mockNonArrivalTransformer = mockk<NonArrivalTransformer>()
   private val mockCancellationTransformer = mockk<CancellationTransformer>()
-  private val mockConfirmationTransformer = mockk<ConfirmationTransformer>()
+  private val mockCas3ConfirmationTransformer = mockk<Cas3ConfirmationTransformer>()
   private val mockDepartureTransformer = mockk<DepartureTransformer>()
   private val mockExtensionTransformer = mockk<ExtensionTransformer>()
   private val mockBedTransformer = mockk<BedTransformer>()
@@ -88,7 +88,7 @@ class BookingTransformerTest {
     mockDepartureTransformer,
     mockNonArrivalTransformer,
     mockCancellationTransformer,
-    mockConfirmationTransformer,
+    mockCas3ConfirmationTransformer,
     mockExtensionTransformer,
     mockBedTransformer,
     mockCas3TurnaroundTransformer,
@@ -170,7 +170,7 @@ class BookingTransformerTest {
     every { mockArrivalTransformer.transformJpaToApi(null) } returns null
     every { mockNonArrivalTransformer.transformJpaToApi(null) } returns null
     every { mockCancellationTransformer.transformJpaToApi(null) } returns null
-    every { mockConfirmationTransformer.transformJpaToApi(null) } returns null
+    every { mockCas3ConfirmationTransformer.transformJpaToApi(null) } returns null
     every { mockDepartureTransformer.transformJpaToApi(null) } returns null
 
     every { mockPersonTransformer.transformModelToPersonApi(PersonInfoResult.Success.Full("crn", offenderDetails, inmateDetail)) } returns FullPerson(
@@ -1775,7 +1775,7 @@ class BookingTransformerTest {
       id = UUID.fromString("1c29a729-6059-4939-8641-1caa61a38815"),
       service = ServiceName.temporaryAccommodation.value,
     ).apply {
-      confirmation = ConfirmationEntity(
+      confirmation = Cas3ConfirmationEntity(
         id = UUID.fromString("69fc6350-b2ec-4e99-9a2f-e829e83535e8"),
         dateTime = OffsetDateTime.parse("2022-11-23T12:34:56.789Z"),
         notes = null,
@@ -1784,7 +1784,7 @@ class BookingTransformerTest {
       )
     }
 
-    every { mockConfirmationTransformer.transformJpaToApi(confirmationBooking.confirmation) } returns Confirmation(
+    every { mockCas3ConfirmationTransformer.transformJpaToApi(confirmationBooking.confirmation) } returns Confirmation(
       id = UUID.fromString("69fc6350-b2ec-4e99-9a2f-e829e83535e8"),
       bookingId = UUID.fromString("1c29a729-6059-4939-8641-1caa61a38815"),
       notes = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3ConfirmationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3ConfirmationTransformerTest.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ConfirmationTransformer
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3ConfirmationTransformerTest {
+  private val cas3ConfirmationTransformer = Cas3ConfirmationTransformer()
+
+  @Test
+  fun `transformJpaToApi transforms the Cas3TurnaroundEntity into a Turnaround`() {
+    val booking = BookingEntityFactory()
+      .withPremises(
+        TemporaryAccommodationPremisesEntityFactory()
+          .withYieldedProbationRegion {
+            ProbationRegionEntityFactory()
+              .withYieldedApArea { ApAreaEntityFactory().produce() }
+              .produce()
+          }
+          .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+          .produce(),
+      )
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .produce()
+
+    val confirmationId = UUID.randomUUID()
+    val cas3ConfirmationEntity = Cas3ConfirmationEntity(
+      id = confirmationId,
+      dateTime = OffsetDateTime.parse("2025-04-08T00:00:00Z"),
+      notes = "Test notes",
+      createdAt = OffsetDateTime.parse("2025-04-08T00:00:00Z"),
+      booking = booking,
+    )
+
+    val result = cas3ConfirmationTransformer.transformJpaToApi(cas3ConfirmationEntity)
+
+    assertThat(result).isEqualTo(
+      Confirmation(
+        id = confirmationId,
+        bookingId = booking.id,
+        dateTime = OffsetDateTime.parse("2025-04-08T00:00:00Z").toInstant(),
+        notes = "Test notes",
+        createdAt = OffsetDateTime.parse("2025-04-08T00:00:00Z").toInstant(),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
This PR is to move confirmations to Cas3 namespace and rename table and entity