### PR TITLE
Remove unused async domain event code

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -43,9 +43,6 @@ generic-service:
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
     # do not disable - these are used by probation-integration e2e tests
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
-    DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
-    DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false
-    DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false
     PREEMPTIVE-CACHE-LOGGING-ENABLED: true
     PREEMPTIVE-CACHE-DELAY-MS: 60000
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -41,9 +41,6 @@ generic-service:
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
-    DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
-    DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false
-    DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false
     HMPPS_SQS_USE_WEB_TOKEN: true
     NOTIFY_MODE: TEST_AND_GUEST_LIST
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -40,9 +40,6 @@ generic-service:
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: true
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
-    DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
-    DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false
-    DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false
     PREEMPTIVE-CACHE-LOGGING-ENABLED: true
     NOTIFY_MODE: ENABLED
     HMPPS_SQS_USE_WEB_TOKEN: true

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -40,9 +40,6 @@ generic-service:
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: false
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: false
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
-    DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED: false
-    DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED: false
-    DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED: false
 
     SEED_ON-STARTUP_ENABLED: true
     SEED_ON-STARTUP_FILE-PREFIXES: classpath:db/seed/local+dev+test

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/DomainEventWorker.kt
@@ -1,11 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Primary
-import org.springframework.retry.support.RetryTemplate
 import org.springframework.stereotype.Component
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
@@ -24,7 +21,6 @@ interface DomainEventWorkerInterface {
 class ConfiguredDomainEventWorker(
   private val hmppsQueueService: HmppsQueueService,
   private val objectMapper: ObjectMapper,
-  @Value("\${domain-events.cas1.async-save-enabled}") private val asyncSaveEnabled: Boolean,
 ) : DomainEventWorkerInterface {
   val domainTopic by lazy {
     hmppsQueueService.findByTopicId("domainevents")
@@ -32,13 +28,7 @@ class ConfiguredDomainEventWorker(
   }
 
   override fun emitEvent(snsEvent: SnsEvent, domainEventId: UUID) {
-    val worker = if (this.asyncSaveEnabled) {
-      AsyncDomainEventWorker(this.domainTopic, this.objectMapper)
-    } else {
-      SyncDomainEventWorker(this.domainTopic, this.objectMapper)
-    }
-
-    worker.emitEvent(snsEvent, domainEventId)
+    SyncDomainEventWorker(this.domainTopic, this.objectMapper).emitEvent(snsEvent, domainEventId)
   }
 }
 
@@ -65,66 +55,5 @@ class SyncDomainEventWorker(
         "Sequence Id: ${publishResult.sequenceNumber()}) for Domain Event:" +
         " $domainEventId of type: ${snsEvent.eventType}",
     )
-  }
-}
-
-class AsyncDomainEventWorker(
-  val domainTopic: HmppsTopic,
-  val objectMapper: ObjectMapper,
-) : DomainEventWorkerInterface {
-  private val log = LoggerFactory.getLogger(this::class.java)
-
-  var retryTemplate: RetryTemplate = RetryTemplate.builder()
-    .exponentialBackoff(INITIAL_INTERVAL, 2.0, MAX_INTERVAL)
-    .maxAttempts(MAX_ATTEMPTS_RETRY_EXPONENTIAL)
-    .build()
-
-  override fun emitEvent(snsEvent: SnsEvent, domainEventId: UUID) {
-    val publishRequest =
-      PublishRequest.builder()
-        .topicArn(domainTopic.arn)
-        .message(objectMapper.writeValueAsString(snsEvent))
-        .messageAttributes(
-          mapOf(
-            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(snsEvent.eventType).build(),
-          ),
-        ).build()
-    runBlocking {
-      publishSnsEventWithRetry(publishRequest, snsEvent, retryTemplate, domainEventId)
-    }
-  }
-
-  fun publishSnsEventWithRetry(
-    publishRequest: PublishRequest,
-    snsEvent: SnsEvent,
-    retryTemplate: RetryTemplate,
-    domainEventId: UUID,
-  ) {
-    retryTemplate.execute<Any?, RuntimeException> {
-      val publishResult = domainTopic.snsClient.publish(publishRequest).get()
-      log.info(
-        "Emitted SNS event (Message Id: ${publishResult.messageId()}, " +
-          "Sequence Id: ${publishResult.sequenceNumber()}) for Domain Event: " +
-          "$domainEventId of type: ${snsEvent.eventType}",
-      )
-    }
-  }
-
-  companion object {
-    /*
-     * The MAX_ATTEMPTS_RETRY_EXPONENTIAL of 166 is worked out like this:
-     * the multiplier is the default of two so we have
-     * 1 2 4 8 16 32 64 128 256 512 which gives us around 25 minutes. After that our max interval is ten minutes
-     * so we have four of them to give us the first hour which is 14 attempts. We follow that with 23 * 6 for the rest
-     * of the fist day which gives us 14 + 138 = 152. We want to retry for 7 days so we have another 6 * 6 * 24 = 864.
-     * Total is 864 + 152 = 1016
-     *
-     * MAX_ATTEMPTS_RETRY is used in the tests with a FixedBackOffPolicy
-     * */
-    const val MAX_ATTEMPTS_RETRY_EXPONENTIAL = 1016
-    const val MAX_ATTEMPTS_RETRY = 4
-    const val BACK_OFF_PERIOD = 1000.toLong()
-    const val INITIAL_INTERVAL = 1000.toLong()
-    const val MAX_INTERVAL = (1000 * 60 * 10).toLong()
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,13 +35,10 @@ hmpps.sqs:
 domain-events:
   cas1:
     emit-enabled: true
-    async-save-enabled: false
   cas2:
     emit-enabled: true
-    async-save-enabled: false
   cas3:
     emit-enabled: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted,personDepartureUpdated,bookingCancelledUpdated,personArrivedUpdated
-    async-save-enabled: false
 
 log-client-credentials-jwt-info: true
 log-request-response: true

--- a/src/main/resources/application-localdev.yml
+++ b/src/main/resources/application-localdev.yml
@@ -5,13 +5,10 @@
 domain-events:
   cas1:
     emit-enabled: true
-    async-save-enabled: false
   cas2:
     emit-enabled: true
-    async-save-enabled: false
   cas3:
     emit-enabled: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
-    async-save-enabled: false
 
 feature-flags:
   cas1-disable-overbooking-summary: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventWorkerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/DomainEventWorkerTest.kt
@@ -2,26 +2,18 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import io.mockk.unmockkConstructor
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.retry.backoff.FixedBackOffPolicy
-import org.springframework.retry.policy.SimpleRetryPolicy
-import org.springframework.retry.support.RetryTemplate
-import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sns.model.PublishResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventAdditionalInformation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReferenceCollection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AsyncDomainEventWorker
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SyncDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -29,14 +21,8 @@ import java.util.concurrent.CompletableFuture
 
 @Suppress("SwallowedException")
 class DomainEventWorkerTest {
-  private val hmppsQueueServiceMock = mockk<HmppsQueueService>()
   private val objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper()
   private val hmppsTopicMock = mockk<HmppsTopic>()
-
-  private val asyncDomainEventWorker = AsyncDomainEventWorker(
-    domainTopic = hmppsTopicMock,
-    objectMapper = objectMapper,
-  )
 
   private val syncDomainEventWorker = SyncDomainEventWorker(
     domainTopic = hmppsTopicMock,
@@ -45,149 +31,11 @@ class DomainEventWorkerTest {
 
   @BeforeEach
   fun clearConstructorMocks() {
-    unmockkConstructor(AsyncDomainEventWorker::class)
     unmockkConstructor(SyncDomainEventWorker::class)
   }
 
   @Test
-  fun `Creating a ConfiguredDomainEventWorker with asyncSaveEnabled set to true gives an AsyncDomainEventWorker`() {
-    mockkConstructor(AsyncDomainEventWorker::class)
-
-    val snsEvent = mockk<SnsEvent>()
-    val domainEventId = UUID.randomUUID()
-
-    every { hmppsQueueServiceMock.findByTopicId("domainevents") } returns hmppsTopicMock
-    every { anyConstructed<AsyncDomainEventWorker>().emitEvent(snsEvent, domainEventId) } returns Unit
-
-    val configuredWorker = ConfiguredDomainEventWorker(
-      hmppsQueueServiceMock,
-      objectMapper,
-      true,
-    )
-    configuredWorker.emitEvent(snsEvent, domainEventId)
-
-    verify {
-      anyConstructed<AsyncDomainEventWorker>().emitEvent(snsEvent, domainEventId)
-    }
-  }
-
-  @Test
-  fun `Creating a ConfiguredDomainEventWorker with asyncSaveEnabled set to false gives a SyncDomainEventWorker`() {
-    mockkConstructor(SyncDomainEventWorker::class)
-
-    val snsEvent = mockk<SnsEvent>()
-    val domainEventId = UUID.randomUUID()
-
-    every { hmppsQueueServiceMock.findByTopicId("domainevents") } returns hmppsTopicMock
-    every { anyConstructed<SyncDomainEventWorker>().emitEvent(snsEvent, domainEventId) } returns Unit
-
-    val configuredWorker = ConfiguredDomainEventWorker(
-      hmppsQueueServiceMock,
-      objectMapper,
-      false,
-    )
-    configuredWorker.emitEvent(snsEvent, domainEventId)
-
-    verify {
-      anyConstructed<SyncDomainEventWorker>().emitEvent(snsEvent, domainEventId)
-    }
-  }
-
-  @Test
-  fun `async emit retries if it fails`() {
-    val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
-    val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
-    val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
-    val crn = "CRN"
-
-    every { asyncDomainEventWorker.domainTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
-
-    val snsEvent = SnsEvent(
-      eventType = "",
-      version = 1,
-      description = "",
-      detailUrl = "detailUrl",
-      occurredAt = occurredAt,
-      additionalInformation = SnsEventAdditionalInformation(
-        applicationId = applicationId,
-      ),
-      personReference = SnsEventPersonReferenceCollection(
-        identifiers = listOf(
-          SnsEventPersonReference("CRN", crn),
-          SnsEventPersonReference("NOMS", ""),
-        ),
-      ),
-    )
-
-    every { asyncDomainEventWorker.domainTopic.snsClient.publish(any<PublishRequest>()) } throws RuntimeException()
-
-    try {
-      val backOffPolicy = FixedBackOffPolicy()
-      backOffPolicy.backOffPeriod = AsyncDomainEventWorker.BACK_OFF_PERIOD
-      val retryPolicy = SimpleRetryPolicy(AsyncDomainEventWorker.MAX_ATTEMPTS_RETRY)
-
-      val retryTemplate = RetryTemplate()
-      retryTemplate.setBackOffPolicy(backOffPolicy)
-      retryTemplate.setRetryPolicy(retryPolicy)
-      asyncDomainEventWorker.retryTemplate = retryTemplate
-      asyncDomainEventWorker.emitEvent(snsEvent, id)
-    } catch (error: RuntimeException) {
-      verify(exactly = AsyncDomainEventWorker.MAX_ATTEMPTS_RETRY) {
-        asyncDomainEventWorker.domainTopic.snsClient.publish(
-          match<PublishRequest> { matchingPublishRequest(it, snsEvent) },
-        )
-      }
-    }
-  }
-
-  @Test
-  fun `async emit works if no exception`() {
-    val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
-    val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
-    val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
-    val crn = "CRN"
-
-    every { asyncDomainEventWorker.domainTopic.arn } returns "arn:aws:sns:eu-west-2:000000000000:domain-events"
-
-    val snsEvent = SnsEvent(
-      eventType = "",
-      version = 1,
-      description = "",
-      detailUrl = "detailUrl",
-      occurredAt = occurredAt,
-      additionalInformation = SnsEventAdditionalInformation(
-        applicationId = applicationId,
-      ),
-      personReference = SnsEventPersonReferenceCollection(
-        identifiers = listOf(
-          SnsEventPersonReference("CRN", crn),
-          SnsEventPersonReference("NOMS", ""),
-        ),
-      ),
-    )
-
-    val publishRequest = PublishRequest.builder()
-      .topicArn("")
-      .message(objectMapper.writeValueAsString(snsEvent))
-      .messageAttributes(
-        mapOf(
-          "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(snsEvent.eventType).build(),
-        ),
-      ).build()
-
-    every { asyncDomainEventWorker.domainTopic.snsClient.publish(any<PublishRequest>()) } returns CompletableFuture.completedFuture(PublishResponse.builder().build())
-
-    asyncDomainEventWorker.emitEvent(snsEvent, id)
-
-    verify(exactly = 1) {
-      asyncDomainEventWorker.domainTopic.snsClient.publish(
-        match<PublishRequest> { matchingPublishRequest(it, snsEvent) },
-      )
-    }
-  }
-
-  @Test
-  fun `sync emit happens once`() {
+  fun `emit happens once`() {
     val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")
@@ -226,7 +74,7 @@ class DomainEventWorkerTest {
   }
 
   @Test
-  fun `sync emit emits event to SNS`() {
+  fun `emit emits event to SNS`() {
     val id = UUID.fromString("c3b98c67-065a-408d-abea-a252f1d70981")
     val applicationId = UUID.fromString("a831ead2-31ae-4907-8e1c-cad74cb9667b")
     val occurredAt = OffsetDateTime.parse("2023-02-01T14:03:00+00:00")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -75,13 +75,10 @@ hmpps.sqs:
 domain-events:
   cas1:
     emit-enabled: true
-    async-save-enabled: false
   cas2:
     emit-enabled: true
-    async-save-enabled: false
   cas3:
     emit-enabled: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted,personDepartureUpdated,bookingCancelledUpdated,personArrivedUpdated
-    async-save-enabled: false
 
 hmpps:
   auth:


### PR DESCRIPTION
The async-save code was added to potentially improve perforamnce when persisting domain events. Load testing shows that other areas of the application typically cause performance issues (i.e. the database), and as such this code has never been used. This commit removes this code.