### PR TITLE
CAS-1592 surfaced omuEmailAddress

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -28,6 +28,7 @@ class ApplicationsTransformer(
 
   fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult): Cas2Application {
     val currentUser = jpa.currentPomUserId?.let { nomisUserService.getNomisUserById(jpa.currentPomUserId!!) }
+    val omu = jpa.currentPrisonCode?.let { offenderManagementUnitRepository.findByPrisonCode(it) }
     return Cas2Application(
       id = jpa.id,
       person = personTransformer.transformModelToPersonApi(personInfo),
@@ -45,9 +46,10 @@ class ApplicationsTransformer(
       timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
       allocatedPomName = currentUser?.name,
       allocatedPomEmailAddress = currentUser?.email,
-      currentPrisonName = jpa.currentPrisonCode?.let { offenderManagementUnitRepository.findByPrisonCode(it)?.prisonName ?: it },
+      currentPrisonName = omu?.prisonName ?: jpa.currentPrisonCode,
       isTransferredApplication = jpa.currentPrisonCode != jpa.referringPrisonCode,
       assignmentDate = jpa.currentAssignmentDate,
+      omuEmailAddress = omu?.email,
     )
   }
 

--- a/src/main/resources/static/cas2-schemas.yml
+++ b/src/main/resources/static/cas2-schemas.yml
@@ -66,6 +66,8 @@ components:
               type: string
             allocatedPomEmailAddress:
               type: string
+            omuEmailAddress:
+              type: string
             isTransferredApplication:
               type: boolean
             assignmentDate:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5042,6 +5042,8 @@ components:
               type: string
             allocatedPomEmailAddress:
               type: string
+            omuEmailAddress:
+              type: string
             isTransferredApplication:
               type: boolean
             assignmentDate:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -1259,7 +1259,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           givenAnOffender { offenderDetails, _ ->
             val prisonName = "PRISON"
             val prisonCode = "PRI"
-            val applicationEntity = setUpSubmittedApplicationWithTimeline(offenderDetails, userEntity, prisonName, prisonCode)
+            val omuEmail = "test@test.com"
+            val applicationEntity = setUpSubmittedApplicationWithTimeline(offenderDetails, userEntity, prisonName, prisonCode, omuEmail)
 
             val rawResponseBody = webTestClient.get()
               .uri("/cas2/applications/${applicationEntity.id}")
@@ -1282,6 +1283,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             assertThat(responseBody.assignmentDate).isEqualTo(applicationEntity.currentAssignmentDate)
             assertThat(responseBody.currentPrisonName).isEqualTo(prisonName)
             assertThat(responseBody.isTransferredApplication).isFalse()
+            assertThat(responseBody.omuEmailAddress).isEqualTo(omuEmail)
 
             assertThat(responseBody.timelineEvents!!.map { event -> event.label })
               .isEqualTo(listOf("Application submitted"))
@@ -1295,7 +1297,8 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           givenAnOffender { offenderDetails, _ ->
             val prisonName = "PRISON"
             val prisonCode = "PRI"
-            val applicationEntity = setUpSubmittedApplicationWithTimeline(offenderDetails, userEntity, prisonName, prisonCode)
+            val omuEmail = "test@test.com"
+            val applicationEntity = setUpSubmittedApplicationWithTimeline(offenderDetails, userEntity, prisonName, prisonCode, omuEmail)
 
             val omuNew = offenderManagementUnitEntityFactory.produceAndPersist {
               withEmail("test@test.com")
@@ -1326,6 +1329,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             assertThat(responseBody.assignmentDate).isEqualTo(applicationEntity.currentAssignmentDate)
             assertThat(responseBody.currentPrisonName).isEqualTo(omuNew.prisonName)
             assertThat(responseBody.isTransferredApplication).isTrue()
+            assertThat(responseBody.omuEmailAddress).isEqualTo(omuNew.email)
 
             assertThat(responseBody.timelineEvents!!.map { event -> event.label })
               .isEqualTo(listOf("Prison transfer from $prisonCode to ${omuNew.prisonCode}", "Application submitted"))
@@ -1773,7 +1777,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     return application
   }
 
-  private fun setUpSubmittedApplicationWithTimeline(offenderDetails: OffenderDetailSummary, userEntity: NomisUserEntity, prisonName: String, prisonCode: String): Cas2ApplicationEntity {
+  private fun setUpSubmittedApplicationWithTimeline(offenderDetails: OffenderDetailSummary, userEntity: NomisUserEntity, prisonName: String, prisonCode: String, omuEmail: String): Cas2ApplicationEntity {
     cas2ApplicationJsonSchemaRepository.deleteAll()
 
     val newestJsonSchema = cas2ApplicationJsonSchemaEntityFactory
@@ -1787,6 +1791,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     val omu = offenderManagementUnitEntityFactory.produceAndPersist {
       withPrisonName(prisonName)
       withPrisonCode(prisonCode)
+      withEmail(omuEmail)
     }
 
     val applicationEntity = cas2ApplicationEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/ApplicationsTransformerTest.kt
@@ -115,6 +115,7 @@ class ApplicationsTransformerTest {
         "assignmentDate",
         "currentPrisonName",
         "isTransferredApplication",
+        "omuEmailAddress",
       )
 
       assertThat(result.id).isEqualTo(application.id)
@@ -129,6 +130,7 @@ class ApplicationsTransformerTest {
       assertThat(result.assignmentDate).isNull()
       assertThat(result.currentPrisonName).isNull()
       assertThat(result.isTransferredApplication).isFalse()
+      assertThat(result.omuEmailAddress).isNull()
     }
 
     @Test
@@ -158,6 +160,7 @@ class ApplicationsTransformerTest {
       assertThat(result.assignmentDate).isEqualTo(application.currentAssignmentDate)
       assertThat(result.currentPrisonName).isEqualTo(prison.prisonName)
       assertThat(result.isTransferredApplication).isFalse()
+      assertThat(result.omuEmailAddress).isEqualTo(prison.email)
     }
 
     @Test
@@ -195,6 +198,7 @@ class ApplicationsTransformerTest {
       assertThat(result.assignmentDate).isEqualTo(application.currentAssignmentDate)
       assertThat(result.currentPrisonName).isEqualTo(prison.prisonName)
       assertThat(result.isTransferredApplication).isFalse()
+      assertThat(result.omuEmailAddress).isEqualTo(prison.email)
     }
 
     @Test
@@ -228,6 +232,7 @@ class ApplicationsTransformerTest {
       assertThat(result.assignmentDate).isEqualTo(application.currentAssignmentDate)
       assertThat(result.currentPrisonName).isEqualTo(newPrison.prisonName)
       assertThat(result.isTransferredApplication).isTrue()
+      assertThat(result.omuEmailAddress).isEqualTo(newPrison.email)
     }
   }
 


### PR DESCRIPTION
After discussion with @gregkhawkins  the only change the Backend is going to make is surface an additional field `omuEmailAddress`
which will always be populated with the offender management email address (from that big spreadsheet) and then the FE is going to do the relevant business logic to display it in the right way.