### PR TITLE
Add default responses to Swagger config

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
@@ -1,11 +1,19 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger
 
+import io.swagger.v3.core.converter.AnnotatedType
+import io.swagger.v3.core.converter.ModelConverters
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.responses.ApiResponse
+import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Problem
 
 @Configuration
 class SwaggerConfiguration {
@@ -31,6 +39,7 @@ class SwaggerConfiguration {
     .group("allCas")
     .displayName("All CAS")
     .pathsToMatch("/**")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
   @Bean
@@ -38,6 +47,7 @@ class SwaggerConfiguration {
     .group("CAS1Shared")
     .displayName("CAS1 & Shared")
     .pathsToExclude("/**/cas2/**", "/**/cas3/**", "/**/events/**")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
   @Bean
@@ -46,6 +56,7 @@ class SwaggerConfiguration {
     .displayName("CAS1 Domain Events")
     .pathsToExclude("/**/events/cas2/**", "/**/events/cas3/**")
     .pathsToMatch("/**/events/**")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
   @Bean
@@ -53,6 +64,7 @@ class SwaggerConfiguration {
     .group("CAS2Shared")
     .displayName("CAS2 & Shared")
     .pathsToExclude("/**/cas1/**", "/**/cas3/**", "/**/events/**")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
   @Bean
@@ -60,6 +72,7 @@ class SwaggerConfiguration {
     .group("CAS2DomainEvents")
     .displayName("CAS2 Domain Events")
     .pathsToMatch("/**/events/cas2/**")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
   @Bean
@@ -67,6 +80,7 @@ class SwaggerConfiguration {
     .group("CAS2v2Shared")
     .displayName("CAS2v2 & Shared")
     .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas3/**", "/**/events/**")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
   @Bean
@@ -74,6 +88,7 @@ class SwaggerConfiguration {
     .group("CAS3Shared")
     .displayName("CAS3 & Shared")
     .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/events/**")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
   @Bean
@@ -82,4 +97,38 @@ class SwaggerConfiguration {
     .displayName("CAS3 Domain Events")
     .pathsToMatch("/**/events/cas3/**")
     .build()
+
+  @Bean
+  fun errorResponsesCustomizer(): OpenApiCustomizer = OpenApiCustomizer { openApi: OpenAPI ->
+    openApi.paths.values.forEach { pathItem ->
+      pathItem.readOperations().forEach { operation ->
+        val responses = operation.responses
+
+        addDefaultErrorResponse(responses, "401", "Not authenticated")
+        addDefaultErrorResponse(responses, "403", "Unauthorized")
+        addDefaultErrorResponse(responses, "500", "Unexpected error")
+      }
+    }
+  }
+
+  private fun createProblemSchema(): Schema<*> = ModelConverters.getInstance()
+    .resolveAsResolvedSchema(AnnotatedType(Problem::class.java))
+    .schema
+
+  private fun addDefaultErrorResponse(
+    responses: MutableMap<String, ApiResponse>,
+    code: String,
+    description: String,
+  ) {
+    if (!responses.containsKey(code)) {
+      responses[code] = ApiResponse()
+        .description(description)
+        .content(
+          Content().addMediaType(
+            "application/json",
+            MediaType().schema(createProblemSchema()),
+          ),
+        )
+    }
+  }
 }

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1,23 +1,4 @@
 components:
-  responses:
-    401Response:
-      description: not authenticated
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    403Response:
-      description: unauthorised
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    500Response:
-      description: unexpected error
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
   headers:
     X-Pagination-CurrentPage:
       schema:

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -37,12 +37,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
       x-codegen-request-body-name: body
   /premises/summary:
     get:
@@ -79,12 +74,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/PremisesSummary'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /premises/{premisesId}:
     get:
       tags:
@@ -106,18 +96,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Premises'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
     put:
       tags:
         - Operations on premises
@@ -151,12 +135,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
       x-codegen-request-body-name: body
   /premises/{premisesId}/staff:
     get:
@@ -183,18 +162,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/StaffMember'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/bookings:
     get:
       tags:
@@ -218,18 +191,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Booking'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
     post:
       tags:
         - Operations on premises
@@ -262,10 +229,6 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
@@ -278,8 +241,6 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}:
     get:
@@ -309,18 +270,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Booking'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/bookings/{bookingId}/arrivals:
     post:
       tags:
@@ -362,18 +317,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/extensions:
     post:
@@ -416,18 +365,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/date-changes:
     post:
@@ -470,18 +413,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/departures:
     post:
@@ -524,18 +461,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/cancellations:
     post:
@@ -578,18 +509,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/confirmations:
     post:
@@ -632,18 +557,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/turnarounds:
     post:
@@ -686,10 +605,6 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
@@ -702,8 +617,6 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/beds:
     get:
@@ -728,12 +641,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/BedSummary'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /premises/{premisesId}/rooms:
     get:
       tags:
@@ -757,12 +665,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Room'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     post:
       tags:
         - Rooms
@@ -796,18 +699,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/rooms/{roomId}:
     get:
       summary: Returns a specific room for a premises
@@ -834,18 +731,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Room'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or room ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
     put:
       summary: Updates a room
       operationId: premisesPremisesIdRoomsRoomIdPut
@@ -884,18 +775,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or room ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/search:
     get:
       summary: Searches for a Person by their CRN
@@ -926,12 +811,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /people/{crn}/risks:
     get:
       summary: Returns the risks for a Person
@@ -956,18 +836,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/prison-case-notes:
     get:
       summary: Returns the prison case notes for a Person
@@ -994,18 +868,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/PrisonCaseNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/adjudications:
     get:
       summary: Returns the adjudications for a Person
@@ -1032,18 +900,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Adjudication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/acct-alerts:
     get:
       summary: Returns the ACCT alerts for a Person
@@ -1064,18 +926,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/PersonAcctAlert'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/oasys/selection:
     get:
       tags:
@@ -1098,18 +954,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/OASysSection'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/oasys/sections:
     get:
       tags:
@@ -1138,18 +988,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/OASysSections'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/oasys/risk-to-self:
     get:
       tags:
@@ -1170,18 +1014,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/OASysRiskToSelf'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/oasys/rosh:
     get:
       tags:
@@ -1202,18 +1040,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/OASysRiskOfSeriousHarm'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/offences:
     get:
       summary: Returns all active offences for a Person.
@@ -1234,18 +1066,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/ActiveOffence'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -1280,18 +1106,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       tags:
@@ -1315,12 +1135,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/LostBed'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /premises/{premisesId}/lost-beds/{lostBedId}:
     get:
       tags:
@@ -1349,18 +1164,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/LostBed'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises or lost bed ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
     put:
       tags:
         - Operations on premises
@@ -1401,18 +1210,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/lost-beds/{lostBedId}/cancellations:
     post:
@@ -1455,18 +1258,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or lost bed ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/all:
     get:
@@ -1541,12 +1338,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications:
     post:
       tags:
@@ -1587,18 +1379,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       deprecated: true
@@ -1623,12 +1409,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/ApplicationSummary'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications/{applicationId}:
     put:
       tags:
@@ -1663,12 +1444,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     get:
       tags:
@@ -1691,12 +1467,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Application'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications/{applicationId}/withdrawal:
     post:
       tags:
@@ -1721,18 +1492,12 @@ paths:
       responses:
         200:
           description: successful operation
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid applicationId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/{applicationId}/notes:
     post:
@@ -1762,18 +1527,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ApplicationTimelineNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid applicationId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/{applicationId}/documents:
     get:
@@ -1798,18 +1557,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Document'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /applications/{applicationId}/appeals:
     post:
       tags:
@@ -1838,18 +1591,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Appeal'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid applicationId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/{applicationId}/appeals/{appealId}:
     get:
@@ -1879,18 +1626,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Appeal'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid applicationId or appealId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /documents/{crn}/{documentId}:
     get:
       tags:
@@ -1919,18 +1660,12 @@ paths:
               schema:
                 type: string
                 format: binary
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid applicationId or documentId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /applications/{applicationId}/submission:
     post:
       tags:
@@ -1961,12 +1696,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications/{applicationId}/assessment:
     get:
       tags:
@@ -1988,12 +1718,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications/{applicationId}/withdrawablesWithNotes:
     get:
       tags:
@@ -2021,12 +1746,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Withdrawables'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications/{applicationId}/requests-for-placement:
     get:
       summary: Returns a list of Requests for Placement for the given application.
@@ -2048,18 +1768,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/RequestForPlacement'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /bookings/{bookingId}:
     get:
       summary: Gets a booking
@@ -2079,12 +1793,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Booking'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /bookings/search:
     get:
       summary: Searches for bookings with the given parameters
@@ -2141,12 +1850,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/departure-reasons:
     get:
       tags:
@@ -2175,12 +1879,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/DepartureReason'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/move-on-categories:
     get:
       tags:
@@ -2209,12 +1908,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/MoveOnCategory'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/destination-providers:
     get:
       tags:
@@ -2230,12 +1924,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/DestinationProvider'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/non-arrival-reasons:
     get:
       description: deprecated, use /cas1/reference-data/non-arrival-reasons
@@ -2253,12 +1942,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/NonArrivalReason'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/lost-bed-reasons:
     get:
       tags:
@@ -2281,12 +1965,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/LostBedReason'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/cancellation-reasons:
     get:
       tags:
@@ -2309,12 +1988,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/CancellationReason'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/local-authority-areas:
     get:
       tags:
@@ -2330,12 +2004,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/LocalAuthorityArea'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/probation-regions:
     get:
       tags:
@@ -2351,12 +2020,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/ProbationRegion'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/ap-areas:
     get:
       tags:
@@ -2372,12 +2036,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/ApArea'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/characteristics:
     get:
       tags:
@@ -2406,12 +2065,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Characteristic'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/probation-delivery-units:
     get:
       tags:
@@ -2435,12 +2089,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/ProbationDeliveryUnit'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/referral-rejection-reasons:
     get:
       tags:
@@ -2463,12 +2112,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/ReferralRejectionReason'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /tasks:
     get:
       tags:
@@ -2576,12 +2220,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /tasks/{taskType}/{id}:
     get:
       tags:
@@ -2609,12 +2248,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/TaskWrapper'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /tasks/{taskType}/{id}/allocations:
     post:
       tags:
@@ -2660,12 +2294,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     delete:
       tags:
@@ -2695,12 +2324,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-requests/dashboard:
     get:
       description: Deprecated, use cas1/placement-requests instead.
@@ -2795,12 +2419,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-requests/{id}:
     get:
       tags:
@@ -2822,12 +2441,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/PlacementRequestDetail'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-requests/{id}/withdrawal:
     post:
       tags:
@@ -2855,18 +2469,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/PlacementRequestDetail'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid applicationId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /placement-requests/{id}/booking:
     post:
@@ -2896,12 +2504,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/NewPlacementRequestBookingConfirmation'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-requests/{id}/booking-not-made:
     post:
       tags:
@@ -2930,12 +2533,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/BookingNotMade'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications:
     post:
       tags:
@@ -2956,12 +2554,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/PlacementApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications/{id}:
     get:
       tags:
@@ -2983,12 +2576,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/PlacementApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     put:
       tags:
         - Placement applications
@@ -3016,12 +2604,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/PlacementApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications/{id}/submission:
     post:
       tags:
@@ -3058,12 +2641,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications/{id}/decision:
     post:
       tags:
@@ -3098,12 +2676,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications/{id}/withdraw:
     post:
       tags:
@@ -3137,12 +2710,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments:
     get:
       deprecated: true
@@ -3220,12 +2788,7 @@ paths:
               schema:
                 type: integer
               description: The size of each page
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}:
     get:
       tags:
@@ -3247,12 +2810,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     put:
       tags:
         - Assessment data
@@ -3286,12 +2844,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes:
     post:
       tags:
@@ -3320,12 +2873,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ClarificationNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes/{noteId}:
     put:
       tags:
@@ -3361,12 +2909,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ClarificationNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/referral-history-notes:
     post:
       tags:
@@ -3395,12 +2938,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ReferralHistoryNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/acceptance:
     post:
       tags:
@@ -3425,12 +2963,7 @@ paths:
       responses:
         200:
           description: successfully accepted the assessment
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/rejection:
     post:
       tags:
@@ -3455,12 +2988,7 @@ paths:
       responses:
         200:
           description: successfully rejected the assessment
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/closure:
     post:
       tags:
@@ -3478,12 +3006,7 @@ paths:
       responses:
         200:
           description: successfully closed the assessment
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /profile/v2:
     get:
       tags:
@@ -3510,12 +3033,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ProfileResponse'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /users:
     get:
       tags:
@@ -3606,12 +3124,7 @@ paths:
               schema:
                 type: integer
               description: The size of each page
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /users/summary:
     get:
       tags:
@@ -3694,12 +3207,7 @@ paths:
               schema:
                 type: integer
               description: The size of each page
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /users/search:
     get:
       tags:
@@ -3728,12 +3236,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/User'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /users/delius:
     get:
       tags:
@@ -3760,18 +3263,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/User'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: User not found
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /seed:
     post:
       summary: Starts the data seeding process, can only be called from a local connection
@@ -3785,12 +3282,7 @@ paths:
       responses:
         202:
           description: successfully requested task
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /seedFromExcel/file:
     post:
       tags:
@@ -3806,12 +3298,7 @@ paths:
       responses:
         202:
           description: successfully requested task
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /seedFromExcel/directory:
     post:
       tags:
@@ -3827,12 +3314,7 @@ paths:
       responses:
         202:
           description: successfully requested task
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /cache/{cacheName}:
     delete:
       summary: Clears the given cache, can only be called from a local connection
@@ -3846,12 +3328,7 @@ paths:
       responses:
         200:
           description: successfully cleared cache
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /migration-job:
     post:
       summary: Starts a migration job (process for data migrations that can't be achieved solely via SQL migrations), can only be called from a local connection
@@ -3865,9 +3342,4 @@ paths:
       responses:
         202:
           description: successfully requested task
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -51,12 +51,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-request/{placementRequestId}/change-request:
     post:
       tags:
@@ -84,12 +79,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /placement-request/{placementRequestId}/change-requests/{changeRequestId}:
     get:
@@ -116,12 +106,6 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1ChangeRequest'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
     patch:
       tags:
         - change requests
@@ -148,12 +132,7 @@ paths:
       responses:
         200:
           description: successfully rejected a change request
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
 
   /spaces/search:
@@ -181,12 +160,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-requests/{placementRequestId}/space-bookings:
     post:
       tags:
@@ -221,18 +195,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /placement-applications:
     post:
@@ -255,12 +223,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/PlacementApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications/{id}:
     get:
       deprecated: true
@@ -283,12 +246,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/PlacementApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     put:
       tags:
         - Placement applications
@@ -316,12 +274,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/PlacementApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications/{id}/submission:
     post:
       deprecated: true
@@ -359,12 +312,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications/{id}/decision:
     post:
       deprecated: true
@@ -400,12 +348,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-applications/{id}/withdraw:
     post:
       deprecated: true
@@ -440,12 +383,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /placement-requests:
     get:
       tags:
@@ -525,12 +463,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /premises/occupancy-report:
     get:
@@ -580,12 +513,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /premises/{premisesId}/out-of-service-beds:
     post:
@@ -621,18 +549,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       tags:
@@ -656,12 +578,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas1-schemas.yml#/components/schemas/Cas1OutOfServiceBed'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}:
     get:
       tags:
@@ -690,18 +607,12 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1OutOfServiceBed'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises or out-of-service bed ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
     put:
       tags:
         - out-of-service beds
@@ -742,18 +653,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}/cancellations:
     post:
@@ -796,18 +701,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or out-of-service bed ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
 
   /premises/{premisesId}:
@@ -830,18 +729,12 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1Premises'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /premises/{premisesId}/beds:
     get:
       tags:
@@ -865,12 +758,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremisesBedSummary'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /premises/{premisesId}/beds/{bedId}:
     get:
       tags:
@@ -899,12 +787,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1BedDetail'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /premises/{premisesId}/capacity:
     get:
       tags:
@@ -953,18 +836,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
 
   /premises/{premisesId}/staff:
@@ -990,18 +867,12 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/StaffMember'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings:
     get:
@@ -1076,12 +947,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-PageSize'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /premises/{premisesId}/space-bookings/{bookingId}:
     get:
@@ -1111,12 +977,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1SpaceBooking'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     patch:
       tags:
         - space bookings
@@ -1145,12 +1006,7 @@ paths:
       responses:
         200:
           description: successful operation
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /premises/{premisesId}/space-bookings/{bookingId}/timeline:
     get:
@@ -1182,12 +1038,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas1-schemas.yml#/components/schemas/Cas1TimelineEvent'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /premises/{premisesId}/space-bookings/{bookingId}/arrival:
     post:
@@ -1225,18 +1076,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
 
 
   /premises/{premisesId}/space-bookings/{bookingId}/keyworker:
@@ -1275,18 +1120,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings/{bookingId}/departure:
     post:
@@ -1324,18 +1163,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings/{bookingId}/cancellations:
     post:
@@ -1374,18 +1207,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
 
 
@@ -1425,18 +1252,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings/{bookingId}/emergency-transfer:
     post:
@@ -1474,18 +1295,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings/{bookingId}/planned-transfer:
     post:
@@ -1523,18 +1338,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
 
   /premises/{premisesId}/day-summary/{date}:
     get:
@@ -1600,12 +1409,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-PageSize'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/change-request-reasons/{changeRequestType}:
     get:
       tags:
@@ -1626,12 +1430,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/NamedId'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/change-request-rejection-reasons/{changeRequestType}:
     get:
       tags:
@@ -1652,12 +1451,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/NamedId'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/move-on-categories:
     get:
       tags:
@@ -1673,12 +1467,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/MoveOnCategory'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/non-arrival-reasons:
     get:
       tags:
@@ -1694,12 +1483,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/NonArrivalReason'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reference-data/out-of-service-bed-reasons:
     get:
       tags:
@@ -1715,12 +1499,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas1-schemas.yml#/components/schemas/Cas1OutOfServiceBedReason'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /reference-data/cru-management-areas:
     get:
@@ -1737,12 +1516,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/Cas1CruManagementArea'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /reference-data/departure-reasons:
     get:
@@ -1759,12 +1533,7 @@ paths:
                 type: array
                 items:
                   $ref: '_shared.yml#/components/schemas/DepartureReason'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /reports/{reportName}:
     get:
@@ -1828,12 +1597,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1SpaceBooking'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /out-of-service-beds:
     get:
@@ -1900,12 +1664,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-PageSize'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /users/{id}:
     get:
       summary: Get information about a specific user
@@ -1927,12 +1686,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ApprovedPremisesUser'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     put:
       summary: Update a user
       operationId: updateUser
@@ -1959,12 +1713,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/User'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     delete:
       summary: Deletes the user
       operationId: deleteUser
@@ -1987,12 +1736,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications/{applicationId}/timeline:
     get:
       tags:
@@ -2016,18 +1760,12 @@ paths:
                 type: array
                 items:
                   $ref: 'cas1-schemas.yml#/components/schemas/Cas1TimelineEvent'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /applications/all:
     get:
       tags:
@@ -2093,12 +1831,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications:
     get:
       tags:
@@ -2114,12 +1847,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas1-schemas.yml#/components/schemas/Cas1ApplicationSummary'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /people/{crn}/timeline:
     get:
       tags:
@@ -2140,18 +1868,12 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1PersonalTimeline'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /assessments:
     get:
       tags:
@@ -2221,12 +1943,7 @@ paths:
               schema:
                 type: integer
               description: The size of each page
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}:
     get:
       tags:
@@ -2248,12 +1965,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     put:
       tags:
         - Assessments
@@ -2281,12 +1993,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes:
     post:
       tags:
@@ -2315,12 +2022,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1ClarificationNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes/{noteId}:
     put:
       tags:
@@ -2356,12 +2058,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas1-schemas.yml#/components/schemas/Cas1ClarificationNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/acceptance:
     post:
       tags:
@@ -2386,12 +2083,7 @@ paths:
       responses:
         200:
           description: successfully accepted the assessment
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/rejection:
     post:
       tags:
@@ -2416,12 +2108,7 @@ paths:
       responses:
         200:
           description: successfully rejected the assessment
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
 
 

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -31,18 +31,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       tags:
@@ -89,12 +83,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /applications/{applicationId}:
     put:
@@ -130,12 +119,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     get:
       tags:
@@ -157,12 +141,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas2-schemas.yml#/components/schemas/Cas2Application'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications/{applicationId}/abandon:
     put:
       tags:
@@ -180,16 +159,12 @@ paths:
       responses:
         200:
           description: successful operation
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
         409:
           description: The application has been submitted
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /assessments/{assessmentId}:
     put:
       tags:
@@ -218,18 +193,12 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas2-schemas.yml#/components/schemas/Cas2Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
     get:
       tags:
         - Operations on submitted CAS2 applications (Assessors)
@@ -250,18 +219,12 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas2-schemas.yml#/components/schemas/Cas2Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /assessments/{assessmentId}/status-updates:
     post:
       tags:
@@ -292,12 +255,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes:
     post:
       tags:
@@ -326,18 +284,12 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas2-schemas.yml#/components/schemas/Cas2ApplicationNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /submissions:
     get:
@@ -369,12 +321,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     post:
       tags:
         - Operations on CAS2 applications
@@ -396,12 +343,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /submissions/{applicationId}:
     get:
       tags:
@@ -423,12 +365,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas2-schemas.yml#/components/schemas/Cas2SubmittedApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /people/search:
     get:
       tags:
@@ -461,12 +398,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /people/{crn}/oasys/risk-to-self:
     get:
       tags:
@@ -487,18 +419,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/OASysRiskToSelf'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/oasys/rosh:
     get:
       tags:
@@ -519,18 +445,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/OASysRiskOfSeriousHarm'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/risks:
     get:
       tags:
@@ -557,18 +477,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /reference-data/application-status:
     get:
       tags:
@@ -584,12 +498,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas2-schemas.yml#/components/schemas/Cas2ApplicationStatus'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reports/{reportName}:
     get:
       tags:

--- a/src/main/resources/static/cas2v2-api.yml
+++ b/src/main/resources/static/cas2v2-api.yml
@@ -30,18 +30,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       tags:
@@ -82,12 +76,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
 
   /applications/{applicationId}:
     put:
@@ -122,12 +111,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     get:
       tags:
@@ -148,12 +132,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Application'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /applications/{applicationId}/abandon:
     put:
       tags:
@@ -170,16 +149,12 @@ paths:
       responses:
         200:
           description: successful operation
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
         409:
           description: The application has been submitted
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /assessments/{assessmentId}:
     put:
       tags:
@@ -207,18 +182,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Cas2v2Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
     get:
       tags:
         - Operations on submitted CAS2 version 2 applications (Assessors)
@@ -238,18 +207,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Cas2v2Assessment'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /assessments/{assessmentId}/status-updates:
     post:
       tags:
@@ -279,12 +242,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes:
     post:
       tags:
@@ -312,18 +270,12 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas2v2-schemas.yml#/components/schemas/Cas2v2ApplicationNote'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /submissions:
     get:
@@ -354,12 +306,7 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     post:
       tags:
         - Operations on CAS2 version 2 applications
@@ -380,12 +327,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /submissions/{applicationId}:
     get:
       tags:
@@ -406,12 +348,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas2v2-schemas.yml#/components/schemas/Cas2v2SubmittedApplication'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /people/search-by-crn/{crn}:
     get:
       tags:
@@ -444,12 +381,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /people/search-by-noms/{nomsNumber}:
     get:
       tags:
@@ -482,12 +414,7 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /people/{crn}/oasys/risk-to-self:
     get:
       tags:
@@ -507,18 +434,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/OASysRiskToSelf'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/oasys/rosh:
     get:
       tags:
@@ -538,18 +459,12 @@ paths:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/OASysRiskOfSeriousHarm'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /people/{crn}/risks:
     get:
       tags:
@@ -575,18 +490,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
   /reference-data/application-status:
     get:
       tags:
@@ -601,12 +510,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas2v2-schemas.yml#/components/schemas/Cas2v2ApplicationStatus'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reports/{reportName}:
     get:
       tags:

--- a/src/main/resources/static/cas3-api.yml
+++ b/src/main/resources/static/cas3-api.yml
@@ -20,12 +20,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas3-schemas.yml#/components/schemas/Cas3ApplicationSummary'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     post:
       tags:
         - Operations on applications
@@ -58,18 +53,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/{applicationId}:
     get:
@@ -92,12 +81,7 @@ paths:
             'application/json':
               schema:
                 $ref: 'cas3-schemas.yml#/components/schemas/Cas3Application'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
     put:
       tags:
         - Operations on applications
@@ -131,12 +115,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     delete:
       operationId: deleteApplication
@@ -190,12 +169,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /reports/{reportName}:
     get:
       tags:
@@ -283,12 +257,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas3-schemas.yml#/components/schemas/Cas3PremisesSummary'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /premises/{premisesId}/bookings/{bookingId}/departures:
     post:
       tags:
@@ -330,18 +299,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/future-bookings:
     get:
@@ -374,12 +337,7 @@ paths:
                 type: array
                 items:
                   $ref: 'cas3-schemas.yml#/components/schemas/FutureBooking'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+
   /bedspaces/search:
     post:
       summary: Searches for available Beds within the given parameters
@@ -403,9 +361,4 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-        401:
-          $ref: '_shared.yml#/components/responses/401Response'
-        403:
-          $ref: '_shared.yml#/components/responses/403Response'
-        500:
-          $ref: '_shared.yml#/components/responses/500Response'
+

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -39,12 +39,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
       x-codegen-request-body-name: body
   /premises/summary:
     get:
@@ -81,12 +76,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PremisesSummary'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /premises/{premisesId}:
     get:
       tags:
@@ -108,18 +98,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Premises'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
     put:
       tags:
         - Operations on premises
@@ -153,12 +137,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
       x-codegen-request-body-name: body
   /premises/{premisesId}/staff:
     get:
@@ -185,18 +164,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StaffMember'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/bookings:
     get:
       tags:
@@ -220,18 +193,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Booking'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
     post:
       tags:
         - Operations on premises
@@ -264,10 +231,6 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
@@ -280,8 +243,6 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}:
     get:
@@ -311,18 +272,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Booking'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/bookings/{bookingId}/arrivals:
     post:
       tags:
@@ -364,18 +319,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/extensions:
     post:
@@ -418,18 +367,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/date-changes:
     post:
@@ -472,18 +415,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/departures:
     post:
@@ -526,18 +463,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/cancellations:
     post:
@@ -580,18 +511,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/confirmations:
     post:
@@ -634,18 +559,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/bookings/{bookingId}/turnarounds:
     post:
@@ -688,10 +607,6 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
@@ -704,8 +619,6 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/beds:
     get:
@@ -730,12 +643,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/BedSummary'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /premises/{premisesId}/rooms:
     get:
       tags:
@@ -759,12 +667,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Room'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     post:
       tags:
         - Rooms
@@ -798,18 +701,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/rooms/{roomId}:
     get:
       summary: Returns a specific room for a premises
@@ -836,18 +733,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Room'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or room ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
     put:
       summary: Updates a room
       operationId: premisesPremisesIdRoomsRoomIdPut
@@ -886,18 +777,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or room ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/search:
     get:
       summary: Searches for a Person by their CRN
@@ -928,12 +813,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /people/{crn}/risks:
     get:
       summary: Returns the risks for a Person
@@ -958,18 +838,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/prison-case-notes:
     get:
       summary: Returns the prison case notes for a Person
@@ -996,18 +870,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PrisonCaseNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/adjudications:
     get:
       summary: Returns the adjudications for a Person
@@ -1034,18 +902,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Adjudication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/acct-alerts:
     get:
       summary: Returns the ACCT alerts for a Person
@@ -1066,18 +928,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PersonAcctAlert'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/oasys/selection:
     get:
       tags:
@@ -1100,18 +956,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/OASysSection'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/oasys/sections:
     get:
       tags:
@@ -1140,18 +990,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/OASysSections'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/oasys/risk-to-self:
     get:
       tags:
@@ -1172,18 +1016,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/OASysRiskToSelf'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/oasys/rosh:
     get:
       tags:
@@ -1204,18 +1042,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/OASysRiskOfSeriousHarm'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/offences:
     get:
       summary: Returns all active offences for a Person.
@@ -1236,18 +1068,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ActiveOffence'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/lost-beds:
     post:
       tags:
@@ -1282,18 +1108,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       tags:
@@ -1317,12 +1137,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LostBed'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /premises/{premisesId}/lost-beds/{lostBedId}:
     get:
       tags:
@@ -1351,18 +1166,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/LostBed'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises or lost bed ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
     put:
       tags:
         - Operations on premises
@@ -1403,18 +1212,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/lost-beds/{lostBedId}/cancellations:
     post:
@@ -1457,18 +1260,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or lost bed ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/all:
     get:
@@ -1543,12 +1340,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications:
     post:
       tags:
@@ -1589,18 +1381,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       deprecated: true
@@ -1625,12 +1411,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApplicationSummary'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications/{applicationId}:
     put:
       tags:
@@ -1665,12 +1446,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     get:
       tags:
@@ -1693,12 +1469,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Application'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications/{applicationId}/withdrawal:
     post:
       tags:
@@ -1723,18 +1494,12 @@ paths:
       responses:
         200:
           description: successful operation
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid applicationId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/{applicationId}/notes:
     post:
@@ -1764,18 +1529,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ApplicationTimelineNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid applicationId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/{applicationId}/documents:
     get:
@@ -1800,18 +1559,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Document'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /applications/{applicationId}/appeals:
     post:
       tags:
@@ -1840,18 +1593,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Appeal'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid applicationId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/{applicationId}/appeals/{appealId}:
     get:
@@ -1881,18 +1628,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Appeal'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid applicationId or appealId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /documents/{crn}/{documentId}:
     get:
       tags:
@@ -1921,18 +1662,12 @@ paths:
               schema:
                 type: string
                 format: binary
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid applicationId or documentId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /applications/{applicationId}/submission:
     post:
       tags:
@@ -1963,12 +1698,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications/{applicationId}/assessment:
     get:
       tags:
@@ -1990,12 +1720,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications/{applicationId}/withdrawablesWithNotes:
     get:
       tags:
@@ -2023,12 +1748,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Withdrawables'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications/{applicationId}/requests-for-placement:
     get:
       summary: Returns a list of Requests for Placement for the given application.
@@ -2050,18 +1770,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RequestForPlacement'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /bookings/{bookingId}:
     get:
       summary: Gets a booking
@@ -2081,12 +1795,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Booking'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /bookings/search:
     get:
       summary: Searches for bookings with the given parameters
@@ -2143,12 +1852,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/departure-reasons:
     get:
       tags:
@@ -2177,12 +1881,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DepartureReason'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/move-on-categories:
     get:
       tags:
@@ -2211,12 +1910,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/MoveOnCategory'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/destination-providers:
     get:
       tags:
@@ -2232,12 +1926,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DestinationProvider'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/non-arrival-reasons:
     get:
       description: deprecated, use /cas1/reference-data/non-arrival-reasons
@@ -2255,12 +1944,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NonArrivalReason'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/lost-bed-reasons:
     get:
       tags:
@@ -2283,12 +1967,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LostBedReason'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/cancellation-reasons:
     get:
       tags:
@@ -2311,12 +1990,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/CancellationReason'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/local-authority-areas:
     get:
       tags:
@@ -2332,12 +2006,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LocalAuthorityArea'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/probation-regions:
     get:
       tags:
@@ -2353,12 +2022,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ProbationRegion'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/ap-areas:
     get:
       tags:
@@ -2374,12 +2038,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApArea'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/characteristics:
     get:
       tags:
@@ -2408,12 +2067,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Characteristic'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/probation-delivery-units:
     get:
       tags:
@@ -2437,12 +2091,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ProbationDeliveryUnit'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/referral-rejection-reasons:
     get:
       tags:
@@ -2465,12 +2114,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ReferralRejectionReason'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /tasks:
     get:
       tags:
@@ -2578,12 +2222,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /tasks/{taskType}/{id}:
     get:
       tags:
@@ -2611,12 +2250,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/TaskWrapper'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /tasks/{taskType}/{id}/allocations:
     post:
       tags:
@@ -2662,12 +2296,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     delete:
       tags:
@@ -2697,12 +2326,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-requests/dashboard:
     get:
       description: Deprecated, use cas1/placement-requests instead.
@@ -2797,12 +2421,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-requests/{id}:
     get:
       tags:
@@ -2824,12 +2443,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/PlacementRequestDetail'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-requests/{id}/withdrawal:
     post:
       tags:
@@ -2857,18 +2471,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/PlacementRequestDetail'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid applicationId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /placement-requests/{id}/booking:
     post:
@@ -2898,12 +2506,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/NewPlacementRequestBookingConfirmation'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-requests/{id}/booking-not-made:
     post:
       tags:
@@ -2932,12 +2535,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/BookingNotMade'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications:
     post:
       tags:
@@ -2958,12 +2556,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/PlacementApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications/{id}:
     get:
       tags:
@@ -2985,12 +2578,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/PlacementApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     put:
       tags:
         - Placement applications
@@ -3018,12 +2606,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/PlacementApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications/{id}/submission:
     post:
       tags:
@@ -3060,12 +2643,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications/{id}/decision:
     post:
       tags:
@@ -3100,12 +2678,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications/{id}/withdraw:
     post:
       tags:
@@ -3139,12 +2712,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments:
     get:
       deprecated: true
@@ -3222,12 +2790,7 @@ paths:
               schema:
                 type: integer
               description: The size of each page
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}:
     get:
       tags:
@@ -3249,12 +2812,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     put:
       tags:
         - Assessment data
@@ -3288,12 +2846,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes:
     post:
       tags:
@@ -3322,12 +2875,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ClarificationNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes/{noteId}:
     put:
       tags:
@@ -3363,12 +2911,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ClarificationNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/referral-history-notes:
     post:
       tags:
@@ -3397,12 +2940,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ReferralHistoryNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/acceptance:
     post:
       tags:
@@ -3427,12 +2965,7 @@ paths:
       responses:
         200:
           description: successfully accepted the assessment
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/rejection:
     post:
       tags:
@@ -3457,12 +2990,7 @@ paths:
       responses:
         200:
           description: successfully rejected the assessment
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/closure:
     post:
       tags:
@@ -3480,12 +3008,7 @@ paths:
       responses:
         200:
           description: successfully closed the assessment
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /profile/v2:
     get:
       tags:
@@ -3512,12 +3035,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ProfileResponse'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /users:
     get:
       tags:
@@ -3608,12 +3126,7 @@ paths:
               schema:
                 type: integer
               description: The size of each page
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /users/summary:
     get:
       tags:
@@ -3696,12 +3209,7 @@ paths:
               schema:
                 type: integer
               description: The size of each page
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /users/search:
     get:
       tags:
@@ -3730,12 +3238,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /users/delius:
     get:
       tags:
@@ -3762,18 +3265,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/User'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: User not found
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /seed:
     post:
       summary: Starts the data seeding process, can only be called from a local connection
@@ -3787,12 +3284,7 @@ paths:
       responses:
         202:
           description: successfully requested task
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /seedFromExcel/file:
     post:
       tags:
@@ -3808,12 +3300,7 @@ paths:
       responses:
         202:
           description: successfully requested task
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /seedFromExcel/directory:
     post:
       tags:
@@ -3829,12 +3316,7 @@ paths:
       responses:
         202:
           description: successfully requested task
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /cache/{cacheName}:
     delete:
       summary: Clears the given cache, can only be called from a local connection
@@ -3848,12 +3330,7 @@ paths:
       responses:
         200:
           description: successfully cleared cache
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /migration-job:
     post:
       summary: Starts a migration job (process for data migrations that can't be achieved solely via SQL migrations), can only be called from a local connection
@@ -3867,32 +3344,8 @@ paths:
       responses:
         202:
           description: successfully requested task
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 components:
-  responses:
-    401Response:
-      description: not authenticated
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    403Response:
-      description: unauthorised
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    500Response:
-      description: unexpected error
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
   headers:
     X-Pagination-CurrentPage:
       schema:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -53,12 +53,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-request/{placementRequestId}/change-request:
     post:
       tags:
@@ -86,12 +81,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /placement-request/{placementRequestId}/change-requests/{changeRequestId}:
     get:
@@ -118,12 +108,6 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1ChangeRequest'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
     patch:
       tags:
         - change requests
@@ -150,12 +134,7 @@ paths:
       responses:
         200:
           description: successfully rejected a change request
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
 
   /spaces/search:
@@ -183,12 +162,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-requests/{placementRequestId}/space-bookings:
     post:
       tags:
@@ -223,18 +197,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /placement-applications:
     post:
@@ -257,12 +225,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/PlacementApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications/{id}:
     get:
       deprecated: true
@@ -285,12 +248,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/PlacementApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     put:
       tags:
         - Placement applications
@@ -318,12 +276,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/PlacementApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications/{id}/submission:
     post:
       deprecated: true
@@ -361,12 +314,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications/{id}/decision:
     post:
       deprecated: true
@@ -402,12 +350,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-applications/{id}/withdraw:
     post:
       deprecated: true
@@ -442,12 +385,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /placement-requests:
     get:
       tags:
@@ -527,12 +465,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /premises/occupancy-report:
     get:
@@ -582,12 +515,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /premises/{premisesId}/out-of-service-beds:
     post:
@@ -623,18 +551,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       tags:
@@ -658,12 +580,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas1OutOfServiceBed'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}:
     get:
       tags:
@@ -692,18 +609,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1OutOfServiceBed'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises or out-of-service bed ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
     put:
       tags:
         - out-of-service beds
@@ -744,18 +655,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/out-of-service-beds/{outOfServiceBedId}/cancellations:
     post:
@@ -798,18 +703,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or out-of-service bed ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
 
   /premises/{premisesId}:
@@ -832,18 +731,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1Premises'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /premises/{premisesId}/beds:
     get:
       tags:
@@ -867,12 +760,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas1PremisesBedSummary'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /premises/{premisesId}/beds/{bedId}:
     get:
       tags:
@@ -901,12 +789,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1BedDetail'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /premises/{premisesId}/capacity:
     get:
       tags:
@@ -955,18 +838,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
 
   /premises/{premisesId}/staff:
@@ -992,18 +869,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StaffMember'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings:
     get:
@@ -1078,12 +949,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-PageSize'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /premises/{premisesId}/space-bookings/{bookingId}:
     get:
@@ -1113,12 +979,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1SpaceBooking'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     patch:
       tags:
         - space bookings
@@ -1147,12 +1008,7 @@ paths:
       responses:
         200:
           description: successful operation
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /premises/{premisesId}/space-bookings/{bookingId}/timeline:
     get:
@@ -1184,12 +1040,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas1TimelineEvent'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /premises/{premisesId}/space-bookings/{bookingId}/arrival:
     post:
@@ -1227,18 +1078,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
 
 
   /premises/{premisesId}/space-bookings/{bookingId}/keyworker:
@@ -1277,18 +1122,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings/{bookingId}/departure:
     post:
@@ -1326,18 +1165,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings/{bookingId}/cancellations:
     post:
@@ -1376,18 +1209,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
 
 
@@ -1427,18 +1254,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings/{bookingId}/emergency-transfer:
     post:
@@ -1476,18 +1297,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
 
   /premises/{premisesId}/space-bookings/{bookingId}/planned-transfer:
     post:
@@ -1525,18 +1340,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
 
   /premises/{premisesId}/day-summary/{date}:
     get:
@@ -1602,12 +1411,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-PageSize'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/change-request-reasons/{changeRequestType}:
     get:
       tags:
@@ -1628,12 +1432,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NamedId'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/change-request-rejection-reasons/{changeRequestType}:
     get:
       tags:
@@ -1654,12 +1453,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NamedId'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/move-on-categories:
     get:
       tags:
@@ -1675,12 +1469,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/MoveOnCategory'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/non-arrival-reasons:
     get:
       tags:
@@ -1696,12 +1485,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NonArrivalReason'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reference-data/out-of-service-bed-reasons:
     get:
       tags:
@@ -1717,12 +1501,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas1OutOfServiceBedReason'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /reference-data/cru-management-areas:
     get:
@@ -1739,12 +1518,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas1CruManagementArea'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /reference-data/departure-reasons:
     get:
@@ -1761,12 +1535,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DepartureReason'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /reports/{reportName}:
     get:
@@ -1830,12 +1599,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1SpaceBooking'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /out-of-service-beds:
     get:
@@ -1902,12 +1666,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-PageSize'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /users/{id}:
     get:
       summary: Get information about a specific user
@@ -1929,12 +1688,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ApprovedPremisesUser'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     put:
       summary: Update a user
       operationId: updateUser
@@ -1961,12 +1715,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/User'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     delete:
       summary: Deletes the user
       operationId: deleteUser
@@ -1989,12 +1738,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications/{applicationId}/timeline:
     get:
       tags:
@@ -2018,18 +1762,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas1TimelineEvent'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /applications/all:
     get:
       tags:
@@ -2095,12 +1833,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications:
     get:
       tags:
@@ -2116,12 +1849,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas1ApplicationSummary'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /people/{crn}/timeline:
     get:
       tags:
@@ -2142,18 +1870,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1PersonalTimeline'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /assessments:
     get:
       tags:
@@ -2223,12 +1945,7 @@ paths:
               schema:
                 type: integer
               description: The size of each page
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}:
     get:
       tags:
@@ -2250,12 +1967,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     put:
       tags:
         - Assessments
@@ -2283,12 +1995,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes:
     post:
       tags:
@@ -2317,12 +2024,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1ClarificationNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes/{noteId}:
     put:
       tags:
@@ -2358,12 +2060,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas1ClarificationNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/acceptance:
     post:
       tags:
@@ -2388,12 +2085,7 @@ paths:
       responses:
         200:
           description: successfully accepted the assessment
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/rejection:
     post:
       tags:
@@ -2418,35 +2110,11 @@ paths:
       responses:
         200:
           description: successfully rejected the assessment
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
 
 
 components:
-  responses:
-    401Response:
-      description: not authenticated
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    403Response:
-      description: unauthorised
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    500Response:
-      description: unexpected error
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
   headers:
     X-Pagination-CurrentPage:
       schema:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -33,18 +33,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       tags:
@@ -91,12 +85,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /applications/{applicationId}:
     put:
@@ -132,12 +121,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     get:
       tags:
@@ -159,12 +143,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2Application'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications/{applicationId}/abandon:
     put:
       tags:
@@ -182,16 +161,12 @@ paths:
       responses:
         200:
           description: successful operation
-        401:
-          $ref: '#/components/responses/401Response'
         409:
           description: The application has been submitted
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /assessments/{assessmentId}:
     put:
       tags:
@@ -220,18 +195,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
     get:
       tags:
         - Operations on submitted CAS2 applications (Assessors)
@@ -252,18 +221,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /assessments/{assessmentId}/status-updates:
     post:
       tags:
@@ -294,12 +257,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes:
     post:
       tags:
@@ -328,18 +286,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2ApplicationNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /submissions:
     get:
@@ -371,12 +323,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     post:
       tags:
         - Operations on CAS2 applications
@@ -398,12 +345,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /submissions/{applicationId}:
     get:
       tags:
@@ -425,12 +367,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2SubmittedApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /people/search:
     get:
       tags:
@@ -463,12 +400,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /people/{crn}/oasys/risk-to-self:
     get:
       tags:
@@ -489,18 +421,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/OASysRiskToSelf'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/oasys/rosh:
     get:
       tags:
@@ -521,18 +447,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/OASysRiskOfSeriousHarm'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/risks:
     get:
       tags:
@@ -559,18 +479,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /reference-data/application-status:
     get:
       tags:
@@ -586,12 +500,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas2ApplicationStatus'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reports/{reportName}:
     get:
       tags:
@@ -614,25 +523,6 @@ paths:
                 type: string
                 format: binary
 components:
-  responses:
-    401Response:
-      description: not authenticated
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    403Response:
-      description: unauthorised
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    500Response:
-      description: unexpected error
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
   headers:
     X-Pagination-CurrentPage:
       schema:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -32,18 +32,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
     get:
       tags:
@@ -84,12 +78,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 
   /applications/{applicationId}:
     put:
@@ -124,12 +113,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     get:
       tags:
@@ -150,12 +134,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Application'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /applications/{applicationId}/abandon:
     put:
       tags:
@@ -172,16 +151,12 @@ paths:
       responses:
         200:
           description: successful operation
-        401:
-          $ref: '#/components/responses/401Response'
         409:
           description: The application has been submitted
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /assessments/{assessmentId}:
     put:
       tags:
@@ -209,18 +184,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2v2Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
     get:
       tags:
         - Operations on submitted CAS2 version 2 applications (Assessors)
@@ -240,18 +209,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2v2Assessment'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /assessments/{assessmentId}/status-updates:
     post:
       tags:
@@ -281,12 +244,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /assessments/{assessmentId}/notes:
     post:
       tags:
@@ -314,18 +272,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2v2ApplicationNote'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid assessmentId
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /submissions:
     get:
@@ -356,12 +308,7 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     post:
       tags:
         - Operations on CAS2 version 2 applications
@@ -382,12 +329,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /submissions/{applicationId}:
     get:
       tags:
@@ -408,12 +350,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas2v2SubmittedApplication'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /people/search-by-crn/{crn}:
     get:
       tags:
@@ -446,12 +383,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /people/search-by-noms/{nomsNumber}:
     get:
       tags:
@@ -484,12 +416,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /people/{crn}/oasys/risk-to-self:
     get:
       tags:
@@ -509,18 +436,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/OASysRiskToSelf'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/oasys/rosh:
     get:
       tags:
@@ -540,18 +461,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/OASysRiskOfSeriousHarm'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /people/{crn}/risks:
     get:
       tags:
@@ -577,18 +492,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
   /reference-data/application-status:
     get:
       tags:
@@ -603,12 +512,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas2v2ApplicationStatus'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reports/{reportName}:
     get:
       tags:
@@ -630,25 +534,6 @@ paths:
                 type: string
                 format: binary
 components:
-  responses:
-    401Response:
-      description: not authenticated
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    403Response:
-      description: unauthorised
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    500Response:
-      description: unexpected error
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
   headers:
     X-Pagination-CurrentPage:
       schema:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -22,12 +22,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas3ApplicationSummary'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     post:
       tags:
         - Operations on applications
@@ -60,18 +55,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid CRN
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /applications/{applicationId}:
     get:
@@ -94,12 +83,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Cas3Application'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
     put:
       tags:
         - Operations on applications
@@ -133,12 +117,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
       x-codegen-request-body-name: body
     delete:
       operationId: deleteApplication
@@ -192,12 +171,7 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /reports/{reportName}:
     get:
       tags:
@@ -285,12 +259,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Cas3PremisesSummary'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /premises/{premisesId}/bookings/{bookingId}/departures:
     post:
       tags:
@@ -332,18 +301,12 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
         404:
           description: invalid premises ID or booking ID
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Problem'
-        500:
-          $ref: '#/components/responses/500Response'
       x-codegen-request-body-name: body
   /premises/{premisesId}/future-bookings:
     get:
@@ -376,12 +339,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FutureBooking'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
   /bedspaces/search:
     post:
       summary: Searches for available Beds within the given parameters
@@ -405,32 +363,8 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-        401:
-          $ref: '#/components/responses/401Response'
-        403:
-          $ref: '#/components/responses/403Response'
-        500:
-          $ref: '#/components/responses/500Response'
+
 components:
-  responses:
-    401Response:
-      description: not authenticated
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    403Response:
-      description: unauthorised
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
-    500Response:
-      description: unexpected error
-      content:
-        'application/json':
-          schema:
-            $ref: '#/components/schemas/Problem'
   headers:
     X-Pagination-CurrentPage:
       schema:


### PR DESCRIPTION
This adds default responses for 401, 403, and 500 responses. This removes duplicated code from the open API spec files, and means there will be less noise in the generated controllers, which will make things easier when moving away from the openApi generator.

This only adds in responses where there is NOT a defined response for a given HttpStatus code, so any non-standard responses or additional responses will still be added (eg, 404, see 2nd pic).


<img width="973" alt="image" src="https://github.com/user-attachments/assets/1fe13d12-7a95-4b60-a410-9262e709c83d" />



<img width="978" alt="image" src="https://github.com/user-attachments/assets/8518337a-d6db-474f-b9b3-371858bd5e08" />
