### PR TITLE
APS-2182 - Rename `appeal` to `placement appeal`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ChangeRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ChangeRequestsController.kt
@@ -37,9 +37,9 @@ class Cas1ChangeRequestsController(
 
   override fun create(placementRequestId: UUID, cas1NewChangeRequest: Cas1NewChangeRequest): ResponseEntity<Unit> {
     when (cas1NewChangeRequest.type) {
-      Cas1ChangeRequestType.APPEAL -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_APPEAL_CREATE)
+      Cas1ChangeRequestType.PLACEMENT_APPEAL -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLACEMENT_APPEAL_CREATE)
       Cas1ChangeRequestType.PLANNED_TRANSFER -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLANNED_TRANSFER_CREATE)
-      Cas1ChangeRequestType.EXTENSION -> throw BadRequestProblem(errorDetail = "Change request type is not ${Cas1ChangeRequestType.PLANNED_TRANSFER} or ${Cas1ChangeRequestType.APPEAL}")
+      Cas1ChangeRequestType.PLACEMENT_EXTENSION -> throw BadRequestProblem(errorDetail = "Change request type is not ${Cas1ChangeRequestType.PLANNED_TRANSFER} or ${Cas1ChangeRequestType.PLACEMENT_APPEAL}")
     }
 
     val result = cas1ChangeRequestService.createChangeRequest(placementRequestId, cas1NewChangeRequest)
@@ -96,9 +96,9 @@ class Cas1ChangeRequestsController(
       ?: throw NotFoundProblem(changeRequestId, "ChangeRequest")
 
     when (changeRequest.type) {
-      ChangeRequestType.APPEAL -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_APPEAL_ASSESS)
-      ChangeRequestType.EXTENSION -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLANNED_TRANSFER_ASSESS)
-      ChangeRequestType.PLANNED_TRANSFER -> throw BadRequestProblem(errorDetail = "Change request type is not ${Cas1ChangeRequestType.PLANNED_TRANSFER} or ${Cas1ChangeRequestType.APPEAL}")
+      ChangeRequestType.PLACEMENT_APPEAL -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLACEMENT_APPEAL_ASSESS)
+      ChangeRequestType.PLACEMENT_EXTENSION -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLANNED_TRANSFER_ASSESS)
+      ChangeRequestType.PLANNED_TRANSFER -> throw BadRequestProblem(errorDetail = "Change request type is not ${Cas1ChangeRequestType.PLANNED_TRANSFER} or ${Cas1ChangeRequestType.PLACEMENT_APPEAL}")
     }
 
     val result = cas1ChangeRequestService.rejectChangeRequest(placementRequestId, changeRequestId, cas1RejectChangeRequest)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReferenceDataController.kt
@@ -47,8 +47,8 @@ class Cas1ReferenceDataController(
   override fun getChangeRequestReasons(changeRequestType: Cas1ChangeRequestType): ResponseEntity<List<NamedId>> = ResponseEntity.ok(
     changeRequestReasonRepository.findByChangeRequestTypeAndArchivedIsFalse(
       when (changeRequestType) {
-        Cas1ChangeRequestType.APPEAL -> ChangeRequestType.APPEAL
-        Cas1ChangeRequestType.EXTENSION -> ChangeRequestType.EXTENSION
+        Cas1ChangeRequestType.PLACEMENT_APPEAL -> ChangeRequestType.PLACEMENT_APPEAL
+        Cas1ChangeRequestType.PLACEMENT_EXTENSION -> ChangeRequestType.PLACEMENT_EXTENSION
         Cas1ChangeRequestType.PLANNED_TRANSFER -> ChangeRequestType.PLANNED_TRANSFER
       },
     ).map { NamedId(it.id, it.code) },
@@ -57,8 +57,8 @@ class Cas1ReferenceDataController(
   override fun getChangeRequestRejectionReasons(changeRequestType: Cas1ChangeRequestType): ResponseEntity<List<NamedId>> = ResponseEntity.ok(
     changeRequestRejectionReasonRepository.findByChangeRequestTypeAndArchivedIsFalse(
       when (changeRequestType) {
-        Cas1ChangeRequestType.APPEAL -> ChangeRequestType.APPEAL
-        Cas1ChangeRequestType.EXTENSION -> ChangeRequestType.EXTENSION
+        Cas1ChangeRequestType.PLACEMENT_APPEAL -> ChangeRequestType.PLACEMENT_APPEAL
+        Cas1ChangeRequestType.PLACEMENT_EXTENSION -> ChangeRequestType.PLACEMENT_EXTENSION
         Cas1ChangeRequestType.PLANNED_TRANSFER -> ChangeRequestType.PLANNED_TRANSFER
       },
     ).map { NamedId(it.id, it.code) },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
@@ -76,8 +76,8 @@ enum class UserPermission(val cas1ApiValue: ApprovedPremisesUserPermission?) {
   CAS1_REPORTS_VIEW_WITH_PII(ApprovedPremisesUserPermission.reportsViewWithPii),
   CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS(ApprovedPremisesUserPermission.requestForPlacementWithdrawOthers),
 
-  CAS1_APPEAL_CREATE(ApprovedPremisesUserPermission.appealCreate),
+  CAS1_PLACEMENT_APPEAL_CREATE(ApprovedPremisesUserPermission.placementAppealCreate),
   CAS1_PLANNED_TRANSFER_CREATE(ApprovedPremisesUserPermission.plannedTransferCreate),
-  CAS1_APPEAL_ASSESS(ApprovedPremisesUserPermission.appealAssess),
+  CAS1_PLACEMENT_APPEAL_ASSESS(ApprovedPremisesUserPermission.placementAppealAssess),
   CAS1_PLANNED_TRANSFER_ASSESS(ApprovedPremisesUserPermission.plannedTransferAssess),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -119,9 +119,9 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
     ApprovedPremisesUserRole.changeRequestDev,
     permissions = listOf(
       UserPermission.CAS1_CHANGE_REQUEST_LIST,
-      UserPermission.CAS1_APPEAL_CREATE,
+      UserPermission.CAS1_PLACEMENT_APPEAL_CREATE,
       UserPermission.CAS1_PLANNED_TRANSFER_CREATE,
-      UserPermission.CAS1_APPEAL_ASSESS,
+      UserPermission.CAS1_PLACEMENT_APPEAL_ASSESS,
       UserPermission.CAS1_PLANNED_TRANSFER_ASSESS,
     ),
   ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ChangeRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ChangeRequestEntity.kt
@@ -138,7 +138,7 @@ enum class ChangeRequestDecision {
 }
 
 enum class ChangeRequestType {
-  APPEAL,
-  EXTENSION,
+  PLACEMENT_APPEAL,
+  PLACEMENT_EXTENSION,
   PLANNED_TRANSFER,
 }

--- a/src/main/resources/db/migration/all/20250416133312__update_change_request_types.sql
+++ b/src/main/resources/db/migration/all/20250416133312__update_change_request_types.sql
@@ -1,0 +1,5 @@
+UPDATE cas1_change_request_reasons SET change_request_type = 'PLACEMENT_APPEAL' WHERE  change_request_type = 'APPEAL';
+UPDATE cas1_change_request_reasons SET change_request_type = 'PLACEMENT_EXTENSION' WHERE  change_request_type = 'EXTENSION';
+
+UPDATE cas1_change_request_rejection_reasons SET change_request_type = 'PLACEMENT_APPEAL' WHERE  change_request_type = 'APPEAL';
+UPDATE cas1_change_request_rejection_reasons SET change_request_type = 'PLACEMENT_EXTENSION' WHERE  change_request_type = 'EXTENSION';

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2902,8 +2902,6 @@ components:
       enum:
         - cas1_adhoc_booking_create
         - cas1_application_withdraw_others
-        - cas1_appeal_create
-        - cas1_appeal_assess
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -2917,6 +2915,8 @@ components:
         - cas1_out_of_service_bed_create
         - cas1_out_of_service_bed_create_bed_on_hold
         - cas1_out_of_service_bed_cancel
+        - cas1_placement_appeal_create
+        - cas1_placement_appeal_assess
         - cas1_placement_request_record_unable_to_match
         - cas1_process_an_appeal
         - cas1_user_list

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1254,12 +1254,12 @@ components:
     Cas1ChangeRequestType:
       type: string
       enum:
-        - appeal
-        - extension
+        - placementAppeal
+        - placementExtension
         - plannedTransfer
       x-enum-varnames:
-        - APPEAL
-        - EXTENSION
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
         - PLANNED_TRANSFER
     Cas1ChangeRequest:
       type: object

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6777,8 +6777,6 @@ components:
       enum:
         - cas1_adhoc_booking_create
         - cas1_application_withdraw_others
-        - cas1_appeal_create
-        - cas1_appeal_assess
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -6792,6 +6790,8 @@ components:
         - cas1_out_of_service_bed_create
         - cas1_out_of_service_bed_create_bed_on_hold
         - cas1_out_of_service_bed_cancel
+        - cas1_placement_appeal_create
+        - cas1_placement_appeal_assess
         - cas1_placement_request_record_unable_to_match
         - cas1_process_an_appeal
         - cas1_user_list

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5333,8 +5333,6 @@ components:
       enum:
         - cas1_adhoc_booking_create
         - cas1_application_withdraw_others
-        - cas1_appeal_create
-        - cas1_appeal_assess
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -5348,6 +5346,8 @@ components:
         - cas1_out_of_service_bed_create
         - cas1_out_of_service_bed_create_bed_on_hold
         - cas1_out_of_service_bed_cancel
+        - cas1_placement_appeal_create
+        - cas1_placement_appeal_assess
         - cas1_placement_request_record_unable_to_match
         - cas1_process_an_appeal
         - cas1_user_list
@@ -8145,12 +8145,12 @@ components:
     Cas1ChangeRequestType:
       type: string
       enum:
-        - appeal
-        - extension
+        - placementAppeal
+        - placementExtension
         - plannedTransfer
       x-enum-varnames:
-        - APPEAL
-        - EXTENSION
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
         - PLANNED_TRANSFER
     Cas1ChangeRequest:
       type: object

--- a/src/main/resources/static/codegen/built-cas1-roles.json
+++ b/src/main/resources/static/codegen/built-cas1-roles.json
@@ -95,9 +95,9 @@
   {
     "name" : "change_request_dev",
     "permissions" : [
-      "cas1_appeal_assess",
-      "cas1_appeal_create",
       "cas1_change_request_list",
+      "cas1_placement_appeal_assess",
+      "cas1_placement_appeal_create",
       "cas1_planned_transfer_assess",
       "cas1_planned_transfer_create"
     ]
@@ -144,8 +144,6 @@
     "name" : "janitor",
     "permissions" : [
       "cas1_adhoc_booking_create",
-      "cas1_appeal_assess",
-      "cas1_appeal_create",
       "cas1_application_withdraw_others",
       "cas1_assess_appealed_application",
       "cas1_assess_application",
@@ -158,6 +156,8 @@
       "cas1_out_of_service_bed_cancel",
       "cas1_out_of_service_bed_create",
       "cas1_out_of_service_bed_create_bed_on_hold",
+      "cas1_placement_appeal_assess",
+      "cas1_placement_appeal_create",
       "cas1_placement_request_record_unable_to_match",
       "cas1_planned_transfer_assess",
       "cas1_planned_transfer_create",

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3517,8 +3517,6 @@ components:
       enum:
         - cas1_adhoc_booking_create
         - cas1_application_withdraw_others
-        - cas1_appeal_create
-        - cas1_appeal_assess
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -3532,6 +3530,8 @@ components:
         - cas1_out_of_service_bed_create
         - cas1_out_of_service_bed_create_bed_on_hold
         - cas1_out_of_service_bed_cancel
+        - cas1_placement_appeal_create
+        - cas1_placement_appeal_assess
         - cas1_placement_request_record_unable_to_match
         - cas1_process_an_appeal
         - cas1_user_list

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3533,8 +3533,6 @@ components:
       enum:
         - cas1_adhoc_booking_create
         - cas1_application_withdraw_others
-        - cas1_appeal_create
-        - cas1_appeal_assess
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -3548,6 +3546,8 @@ components:
         - cas1_out_of_service_bed_create
         - cas1_out_of_service_bed_create_bed_on_hold
         - cas1_out_of_service_bed_cancel
+        - cas1_placement_appeal_create
+        - cas1_placement_appeal_assess
         - cas1_placement_request_record_unable_to_match
         - cas1_process_an_appeal
         - cas1_user_list

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3315,8 +3315,6 @@ components:
       enum:
         - cas1_adhoc_booking_create
         - cas1_application_withdraw_others
-        - cas1_appeal_create
-        - cas1_appeal_assess
         - cas1_assess_appealed_application
         - cas1_assess_application
         - cas1_assess_placement_application
@@ -3330,6 +3328,8 @@ components:
         - cas1_out_of_service_bed_create
         - cas1_out_of_service_bed_create_bed_on_hold
         - cas1_out_of_service_bed_cancel
+        - cas1_placement_appeal_create
+        - cas1_placement_appeal_assess
         - cas1_placement_request_record_unable_to_match
         - cas1_process_an_appeal
         - cas1_user_list

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1ChangeRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1ChangeRequestEntityFactory.kt
@@ -21,7 +21,7 @@ class Cas1ChangeRequestEntityFactory : Factory<Cas1ChangeRequestEntity> {
   private var id = { UUID.randomUUID() }
   private var placementRequest = { PlacementRequestEntityFactory().withDefaults().produce() }
   private var spaceBooking = { Cas1SpaceBookingEntityFactory().produce() }
-  private var type = { ChangeRequestType.APPEAL }
+  private var type = { ChangeRequestType.PLACEMENT_APPEAL }
   private var requestJson = { "{}" }
   private var requestReason = { Cas1ChangeRequestReasonEntityFactory().produce() }
   private var decisionJson = { null }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1ChangeRequestReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1ChangeRequestReasonEntityFactory.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 class Cas1ChangeRequestReasonEntityFactory : Factory<Cas1ChangeRequestReasonEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var code: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
-  private var changeRequestType: Yielded<ChangeRequestType> = { ChangeRequestType.APPEAL }
+  private var changeRequestType: Yielded<ChangeRequestType> = { ChangeRequestType.PLACEMENT_APPEAL }
   private var archived: Yielded<Boolean> = { false }
 
   fun withCode(code: String) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1ChangeRequestRejectionReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1ChangeRequestRejectionReasonEntityFactory.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 class Cas1ChangeRequestRejectionReasonEntityFactory : Factory<Cas1ChangeRequestRejectionReasonEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var code: Yielded<String> = { randomStringMultiCaseWithNumbers(4) }
-  private var changeRequestType: Yielded<ChangeRequestType> = { ChangeRequestType.APPEAL }
+  private var changeRequestType: Yielded<ChangeRequestType> = { ChangeRequestType.PLACEMENT_APPEAL }
   private var archived: Yielded<Boolean> = { false }
 
   fun withCode(code: String) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1NewChangeRequestFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1NewChangeRequestFactory.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 
 class Cas1NewChangeRequestFactory : Factory<Cas1NewChangeRequest> {
   private var spaceBookingId: Yielded<UUID> = { UUID.randomUUID() }
-  private var type = { Cas1ChangeRequestType.APPEAL }
+  private var type = { Cas1ChangeRequestType.PLACEMENT_APPEAL }
   private var requestJson = { "{test: 1}" }
   private var reasonId: Yielded<UUID> = { UUID.randomUUID() }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
@@ -66,7 +66,7 @@ class Cas1ChangeRequestTest {
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewChangeRequest(
-                type = Cas1ChangeRequestType.APPEAL,
+                type = Cas1ChangeRequestType.PLACEMENT_APPEAL,
                 requestJson = "{}",
                 reasonId = UUID.randomUUID(),
                 spaceBookingId = UUID.randomUUID(),
@@ -128,7 +128,7 @@ class Cas1ChangeRequestTest {
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewChangeRequest(
-                type = Cas1ChangeRequestType.EXTENSION,
+                type = Cas1ChangeRequestType.PLACEMENT_EXTENSION,
                 requestJson = "{}",
                 reasonId = UUID.randomUUID(),
                 spaceBookingId = UUID.randomUUID(),
@@ -143,7 +143,7 @@ class Cas1ChangeRequestTest {
 
     @Test
     fun `Returns 200 when post new appeal change request is successful`() {
-      givenAUser(roles = listOf(UserRole.CAS1_CHANGE_REQUEST_DEV)) { user, jwt ->
+      givenAUser(roles = listOf(CAS1_CHANGE_REQUEST_DEV)) { user, jwt ->
         givenAPlacementRequest(
           placementRequestAllocatedTo = user,
           assessmentAllocatedTo = user,
@@ -159,7 +159,7 @@ class Cas1ChangeRequestTest {
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewChangeRequest(
-                type = Cas1ChangeRequestType.APPEAL,
+                type = Cas1ChangeRequestType.PLACEMENT_APPEAL,
                 requestJson = "{test: 1}",
                 reasonId = changeRequestReason.id,
                 spaceBookingId = spaceBooking.id,
@@ -170,7 +170,7 @@ class Cas1ChangeRequestTest {
             .isOk
 
           val persistedChangeRequest = cas1ChangeRequestRepository.findAll()[0]
-          assertThat(persistedChangeRequest.type).isEqualTo(ChangeRequestType.APPEAL)
+          assertThat(persistedChangeRequest.type).isEqualTo(ChangeRequestType.PLACEMENT_APPEAL)
           assertThat(persistedChangeRequest.requestJson).isEqualTo("\"{test: 1}\"")
           assertThat(persistedChangeRequest.requestReason).isEqualTo(changeRequestReason)
           assertThat(persistedChangeRequest.spaceBooking.id).isEqualTo(spaceBooking.id)
@@ -251,7 +251,7 @@ class Cas1ChangeRequestTest {
       ).first
 
       cruManagementArea1ChangeRequest1 = givenACas1ChangeRequest(
-        type = ChangeRequestType.APPEAL,
+        type = ChangeRequestType.PLACEMENT_APPEAL,
         decision = null,
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest1.application.crn,
@@ -264,7 +264,7 @@ class Cas1ChangeRequestTest {
 
       // has decision, will be ignored
       givenACas1ChangeRequest(
-        type = ChangeRequestType.APPEAL,
+        type = ChangeRequestType.PLACEMENT_APPEAL,
         decision = ChangeRequestDecision.APPROVED,
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest1.application.crn,
@@ -291,7 +291,7 @@ class Cas1ChangeRequestTest {
       ).first
 
       cruManagementArea2ChangeRequest1 = givenACas1ChangeRequest(
-        type = ChangeRequestType.EXTENSION,
+        type = ChangeRequestType.PLACEMENT_EXTENSION,
         decision = null,
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest2.application.crn,
@@ -536,8 +536,8 @@ class Cas1ChangeRequestTest {
           assertThat(response.map { it.type })
             .containsExactly(
               Cas1ChangeRequestType.PLANNED_TRANSFER,
-              Cas1ChangeRequestType.EXTENSION,
-              Cas1ChangeRequestType.APPEAL,
+              Cas1ChangeRequestType.PLACEMENT_EXTENSION,
+              Cas1ChangeRequestType.PLACEMENT_APPEAL,
             )
         }
 
@@ -550,8 +550,8 @@ class Cas1ChangeRequestTest {
         .bodyAsListOfObjects<Cas1ChangeRequestSummary>().let { response ->
           assertThat(response.map { it.type })
             .containsExactly(
-              Cas1ChangeRequestType.APPEAL,
-              Cas1ChangeRequestType.EXTENSION,
+              Cas1ChangeRequestType.PLACEMENT_APPEAL,
+              Cas1ChangeRequestType.PLACEMENT_EXTENSION,
               Cas1ChangeRequestType.PLANNED_TRANSFER,
             )
         }
@@ -595,7 +595,7 @@ class Cas1ChangeRequestTest {
       ).first
 
       changeRequest = givenACas1ChangeRequest(
-        type = ChangeRequestType.APPEAL,
+        type = ChangeRequestType.PLACEMENT_APPEAL,
         decision = null,
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest1.application.crn,
@@ -625,16 +625,16 @@ class Cas1ChangeRequestTest {
 
       extensionRejectionReason = cas1ChangeRequestRejectionReasonEntityFactory
         .produceAndPersist {
-          withChangeRequestType(ChangeRequestType.EXTENSION)
+          withChangeRequestType(ChangeRequestType.PLACEMENT_EXTENSION)
         }
 
       appealRejectionReason = cas1ChangeRequestRejectionReasonEntityFactory
         .produceAndPersist {
-          withChangeRequestType(ChangeRequestType.APPEAL)
+          withChangeRequestType(ChangeRequestType.PLACEMENT_APPEAL)
         }
 
       changeRequest1 = givenACas1ChangeRequest(
-        type = ChangeRequestType.EXTENSION,
+        type = ChangeRequestType.PLACEMENT_EXTENSION,
         decision = ChangeRequestDecision.REJECTED,
         rejectReason = extensionRejectionReason,
         decisionMadeAt = LocalDateTime.of(2025, 3, 1, 15, 30).atOffset(ZoneOffset.UTC),
@@ -698,7 +698,7 @@ class Cas1ChangeRequestTest {
 
       val changeRequestAfter = cas1ChangeRequestRepository.findById(changeRequest.id).get()
       assertThat(changeRequestAfter.rejectionReason).isNotNull()
-      assertThat(changeRequestAfter.rejectionReason?.changeRequestType).isEqualTo(ChangeRequestType.APPEAL)
+      assertThat(changeRequestAfter.rejectionReason?.changeRequestType).isEqualTo(ChangeRequestType.PLACEMENT_APPEAL)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
@@ -46,37 +46,37 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
 
       cas1ChangeRequestReasonEntityFactory.produceAndPersist {
         withCode("appeal_reason_1")
-        withChangeRequestType(ChangeRequestType.APPEAL)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_APPEAL)
         withArchived(false)
       }
 
       cas1ChangeRequestReasonEntityFactory.produceAndPersist {
         withCode("appeal_reason_2_archived")
-        withChangeRequestType(ChangeRequestType.APPEAL)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_APPEAL)
         withArchived(true)
       }
 
       cas1ChangeRequestReasonEntityFactory.produceAndPersist {
         withCode("appeal_reason_3")
-        withChangeRequestType(ChangeRequestType.APPEAL)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_APPEAL)
         withArchived(false)
       }
 
       cas1ChangeRequestReasonEntityFactory.produceAndPersist {
         withCode("extension_reason_1")
-        withChangeRequestType(ChangeRequestType.EXTENSION)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_EXTENSION)
         withArchived(false)
       }
 
       cas1ChangeRequestReasonEntityFactory.produceAndPersist {
         withCode("extension_reason_2")
-        withChangeRequestType(ChangeRequestType.EXTENSION)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_EXTENSION)
         withArchived(false)
       }
 
       cas1ChangeRequestReasonEntityFactory.produceAndPersist {
         withCode("extension_reason_3_archived")
-        withChangeRequestType(ChangeRequestType.EXTENSION)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_EXTENSION)
         withArchived(true)
       }
 
@@ -104,7 +104,7 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
       val result = webTestClient.get()
-        .uri("/cas1/reference-data/change-request-reasons/appeal")
+        .uri("/cas1/reference-data/change-request-reasons/placementAppeal")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -119,7 +119,7 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
       val result = webTestClient.get()
-        .uri("/cas1/reference-data/change-request-reasons/extension")
+        .uri("/cas1/reference-data/change-request-reasons/placementExtension")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -154,37 +154,37 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
 
       cas1ChangeRequestRejectionReasonEntityFactory.produceAndPersist {
         withCode("appeal_reason_1")
-        withChangeRequestType(ChangeRequestType.APPEAL)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_APPEAL)
         withArchived(false)
       }
 
       cas1ChangeRequestRejectionReasonEntityFactory.produceAndPersist {
         withCode("appeal_reason_2_archived")
-        withChangeRequestType(ChangeRequestType.APPEAL)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_APPEAL)
         withArchived(true)
       }
 
       cas1ChangeRequestRejectionReasonEntityFactory.produceAndPersist {
         withCode("appeal_reason_3")
-        withChangeRequestType(ChangeRequestType.APPEAL)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_APPEAL)
         withArchived(false)
       }
 
       cas1ChangeRequestRejectionReasonEntityFactory.produceAndPersist {
         withCode("extension_reason_1")
-        withChangeRequestType(ChangeRequestType.EXTENSION)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_EXTENSION)
         withArchived(false)
       }
 
       cas1ChangeRequestRejectionReasonEntityFactory.produceAndPersist {
         withCode("extension_reason_2")
-        withChangeRequestType(ChangeRequestType.EXTENSION)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_EXTENSION)
         withArchived(false)
       }
 
       cas1ChangeRequestRejectionReasonEntityFactory.produceAndPersist {
         withCode("extension_reason_3_archived")
-        withChangeRequestType(ChangeRequestType.EXTENSION)
+        withChangeRequestType(ChangeRequestType.PLACEMENT_EXTENSION)
         withArchived(true)
       }
 
@@ -212,7 +212,7 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
       val result = webTestClient.get()
-        .uri("/cas1/reference-data/change-request-rejection-reasons/appeal")
+        .uri("/cas1/reference-data/change-request-rejection-reasons/placementAppeal")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -227,7 +227,7 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
 
       val result = webTestClient.get()
-        .uri("/cas1/reference-data/change-request-rejection-reasons/extension")
+        .uri("/cas1/reference-data/change-request-rejection-reasons/placementExtension")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestServiceTest.kt
@@ -120,7 +120,7 @@ class Cas1ChangeRequestServiceTest {
       val cas1ChangeRequestReason = Cas1ChangeRequestReasonEntityFactory().produce()
 
       val cas1NewChangeRequest = Cas1NewChangeRequestFactory()
-        .withType(Cas1ChangeRequestType.APPEAL)
+        .withType(Cas1ChangeRequestType.PLACEMENT_APPEAL)
         .withReasonId(cas1ChangeRequestReason.id)
         .withSpaceBookingId(cas1SpaceBooking.id)
         .produce()


### PR DESCRIPTION
This is to disambiguate it from an assessment appeal.

I’ve also renamed ‘extension’ to ‘placement extension’ for clarity