### PR TITLE
APS-2227 - Add transfer info to space booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -456,9 +456,16 @@ data class Cas1SpaceBookingEntity(
    * purposes
    */
   val deliusId: String?,
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "transferred_to", referencedColumnName = "id")
   var transferredTo: Cas1SpaceBookingEntity?,
+  @OneToOne(mappedBy = "transferredTo", fetch = FetchType.LAZY)
+  val transferredFrom: Cas1SpaceBookingEntity? = null,
+  /**
+   * If [transferredFrom] is not null, this indicates the type of transfer
+   */
+  @Enumerated(EnumType.STRING)
+  var transferType: TransferType? = null,
   @Version
   var version: Long = 1,
 ) {
@@ -514,4 +521,9 @@ data class Cas1SpaceBookingEntity(
 enum class ManagementInfoSource {
   DELIUS,
   LEGACY_CAS_1,
+}
+
+enum class TransferType {
+  PLANNED,
+  EMERGENCY,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository.Constants.MOVE_ON_CATEGORY_NOT_APPLICABLE_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TransferType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
@@ -131,6 +132,7 @@ class Cas1SpaceBookingService(
       expectedDepartureDate = departureDate,
       createdBy = createdBy,
       characteristics = characteristics,
+      transferType = null,
     )
 
     cas1ApplicationStatusService.spaceBookingMade(spaceBooking)
@@ -645,6 +647,7 @@ class Cas1SpaceBookingService(
       expectedDepartureDate = cas1NewEmergencyTransfer.departureDate,
       createdBy = user,
       characteristics = existingCas1SpaceBooking.criteria,
+      transferType = TransferType.EMERGENCY,
     )
 
     updateSpaceBookingForTransfer(existingCas1SpaceBooking, emergencyTransferSpaceBooking, cas1NewEmergencyTransfer.arrivalDate)
@@ -695,6 +698,7 @@ class Cas1SpaceBookingService(
       expectedDepartureDate = cas1NewPlannedTransfer.departureDate,
       createdBy = user,
       characteristics = getCharacteristicsEntity(cas1NewPlannedTransfer.characteristics),
+      transferType = TransferType.PLANNED,
     )
 
     updateSpaceBookingForTransfer(existingCas1SpaceBooking, plannedTransferSpaceBooking, cas1NewPlannedTransfer.arrivalDate)
@@ -837,6 +841,7 @@ class Cas1SpaceBookingService(
     expectedDepartureDate: LocalDate,
     createdBy: UserEntity,
     characteristics: List<CharacteristicEntity>,
+    transferType: TransferType?,
   ): Cas1SpaceBookingEntity = cas1SpaceBookingRepository.saveAndFlush(
     Cas1SpaceBookingEntity(
       id = UUID.randomUUID(),
@@ -872,6 +877,7 @@ class Cas1SpaceBookingService(
       deliusEventNumber = application.eventNumber,
       migratedManagementInfoFrom = null,
       transferredTo = null,
+      transferType = transferType,
       deliusId = null,
     ),
   )

--- a/src/main/resources/db/migration/all/20250425123534__add_transfer_info_to_space_booking.sql
+++ b/src/main/resources/db/migration/all/20250425123534__add_transfer_info_to_space_booking.sql
@@ -1,0 +1,2 @@
+CREATE INDEX cas1_space_bookings_transferred_to_idx ON cas1_space_bookings (transferred_to);
+ALTER TABLE cas1_space_bookings ADD transfer_type text NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TransferType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.Instant
@@ -55,6 +56,8 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
   private var migratedManagementInfoFrom: Yielded<ManagementInfoSource?> = { null }
   private var deliusEventNumber: Yielded<String?> = { null }
   private var transferredTo: Yielded<Cas1SpaceBookingEntity?> = { null }
+  private var transferredFrom: Yielded<Cas1SpaceBookingEntity?> = { null }
+  private var transferType: Yielded<TransferType?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -239,5 +242,7 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     migratedManagementInfoFrom = this.migratedManagementInfoFrom(),
     deliusId = null,
     transferredTo = this.transferredTo(),
+    transferredFrom = this.transferredFrom(),
+    transferType = this.transferType(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -60,6 +60,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository.Constants.MOVE_ON_CATEGORY_NOT_APPLICABLE_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TransferType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
@@ -2649,6 +2650,7 @@ class Cas1SpaceBookingServiceTest {
       assertThat(emergencyBooking.premises.id).isEqualTo(DESTINATION_PREMISES_ID)
       assertThat(emergencyBooking.expectedArrivalDate).isEqualTo(LocalDate.now())
       assertThat(emergencyBooking.expectedDepartureDate).isEqualTo(LocalDate.now().plusMonths(2))
+      assertThat(emergencyBooking.transferType).isEqualTo(TransferType.EMERGENCY)
 
       verify {
         cas1SpaceBookingManagementDomainEventService.emergencyTransferCreated(
@@ -2956,6 +2958,7 @@ class Cas1SpaceBookingServiceTest {
       assertThat(transferredBooking.premises.id).isEqualTo(DESTINATION_PREMISES_ID)
       assertThat(transferredBooking.expectedArrivalDate).isEqualTo(LocalDate.now().plusDays(2))
       assertThat(transferredBooking.expectedDepartureDate).isEqualTo(LocalDate.now().plusMonths(1))
+      assertThat(transferredBooking.transferType).isEqualTo(TransferType.PLANNED)
     }
   }
 


### PR DESCRIPTION
We need to record if a space booking is an emergency or planned transfer to know if emails should be triggered on arrivals. This commit captures that information.