### PR TITLE
Create draft CAS1 application for dev profile

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1StartupScript.kt
@@ -85,6 +85,12 @@ class Cas1StartupScript(
   fun scriptDev() {
     seedLogger.info("Running Startup Script for CAS1 dev")
     seedUsers(usersToSeedDev())
+
+    createApplicationPendingSubmission(
+      deliusUserName = "AP_USER_TEST_1",
+      crn = "X320741",
+    )
+    createOfflineApplicationWithBooking(deliusUserName = "AP_USER_TEST_1", crn = "X320741")
   }
 
   private fun seedUsers(usersToSeed: List<SeedUser>) = usersToSeed.forEach { seedUser(it) }


### PR DESCRIPTION
As we’re moving to using the dev profile locally this ensures there’s a draft application available in dev