### PR TITLE
APS-2024 - Tidy up PLACEMENT_APPEAL_ASSESS permissions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -252,6 +252,9 @@ data class UserEntity(
 
   fun hasAllQualifications(requiredQualifications: List<UserQualification>) = requiredQualifications.all(::hasQualification)
   fun hasPermission(permission: UserPermission) = roles.any { it.role.hasPermission(permission) }
+  fun hasAtLeastOnePermission(vararg permissions: UserPermission) = roles.any { roleAssignment ->
+    permissions.any { permission -> roleAssignment.role.hasPermission(permission) }
+  }
 
   override fun toString() = "User $id"
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -124,7 +124,6 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_PLANNED_TRANSFER_CREATE,
       UserPermission.CAS1_PLACEMENT_APPEAL_ASSESS,
       UserPermission.CAS1_PLANNED_TRANSFER_ASSESS,
-      UserPermission.CAS1_SPACE_BOOKING_WITHDRAW,
     ),
   ),
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -472,7 +472,10 @@ class Cas1SpaceBookingService(
   fun getWithdrawableState(spaceBooking: Cas1SpaceBookingEntity, user: UserEntity): WithdrawableState = WithdrawableState(
     withdrawable = !spaceBooking.isCancelled() && !spaceBooking.hasArrival() && !spaceBooking.hasNonArrival(),
     withdrawn = spaceBooking.isCancelled(),
-    userMayDirectlyWithdraw = user.hasPermission(UserPermission.CAS1_SPACE_BOOKING_WITHDRAW),
+    userMayDirectlyWithdraw = user.hasAtLeastOnePermission(
+      UserPermission.CAS1_SPACE_BOOKING_WITHDRAW,
+      UserPermission.CAS1_PLACEMENT_APPEAL_ASSESS,
+    ),
     blockingReason = if (spaceBooking.hasArrival()) {
       BlockingReason.ArrivalRecordedInCas1
     } else if (spaceBooking.hasNonArrival()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -1640,10 +1640,10 @@ class Cas1SpaceBookingServiceTest {
     }
 
     @Test
-    fun `user without CAS1_SPACE_BOOKING_WITHDRAW permission cannot directly withdraw`() {
+    fun `user without CAS1_SPACE_BOOKING_WITHDRAW or CAS1_PLACEMENT_APPEAL_ASSESS permission cannot directly withdraw`() {
       val result = service.getWithdrawableState(
         Cas1SpaceBookingEntityFactory().produce(),
-        UserEntityFactory.mockUserWithoutPermission(UserPermission.CAS1_SPACE_BOOKING_WITHDRAW),
+        UserEntityFactory.mockUserWithoutPermission(UserPermission.CAS1_SPACE_BOOKING_WITHDRAW, UserPermission.CAS1_PLACEMENT_APPEAL_ASSESS),
       )
 
       assertThat(result.userMayDirectlyWithdraw).isEqualTo(false)
@@ -1654,6 +1654,16 @@ class Cas1SpaceBookingServiceTest {
       val result = service.getWithdrawableState(
         Cas1SpaceBookingEntityFactory().produce(),
         UserEntityFactory.mockUserWithPermission(UserPermission.CAS1_SPACE_BOOKING_WITHDRAW),
+      )
+
+      assertThat(result.userMayDirectlyWithdraw).isEqualTo(true)
+    }
+
+    @Test
+    fun `user with CAS1_PLACEMENT_APPEAL_ASSESS can directly withdraw`() {
+      val result = service.getWithdrawableState(
+        Cas1SpaceBookingEntityFactory().produce(),
+        UserEntityFactory.mockUserWithPermission(UserPermission.CAS1_PLACEMENT_APPEAL_ASSESS),
       )
 
       assertThat(result.userMayDirectlyWithdraw).isEqualTo(true)


### PR DESCRIPTION
Before this commit any user assessing a placement appeal also needed the `CAS1_SPACE_BOOKING_WITHDRAW` permission, alongside the `CAS1_PLACEMENT_APPEAL_ASSESS`. This commit modifies withdrawal permission checks to remove this requirement.