### PR TITLE
Remove unnecessary test migrations

### DIFF
--- a/src/main/resources/db/migration/test/20230802101239__remove_users.sql
+++ b/src/main/resources/db/migration/test/20230802101239__remove_users.sql
@@ -1,3 +1,0 @@
--- ${flyway:timestamp}
-
-TRUNCATE TABLE users CASCADE;

--- a/src/main/resources/db/migration/test/20230802101240__remove_bookings.sql
+++ b/src/main/resources/db/migration/test/20230802101240__remove_bookings.sql
@@ -1,3 +1,0 @@
--- ${flyway:timestamp}
-
-TRUNCATE TABLE bookings CASCADE;


### PR DESCRIPTION
These migrations only apply to the test environment.

They remove users and bookings, but reviewing the `all` migrations applied before these, neither add users or bookings. I suspect these migrations were added as a way to clear down the test environment, which should have really be done as a one-off direct SQL execution