### PR TITLE
APS-2208 Add separate POST endpoints for appeals, transfers and extensions.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ChangeRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ChangeRequestsController.kt
@@ -37,12 +37,8 @@ class Cas1ChangeRequestsController(
   private val userAccessService: UserAccessService,
 ) : ChangeRequestsCas1Delegate {
 
-  override fun create(placementRequestId: UUID, cas1NewChangeRequest: Cas1NewChangeRequest): ResponseEntity<Unit> {
-    when (cas1NewChangeRequest.type) {
-      Cas1ChangeRequestType.PLACEMENT_APPEAL -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLACEMENT_APPEAL_CREATE)
-      Cas1ChangeRequestType.PLANNED_TRANSFER -> userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLANNED_TRANSFER_CREATE)
-      Cas1ChangeRequestType.PLACEMENT_EXTENSION -> throw BadRequestProblem(errorDetail = "Change request type is not ${Cas1ChangeRequestType.PLANNED_TRANSFER} or ${Cas1ChangeRequestType.PLACEMENT_APPEAL}")
-    }
+  override fun createPlacementAppeal(placementRequestId: UUID, cas1NewChangeRequest: Cas1NewChangeRequest): ResponseEntity<Unit> {
+    userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLACEMENT_APPEAL_CREATE)
 
     val result = cas1ChangeRequestService.createChangeRequest(placementRequestId, cas1NewChangeRequest)
 
@@ -50,6 +46,20 @@ class Cas1ChangeRequestsController(
 
     return ResponseEntity(HttpStatus.OK)
   }
+
+  override fun createPlannedTransfer(placementRequestId: UUID, cas1NewChangeRequest: Cas1NewChangeRequest): ResponseEntity<Unit> {
+    userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLANNED_TRANSFER_CREATE)
+
+    val result = cas1ChangeRequestService.createChangeRequest(placementRequestId, cas1NewChangeRequest)
+
+    ensureEntityFromCasResultIsSuccess(result)
+
+    return ResponseEntity(HttpStatus.OK)
+  }
+
+  override fun createPlacementExtension(placementRequestId: UUID, cas1NewChangeRequest: Cas1NewChangeRequest): ResponseEntity<Unit> = throw BadRequestProblem(
+    errorDetail = "Change request type is not ${Cas1ChangeRequestType.PLANNED_TRANSFER} or ${Cas1ChangeRequestType.PLACEMENT_APPEAL}",
+  )
 
   override fun findOpen(
     page: Int?,

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -52,11 +52,11 @@ paths:
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
 
-  /placement-request/{placementRequestId}/change-request:
+  /placement-request/{placementRequestId}/planned-transfer:
     post:
       tags:
         - change requests
-      operationId: create
+      operationId: createPlannedTransfer
       parameters:
         - name: placementRequestId
           in: path
@@ -80,6 +80,61 @@ paths:
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
 
+  /placement-request/{placementRequestId}/appeal:
+    post:
+      tags:
+        - change requests
+      operationId: createPlacementAppeal
+      parameters:
+        - name: placementRequestId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: 'cas1-schemas.yml#/components/schemas/Cas1NewChangeRequest'
+        required: true
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+
+  /placement-request/{placementRequestId}/extension:
+    post:
+      tags:
+        - change requests
+      operationId: createPlacementExtension
+      parameters:
+        - name: placementRequestId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: 'cas1-schemas.yml#/components/schemas/Cas1NewChangeRequest'
+        required: true
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
 
   /placement-request/{placementRequestId}/change-requests/{changeRequestId}:
     get:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -54,11 +54,11 @@ paths:
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
 
-  /placement-request/{placementRequestId}/change-request:
+  /placement-request/{placementRequestId}/planned-transfer:
     post:
       tags:
         - change requests
-      operationId: create
+      operationId: createPlannedTransfer
       parameters:
         - name: placementRequestId
           in: path
@@ -82,6 +82,61 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
 
+  /placement-request/{placementRequestId}/appeal:
+    post:
+      tags:
+        - change requests
+      operationId: createPlacementAppeal
+      parameters:
+        - name: placementRequestId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Cas1NewChangeRequest'
+        required: true
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+
+  /placement-request/{placementRequestId}/extension:
+    post:
+      tags:
+        - change requests
+      operationId: createPlacementExtension
+      parameters:
+        - name: placementRequestId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Cas1NewChangeRequest'
+        required: true
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
 
   /placement-request/{placementRequestId}/change-requests/{changeRequestId}:
     get:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
@@ -68,7 +68,7 @@ class Cas1ChangeRequestTest {
           createdByUser = user,
         ) { placementRequest, _ ->
           webTestClient.post()
-            .uri("/cas1/placement-request/${placementRequest.id}/change-request")
+            .uri("/cas1/placement-request/${placementRequest.id}/appeal")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewChangeRequest(
@@ -99,7 +99,7 @@ class Cas1ChangeRequestTest {
           createdByUser = user,
         ) { placementRequest, _ ->
           webTestClient.post()
-            .uri("/cas1/placement-request/${placementRequest.id}/change-request")
+            .uri("/cas1/placement-request/${placementRequest.id}/planned-transfer")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewChangeRequest(
@@ -130,7 +130,7 @@ class Cas1ChangeRequestTest {
           createdByUser = user,
         ) { placementRequest, _ ->
           webTestClient.post()
-            .uri("/cas1/placement-request/${placementRequest.id}/change-request")
+            .uri("/cas1/placement-request/${placementRequest.id}/extension")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewChangeRequest(
@@ -162,7 +162,7 @@ class Cas1ChangeRequestTest {
           )
           val changeRequestReason = cas1ChangeRequestReasonEntityFactory.produceAndPersist()
           webTestClient.post()
-            .uri("/cas1/placement-request/${placementRequest.id}/change-request")
+            .uri("/cas1/placement-request/${placementRequest.id}/appeal")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewChangeRequest(
@@ -207,7 +207,7 @@ class Cas1ChangeRequestTest {
             withChangeRequestType(ChangeRequestType.PLANNED_TRANSFER)
           }
           webTestClient.post()
-            .uri("/cas1/placement-request/${placementRequest.id}/change-request")
+            .uri("/cas1/placement-request/${placementRequest.id}/planned-transfer")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewChangeRequest(


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2208

https://dsdmoj.atlassian.net/browse/APS-1916 implemented a single end point for creating change requests.

It has been decided to split this existing endpoint into three separate endpoints, each of which will deal with the creation of a specific change request i.e. planned transfer, appeal and extensions.

The existing POST for creation of a change request is:

POST /cas1/placement-requests/{id}/change-requests

This will become three separate endpoints:

```
POST /cas1/placement-requests/{id}/change-requests/planned-transfer
POST /cas1/placement-requests/{id}/change-requests/appeal
POST /cas1/placement-requests/{id}/change-requests/extension
```

**_Note: creating an extension change request currently throws BadRequest as per the requirements in [APS-1916](https://dsdmoj.atlassian.net/browse/APS-1916).  Validation logic for the creation of extensions will be defined in a new extension epic (https://dsdmoj.atlassian.net/browse/APS-2225)._**

See additional correspondence here: https://mojdt.slack.com/archives/C03K0HB0LBE/p1742910981819069 

[APS-1916]: https://dsdmoj.atlassian.net/browse/APS-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ