### PR TITLE
Add the domain event url variables for test, preprod, and prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -53,6 +53,9 @@ generic-service:
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
+    URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION: https://community-accommodation-tier-2-bail-preprod.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-preprod.hmpps.service.justice.gov.uk/applications/#id/overview
+    URL-TEMPLATES_FRONTEND_CAS2V2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-preprod.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
     URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -53,6 +53,9 @@ generic-service:
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
+    URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION: https://short-term-accommodation-cas-2-bail.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2-bail.hmpps.service.justice.gov.uk/applications/#id/overview
+    URL-TEMPLATES_FRONTEND_CAS2V2_SUBMITTED-APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2-bail.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
     URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -57,6 +57,9 @@ generic-service:
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_CAS2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-test.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
+    URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION: https://community-accommodation-tier-2-bail-test.hmpps.service.justice.gov.uk/applications/#id
+    URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-test.hmpps.service.justice.gov.uk/applications/#id/overview
+    URL-TEMPLATES_FRONTEND_CAS2V2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-test.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
     URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-made/#eventId


### PR DESCRIPTION
This change will allow the domain events in CAS2V2 to correctly display the URLs instead of localhost

This will be tested manually in ndelius preprod to verify it's working and monitored closely in prod