### PR TITLE
Speed up CAS1 dev premise/room seeding

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedPremisesFromCsvJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedPremisesFromCsvJob.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
 import java.util.UUID
 
 /**
- * This seed job is only used for seed test data
+ * This seed job is only used for seeding test data
  *
  * If seeding actual premises, use [Cas1SeedPremisesFromSiteSurveyXlsxJob]
  */
@@ -71,6 +71,7 @@ class Cas1SeedPremisesFromCsvJob(
     "isMHAPElliottHouse",
     "isMHAPStJosephs",
   ),
+  processRowsConcurrently = true,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromCsvJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1SeedRoomsFromCsvJob.kt
@@ -15,7 +15,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 /**
- * This seed job is only used for seed test data
+ * This seed job is only used for seeding test data
  *
  * If seeding actual premises, use [Cas1SeedRoomsFromSiteSurveyXlsxJob]
  */
@@ -54,6 +54,7 @@ class ApprovedPremisesRoomsSeedJob(
     "isStepFreeDesignated",
     "notes",
   ),
+  processRowsConcurrently = true,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 


### PR DESCRIPTION
This commit enables `processRowsConcurrently` for the CAS1 premise and room CSV seed jobs, which are only used in test/dev environments.