### PR TITLE
made persosNoms a nullable field in UnsubmittedApplicationsReportRow

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2v2/UnsubmittedApplicationsReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2v2/UnsubmittedApplicationsReportRow.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOri
 class UnsubmittedApplicationsReportRow(
   val applicationId: String,
   val personCrn: String,
-  val personNoms: String,
+  val personNoms: String?,
   val startedAt: String,
   val startedBy: String,
   val applicationOrigin: ApplicationOrigin,


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CBA-547

Fix for UnsubmittedApplicationsReportRow personNoms is now nullable.