### PR TITLE
APS-2186 Simplify `Cas1TimelineEventContentPayload`

### DIFF
--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1140,13 +1140,10 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/Cas1TimelineEventType'
-        premises:
-          $ref: '_shared.yml#/components/schemas/NamedId'
         schemaVersion:
           type: integer
       required:
         - type
-        - premises
         - schemaVersion
       discriminator:
         propertyName: "type"
@@ -1157,6 +1154,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
       properties:
+        premises:
+          $ref: '_shared.yml#/components/schemas/NamedId'
         expectedArrival:
           type: string
           format: date
@@ -1181,6 +1180,7 @@ components:
           items:
             $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
       required:
+        - premises
         - expectedArrival
         - expectedDeparture
     Cas1PlacementRequestSummary:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -8031,13 +8031,10 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/Cas1TimelineEventType'
-        premises:
-          $ref: '#/components/schemas/NamedId'
         schemaVersion:
           type: integer
       required:
         - type
-        - premises
         - schemaVersion
       discriminator:
         propertyName: "type"
@@ -8048,6 +8045,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
       properties:
+        premises:
+          $ref: '#/components/schemas/NamedId'
         expectedArrival:
           type: string
           format: date
@@ -8072,6 +8071,7 @@ components:
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
       required:
+        - premises
         - expectedArrival
         - expectedDeparture
     Cas1PlacementRequestSummary:


### PR DESCRIPTION
This commit removes the `premises` property from `Cas1TimelineEventContentPayload` as it will not apply to all payload types. It moves it onto the individual payload definitions where required.