### PR TITLE
APS-2057 - Use generic domain event envelope for CAS1 GET

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationAssessedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationAssessedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class ApplicationAssessedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationExpiredEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationExpiredEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class ApplicationExpiredEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationSubmittedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationSubmittedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class ApplicationSubmittedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationWithdrawnEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/ApplicationWithdrawnEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class ApplicationWithdrawnEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/AssessmentAllocatedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/AssessmentAllocatedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class AssessmentAllocatedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/AssessmentAppealedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/AssessmentAppealedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class AssessmentAppealedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingCancelledEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingCancelledEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class BookingCancelledEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingChangedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingChangedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class BookingChangedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingKeyWorkerAssignedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/BookingKeyWorkerAssignedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class BookingKeyWorkerAssignedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/Cas1DomainEventEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/Cas1DomainEventEnvelope.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
+
+import java.time.Instant
+import java.util.UUID
+
+data class Cas1DomainEventEnvelope<T : Cas1DomainEventPayload>(
+  val id: UUID,
+  val timestamp: Instant,
+  val eventType: EventType,
+  val eventDetails: T,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/EmergencyTransferCreatedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/EmergencyTransferCreatedEnvelope.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
 import java.time.Instant
 import java.util.UUID
 
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class EmergencyTransferCreatedEnvelope(
   override val id: UUID,
   override val timestamp: Instant,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/FurtherInformationRequestedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/FurtherInformationRequestedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class FurtherInformationRequestedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/MatchRequestWithdrawnEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/MatchRequestWithdrawnEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class MatchRequestWithdrawnEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonDepartedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonDepartedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class PersonDepartedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonNotArrivedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PersonNotArrivedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class PersonNotArrivedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementAppealAcceptedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementAppealAcceptedEnvelope.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.util.UUID
 
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class PlacementAppealAcceptedEnvelope(
   @Schema(required = true)
   @get:JsonProperty("id", required = true) override val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementAppealCreatedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementAppealCreatedEnvelope.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.util.UUID
 
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class PlacementAppealCreatedEnvelope(
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")
   @get:JsonProperty("id", required = true) override val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementAppealRejectedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementAppealRejectedEnvelope.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.util.UUID
 
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class PlacementAppealRejectedEnvelope(
   @Schema(required = true)
   @get:JsonProperty("id", required = true) override val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementApplicationAllocatedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementApplicationAllocatedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class PlacementApplicationAllocatedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementApplicationWithdrawnEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlacementApplicationWithdrawnEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class PlacementApplicationWithdrawnEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/RequestForPlacementAssessedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/RequestForPlacementAssessedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class RequestForPlacementAssessedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/RequestForPlacementCreatedEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/RequestForPlacementCreatedEnvelope.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param eventType
  * @param eventDetails
  */
+@Deprecated("The generic [Cas1DomainEventEnvelope] should be used instead of type-specific envelopes")
 data class RequestForPlacementCreatedEnvelope(
 
   @Schema(example = "364145f9-0af8-488e-9901-b4c46cd9ba37", required = true, description = "The UUID of an event")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1DomainEventsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1DomainEventsController.kt
@@ -10,24 +10,26 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmittedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAppealedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelledEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChangedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.FurtherInformationRequestedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.MatchRequestWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonDepartedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmitted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAllocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAppealed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelled
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChanged
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.FurtherInformationRequested
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.MatchRequestWithdrawn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrived
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonDeparted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrived
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Problem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
@@ -70,7 +72,7 @@ class Cas1DomainEventsController(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId")
     eventId: UUID,
-  ): ResponseEntity<ApplicationAssessedEnvelope> = getDomainEvent(eventId, domainEventService::getApplicationAssessedDomainEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<ApplicationAssessed>> = getDomainEvent(eventId, domainEventService::getApplicationAssessedDomainEvent)
 
   @Operation(
     summary = "An application-submitted event",
@@ -101,8 +103,8 @@ class Cas1DomainEventsController(
   fun eventsApplicationSubmittedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId")
-    eventId: java.util.UUID,
-  ): ResponseEntity<ApplicationSubmittedEnvelope> = getDomainEvent(eventId, domainEventService::getApplicationSubmittedDomainEvent)
+    eventId: UUID,
+  ): ResponseEntity<Cas1DomainEventEnvelope<ApplicationSubmitted>> = getDomainEvent(eventId, domainEventService::getApplicationSubmittedDomainEvent)
 
   @Operation(
     summary = "An application-withdrawn event",
@@ -133,7 +135,7 @@ class Cas1DomainEventsController(
   fun eventsApplicationWithdrawnEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<ApplicationWithdrawnEnvelope> = getDomainEvent(eventId, domainEventService::getApplicationWithdrawnEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<ApplicationWithdrawn>> = getDomainEvent(eventId, domainEventService::getApplicationWithdrawnEvent)
 
   @Operation(
     summary = "An assessment-allocated event",
@@ -164,7 +166,7 @@ class Cas1DomainEventsController(
   fun eventsAssessmentAllocatedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<AssessmentAllocatedEnvelope> = getDomainEvent(eventId, domainEventService::getAssessmentAllocatedEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<AssessmentAllocated>> = getDomainEvent(eventId, domainEventService::getAssessmentAllocatedEvent)
 
   @Operation(
     summary = "An 'assessment-appealed' event",
@@ -195,7 +197,7 @@ class Cas1DomainEventsController(
   fun eventsAssessmentAppealedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<AssessmentAppealedEnvelope> = getDomainEvent(eventId, domainEventService::getAssessmentAppealedEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<AssessmentAppealed>> = getDomainEvent(eventId, domainEventService::getAssessmentAppealedEvent)
 
   @Operation(
     summary = "A 'booking-cancelled' event",
@@ -226,7 +228,7 @@ class Cas1DomainEventsController(
   fun eventsBookingCancelledEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<BookingCancelledEnvelope> = getDomainEvent(eventId, domainEventService::getBookingCancelledEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<BookingCancelled>> = getDomainEvent(eventId, domainEventService::getBookingCancelledEvent)
 
   @Operation(
     summary = "A 'booking-changed' event",
@@ -257,7 +259,7 @@ class Cas1DomainEventsController(
   fun eventsBookingChangedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<BookingChangedEnvelope> = getDomainEvent(eventId, domainEventService::getBookingChangedEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<BookingChanged>> = getDomainEvent(eventId, domainEventService::getBookingChangedEvent)
 
   @Operation(
     summary = "A 'booking-made' event",
@@ -288,7 +290,7 @@ class Cas1DomainEventsController(
   fun eventsBookingMadeEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<BookingMadeEnvelope> = getDomainEvent(eventId, domainEventService::getBookingMadeEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<BookingMade>> = getDomainEvent(eventId, domainEventService::getBookingMadeEvent)
 
   @Operation(
     summary = "A 'booking-not-made' event",
@@ -319,7 +321,7 @@ class Cas1DomainEventsController(
   fun eventsBookingNotMadeEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<BookingNotMadeEnvelope> = getDomainEvent(eventId, domainEventService::getBookingNotMadeEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<BookingNotMade>> = getDomainEvent(eventId, domainEventService::getBookingNotMadeEvent)
 
   @Operation(
     summary = "A 'further-information-requested' event",
@@ -350,7 +352,7 @@ class Cas1DomainEventsController(
   fun eventsFurtherInformationRequestedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<FurtherInformationRequestedEnvelope> = getDomainEvent(eventId, domainEventService::getFurtherInformationRequestMadeEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<FurtherInformationRequested>> = getDomainEvent(eventId, domainEventService::getFurtherInformationRequestMadeEvent)
 
   @Operation(
     summary = "A 'match-request-withdrawn' event",
@@ -381,7 +383,7 @@ class Cas1DomainEventsController(
   fun eventsMatchRequestWithdrawnEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<MatchRequestWithdrawnEnvelope> = getDomainEvent(eventId, domainEventService::getMatchRequestWithdrawnEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<MatchRequestWithdrawn>> = getDomainEvent(eventId, domainEventService::getMatchRequestWithdrawnEvent)
 
   @Operation(
     summary = "A 'person-arrived' event",
@@ -412,7 +414,7 @@ class Cas1DomainEventsController(
   fun eventsPersonArrivedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<PersonArrivedEnvelope> = getDomainEvent(eventId, domainEventService::getPersonArrivedEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<PersonArrived>> = getDomainEvent(eventId, domainEventService::getPersonArrivedEvent)
 
   @Operation(
     summary = "A 'person-departed' event",
@@ -443,7 +445,7 @@ class Cas1DomainEventsController(
   fun eventsPersonDepartedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<PersonDepartedEnvelope> = getDomainEvent(eventId, domainEventService::getPersonDepartedEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<PersonDeparted>> = getDomainEvent(eventId, domainEventService::getPersonDepartedEvent)
 
   @Operation(
     summary = "A 'person-not-arrived' event",
@@ -474,7 +476,7 @@ class Cas1DomainEventsController(
   fun eventsPersonNotArrivedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<PersonNotArrivedEnvelope> = getDomainEvent(eventId, domainEventService::getPersonNotArrivedEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<PersonNotArrived>> = getDomainEvent(eventId, domainEventService::getPersonNotArrivedEvent)
 
   @Operation(
     summary = "A 'placement-application-allocated' event",
@@ -505,7 +507,7 @@ class Cas1DomainEventsController(
   fun eventsPlacementApplicationAllocatedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<PlacementApplicationAllocatedEnvelope> = getDomainEvent(eventId, domainEventService::getPlacementApplicationAllocatedEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<PlacementApplicationAllocated>> = getDomainEvent(eventId, domainEventService::getPlacementApplicationAllocatedEvent)
 
   @Operation(
     summary = "A 'placement-application-withdrawn' event",
@@ -536,7 +538,7 @@ class Cas1DomainEventsController(
   fun eventsPlacementApplicationWithdrawnEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<PlacementApplicationWithdrawnEnvelope> = getDomainEvent(eventId, domainEventService::getPlacementApplicationWithdrawnEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<PlacementApplicationWithdrawn>> = getDomainEvent(eventId, domainEventService::getPlacementApplicationWithdrawnEvent)
 
   @Operation(
     summary = "A 'request-for-placement-assessed' event",
@@ -567,10 +569,10 @@ class Cas1DomainEventsController(
   fun eventsRequestForPlacementAssessedEventIdGet(
     @Parameter(description = "UUID of the event", required = true)
     @PathVariable("eventId") eventId: UUID,
-  ): ResponseEntity<RequestForPlacementAssessedEnvelope> = getDomainEvent(eventId, domainEventService::getRequestForPlacementAssessedEvent)
+  ): ResponseEntity<Cas1DomainEventEnvelope<RequestForPlacementAssessed>> = getDomainEvent(eventId, domainEventService::getRequestForPlacementAssessedEvent)
 
-  private inline fun <reified T> getDomainEvent(eventId: UUID, serviceMethod: (id: UUID) -> GetCas1DomainEvent<T>?): ResponseEntity<T> {
+  private fun <T : Cas1DomainEventPayload> getDomainEvent(eventId: UUID, serviceMethod: (id: UUID) -> GetCas1DomainEvent<Cas1DomainEventEnvelope<T>>?): ResponseEntity<Cas1DomainEventEnvelope<T>> {
     val event = serviceMethod(eventId) ?: throw NotFoundProblem(eventId, "DomainEvent")
-    return ResponseEntity.ok(event.data) as ResponseEntity<T>
+    return ResponseEntity.ok(event.data) as ResponseEntity<Cas1DomainEventEnvelope<T>>
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -17,31 +17,31 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpiredEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmittedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAppealedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelledEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChangedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingKeyWorkerAssignedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelopeInterface
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EmergencyTransferCreatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.FurtherInformationRequestedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.MatchRequestWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonDepartedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealAcceptedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealCreatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejectedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreatedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmitted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAllocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAppealed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelled
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChanged
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingKeyWorkerAssigned
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EmergencyTransferCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.FurtherInformationRequested
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.MatchRequestWithdrawn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrived
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonDeparted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrived
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejected
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import java.time.OffsetDateTime
@@ -220,7 +220,8 @@ enum class DomainEventType(
     "An application has been submitted for an Approved Premises placement",
     cas1Info = Cas1DomainEventTypeInfo(
       timelineEventType = Cas1TimelineEventType.applicationSubmitted,
-      envelopeType = ApplicationSubmittedEnvelope::class,
+      payloadType = ApplicationSubmitted::class,
+      apiType = Cas1EventType.applicationSubmitted,
     ),
   ),
   APPROVED_PREMISES_APPLICATION_ASSESSED(
@@ -233,7 +234,8 @@ enum class DomainEventType(
         DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
         DomainEventSchemaVersion(2, "Added assessmentId field"),
       ),
-      envelopeType = ApplicationAssessedEnvelope::class,
+      payloadType = ApplicationAssessed::class,
+      apiType = Cas1EventType.applicationAssessed,
     ),
   ),
   APPROVED_PREMISES_APPLICATION_EXPIRED(
@@ -243,7 +245,8 @@ enum class DomainEventType(
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.applicationExpired,
       emittable = false,
-      envelopeType = ApplicationExpiredEnvelope::class,
+      payloadType = ApplicationExpired::class,
+      apiType = Cas1EventType.applicationExpired,
     ),
   ),
   APPROVED_PREMISES_BOOKING_MADE(
@@ -257,7 +260,8 @@ enum class DomainEventType(
         DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
         DomainEventSchemaVersion(2, "Added characteristics field"),
       ),
-      envelopeType = BookingMadeEnvelope::class,
+      payloadType = BookingMade::class,
+      apiType = Cas1EventType.bookingMade,
     ),
   ),
   APPROVED_PREMISES_PERSON_ARRIVED(
@@ -270,7 +274,8 @@ enum class DomainEventType(
         DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
         DomainEventSchemaVersion(2, "Added recordedBy field"),
       ),
-      envelopeType = PersonArrivedEnvelope::class,
+      payloadType = PersonArrived::class,
+      apiType = Cas1EventType.personArrived,
     ),
   ),
   APPROVED_PREMISES_PERSON_NOT_ARRIVED(
@@ -279,7 +284,8 @@ enum class DomainEventType(
     "Someone has failed to arrive at an Approved Premises for their Booking",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.personNotArrived,
-      envelopeType = PersonNotArrivedEnvelope::class,
+      payloadType = PersonNotArrived::class,
+      apiType = Cas1EventType.personNotArrived,
     ),
   ),
   APPROVED_PREMISES_PERSON_DEPARTED(
@@ -292,7 +298,8 @@ enum class DomainEventType(
         DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
         DomainEventSchemaVersion(2, "Added recordedBy field"),
       ),
-      envelopeType = PersonDepartedEnvelope::class,
+      payloadType = PersonDeparted::class,
+      apiType = Cas1EventType.personDeparted,
     ),
   ),
   APPROVED_PREMISES_BOOKING_NOT_MADE(
@@ -301,7 +308,8 @@ enum class DomainEventType(
     "It was not possible to create a Booking on this attempt",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.bookingNotMade,
-      envelopeType = BookingNotMadeEnvelope::class,
+      payloadType = BookingNotMade::class,
+      apiType = Cas1EventType.bookingNotMade,
     ),
   ),
   APPROVED_PREMISES_BOOKING_CANCELLED(
@@ -314,7 +322,8 @@ enum class DomainEventType(
         DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
         DomainEventSchemaVersion(2, "Added mandatory cancelledAtDate and cancellationRecordedAt fields"),
       ),
-      envelopeType = BookingCancelledEnvelope::class,
+      payloadType = BookingCancelled::class,
+      apiType = Cas1EventType.bookingCancelled,
     ),
   ),
   APPROVED_PREMISES_BOOKING_CHANGED(
@@ -327,7 +336,8 @@ enum class DomainEventType(
         DEFAULT_DOMAIN_EVENT_SCHEMA_VERSION,
         DomainEventSchemaVersion(2, "Captures previous set values, if changed."),
       ),
-      envelopeType = BookingChangedEnvelope::class,
+      payloadType = BookingChanged::class,
+      apiType = Cas1EventType.bookingChanged,
     ),
   ),
   APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED(
@@ -337,7 +347,8 @@ enum class DomainEventType(
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.bookingKeyworkerAssigned,
       emittable = false,
-      envelopeType = BookingKeyWorkerAssignedEnvelope::class,
+      payloadType = BookingKeyWorkerAssigned::class,
+      apiType = Cas1EventType.bookingKeyWorkerAssigned,
     ),
   ),
   APPROVED_PREMISES_APPLICATION_WITHDRAWN(
@@ -346,7 +357,8 @@ enum class DomainEventType(
     "An Approved Premises Application has been withdrawn",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.applicationWithdrawn,
-      envelopeType = ApplicationWithdrawnEnvelope::class,
+      payloadType = ApplicationWithdrawn::class,
+      apiType = Cas1EventType.bookingKeyWorkerAssigned,
     ),
   ),
   APPROVED_PREMISES_ASSESSMENT_APPEALED(
@@ -355,7 +367,8 @@ enum class DomainEventType(
     "An Approved Premises Assessment has been appealed",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.assessmentAppealed,
-      envelopeType = AssessmentAppealedEnvelope::class,
+      payloadType = AssessmentAppealed::class,
+      apiType = Cas1EventType.assessmentAppealed,
     ),
   ),
   APPROVED_PREMISES_ASSESSMENT_ALLOCATED(
@@ -364,7 +377,8 @@ enum class DomainEventType(
     "An Approved Premises Assessment has been allocated",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.assessmentAllocated,
-      envelopeType = AssessmentAllocatedEnvelope::class,
+      payloadType = AssessmentAllocated::class,
+      apiType = Cas1EventType.assessmentAllocated,
     ),
   ),
   APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED(
@@ -373,7 +387,8 @@ enum class DomainEventType(
     "An information request has been made for an Approved Premises Assessment",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.informationRequest,
-      envelopeType = FurtherInformationRequestedEnvelope::class,
+      payloadType = FurtherInformationRequested::class,
+      apiType = Cas1EventType.informationRequestMade,
     ),
   ),
   APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN(
@@ -382,7 +397,8 @@ enum class DomainEventType(
     "An Approved Premises Request for Placement has been withdrawn",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.applicationWithdrawn,
-      envelopeType = PlacementApplicationWithdrawnEnvelope::class,
+      payloadType = PlacementApplicationWithdrawn::class,
+      apiType = Cas1EventType.placementApplicationWithdrawn,
     ),
   ),
   APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED(
@@ -391,7 +407,8 @@ enum class DomainEventType(
     "An Approved Premises Request for Placement has been allocated",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.placementApplicationAllocated,
-      envelopeType = PlacementApplicationAllocatedEnvelope::class,
+      payloadType = PlacementApplicationAllocated::class,
+      apiType = Cas1EventType.placementApplicationAllocated,
     ),
   ),
   APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN(
@@ -400,7 +417,8 @@ enum class DomainEventType(
     "An Approved Premises Match Request has been withdrawn",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.matchRequestWithdrawn,
-      envelopeType = MatchRequestWithdrawnEnvelope::class,
+      payloadType = MatchRequestWithdrawn::class,
+      apiType = Cas1EventType.matchRequestWithdrawn,
     ),
   ),
   APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED(
@@ -410,7 +428,8 @@ enum class DomainEventType(
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.requestForPlacementCreated,
       emittable = false,
-      envelopeType = RequestForPlacementCreatedEnvelope::class,
+      payloadType = RequestForPlacementCreated::class,
+      apiType = Cas1EventType.requestForPlacementCreated,
     ),
   ),
   APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED(
@@ -419,7 +438,8 @@ enum class DomainEventType(
     "An request for placement has been assessed",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.requestForPlacementAssessed,
-      envelopeType = RequestForPlacementAssessedEnvelope::class,
+      payloadType = RequestForPlacementAssessed::class,
+      apiType = Cas1EventType.requestForPlacementAssessed,
     ),
   ),
   APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED(
@@ -428,7 +448,8 @@ enum class DomainEventType(
     "An emergency transfer has been created",
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.emergencyTransferCreated,
-      envelopeType = EmergencyTransferCreatedEnvelope::class,
+      payloadType = EmergencyTransferCreated::class,
+      apiType = Cas1EventType.emergencyTransferCreated,
       emittable = false,
     ),
   ),
@@ -439,7 +460,8 @@ enum class DomainEventType(
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.placementAppealCreated,
       emittable = false,
-      envelopeType = PlacementAppealCreatedEnvelope::class,
+      payloadType = PlacementAppealCreated::class,
+      apiType = Cas1EventType.placementAppealCreated,
     ),
   ),
   APPROVED_PREMISES_PLACEMENT_APPEAL_ACCEPTED(
@@ -449,7 +471,8 @@ enum class DomainEventType(
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.placementAppealAccepted,
       emittable = false,
-      envelopeType = PlacementAppealAcceptedEnvelope::class,
+      apiType = Cas1EventType.placementAppealAccepted,
+      payloadType = PlacementAppealAccepted::class,
     ),
   ),
   APPROVED_PREMISES_PLACEMENT_APPEAL_REJECTED(
@@ -459,7 +482,8 @@ enum class DomainEventType(
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.placementAppealRejected,
       emittable = false,
-      envelopeType = PlacementAppealRejectedEnvelope::class,
+      apiType = Cas1EventType.placementAppealRejected,
+      payloadType = PlacementAppealRejected::class,
     ),
   ),
   CAS2_APPLICATION_SUBMITTED(
@@ -536,5 +560,6 @@ data class Cas1DomainEventTypeInfo(
    * If this domain event can be considered to be emitted.
    */
   val emittable: Boolean = true,
-  val envelopeType: KClass<out Cas1DomainEventEnvelopeInterface<*>>,
+  val payloadType: KClass<out Cas1DomainEventPayload>,
+  val apiType: Cas1EventType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/DailyMetricsReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/generator/DailyMetricsReportGenerator.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmittedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmitted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.ApprovedPremisesApplicationMetricsSummaryDto
@@ -31,15 +31,15 @@ class DailyMetricsReportGenerator(
 
     val applicationsSubmittedToday = domainEventsToday.filter { domainEventEntity ->
       domainEventEntity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED
-    }.map { domainEventService.toDomainEvent(it, ApplicationSubmittedEnvelope::class) }
+    }.map { domainEventService.toDomainEvent(it, ApplicationSubmitted::class) }
 
     val assessmentsCompletedToday = domainEventsToday.filter { domainEventEntity ->
       domainEventEntity.type == DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED
-    }.map { domainEventService.toDomainEvent(it, ApplicationAssessedEnvelope::class) }
+    }.map { domainEventService.toDomainEvent(it, ApplicationAssessed::class) }
 
     val bookingsMadeToday = domainEventsToday.filter { domainEventEntity ->
       domainEventEntity.type == DomainEventType.APPROVED_PREMISES_BOOKING_MADE
-    }.map { domainEventService.toDomainEvent(it, BookingMadeEnvelope::class) }
+    }.map { domainEventService.toDomainEvent(it, BookingMade::class) }
 
     listOf(
       DailyMetricReportRow(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -4,7 +4,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import org.springframework.transaction.support.TransactionTemplate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
@@ -171,7 +172,7 @@ class Cas1BookingToSpaceBookingSeedJob(
     ?.toList()
     ?: emptyList()
 
-  private fun GetCas1DomainEvent<BookingMadeEnvelope>.getCreatedByUser(): UserEntity {
+  private fun GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingMade>>.getCreatedByUser(): UserEntity {
     val createdByUsernameUpper =
       data.eventDetails.bookedBy.staffMember!!.username?.uppercase()
         ?: error("Can't find created by username for booking ${data.eventDetails.bookingId}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
@@ -2,7 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelledEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelled
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.SpaceCharacteristic
@@ -273,7 +274,7 @@ class Cas1DomainEventDescriber(
     val event = domainEventService.getBookingCancelledEvent(domainEventSummary.id())
     val bookingId = event!!.data.eventDetails.bookingId
 
-    var bookingDetail: BookingCancellationDetail = if (domainEventSummary.cas1SpaceBookingId != null) {
+    val bookingDetail: BookingCancellationDetail = if (domainEventSummary.cas1SpaceBookingId != null) {
       getSpaceBookingCancellationDetailForEvent(bookingId, event)
     } else {
       getBookingCancellationDetailForEvent(bookingId, event)
@@ -486,7 +487,7 @@ class Cas1DomainEventDescriber(
   }
 
   @SuppressWarnings("TooGenericExceptionThrown")
-  private fun getSpaceBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<BookingCancelledEnvelope>): BookingCancellationDetail {
+  private fun getSpaceBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingCancelled>>): BookingCancellationDetail {
     val spaceBooking = cas1SpaceBookingRepository.findByIdOrNull(bookingId)
       ?: throw RuntimeException("Space Booking ID $bookingId with cancellation not found")
     if (spaceBooking.cancellationReason == null) {
@@ -501,7 +502,7 @@ class Cas1DomainEventDescriber(
   }
 
   @SuppressWarnings("TooGenericExceptionThrown")
-  private fun getBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<BookingCancelledEnvelope>): BookingCancellationDetail {
+  private fun getBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingCancelled>>): BookingCancellationDetail {
     val booking = bookingRepository.findByIdOrNull(bookingId)
       ?: throw RuntimeException("Booking ID $bookingId with cancellation not found")
     if (booking.cancellations.count() != 1) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -6,30 +6,55 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpiredEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmitted
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmittedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAllocated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAllocatedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAppealed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAppealedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelled
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelledEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChanged
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChangedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingKeyWorkerAssigned
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingKeyWorkerAssignedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelopeInterface
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EmergencyTransferCreated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EmergencyTransferCreatedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.FurtherInformationRequested
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.FurtherInformationRequestedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.MatchRequestWithdrawn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.MatchRequestWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrived
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrivedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonDeparted
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonDepartedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrived
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrivedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealAccepted
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealAcceptedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealCreated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealCreatedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejectedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocatedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawnEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
@@ -65,44 +90,44 @@ class Cas1DomainEventService(
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun getApplicationSubmittedDomainEvent(id: UUID) = get(id, ApplicationSubmittedEnvelope::class)
-  fun getApplicationAssessedDomainEvent(id: UUID) = get(id, ApplicationAssessedEnvelope::class)
-  fun getBookingMadeEvent(id: UUID) = get(id, BookingMadeEnvelope::class)
-  fun getEmergencyTransferCreatedEvent(id: UUID) = get(id, EmergencyTransferCreatedEnvelope::class)
-  fun getPersonArrivedEvent(id: UUID) = get(id, PersonArrivedEnvelope::class)
-  fun getPersonNotArrivedEvent(id: UUID) = get(id, PersonNotArrivedEnvelope::class)
-  fun getPersonDepartedEvent(id: UUID) = get(id, PersonDepartedEnvelope::class)
-  fun getBookingNotMadeEvent(id: UUID) = get(id, BookingNotMadeEnvelope::class)
-  fun getBookingCancelledEvent(id: UUID) = get(id, BookingCancelledEnvelope::class)
-  fun getBookingChangedEvent(id: UUID) = get(id, BookingChangedEnvelope::class)
-  fun getBookingKeyWorkerAssignedEvent(id: UUID) = get(id, BookingKeyWorkerAssignedEnvelope::class)
-  fun getApplicationWithdrawnEvent(id: UUID) = get(id, ApplicationWithdrawnEnvelope::class)
-  fun getApplicationExpiredEvent(id: UUID) = get(id, ApplicationExpiredEnvelope::class)
-  fun getPlacementAppealAcceptedEvent(id: UUID) = get(id, PlacementAppealAcceptedEnvelope::class)
-  fun getPlacementAppealCreatedEvent(id: UUID) = get(id, PlacementAppealCreatedEnvelope::class)
-  fun getPlacementAppealRejectedEvent(id: UUID) = get(id, PlacementAppealRejectedEnvelope::class)
-  fun getPlacementApplicationWithdrawnEvent(id: UUID) = get(id, PlacementApplicationWithdrawnEnvelope::class)
-  fun getPlacementApplicationAllocatedEvent(id: UUID) = get(id, PlacementApplicationAllocatedEnvelope::class)
-  fun getMatchRequestWithdrawnEvent(id: UUID) = get(id, MatchRequestWithdrawnEnvelope::class)
-  fun getAssessmentAppealedEvent(id: UUID) = get(id, AssessmentAppealedEnvelope::class)
-  fun getAssessmentAllocatedEvent(id: UUID) = get(id, AssessmentAllocatedEnvelope::class)
-  fun getRequestForPlacementCreatedEvent(id: UUID) = get(id, RequestForPlacementCreatedEnvelope::class)
-  fun getRequestForPlacementAssessedEvent(id: UUID) = get(id, RequestForPlacementAssessedEnvelope::class)
-  fun getFurtherInformationRequestMadeEvent(id: UUID) = get(id, FurtherInformationRequestedEnvelope::class)
+  fun getApplicationSubmittedDomainEvent(id: UUID) = get(id, ApplicationSubmitted::class)
+  fun getApplicationAssessedDomainEvent(id: UUID) = get(id, ApplicationAssessed::class)
+  fun getBookingMadeEvent(id: UUID) = get(id, BookingMade::class)
+  fun getEmergencyTransferCreatedEvent(id: UUID) = get(id, EmergencyTransferCreated::class)
+  fun getPersonArrivedEvent(id: UUID) = get(id, PersonArrived::class)
+  fun getPersonNotArrivedEvent(id: UUID) = get(id, PersonNotArrived::class)
+  fun getPersonDepartedEvent(id: UUID) = get(id, PersonDeparted::class)
+  fun getBookingNotMadeEvent(id: UUID) = get(id, BookingNotMade::class)
+  fun getBookingCancelledEvent(id: UUID) = get(id, BookingCancelled::class)
+  fun getBookingChangedEvent(id: UUID) = get(id, BookingChanged::class)
+  fun getBookingKeyWorkerAssignedEvent(id: UUID) = get(id, BookingKeyWorkerAssigned::class)
+  fun getApplicationWithdrawnEvent(id: UUID) = get(id, ApplicationWithdrawn::class)
+  fun getApplicationExpiredEvent(id: UUID) = get(id, ApplicationExpired::class)
+  fun getPlacementAppealAcceptedEvent(id: UUID) = get(id, PlacementAppealAccepted::class)
+  fun getPlacementAppealCreatedEvent(id: UUID) = get(id, PlacementAppealCreated::class)
+  fun getPlacementAppealRejectedEvent(id: UUID) = get(id, PlacementAppealRejected::class)
+  fun getPlacementApplicationWithdrawnEvent(id: UUID) = get(id, PlacementApplicationWithdrawn::class)
+  fun getPlacementApplicationAllocatedEvent(id: UUID) = get(id, PlacementApplicationAllocated::class)
+  fun getMatchRequestWithdrawnEvent(id: UUID) = get(id, MatchRequestWithdrawn::class)
+  fun getAssessmentAppealedEvent(id: UUID) = get(id, AssessmentAppealed::class)
+  fun getAssessmentAllocatedEvent(id: UUID) = get(id, AssessmentAllocated::class)
+  fun getRequestForPlacementCreatedEvent(id: UUID) = get(id, RequestForPlacementCreated::class)
+  fun getRequestForPlacementAssessedEvent(id: UUID) = get(id, RequestForPlacementAssessed::class)
+  fun getFurtherInformationRequestMadeEvent(id: UUID) = get(id, FurtherInformationRequested::class)
 
-  private fun <T : Cas1DomainEventEnvelopeInterface<*>> get(id: UUID, envelopeType: KClass<T>): GetCas1DomainEvent<T>? {
+  private fun <T : Cas1DomainEventPayload> get(id: UUID, payloadType: KClass<T>): GetCas1DomainEvent<Cas1DomainEventEnvelope<T>>? {
     val entity = domainEventRepository.findByIdOrNull(id) ?: return null
-    return toDomainEvent(entity, envelopeType)
+    return toDomainEvent(entity, payloadType)
   }
 
   @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
-  fun <T : Cas1DomainEventEnvelopeInterface<*>> toDomainEvent(entity: DomainEventEntity, envelopeType: KClass<T>): GetCas1DomainEvent<T> {
+  fun <T : Cas1DomainEventPayload> toDomainEvent(entity: DomainEventEntity, payloadType: KClass<T>): GetCas1DomainEvent<Cas1DomainEventEnvelope<T>> {
     checkNotNull(entity.applicationId) { "application id should not be null" }
 
-    if (entity.type.cas1Info!!.envelopeType != envelopeType) {
+    if (entity.type.cas1Info!!.payloadType != payloadType) {
       error(
-        "Entity with id ${entity.id} has type ${entity.type}, which contains data of type ${entity.type.cas1Info!!.envelopeType}. " +
-          "This is incompatible with the requested data type $envelopeType.",
+        "Entity with id ${entity.id} has type ${entity.type}, which contains data of type ${entity.type.cas1Info!!.payloadType}. " +
+          "This is incompatible with the requested payload type $payloadType.",
       )
     }
 
@@ -113,7 +138,13 @@ class Cas1DomainEventService(
       else -> entity.data
     }
 
-    val data = objectMapper.readValue(dataJson, envelopeType.java)
+    val data = objectMapper.readValue<Cas1DomainEventEnvelope<T>>(
+      dataJson,
+      objectMapper.typeFactory.constructParametricType(
+        Cas1DomainEventEnvelope::class.java,
+        payloadType.java,
+      ),
+    )
 
     return GetCas1DomainEvent(
       id = entity.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
@@ -11,31 +11,10 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AppealDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAppealedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelledEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChangedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingKeyWorkerAssignedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMadeEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.DatePeriod
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EmergencyTransferCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.FurtherInformationRequestedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.MatchRequestWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonDepartedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealAcceptedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealCreatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejectedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawnEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BookingChangedContentPayload
@@ -136,7 +115,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED)
 
     every { mockDomainEventService.getApplicationAssessedDomainEvent(any()) } returns buildDomainEvent {
-      ApplicationAssessedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.applicationAssessed,
@@ -158,7 +137,7 @@ class Cas1DomainEventDescriberTest {
     val departureDate = LocalDate.of(2024, 4, 1)
 
     every { mockDomainEventService.getBookingMadeEvent(any()) } returns buildDomainEvent {
-      BookingMadeEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingMade,
@@ -186,7 +165,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED)
 
     every { mockDomainEventService.getPersonArrivedEvent(any()) } returns buildDomainEvent {
-      PersonArrivedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.personArrived,
@@ -207,7 +186,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED)
 
     every { mockDomainEventService.getPersonNotArrivedEvent(any()) } returns buildDomainEvent {
-      PersonNotArrivedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.personNotArrived,
@@ -228,7 +207,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED)
 
     every { mockDomainEventService.getPersonDepartedEvent(any()) } returns buildDomainEvent {
-      PersonDepartedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.personDeparted,
@@ -249,7 +228,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE)
 
     every { mockDomainEventService.getBookingNotMadeEvent(any()) } returns buildDomainEvent {
-      BookingNotMadeEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingNotMade,
@@ -270,7 +249,7 @@ class Cas1DomainEventDescriberTest {
     val bookingNotMade = BookingNotMadeFactory().produce().copy(failureDescription = null)
 
     every { mockDomainEventService.getBookingNotMadeEvent(any()) } returns buildDomainEvent {
-      BookingNotMadeEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingNotMade,
@@ -288,7 +267,7 @@ class Cas1DomainEventDescriberTest {
     val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
 
     every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      BookingCancelledEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingCancelled,
@@ -311,7 +290,7 @@ class Cas1DomainEventDescriberTest {
     val bookingEntity = getBookingEntity()
 
     every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      BookingCancelledEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingCancelled,
@@ -342,7 +321,7 @@ class Cas1DomainEventDescriberTest {
     bookingEntity.cancellations += cancellation
 
     every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      BookingCancelledEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingCancelled,
@@ -379,7 +358,7 @@ class Cas1DomainEventDescriberTest {
     bookingEntity.cancellations += cancellation
 
     every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      BookingCancelledEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingCancelled,
@@ -413,7 +392,7 @@ class Cas1DomainEventDescriberTest {
     bookingEntity.cancellations += cancellation
 
     every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      BookingCancelledEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingCancelled,
@@ -458,7 +437,7 @@ class Cas1DomainEventDescriberTest {
     every { mockSpaceBookingRepository.findByIdOrNull(any()) } returns spaceBooking
 
     every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      BookingCancelledEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingCancelled,
@@ -486,7 +465,7 @@ class Cas1DomainEventDescriberTest {
     every { mockSpaceBookingRepository.findByIdOrNull(any()) } returns null
 
     every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      BookingCancelledEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingCancelled,
@@ -525,7 +504,7 @@ class Cas1DomainEventDescriberTest {
         .produce()
 
     every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      BookingCancelledEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingCancelled,
@@ -552,7 +531,7 @@ class Cas1DomainEventDescriberTest {
       val departureDate = LocalDate.of(2024, 4, 1)
 
       every { mockDomainEventService.getBookingChangedEvent(any()) } returns buildDomainEvent {
-        BookingChangedEnvelope(
+        Cas1DomainEventEnvelope(
           id = it,
           timestamp = Instant.now(),
           eventType = EventType.bookingChanged,
@@ -585,7 +564,7 @@ class Cas1DomainEventDescriberTest {
       every { mockDomainEventService.getBookingChangedEvent(any()) } returns buildDomainEvent(
         builder =
         {
-          BookingChangedEnvelope(
+          Cas1DomainEventEnvelope(
             id = it,
             timestamp = Instant.now(),
             eventType = EventType.bookingChanged,
@@ -632,7 +611,7 @@ class Cas1DomainEventDescriberTest {
       every { mockDomainEventService.getBookingChangedEvent(any()) } returns buildDomainEvent(
         builder =
         {
-          BookingChangedEnvelope(
+          Cas1DomainEventEnvelope(
             id = it,
             timestamp = Instant.now(),
             eventType = EventType.bookingChanged,
@@ -680,7 +659,7 @@ class Cas1DomainEventDescriberTest {
       every { mockDomainEventService.getBookingChangedEvent(any()) } returns buildDomainEvent(
         builder =
         {
-          BookingChangedEnvelope(
+          Cas1DomainEventEnvelope(
             id = it,
             timestamp = Instant.now(),
             eventType = EventType.bookingChanged,
@@ -727,7 +706,7 @@ class Cas1DomainEventDescriberTest {
       every { mockDomainEventService.getPlacementAppealAcceptedEvent(any()) } returns buildDomainEvent(
         builder =
         {
-          PlacementAppealAcceptedEnvelope(
+          Cas1DomainEventEnvelope(
             id = it,
             timestamp = Instant.now(),
             eventType = EventType.placementAppealAccepted,
@@ -768,7 +747,7 @@ class Cas1DomainEventDescriberTest {
       every { mockDomainEventService.getPlacementAppealCreatedEvent(any()) } returns buildDomainEvent(
         builder =
         {
-          PlacementAppealCreatedEnvelope(
+          Cas1DomainEventEnvelope(
             id = it,
             timestamp = Instant.now(),
             eventType = EventType.placementAppealCreated,
@@ -814,7 +793,7 @@ class Cas1DomainEventDescriberTest {
       every { mockDomainEventService.getPlacementAppealRejectedEvent(any()) } returns buildDomainEvent(
         builder =
         {
-          PlacementAppealRejectedEnvelope(
+          Cas1DomainEventEnvelope(
             id = it,
             timestamp = Instant.now(),
             eventType = EventType.placementAppealRejected,
@@ -857,7 +836,7 @@ class Cas1DomainEventDescriberTest {
       every { mockDomainEventService.getEmergencyTransferCreatedEvent(any()) } returns buildDomainEvent(
         builder =
         {
-          EmergencyTransferCreatedEnvelope(
+          Cas1DomainEventEnvelope(
             id = it,
             timestamp = Instant.now(),
             eventType = EventType.emergencyTransferCreated,
@@ -918,7 +897,7 @@ class Cas1DomainEventDescriberTest {
     val departureDate = LocalDate.of(2024, 4, 1)
 
     every { mockDomainEventService.getBookingKeyWorkerAssignedEvent(any()) } returns buildDomainEvent {
-      BookingKeyWorkerAssignedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingChanged,
@@ -948,7 +927,7 @@ class Cas1DomainEventDescriberTest {
     val departureDate = LocalDate.of(2024, 4, 1)
 
     every { mockDomainEventService.getBookingKeyWorkerAssignedEvent(any()) } returns buildDomainEvent {
-      BookingKeyWorkerAssignedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.bookingChanged,
@@ -976,7 +955,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN)
 
     every { mockDomainEventService.getApplicationWithdrawnEvent(any()) } returns buildDomainEvent {
-      ApplicationWithdrawnEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.applicationWithdrawn,
@@ -997,7 +976,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN)
 
     every { mockDomainEventService.getApplicationWithdrawnEvent(any()) } returns buildDomainEvent {
-      ApplicationWithdrawnEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.applicationWithdrawn,
@@ -1019,7 +998,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED)
 
     every { mockDomainEventService.getAssessmentAppealedEvent(any()) } returns buildDomainEvent {
-      AssessmentAppealedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.assessmentAppealed,
@@ -1052,7 +1031,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED)
 
     every { mockDomainEventService.getAssessmentAllocatedEvent(any()) } returns buildDomainEvent {
-      AssessmentAllocatedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.assessmentAllocated,
@@ -1088,7 +1067,7 @@ class Cas1DomainEventDescriberTest {
       DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN)
 
     every { mockDomainEventService.getPlacementApplicationWithdrawnEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      PlacementApplicationWithdrawnEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.placementApplicationWithdrawn,
@@ -1109,7 +1088,7 @@ class Cas1DomainEventDescriberTest {
       DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN)
 
     every { mockDomainEventService.getPlacementApplicationWithdrawnEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      PlacementApplicationWithdrawnEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.placementApplicationWithdrawn,
@@ -1138,7 +1117,7 @@ class Cas1DomainEventDescriberTest {
     val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN)
 
     every { mockDomainEventService.getMatchRequestWithdrawnEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      MatchRequestWithdrawnEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.matchRequestWithdrawn,
@@ -1168,7 +1147,7 @@ class Cas1DomainEventDescriberTest {
       DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED)
 
     every { mockDomainEventService.getRequestForPlacementCreatedEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      RequestForPlacementCreatedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.requestForPlacementCreated,
@@ -1194,7 +1173,7 @@ class Cas1DomainEventDescriberTest {
       DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED)
 
     every { mockDomainEventService.getRequestForPlacementCreatedEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      RequestForPlacementCreatedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.requestForPlacementCreated,
@@ -1222,7 +1201,7 @@ class Cas1DomainEventDescriberTest {
     val expectedTermUsed = if (decision == RequestForPlacementAssessed.Decision.rejected) "was" else "is"
 
     every { mockDomainEventService.getRequestForPlacementAssessedEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      RequestForPlacementAssessedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.requestForPlacementCreated,
@@ -1250,7 +1229,7 @@ class Cas1DomainEventDescriberTest {
     val expectedTermUsed = if (decision == RequestForPlacementAssessed.Decision.rejected) "was" else "is"
 
     every { mockDomainEventService.getRequestForPlacementAssessedEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      RequestForPlacementAssessedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.requestForPlacementCreated,
@@ -1288,7 +1267,7 @@ class Cas1DomainEventDescriberTest {
       DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED)
 
     every { mockDomainEventService.getPlacementApplicationAllocatedEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      PlacementApplicationAllocatedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.placementApplicationAllocated,
@@ -1332,7 +1311,7 @@ class Cas1DomainEventDescriberTest {
     val requestId = UUID.randomUUID()
 
     every { mockDomainEventService.getFurtherInformationRequestMadeEvent(UUID.fromString(domainEventSummary.id)) } returns buildDomainEvent {
-      FurtherInformationRequestedEnvelope(
+      Cas1DomainEventEnvelope(
         id = it,
         timestamp = Instant.now(),
         eventType = EventType.informationRequestMade,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -128,6 +128,27 @@ class Cas1DomainEventServiceTest {
   @Nested
   inner class GetDomainEvents {
 
+    @Test
+    fun `getDomainEvent returns error for payload mismatch`() {
+      val id = UUID.fromString("0adab8a6-14a6-4c41-a56e-7f0bb76d3d02")
+
+      every { domainEventRepositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
+        .withId(id)
+        .withData(domainEventsFactory.createEnvelopeLatestVersion(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED).persistedJson)
+        .produce()
+
+      assertThatThrownBy(
+        {
+          domainEventService.getPlacementAppealRejectedEvent(id)
+        },
+      ).hasMessage(
+        "Entity with id 0adab8a6-14a6-4c41-a56e-7f0bb76d3d02 has type APPROVED_PREMISES_APPLICATION_SUBMITTED, " +
+          "which contains data of type class uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmitted. " +
+          "This is incompatible with the requested payload type class " +
+          "uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejected.",
+      )
+    }
+
     @ParameterizedTest
     @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1DomainEventServiceTest#allCas1DomainEventTypes")
     fun `getDomainEvent returns null when event not found`(type: DomainEventType) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
@@ -3,31 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpiredEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmittedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.AssessmentAppealedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelledEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChangedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingKeyWorkerAssignedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingNotMadeEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EmergencyTransferCreatedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.FurtherInformationRequestedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.MatchRequestWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonDepartedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrivedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealAcceptedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealCreatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejectedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocatedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawnEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessedEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationExpiredFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationSubmittedFactory
@@ -86,159 +63,40 @@ class Cas1DomainEventsFactory(val objectMapper: ObjectMapper) {
     val id = UUID.randomUUID()
     val eventType = EventType.entries.find { it.value == type.typeName } ?: throw RuntimeException("Cannot find EventType for $type")
 
-    return when (type) {
-      DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> ApplicationSubmittedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = ApplicationSubmittedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> ApplicationAssessedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = ApplicationAssessedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> BookingMadeEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = BookingMadeFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> PersonArrivedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = PersonArrivedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> PersonNotArrivedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = PersonNotArrivedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> PersonDepartedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = PersonDepartedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> BookingNotMadeEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = BookingNotMadeFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> {
-        return BookingCancelledEnvelope(
-          id = id,
-          timestamp = occurredAt,
-          eventType = eventType,
-          eventDetails = BookingCancelledFactory()
-            .withCancellationRecordedAt(occurredAt)
-            .produce(),
-        )
-      }
-      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> BookingChangedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = BookingChangedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED -> BookingKeyWorkerAssignedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = BookingKeyWorkerAssignedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> ApplicationWithdrawnEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = ApplicationWithdrawnFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> AssessmentAppealedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = AssessmentAppealedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> AssessmentAllocatedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = AssessmentAllocatedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> PlacementApplicationWithdrawnEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = PlacementApplicationWithdrawnFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED -> PlacementApplicationAllocatedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = PlacementApplicationAllocatedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN -> MatchRequestWithdrawnEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = MatchRequestWithdrawnFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED -> RequestForPlacementCreatedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = RequestForPlacementCreatedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED -> RequestForPlacementAssessedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = RequestForPlacementAssessedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED -> FurtherInformationRequestedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = FurtherInformationRequestedFactory()
-          .withRequestId(requestId)
-          .produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED -> ApplicationExpiredEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = ApplicationExpiredFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_ACCEPTED -> PlacementAppealAcceptedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = PlacementAppealAcceptedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_CREATED -> PlacementAppealCreatedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = PlacementAppealCreatedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_REJECTED -> PlacementAppealRejectedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = PlacementAppealRejectedFactory().produce(),
-      )
-      DomainEventType.APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED -> EmergencyTransferCreatedEnvelope(
-        id = id,
-        timestamp = occurredAt,
-        eventType = eventType,
-        eventDetails = EmergencyTransferCreatedFactory().produce(),
-      )
+    val eventDetails = when (type) {
+      DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> ApplicationSubmittedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> ApplicationAssessedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> BookingMadeFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> PersonArrivedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> PersonNotArrivedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> PersonDepartedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> BookingNotMadeFactory().produce()
+      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> BookingCancelledFactory().withCancellationRecordedAt(occurredAt).produce()
+      DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED -> BookingChangedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED -> BookingKeyWorkerAssignedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> ApplicationWithdrawnFactory().produce()
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED -> AssessmentAppealedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED -> AssessmentAllocatedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN -> PlacementApplicationWithdrawnFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED -> PlacementApplicationAllocatedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN -> MatchRequestWithdrawnFactory().produce()
+      DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED -> RequestForPlacementCreatedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED -> RequestForPlacementAssessedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED -> FurtherInformationRequestedFactory().withRequestId(requestId).produce()
+      DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED -> ApplicationExpiredFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_ACCEPTED -> PlacementAppealAcceptedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_CREATED -> PlacementAppealCreatedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_REJECTED -> PlacementAppealRejectedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED -> EmergencyTransferCreatedFactory().produce()
       else -> throw RuntimeException("Domain event type $type not supported")
     }
+
+    return Cas1DomainEventEnvelope(
+      id = id,
+      timestamp = occurredAt,
+      eventType = eventType,
+      eventDetails = eventDetails,
+    )
   }
 
   fun removeEventDetails(json: String, fields: List<String>): String {


### PR DESCRIPTION
We currently define an envelope type for each individual domain event, despite the envelope always containing the same 4 fields (as defined by the `Cas1DomainEventEnvelopeInterface`). This was previously required when defining domain event schema in YML to differentiate between the different types.

This commit introduces a generic envelope (`Cas1DomainEventEnvelope`) that can be used for all domain events, removing the need to add individual envelope types. It updates all GET requests to use this generic envelope, and deprecates all bespoke envelopes.

Subsequent commits will use the envelope when persisting domain events, which should unlock removing some additional duplication of logic when building the envelope. Because this will be quite a bit of effort, this change will be made over time.

Swagger ui generates types 'on the fly' for the new generic envelope e.g.

![Screenshot 2025-04-29 at 11 55 47](https://github.com/user-attachments/assets/68bf59a2-63b0-4a19-90c7-4ab20a6f4d36)

I've tested domain events against delius in the test environment and all continue to work and are readable by probation-integration

app submitted DONE
app assessed DONE
app withdrawn DONE
booking made DONE
booking changed DONE
booking cancelled DONE
not arrived DONE
arrived DONE
departed DONE