### PR TITLE
APS-2231 - Add `CAS1_SPACE_BOOKING_ID` metadata name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -190,6 +190,7 @@ enum class MetaDataName {
   CAS1_REQUESTED_AP_TYPE,
   CAS1_PLACEMENT_REQUEST_ID,
   CAS1_CANCELLATION_ID,
+  CAS1_SPACE_BOOKING_ID,
 }
 
 enum class DomainEventCas {


### PR DESCRIPTION
This is to allow us to performance test moving space booking id from a dedicated column to metadata, enabling one-to-many relationships between domain events and space bookings, required for transfer domain events