### PR TITLE
APS-2083 Update timeframes from 2 days to 5 days.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskDeadlineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TaskDeadlineService.kt
@@ -83,11 +83,11 @@ class TaskDeadlineService(
 
   companion object {
     private const val ASSESSMENT_STANDARD_TIMEFRAME_WORKDAYS = 10
-    private const val ASSESSMENT_SHORT_NOTICE_TIMEFRAME_WORKDAYS = 2
+    private const val ASSESSMENT_SHORT_NOTICE_TIMEFRAME_WORKDAYS = 5
     private const val ASSESSMENT_EMERGENCY_TIMEFRAME_HOURS = 2L
     private const val PLACEMENT_REQUEST_STANDARD_TIMEFRAME_WORKDAYS = 5
     private const val PLACEMENT_REQUEST_SHORT_NOTICE_TIMEFRAME_WORKDAYS = 2
-    private const val PLACEMENT_APPLICATION_TIMEFRAME_WORKDAYS = 2
+    private const val PLACEMENT_APPLICATION_TIMEFRAME_WORKDAYS = 5
 
     private val SAME_WORKING_DAY_DEADLINE_TIME: LocalTime = LocalTime.of(13, 0)
     private val WORKING_DAY_START_TIME: LocalTime = LocalTime.of(9, 0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskDeadlineServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskDeadlineServiceTest.kt
@@ -127,54 +127,54 @@ class TaskDeadlineServiceTest {
     @ParameterizedTest
     @CsvSource(
       // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
-      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T11:00:00Z,2023-01-04T09:00:00Z",
-      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T12:59:59Z,2023-01-04T09:00:00Z",
-      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T13:00:00Z,2023-01-04T09:00:00Z",
-      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T14:00:00Z,2023-01-04T09:00:00Z",
-      // Monday 11am. 2 working days later (Wednesday)
-      "2023-01-02T11:00:00Z,2023-01-04T11:00:00Z",
-      // Monday 12:59pm. 2 working days later (Wednesday)
-      "2023-01-02T12:59:59Z,2023-01-04T12:59:59Z",
-      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-01-02T13:00:00Z,2023-01-05T09:00:00Z",
-      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-01-02T14:00:00Z,2023-01-05T09:00:00Z",
-      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
-      "2023-01-05T14:00:00Z,2023-01-10T09:00:00Z",
-      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-06T14:00:00Z,2023-01-11T09:00:00Z",
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T11:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T12:59:59Z,2023-01-09T09:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T13:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T14:00:00Z,2023-01-09T09:00:00Z",
+      // Monday 11am. 5 working days later (following Monday)
+      "2023-01-02T11:00:00Z,2023-01-09T11:00:00Z",
+      // Monday 12:59pm. 5 working days later (following Monday)
+      "2023-01-02T12:59:59Z,2023-01-09T12:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-01-02T13:00:00Z,2023-01-10T09:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-01-02T14:00:00Z,2023-01-10T09:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so 9am following Friday
+      "2023-01-05T14:00:00Z,2023-01-13T09:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-06T14:00:00Z,2023-01-16T09:00:00Z",
 
       // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
-      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T10:00:00Z,2023-06-07T08:00:00Z",
-      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T11:59:59Z,2023-06-07T08:00:00Z",
-      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T12:00:00Z,2023-06-07T08:00:00Z",
-      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T13:00:00Z,2023-06-07T08:00:00Z",
-      // Monday 11am. 2 working days later (Wednesday)
-      "2023-06-05T10:00:00Z,2023-06-07T10:00:00Z",
-      // Monday 12:59pm. 2 working days later (Wednesday)
-      "2023-06-05T11:59:59Z,2023-06-07T11:59:59Z",
-      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-06-05T12:00:00Z,2023-06-08T08:00:00Z",
-      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-06-05T13:00:00Z,2023-06-08T08:00:00Z",
-      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
-      "2023-06-08T13:00:00Z,2023-06-13T08:00:00Z",
-      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-09T13:00:00Z,2023-06-14T08:00:00Z",
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T10:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T11:59:59Z,2023-06-12T08:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T12:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T13:00:00Z,2023-06-12T08:00:00Z",
+      // Monday 11am. 5 working days later (following Monday)
+      "2023-06-05T10:00:00Z,2023-06-12T10:00:00Z",
+      // Monday 12:59pm. 5 working days later (following Monday)
+      "2023-06-05T11:59:59Z,2023-06-12T11:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-06-05T12:00:00Z,2023-06-13T08:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-06-05T13:00:00Z,2023-06-13T08:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so 9am following Friday
+      "2023-06-08T13:00:00Z,2023-06-16T08:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-09T13:00:00Z,2023-06-19T08:00:00Z",
 
       // Timezone change between task start and deadline
-      // GMT -> BST: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-03-24T13:00:00Z,2023-03-29T08:00:00Z",
-      // BST -> GMT: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-10-27T12:00:00Z,2023-11-01T09:00:00Z",
+      // GMT -> BST: Friday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-03-24T13:00:00Z,2023-04-03T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-10-27T12:00:00Z,2023-11-06T09:00:00Z",
     )
     fun `getDeadline for a short notice assessment returns created date plus 2 working days, or 2 working days after 9am on the next working day if after 1pm or a non-working day`(
       createdAt: OffsetDateTime,
@@ -523,54 +523,54 @@ class TaskDeadlineServiceTest {
     @ParameterizedTest
     @CsvSource(
       // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
-      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T11:00:00Z,2023-01-04T09:00:00Z",
-      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T12:59:59Z,2023-01-04T09:00:00Z",
-      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T13:00:00Z,2023-01-04T09:00:00Z",
-      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T14:00:00Z,2023-01-04T09:00:00Z",
-      // Monday 11am. 2 working days later (Wednesday)
-      "2023-01-02T11:00:00Z,2023-01-04T11:00:00Z",
-      // Monday 12:59pm. 2 working days later (Wednesday)
-      "2023-01-02T12:59:59Z,2023-01-04T12:59:59Z",
-      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-01-02T13:00:00Z,2023-01-05T09:00:00Z",
-      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-01-02T14:00:00Z,2023-01-05T09:00:00Z",
-      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
-      "2023-01-05T14:00:00Z,2023-01-10T09:00:00Z",
-      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-06T14:00:00Z,2023-01-11T09:00:00Z",
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T11:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T12:59:59Z,2023-01-09T09:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T13:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T14:00:00Z,2023-01-09T09:00:00Z",
+      // Monday 11am. 5 working days later (following Monday)
+      "2023-01-02T11:00:00Z,2023-01-09T11:00:00Z",
+      // Monday 12:59pm. 5 working days later (following Monday)
+      "2023-01-02T12:59:59Z,2023-01-09T12:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-01-02T13:00:00Z,2023-01-10T09:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-01-02T14:00:00Z,2023-01-10T09:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so 9am following Friday
+      "2023-01-05T14:00:00Z,2023-01-13T09:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-06T14:00:00Z,2023-01-16T09:00:00Z",
 
       // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
-      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T10:00:00Z,2023-06-07T08:00:00Z",
-      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T11:59:59Z,2023-06-07T08:00:00Z",
-      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T12:00:00Z,2023-06-07T08:00:00Z",
-      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T13:00:00Z,2023-06-07T08:00:00Z",
-      // Monday 11am. 2 working days later (Wednesday)
-      "2023-06-05T10:00:00Z,2023-06-07T10:00:00Z",
-      // Monday 12:59pm. 2 working days later (Wednesday)
-      "2023-06-05T11:59:59Z,2023-06-07T11:59:59Z",
-      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-06-05T12:00:00Z,2023-06-08T08:00:00Z",
-      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-06-05T13:00:00Z,2023-06-08T08:00:00Z",
-      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
-      "2023-06-08T13:00:00Z,2023-06-13T08:00:00Z",
-      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-09T13:00:00Z,2023-06-14T08:00:00Z",
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T10:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T11:59:59Z,2023-06-12T08:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T12:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T13:00:00Z,2023-06-12T08:00:00Z",
+      // Monday 11am. 5 working days later (following Monday)
+      "2023-06-05T10:00:00Z,2023-06-12T10:00:00Z",
+      // Monday 12:59pm. 5 working days later (following Monday)
+      "2023-06-05T11:59:59Z,2023-06-12T11:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-06-05T12:00:00Z,2023-06-13T08:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-06-05T13:00:00Z,2023-06-13T08:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so 9am following Friday
+      "2023-06-08T13:00:00Z,2023-06-16T08:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-09T13:00:00Z,2023-06-19T08:00:00Z",
 
       // Timezone change between task start and deadline
-      // GMT -> BST: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-03-24T13:00:00Z,2023-03-29T08:00:00Z",
-      // BST -> GMT: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-10-27T12:00:00Z,2023-11-01T09:00:00Z",
+      // GMT -> BST: Friday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-03-24T13:00:00Z,2023-04-03T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-10-27T12:00:00Z,2023-11-06T09:00:00Z",
     )
     fun `getDeadline for a standard placement application returns submitted date plus 2 working days, or 2 working days after 9am on the next working day if after 1pm or a non-working day`(
       submittedAt: OffsetDateTime,
@@ -590,54 +590,54 @@ class TaskDeadlineServiceTest {
     @ParameterizedTest
     @CsvSource(
       // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
-      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T11:00:00Z,2023-01-04T09:00:00Z",
-      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T12:59:59Z,2023-01-04T09:00:00Z",
-      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T13:00:00Z,2023-01-04T09:00:00Z",
-      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T14:00:00Z,2023-01-04T09:00:00Z",
-      // Monday 11am. 2 working days later (Wednesday)
-      "2023-01-02T11:00:00Z,2023-01-04T11:00:00Z",
-      // Monday 12:59pm. 2 working days later (Wednesday)
-      "2023-01-02T12:59:59Z,2023-01-04T12:59:59Z",
-      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-01-02T13:00:00Z,2023-01-05T09:00:00Z",
-      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-01-02T14:00:00Z,2023-01-05T09:00:00Z",
-      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
-      "2023-01-05T14:00:00Z,2023-01-10T09:00:00Z",
-      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-06T14:00:00Z,2023-01-11T09:00:00Z",
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T11:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T12:59:59Z,2023-01-09T09:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T13:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T14:00:00Z,2023-01-09T09:00:00Z",
+      // Monday 11am. 5 working days later (following Monday)
+      "2023-01-02T11:00:00Z,2023-01-09T11:00:00Z",
+      // Monday 12:59pm. 5 working days later (following Monday)
+      "2023-01-02T12:59:59Z,2023-01-09T12:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-01-02T13:00:00Z,2023-01-10T09:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-01-02T14:00:00Z,2023-01-10T09:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so 9am following Friday
+      "2023-01-05T14:00:00Z,2023-01-13T09:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-06T14:00:00Z,2023-01-16T09:00:00Z",
 
       // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
-      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T10:00:00Z,2023-06-07T08:00:00Z",
-      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T11:59:59Z,2023-06-07T08:00:00Z",
-      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T12:00:00Z,2023-06-07T08:00:00Z",
-      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T13:00:00Z,2023-06-07T08:00:00Z",
-      // Monday 11am. 2 working days later (Wednesday)
-      "2023-06-05T10:00:00Z,2023-06-07T10:00:00Z",
-      // Monday 12:59pm. 2 working days later (Wednesday)
-      "2023-06-05T11:59:59Z,2023-06-07T11:59:59Z",
-      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-06-05T12:00:00Z,2023-06-08T08:00:00Z",
-      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-06-05T13:00:00Z,2023-06-08T08:00:00Z",
-      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
-      "2023-06-08T13:00:00Z,2023-06-13T08:00:00Z",
-      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-09T13:00:00Z,2023-06-14T08:00:00Z",
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T10:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T11:59:59Z,2023-06-12T08:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T12:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T13:00:00Z,2023-06-12T08:00:00Z",
+      // Monday 11am. 5 working days later (following Monday)
+      "2023-06-05T10:00:00Z,2023-06-12T10:00:00Z",
+      // Monday 12:59pm. 5 working days later (following Monday)
+      "2023-06-05T11:59:59Z,2023-06-12T11:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-06-05T12:00:00Z,2023-06-13T08:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-06-05T13:00:00Z,2023-06-13T08:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so 9am following Friday
+      "2023-06-08T13:00:00Z,2023-06-16T08:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-09T13:00:00Z,2023-06-19T08:00:00Z",
 
       // Timezone change between task start and deadline
-      // GMT -> BST: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-03-24T13:00:00Z,2023-03-29T08:00:00Z",
-      // BST -> GMT: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-10-27T12:00:00Z,2023-11-01T09:00:00Z",
+      // GMT -> BST: Friday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-03-24T13:00:00Z,2023-04-03T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-10-27T12:00:00Z,2023-11-06T09:00:00Z",
     )
     fun `getDeadline for a short notice placement application returns submitted date plus 2 working days, or 2 working days after 9am on the next working day if after 1pm or a non-working day`(
       submittedAt: OffsetDateTime,
@@ -657,54 +657,54 @@ class TaskDeadlineServiceTest {
     @ParameterizedTest
     @CsvSource(
       // Winter (GMT/UTC), i.e. noon local time is at 12:00Z
-      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T11:00:00Z,2023-01-04T09:00:00Z",
-      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T12:59:59Z,2023-01-04T09:00:00Z",
-      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T13:00:00Z,2023-01-04T09:00:00Z",
-      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-01T14:00:00Z,2023-01-04T09:00:00Z",
-      // Monday 11am. 2 working days later (Wednesday)
-      "2023-01-02T11:00:00Z,2023-01-04T11:00:00Z",
-      // Monday 12:59pm. 2 working days later (Wednesday)
-      "2023-01-02T12:59:59Z,2023-01-04T12:59:59Z",
-      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-01-02T13:00:00Z,2023-01-05T09:00:00Z",
-      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-01-02T14:00:00Z,2023-01-05T09:00:00Z",
-      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
-      "2023-01-05T14:00:00Z,2023-01-10T09:00:00Z",
-      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-01-06T14:00:00Z,2023-01-11T09:00:00Z",
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T11:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T12:59:59Z,2023-01-09T09:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T13:00:00Z,2023-01-09T09:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-01T14:00:00Z,2023-01-09T09:00:00Z",
+      // Monday 11am. 5 working days later (following Monday)
+      "2023-01-02T11:00:00Z,2023-01-09T11:00:00Z",
+      // Monday 12:59pm. 5 working days later (following Monday)
+      "2023-01-02T12:59:59Z,2023-01-09T12:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-01-02T13:00:00Z,2023-01-10T09:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-01-02T14:00:00Z,2023-01-10T09:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so 9am following Friday
+      "2023-01-05T14:00:00Z,2023-01-13T09:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-01-06T14:00:00Z,2023-01-16T09:00:00Z",
 
       // Summer (BST/UTC+1), i.e. noon local time is at 11:00Z
-      // Sunday 11am. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T10:00:00Z,2023-06-07T08:00:00Z",
-      // Sunday 12:59pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T11:59:59Z,2023-06-07T08:00:00Z",
-      // Sunday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T12:00:00Z,2023-06-07T08:00:00Z",
-      // Sunday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-04T13:00:00Z,2023-06-07T08:00:00Z",
-      // Monday 11am. 2 working days later (Wednesday)
-      "2023-06-05T10:00:00Z,2023-06-07T10:00:00Z",
-      // Monday 12:59pm. 2 working days later (Wednesday)
-      "2023-06-05T11:59:59Z,2023-06-07T11:59:59Z",
-      // Monday 1pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-06-05T12:00:00Z,2023-06-08T08:00:00Z",
-      // Monday 2pm. 2 working days after 9am on the next working day (Tuesday), so 9am Thursday
-      "2023-06-05T13:00:00Z,2023-06-08T08:00:00Z",
-      // Thursday 2pm. 2 working days after 9am on the next working day (Friday), so 9am Tuesday
-      "2023-06-08T13:00:00Z,2023-06-13T08:00:00Z",
-      // Friday 2pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-06-09T13:00:00Z,2023-06-14T08:00:00Z",
+      // Sunday 11am. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T10:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 12:59pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T11:59:59Z,2023-06-12T08:00:00Z",
+      // Sunday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T12:00:00Z,2023-06-12T08:00:00Z",
+      // Sunday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-04T13:00:00Z,2023-06-12T08:00:00Z",
+      // Monday 11am. 5 working days later (following Monday)
+      "2023-06-05T10:00:00Z,2023-06-12T10:00:00Z",
+      // Monday 12:59pm. 5 working days later (following Monday)
+      "2023-06-05T11:59:59Z,2023-06-12T11:59:59Z",
+      // Monday 1pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-06-05T12:00:00Z,2023-06-13T08:00:00Z",
+      // Monday 2pm. 5 working days after 9am on the next working day (Tuesday), so 9am following Tuesday
+      "2023-06-05T13:00:00Z,2023-06-13T08:00:00Z",
+      // Thursday 2pm. 5 working days after 9am on the next working day (Friday), so 9am following Friday
+      "2023-06-08T13:00:00Z,2023-06-16T08:00:00Z",
+      // Friday 2pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-06-09T13:00:00Z,2023-06-19T08:00:00Z",
 
       // Timezone change between task start and deadline
-      // GMT -> BST: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-03-24T13:00:00Z,2023-03-29T08:00:00Z",
-      // BST -> GMT: Friday 1pm. 2 working days after 9am on the next working day (Monday), so 9am Wednesday
-      "2023-10-27T12:00:00Z,2023-11-01T09:00:00Z",
+      // GMT -> BST: Friday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-03-24T13:00:00Z,2023-04-03T08:00:00Z",
+      // BST -> GMT: Friday 1pm. 5 working days after 9am on the next working day (Monday), so 9am following Monday
+      "2023-10-27T12:00:00Z,2023-11-06T09:00:00Z",
     )
     fun `getDeadline for an emergency placement application returns submitted date plus 2 working days, or 2 working days after 9am on the next working day if after 1pm or a non-working day`(
       submittedAt: OffsetDateTime,


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2083

**Background**

The timeliness expectations for assessments are within 10 working days of allocation to an assessor.  This includes up to 5 working days for an information request to be made to Probation Practitioners where additional information is required to make a decision on suitability. Assessments for emergency applications (those submitted for arrivals within 7 days) will be assigned to the CRU Manager.  Where applications are submitted by 1pm, these should be assessed within 2 hours.  If submitted after 1pm, they should be completed no later than 11am on the following working day.   Assessments for short notice applications (those submitted for arrival between 8 and 28 days) will also be assigned to the CRU Manager.  These should be completed within 5 working days of allocation.  The 'countdown' on assessors dashboard works as expected for all types except the short notice applications which currently shows 2 working days instead of 5.  Please could this be corrected.

**Design**

The setting `ASSESSMENT_SHORT_NOTICE_TIMEFRAME_WORKDAYS` in `TaskDeadlineService.kt `should be increased from 2 to 5.

Furthermore, update `PLACEMENT_APPLICATION_TIMEFRAME_WORKDAYS` to be 5 days 