### PR TITLE
Add CRU Management Area Override to CAS1 user seed job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1CruManagementAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1CruManagementAreaEntity.kt
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface Cas1CruManagementAreaRepository : JpaRepository<Cas1CruManagementAreaEntity, UUID>
+interface Cas1CruManagementAreaRepository : JpaRepository<Cas1CruManagementAreaEntity, UUID> {
+  fun findByName(cruManagementAreaOverride: String): Cas1CruManagementAreaEntity?
+}
 
 /**
  * When an application is submitted it will be assigned to

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1CruManagementArea.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1CruManagementArea.kt
@@ -3,11 +3,14 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AutoAllocationDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 
 fun IntegrationTestBase.givenACas1CruManagementArea(
+  name: String = randomStringMultiCaseWithNumbers(8),
   assessmentAutoAllocationUsername: String? = null,
   assessmentAutoAllocations: MutableMap<AutoAllocationDay, String> = mutableMapOf(),
 ): Cas1CruManagementAreaEntity = cas1CruManagementAreaEntityFactory.produceAndPersist {
+  withName(name)
   if (assessmentAutoAllocations.isEmpty() && assessmentAutoAllocationUsername != null) {
     withAssessmentAutoAllocations(
       mutableMapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -27,7 +27,8 @@ fun IntegrationTestBase.givenAUser(
   probationRegion: ProbationRegionEntity? = null,
   isActive: Boolean = true,
   mockStaffUserDetailsCall: Boolean = true,
-  cruManagementAreaEntity: Cas1CruManagementAreaEntity? = null,
+  cruManagementArea: Cas1CruManagementAreaEntity? = null,
+  cruManagementAreaOverride: Cas1CruManagementAreaEntity? = null,
 ): Pair<UserEntity, String> {
   val resolvedProbationRegion = probationRegion ?: probationRegionEntityFactory.produceAndPersist {
     withYieldedApArea { givenAnApArea() }
@@ -44,7 +45,8 @@ fun IntegrationTestBase.givenAUser(
     withIsActive(isActive)
     withYieldedProbationRegion { resolvedProbationRegion }
     withYieldedApArea { apArea }
-    withCruManagementArea(cruManagementAreaEntity ?: apArea.defaultCruManagementArea)
+    withCruManagementArea(cruManagementArea ?: apArea.defaultCruManagementArea)
+    withCruManagementAreaOverride(cruManagementAreaOverride)
   }
 
   roles.forEach { role ->


### PR DESCRIPTION
This commit updates the approved premises users seed job to support an optional ‘cruManagementAreaOverride’ column. This is required to support us adding users with preconfigured management overrides in the dev/test environments