### PR TITLE
Use dev+test seed in dev & test environments

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -47,7 +47,7 @@ generic-service:
     PREEMPTIVE-CACHE-DELAY-MS: 60000
 
     SEED_ON-STARTUP_ENABLED: true
-    SEED_ON-STARTUP_FILE-PREFIXES: classpath:db/seed/local+dev+test
+    SEED_ON-STARTUP_FILE-PREFIXES: classpath:db/seed/dev+test,classpath:db/seed/local+dev+test
     SEED_ON-STARTUP_SCRIPT_CAS1-ENABLED: true
     SEED_ON-STARTUP_SCRIPT_CAS2-ENABLED: true
     SEED_ON-STARTUP_SCRIPT_NOMS: A5276DZ

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -42,7 +42,7 @@ generic-service:
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
 
     SEED_ON-STARTUP_ENABLED: true
-    SEED_ON-STARTUP_FILE-PREFIXES: classpath:db/seed/local+dev+test
+    SEED_ON-STARTUP_FILE-PREFIXES: classpath:db/seed/dev+test,classpath:db/seed/local+dev+test
     SEED_ON-STARTUP_SCRIPT_CAS1-ENABLED: true
     SEED_ON-STARTUP_SCRIPT_CAS2-ENABLED: true
     SEED_ON-STARTUP_SCRIPT_NOMS: A5276DZ


### PR DESCRIPTION
We recently added a seed config for dev & test environments only, better defining the CAS1 & CAS3 tests users, removing any roles they shouldn’t have. This commit ensures that config is used in the dev & test environments