### PR TITLE
APS-2196 Change ‘get case detail’ cache TTL to 10 minutes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RedisConfiguration.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Staf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.UserOffenderAccess
 import java.time.Duration
 
+@SuppressWarnings("LongParameterList")
 @Configuration
 @EnableCaching
 class RedisConfiguration {
@@ -39,7 +40,7 @@ class RedisConfiguration {
     @Value("\${caches.staffDetails.expiry-seconds}") staffDetailsExpirySeconds: Long,
     @Value("\${caches.teamManagingCases.expiry-seconds}") teamManagingCasesExpirySeconds: Long,
     @Value("\${caches.ukBankHolidays.expiry-seconds}") ukBankHolidaysExpirySeconds: Long,
-    @Value("21600") crnGetCaseDetailExpirySeconds: Long,
+    @Value("600") crnGetCaseDetailExpirySeconds: Long,
   ): RedisCacheManagerBuilderCustomizer? {
     val uniqueBuildId = buildProperties.time.epochSecond.toString()
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-2196

The get case detail cache retains offence information for a given CRN. Before this commit it was cached for 6 hours, which causes issues for emergency referrals where an event has been created very recently.

This commit changes the TTL from 6 hours to 10 minutes.