### PR TITLE
[CBA-551] Make CAS2 Bail e2e tests required for preprod deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,6 +410,7 @@ workflows:
             - cas1_e2e_tests
             - cas2_e2e_tests
             - cas3_e2e_tests
+            - cas2_bail_e2e_tests
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"


### PR DESCRIPTION
[JIRA](https://dsdmoj.atlassian.net/browse/CBA-551?atlOrigin=eyJpIjoiNzRlODNlNzAzMWU5NDk3YThlMDg5ZTM0OTNiMTlmYjkiLCJwIjoiaiJ9)

Previously this was non-blocking as CAS2 Bail hadn't launched into private beta. As this is now live code, these tests will be required to pass before deploying to preprod, bringing it in line with the other UIs.