### PR TITLE
APS-2054 Introduce common domain event envelope interface

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationAssessedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationAssessedEnvelope.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessed
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
 
 /**
  *
@@ -15,14 +13,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class ApplicationAssessedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: ApplicationAssessed,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: ApplicationAssessed,
+): Cas1DomainEventEnvelope<ApplicationAssessed>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationExpiredEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationExpiredEnvelope.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
 
 /**
  *
@@ -15,14 +13,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class ApplicationExpiredEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: ApplicationExpired,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: ApplicationExpired,
+): Cas1DomainEventEnvelope<ApplicationExpired>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationSubmittedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationSubmittedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class ApplicationSubmittedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: ApplicationSubmitted,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: ApplicationSubmitted,
+): Cas1DomainEventEnvelope<ApplicationSubmitted>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationWithdrawnEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationWithdrawnEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class ApplicationWithdrawnEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: ApplicationWithdrawn,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: ApplicationWithdrawn,
+): Cas1DomainEventEnvelope<ApplicationWithdrawn>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/AssessmentAllocatedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/AssessmentAllocatedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class AssessmentAllocatedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: AssessmentAllocated,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: AssessmentAllocated,
+): Cas1DomainEventEnvelope<AssessmentAllocated>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/AssessmentAppealedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/AssessmentAppealedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class AssessmentAppealedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: AssessmentAppealed,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: AssessmentAppealed,
+): Cas1DomainEventEnvelope<AssessmentAppealed>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingCancelledEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingCancelledEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class BookingCancelledEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: BookingCancelled,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: BookingCancelled,
+): Cas1DomainEventEnvelope<BookingCancelled>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingChangedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingChangedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class BookingChangedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: BookingChanged,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: BookingChanged,
+): Cas1DomainEventEnvelope<BookingChanged>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingKeyWorkerAssignedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingKeyWorkerAssignedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class BookingKeyWorkerAssignedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: BookingKeyWorkerAssigned,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: BookingKeyWorkerAssigned,
+): Cas1DomainEventEnvelope<BookingKeyWorkerAssigned>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingMadeEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingMadeEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
 data class BookingMadeEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: BookingMade,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: BookingMade,
+): Cas1DomainEventEnvelope<BookingMade>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingNotMadeEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingNotMadeEnvelope.kt
@@ -2,8 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMade
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
+import java.util.UUID
 
 /**
  *
@@ -12,17 +11,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ev
  * @param eventType
  * @param eventDetails
  */
-data class BookingNotMadeEnvelope(
-
+data class BookingNotMadeEnvelope (
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: BookingNotMade,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: BookingNotMade,
+): Cas1DomainEventEnvelope<BookingNotMade>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/Cas1DomainEventEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/Cas1DomainEventEnvelope.kt
@@ -3,21 +3,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
+import java.time.Instant
+import java.util.UUID
 
-/**
- *
- * @param id The UUID of an event
- * @param timestamp
- * @param eventType
- */
-data class Cas1DomainEventEnvelope(
-
-  @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
-)
+interface Cas1DomainEventEnvelope<D> {
+  val id: UUID
+  val timestamp: Instant
+  val eventType: EventType
+  val eventDetails: D
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/FurtherInformationRequestedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/FurtherInformationRequestedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Fu
 data class FurtherInformationRequestedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: FurtherInformationRequested,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: FurtherInformationRequested,
+): Cas1DomainEventEnvelope<FurtherInformationRequested>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/MatchRequestWithdrawnEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/MatchRequestWithdrawnEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ma
 data class MatchRequestWithdrawnEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: MatchRequestWithdrawn,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: MatchRequestWithdrawn,
+): Cas1DomainEventEnvelope<MatchRequestWithdrawn>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonArrivedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonArrivedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pe
 data class PersonArrivedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: PersonArrived,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: PersonArrived,
+): Cas1DomainEventEnvelope<PersonArrived>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonDepartedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonDepartedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pe
 data class PersonDepartedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: PersonDeparted,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: PersonDeparted,
+): Cas1DomainEventEnvelope<PersonDeparted>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonNotArrivedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonNotArrivedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pe
 data class PersonNotArrivedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: PersonNotArrived,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: PersonNotArrived,
+): Cas1DomainEventEnvelope<PersonNotArrived>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementApplicationAllocatedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementApplicationAllocatedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pl
 data class PlacementApplicationAllocatedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: PlacementApplicationAllocated,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: PlacementApplicationAllocated,
+): Cas1DomainEventEnvelope<PlacementApplicationAllocated>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementApplicationWithdrawnEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementApplicationWithdrawnEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pl
 data class PlacementApplicationWithdrawnEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: PlacementApplicationWithdrawn,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: PlacementApplicationWithdrawn,
+): Cas1DomainEventEnvelope<PlacementApplicationWithdrawn>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/RequestForPlacementAssessedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/RequestForPlacementAssessedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Re
 data class RequestForPlacementAssessedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: RequestForPlacementAssessed,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: RequestForPlacementAssessed,
+): Cas1DomainEventEnvelope<RequestForPlacementAssessed>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/RequestForPlacementCreatedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/RequestForPlacementCreatedEnvelope.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Re
 data class RequestForPlacementCreatedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  @get:JsonProperty("id", required = true) override val id: java.util.UUID,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("timestamp", required = true) val timestamp: java.time.Instant,
+  @get:JsonProperty("timestamp", required = true) override val timestamp: java.time.Instant,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventType", required = true) val eventType: EventType,
+  @get:JsonProperty("eventType", required = true) override val eventType: EventType,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("eventDetails", required = true) val eventDetails: RequestForPlacementCreated,
-)
+  @get:JsonProperty("eventDetails", required = true) override val eventDetails: RequestForPlacementCreated,
+): Cas1DomainEventEnvelope<RequestForPlacementCreated>


### PR DESCRIPTION
This commit updates all CAS1 domain event envelopes to use a common interface. This allows us to then define the envelope type associated with each domain event type on `DomainEventType`, ensure the referenced type is actually an envelope. We can then use this new configuration in the `Cas1DomainEventService` when unmarshalling domain event json without the need for a large, difficult to read `when` structure.

This helps us move towards to moving all high-level domain event configuration into the `DomainEventType`, making it much easier to understand what is required when adding a new domain event