### PR TITLE
Add `cas1_change_requests.resolved`

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -37,6 +37,8 @@ complexity:
       # the number of arguments is non-trivial and may result in worse performance and an unnecessarily fragmented
       # database design.
       - javax.persistence.Entity
+    excludes:
+      - '**/givens/**'
   TooManyFunctions:
     thresholdInInterfaces: 20
     thresholdInClasses: 20

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ChangeRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ChangeRequestEntity.kt
@@ -48,7 +48,7 @@ interface Cas1ChangeRequestRepository : JpaRepository<Cas1ChangeRequestEntity, U
         INNER JOIN placement_requests pr on cr.placement_request_id = pr.id
         INNER JOIN approved_premises_applications apa on apa.id = pr.application_id
         WHERE
-          cr.decision IS NULL AND
+          cr.resolved IS FALSE AND
           ((CAST(:cruManagementAreaId AS pg_catalog.uuid) IS NULL) OR apa.cas1_cru_management_area_id = :cruManagementAreaId)
       )
       select * from results  
@@ -104,7 +104,8 @@ data class Cas1ChangeRequestEntity(
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "decision_made_by_user_id")
   val decisionMadeByUser: UserEntity?,
-  var decisionMadeAt: OffsetDateTime?,
+  var resolved: Boolean,
+  var resolvedAt: OffsetDateTime?,
   val createdAt: OffsetDateTime,
   var updatedAt: OffsetDateTime,
   @Version

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
@@ -66,7 +66,8 @@ class Cas1ChangeRequestService(
         decision = null,
         rejectionReason = null,
         decisionMadeByUser = null,
-        decisionMadeAt = null,
+        resolved = false,
+        resolvedAt = null,
         createdAt = now,
         updatedAt = now,
       ),
@@ -115,8 +116,10 @@ class Cas1ChangeRequestService(
     val changeRequestRejectReason = cas1ChangeRequestRejectionReasonRepository.findByIdAndArchivedIsFalse(cas1RejectChangeRequest.rejectionReasonId)
       ?: return CasResult.GeneralValidationError("The change request reject reason not found")
 
+    changeRequestWithLock.decision = ChangeRequestDecision.REJECTED
     changeRequestWithLock.rejectionReason = changeRequestRejectReason
-    changeRequestWithLock.decisionMadeAt = OffsetDateTime.now()
+    changeRequestWithLock.resolved = true
+    changeRequestWithLock.resolvedAt = OffsetDateTime.now()
     cas1ChangeRequestRepository.saveAndFlush(changeRequestWithLock)
 
     return Success(Unit)

--- a/src/main/resources/db/migration/all/20250416134643__add_resolved_to_change_requests.sql
+++ b/src/main/resources/db/migration/all/20250416134643__add_resolved_to_change_requests.sql
@@ -1,0 +1,3 @@
+ALTER TABLE cas1_change_requests ADD resolved boolean NOT NULL default false;
+ALTER TABLE cas1_change_requests ADD resolved_at timestamptz NULL;
+ALTER TABLE cas1_change_requests DROP COLUMN decision_made_at;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1ChangeRequestEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/Cas1ChangeRequestEntityFactory.kt
@@ -28,7 +28,8 @@ class Cas1ChangeRequestEntityFactory : Factory<Cas1ChangeRequestEntity> {
   private var decision: Yielded<ChangeRequestDecision?> = { ChangeRequestDecision.APPROVED }
   private var rejectionReason: Yielded<Cas1ChangeRequestRejectionReasonEntity?> = { null }
   private var decisionMadeByUser: Yielded<UserEntity?> = { UserEntityFactory().withDefaults().produce() }
-  private var decisionMadeAt: Yielded<OffsetDateTime?> = { null }
+  private var resolved: Yielded<Boolean> = { false }
+  private var resolvedAt: Yielded<OffsetDateTime?> = { null }
   private var createdAt = { OffsetDateTime.now().minusDays(randomInt(0, 365).toLong()) }
   private var updatedAt = { OffsetDateTime.now() }
 
@@ -60,8 +61,12 @@ class Cas1ChangeRequestEntityFactory : Factory<Cas1ChangeRequestEntity> {
     this.decision = { decision }
   }
 
-  fun withDecisionMadeAt(decisionMadeAt: OffsetDateTime?) = apply {
-    this.decisionMadeAt = { decisionMadeAt }
+  fun withResolved(resolved: Boolean) = apply {
+    this.resolved = { resolved }
+  }
+
+  fun withResolvedAt(resolvedAt: OffsetDateTime?) = apply {
+    this.resolvedAt = { resolvedAt }
   }
 
   fun withRejectionReason(rejectionReason: Cas1ChangeRequestRejectionReasonEntity?) = apply {
@@ -78,9 +83,10 @@ class Cas1ChangeRequestEntityFactory : Factory<Cas1ChangeRequestEntity> {
       requestReason = this.requestReason(),
       decisionJson = this.decisionJson(),
       decision = this.decision(),
-      decisionMadeAt = this.decisionMadeAt(),
       rejectionReason = this.rejectionReason(),
       decisionMadeByUser = this.decisionMadeByUser(),
+      resolved = this.resolved(),
+      resolvedAt = this.resolvedAt(),
       createdAt = this.createdAt(),
       updatedAt = this.updatedAt(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
@@ -253,6 +253,7 @@ class Cas1ChangeRequestTest {
       cruManagementArea1ChangeRequest1 = givenACas1ChangeRequest(
         type = ChangeRequestType.PLACEMENT_APPEAL,
         decision = null,
+        resolved = false,
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest1.application.crn,
           application = placementRequest1.application,
@@ -262,10 +263,11 @@ class Cas1ChangeRequestTest {
         ),
       )
 
-      // has decision, will be ignored
+      // is resolved, will be ignored
       givenACas1ChangeRequest(
         type = ChangeRequestType.PLACEMENT_APPEAL,
         decision = ChangeRequestDecision.APPROVED,
+        resolved = true,
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest1.application.crn,
           application = placementRequest1.application,
@@ -293,6 +295,7 @@ class Cas1ChangeRequestTest {
       cruManagementArea2ChangeRequest1 = givenACas1ChangeRequest(
         type = ChangeRequestType.PLACEMENT_EXTENSION,
         decision = null,
+        resolved = false,
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest2.application.crn,
           application = placementRequest2.application,
@@ -319,7 +322,7 @@ class Cas1ChangeRequestTest {
 
       cruManagementArea2ChangeRequest2 = givenACas1ChangeRequest(
         type = ChangeRequestType.PLANNED_TRANSFER,
-        decision = null,
+        resolved = false,
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest3.application.crn,
           application = placementRequest3.application,
@@ -637,7 +640,8 @@ class Cas1ChangeRequestTest {
         type = ChangeRequestType.PLACEMENT_EXTENSION,
         decision = ChangeRequestDecision.REJECTED,
         rejectReason = extensionRejectionReason,
-        decisionMadeAt = LocalDateTime.of(2025, 3, 1, 15, 30).atOffset(ZoneOffset.UTC),
+        resolved = true,
+        resolvedAt = LocalDateTime.of(2025, 3, 1, 15, 30).atOffset(ZoneOffset.UTC),
         spaceBooking = givenACas1SpaceBooking(
           crn = placementRequest2.application.crn,
           application = placementRequest2.application,
@@ -719,7 +723,7 @@ class Cas1ChangeRequestTest {
         .isOk
 
       val changeRequestAfter = cas1ChangeRequestRepository.findById(changeRequest1.id).get()
-      assertThat(changeRequestAfter.decisionMadeAt).isEqualTo(changeRequest1.decisionMadeAt)
+      assertThat(changeRequestAfter.resolvedAt).isEqualTo(changeRequest1.resolvedAt)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1ChangeRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1ChangeRequest.kt
@@ -11,9 +11,10 @@ import java.time.OffsetDateTime
 fun IntegrationTestBase.givenACas1ChangeRequest(
   type: ChangeRequestType,
   decision: ChangeRequestDecision? = null,
-  decisionMadeAt: OffsetDateTime = OffsetDateTime.now(),
+  resolvedAt: OffsetDateTime = OffsetDateTime.now(),
   spaceBooking: Cas1SpaceBookingEntity,
   rejectReason: Cas1ChangeRequestRejectionReasonEntity? = null,
+  resolved: Boolean = decision != null,
 ): Cas1ChangeRequestEntity {
   val requestReason = cas1ChangeRequestReasonEntityFactory.produceAndPersist {
     withChangeRequestType(type)
@@ -24,7 +25,8 @@ fun IntegrationTestBase.givenACas1ChangeRequest(
     withType(type)
     withChangeRequestReason(requestReason)
     withDecision(decision)
-    withDecisionMadeAt(decisionMadeAt)
+    withResolved(resolved)
+    withResolvedAt(resolvedAt)
     withSpaceBooking(spaceBooking)
     withPlacementRequest(spaceBooking.placementRequest!!)
     withRejectionReason(rejectReason)


### PR DESCRIPTION
This commit adds a boolean `resolved` to the change request entity, used to indicate if a change request is resolved. This is requried to support ‘closing’ a change request if the corresponding placement is cancelled, or in a state such that the change request is no longer relevant.

A change request will be resolved if

- It’s accepted
- It’s rejected
- The corresponding placement is in a state such that the change request is no longer relevant

This commit also removes the `decision made at` value and replaces it with `resolved at`, which will be the same date/time.