### PR TITLE
APS-1363 - Remove unused ap_areas columns

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApAreaEntity.kt
@@ -29,10 +29,6 @@ data class ApAreaEntity(
   val id: UUID,
   val name: String,
   val identifier: String,
-  @Deprecated("We should resolve this from Cas1CruManagementAreaEntity")
-  val emailAddress: String?,
-  @Deprecated("We should resolve this from Cas1CruManagementAreaEntity")
-  val notifyReplyToEmailId: String?,
   /**
    * Used to determine a user's [Cas1CruManagementAreaEntity] if no override is specified
    *

--- a/src/main/resources/db/migration/all/20250425115307__remove_unused_ap_area_columnns.sql
+++ b/src/main/resources/db/migration/all/20250425115307__remove_unused_ap_area_columnns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ap_areas DROP COLUMN email_address;
+ALTER TABLE ap_areas DROP COLUMN notify_reply_to_email_id;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApAreaEntityFactory.kt
@@ -13,8 +13,6 @@ class ApAreaEntityFactory : Factory<ApAreaEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
   private var identifier: Yielded<String> = { randomStringUpperCase(10) }
-  private var emailAddress: Yielded<String?> = { randomStringUpperCase(10) }
-  private var notifyReplyToEmailId: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var defaultCruManagementArea: Yielded<Cas1CruManagementAreaEntity> = { Cas1CruManagementAreaEntityFactory().produce() }
 
   fun withId(id: UUID) = apply {
@@ -37,8 +35,6 @@ class ApAreaEntityFactory : Factory<ApAreaEntity> {
     id = this.id(),
     name = this.name(),
     identifier = this.identifier(),
-    emailAddress = this.emailAddress(),
-    notifyReplyToEmailId = this.notifyReplyToEmailId(),
     defaultCruManagementArea = this.defaultCruManagementArea(),
   )
 }


### PR DESCRIPTION
These have been moved to the `cas1_cru_management_areas` table