### PR TITLE
Limit applications loaded into memory when loading the CAS1 timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PeopleController.kt
@@ -27,6 +27,10 @@ class Cas1PeopleController(
   private val sentryService: SentryService,
 ) : PeopleCas1Delegate {
 
+  companion object {
+    const val TIMELINE_APPLICATION_LIMIT = 50
+  }
+
   override fun getPeopleApplicationsTimeline(crn: String): ResponseEntity<Cas1PersonalTimeline> {
     val user = userService.getUserForRequest()
 
@@ -46,9 +50,9 @@ class Cas1PeopleController(
   private fun buildPersonInfoWithTimeline(personInfo: PersonInfoResult.Success.Full, crn: String): Cas1PersonalTimeline {
     val regularApplications = getRegularApplications(crn)
     val offlineApplications = getOfflineApplications(crn)
-    val combinedApplications = (regularApplications + offlineApplications).take(50)
+    val combinedApplications = (regularApplications + offlineApplications).take(TIMELINE_APPLICATION_LIMIT)
 
-    if (combinedApplications.size == 50) {
+    if (combinedApplications.size == TIMELINE_APPLICATION_LIMIT) {
       sentryService.captureErrorMessage(
         "Person Timeline results truncated to 50 applications. CRN: $crn. Regular: ${regularApplications.size}, Offline: ${offlineApplications.size}. Consider adding paging.",
       )
@@ -67,10 +71,10 @@ class Cas1PeopleController(
   }
 
   private fun getRegularApplications(crn: String) = cas1ApplicationService
-    .getApplicationsForCrn(crn)
+    .getApplicationsForCrn(crn, limit = TIMELINE_APPLICATION_LIMIT)
     .map { BoxedApplication.of(it) }
 
   private fun getOfflineApplications(crn: String) = cas1ApplicationService
-    .getOfflineApplicationsForCrn(crn)
+    .getOfflineApplicationsForCrn(crn, limit = TIMELINE_APPLICATION_LIMIT)
     .map { BoxedApplication.of(it) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PeopleController.kt
@@ -4,15 +4,14 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.PeopleCas1Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PersonalTimeline
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.BoxedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1ApplicationTimelineModel
@@ -22,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1Per
 class Cas1PeopleController(
   private val userService: UserService,
   private val offenderService: OffenderService,
-  private val applicationService: ApplicationService,
+  private val cas1ApplicationService: Cas1ApplicationService,
   private val cas1PersonalTimelineTransformer: Cas1PersonalTimelineTransformer,
   private val cas1TimelineService: Cas1TimelineService,
   private val sentryService: SentryService,
@@ -67,11 +66,11 @@ class Cas1PeopleController(
     return cas1PersonalTimelineTransformer.transformApplicationTimelineModels(personInfo, applicationTimelineModels)
   }
 
-  private fun getRegularApplications(crn: String) = applicationService
-    .getApplicationsForCrn(crn, ServiceName.approvedPremises)
-    .map { BoxedApplication.of(it as ApprovedPremisesApplicationEntity) }
+  private fun getRegularApplications(crn: String) = cas1ApplicationService
+    .getApplicationsForCrn(crn)
+    .map { BoxedApplication.of(it) }
 
-  private fun getOfflineApplications(crn: String) = applicationService
-    .getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises)
+  private fun getOfflineApplications(crn: String) = cas1ApplicationService
+    .getOfflineApplicationsForCrn(crn)
     .map { BoxedApplication.of(it) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -20,6 +20,7 @@ import jakarta.persistence.PrimaryKeyJoinColumn
 import jakarta.persistence.Table
 import org.hibernate.annotations.Immutable
 import org.hibernate.annotations.Type
+import org.springframework.data.domain.Limit
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -302,8 +303,7 @@ interface ApprovedPremisesApplicationRepository : JpaRepository<ApprovedPremises
 
   fun findByIdIn(applicationIds: List<UUID>): List<ApprovedPremisesApplicationEntity>
 
-  @Query("SELECT a FROM ApprovedPremisesApplicationEntity a WHERE a.crn = :crn")
-  fun findByCrn(crn: String): List<ApprovedPremisesApplicationEntity>
+  fun findByCrn(crn: String, limit: Limit): List<ApprovedPremisesApplicationEntity>
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -160,9 +160,6 @@ AND (
     fun getNomsNumber(): String
   }
 
-  @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.crn = :crn")
-  fun <T : ApplicationEntity> findByCrn(crn: String, type: Class<T>): List<ApplicationEntity>
-
   @Query(
     """
 SELECT
@@ -304,6 +301,9 @@ interface ApprovedPremisesApplicationRepository : JpaRepository<ApprovedPremises
   fun findAllIdsByCas1OffenderEntityIsNull(): List<UUID>
 
   fun findByIdIn(applicationIds: List<UUID>): List<ApprovedPremisesApplicationEntity>
+
+  @Query("SELECT a FROM ApprovedPremisesApplicationEntity a WHERE a.crn = :crn")
+  fun findByCrn(crn: String): List<ApprovedPremisesApplicationEntity>
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 
 @Repository
 interface OfflineApplicationRepository : JpaRepository<OfflineApplicationEntity, UUID> {
-  fun findAllByServiceAndCrn(name: String, crn: String): List<OfflineApplicationEntity>
+  fun findAllByCrn(crn: String): List<OfflineApplicationEntity>
 
   @Query("SELECT a FROM OfflineApplicationEntity a where a.name is null")
   fun findByNameIsNull(): List<OfflineApplicationEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/OfflineApplicationEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.springframework.data.domain.Limit
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -12,7 +13,7 @@ import java.util.UUID
 
 @Repository
 interface OfflineApplicationRepository : JpaRepository<OfflineApplicationEntity, UUID> {
-  fun findAllByCrn(crn: String): List<OfflineApplicationEntity>
+  fun findAllByCrn(crn: String, limit: Limit): List<OfflineApplicationEntity>
 
   @Query("SELECT a FROM OfflineApplicationEntity a where a.name is null")
   fun findByNameIsNull(): List<OfflineApplicationEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
@@ -302,8 +302,9 @@ class Cas1ApplicationSeedService(
 
   private fun getAssessmentId(application: ApprovedPremisesApplicationEntity) = assessmentRepository.findByApplicationIdAndReallocatedAtNull(applicationId = application.id)!!.id
 
+  @SuppressWarnings("MagicNumber")
   private fun createOfflineApplicationInternal(deliusUserName: String, crn: String) {
-    if (cas1ApplicationService.getOfflineApplicationsForCrn(crn).isNotEmpty()) {
+    if (cas1ApplicationService.getOfflineApplicationsForCrn(crn, limit = 1).isNotEmpty()) {
       log.info("Already have an offline CAS1 application for $crn, not seeding a new application")
       return
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
@@ -43,6 +43,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentServi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService.GetUserResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromCasResultIsSuccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
@@ -61,6 +62,7 @@ class Cas1ApplicationSeedService(
   private val applicationTimelineNoteService: ApplicationTimelineNoteService,
   private val spaceBookingRepository: Cas1SpaceBookingRepository,
   private val applicationService: ApplicationService,
+  private val cas1ApplicationService: Cas1ApplicationService,
   private val userService: UserService,
   private val environmentService: EnvironmentService,
   private val assessmentService: AssessmentService,
@@ -301,7 +303,7 @@ class Cas1ApplicationSeedService(
   private fun getAssessmentId(application: ApprovedPremisesApplicationEntity) = assessmentRepository.findByApplicationIdAndReallocatedAtNull(applicationId = application.id)!!.id
 
   private fun createOfflineApplicationInternal(deliusUserName: String, crn: String) {
-    if (applicationService.getOfflineApplicationsForCrn(crn, ServiceName.approvedPremises).isNotEmpty()) {
+    if (cas1ApplicationService.getOfflineApplicationsForCrn(crn).isNotEmpty()) {
       log.info("Already have an offline CAS1 application for $crn, not seeding a new application")
       return
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -757,18 +757,6 @@ class ApplicationService(
     return null
   }
 
-  fun getApplicationsForCrn(crn: String, serviceName: ServiceName): List<ApplicationEntity> {
-    val entityType = if (serviceName == ServiceName.approvedPremises) {
-      ApprovedPremisesApplicationEntity::class.java
-    } else {
-      TemporaryAccommodationApplicationEntity::class.java
-    }
-
-    return applicationRepository.findByCrn(crn, entityType)
-  }
-
-  fun getOfflineApplicationsForCrn(crn: String, serviceName: ServiceName) = offlineApplicationRepository.findAllByServiceAndCrn(serviceName.value, crn)
-
   private fun getPrisonName(personInfo: PersonInfoResult.Success.Full): String? {
     val prisonName = when (personInfo.inmateDetail?.custodyStatus) {
       InmateStatus.IN,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
+import org.springframework.data.domain.Limit
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
@@ -9,7 +10,7 @@ class Cas1ApplicationService(
   private val applicationRepository: ApprovedPremisesApplicationRepository,
   private val offlineApplicationRepository: OfflineApplicationRepository,
 ) {
-  fun getApplicationsForCrn(crn: String) = applicationRepository.findByCrn(crn)
+  fun getApplicationsForCrn(crn: String, limit: Int) = applicationRepository.findByCrn(crn, Limit.of(limit))
 
-  fun getOfflineApplicationsForCrn(crn: String) = offlineApplicationRepository.findAllByCrn(crn)
+  fun getOfflineApplicationsForCrn(crn: String, limit: Int) = offlineApplicationRepository.findAllByCrn(crn, Limit.of(limit))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
+
+@Service
+class Cas1ApplicationService(
+  private val applicationRepository: ApprovedPremisesApplicationRepository,
+  private val offlineApplicationRepository: OfflineApplicationRepository,
+) {
+  fun getApplicationsForCrn(crn: String) = applicationRepository.findByCrn(crn)
+
+  fun getOfflineApplicationsForCrn(crn: String) = offlineApplicationRepository.findAllByCrn(crn)
+}


### PR DESCRIPTION
Whilst we limit the number of applications returned to the timeline to 50, before this commit we were still loading them into memory.

This commit ensures we only ever load a maximum of 50 applications (and 50 offline applications) into memory when loading the timeline.

The solution isn’t perfect - we could theoretically load 50 regular applications and 50 offline applications into memory, despite only returning 50 of those combined. Given this logic is a fix to handle large timelines when running performance tests reusing the same CRN, this is deemed acceptable.