### PR TITLE
APS-2057 - Stop using common class to get/save domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -19,8 +19,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1DeliusBookingImportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
 import java.util.UUID
 
 @Component
@@ -171,10 +171,10 @@ class Cas1BookingToSpaceBookingSeedJob(
     ?.toList()
     ?: emptyList()
 
-  private fun Cas1DomainEvent<BookingMadeEnvelope>.getCreatedByUser(): UserEntity {
+  private fun GetCas1DomainEvent<BookingMadeEnvelope>.getCreatedByUser(): UserEntity {
     val createdByUsernameUpper =
       data.eventDetails.bookedBy.staffMember!!.username?.uppercase()
-        ?: error("Can't find created by username for booking $bookingId")
+        ?: error("Can't find created by username for booking ${data.eventDetails.bookingId}")
     return userRepository.findByDeliusUsername(createdByUsernameUpper) ?: error("Can't find user with username $createdByUsernameUpper")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AppealDomainEventService.kt
@@ -32,7 +32,7 @@ class Cas1AppealDomainEventService(
     }
 
     domainEventService.saveAssessmentAppealedEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = id,
         applicationId = appeal.application.id,
         assessmentId = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -85,7 +85,7 @@ class Cas1ApplicationDomainEventService(
     }
 
     domainEventService.saveApplicationSubmittedDomainEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
@@ -121,7 +121,7 @@ class Cas1ApplicationDomainEventService(
     val eventOccurredAt = Instant.now(clock)
 
     domainEventService.saveApplicationWithdrawnEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -64,7 +64,7 @@ class Cas1AssessmentDomainEventService(
     val occurredAt = Instant.now()
 
     domainEventService.saveAssessmentAllocatedEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = id,
         applicationId = assessment.application.id,
         assessmentId = assessment.id,
@@ -130,7 +130,7 @@ class Cas1AssessmentDomainEventService(
       ),
     )
 
-    val domainEvent = Cas1DomainEvent(
+    val domainEvent = SaveCas1DomainEvent(
       id = id,
       applicationId = assessment.application.id,
       assessmentId = assessment.id,
@@ -160,7 +160,7 @@ class Cas1AssessmentDomainEventService(
     }
 
     domainEventService.saveApplicationAssessedDomainEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         assessmentId = assessment.id,
@@ -220,7 +220,7 @@ class Cas1AssessmentDomainEventService(
     }
 
     domainEventService.saveApplicationAssessedDomainEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         assessmentId = assessment.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -104,7 +104,7 @@ class Cas1BookingDomainEventService(
     val staffDetails = getStaffDetails(user.deliusUsername)
 
     domainEventService.saveBookingNotMadeEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
@@ -213,7 +213,7 @@ class Cas1BookingDomainEventService(
     val approvedPremises = bookingChangedInfo.approvedPremises
 
     domainEventService.saveBookingChangedEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
         crn = crn,
@@ -328,7 +328,7 @@ class Cas1BookingDomainEventService(
     val isSpaceBooking = bookingInfo.isSpaceBooking
 
     domainEventService.saveBookingMadeDomainEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
         crn = crn,
@@ -413,7 +413,7 @@ class Cas1BookingDomainEventService(
     val eventNumber = cancellationInfo.applicationFacade.eventNumber!!
 
     domainEventService.saveBookingCancelledEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
         crn = crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementDomainEventService.kt
@@ -73,7 +73,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val actualArrivalDateTime = arrivalInfo.actualArrivalDate.atTime(arrivalInfo.actualArrivalTime).toInstant()
 
     domainEventService.savePersonArrivedEvent(
-      domainEvent = Cas1DomainEvent(
+      domainEvent = SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
         crn = updatedCas1SpaceBooking.crn,
@@ -123,7 +123,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val eventNumber = updatedCas1SpaceBooking.deliusEventNumber!!
 
     domainEventService.savePersonNotArrivedEvent(
-      domainEvent = Cas1DomainEvent(
+      domainEvent = SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
         crn = updatedCas1SpaceBooking.crn,
@@ -181,7 +181,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val actualDepartureDateTime = departureInfo.actualDepartureDate.atTime(departureInfo.actualDepartureTime).toInstant()
 
     domainEventService.savePersonDepartedEvent(
-      domainEvent = Cas1DomainEvent(
+      domainEvent = SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
         crn = departedCas1SpaceBooking.crn,
@@ -236,7 +236,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val eventNumber = updatedCas1SpaceBooking.deliusEventNumber!!
 
     domainEventService.saveKeyWorkerAssignedEvent(
-      domainEvent = Cas1DomainEvent(
+      domainEvent = SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
         crn = updatedCas1SpaceBooking.crn,
@@ -282,7 +282,7 @@ class Cas1SpaceBookingManagementDomainEventService(
     val offenderDetails = getOffenderForCrn(crn)
 
     domainEventService.saveEmergencyTransferCreatedEvent(
-      domainEvent = Cas1DomainEvent(
+      domainEvent = SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestDomainEventService.kt
@@ -31,7 +31,7 @@ class Cas1ChangeRequestDomainEventService(
     val spaceBooking = changeRequest.spaceBooking
 
     cas1DomainEventService.savePlacementAppealAccepted(
-      domainEvent = Cas1DomainEvent(
+      domainEvent = SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = changeRequest.placementRequest.application.id,
         crn = changeRequest.placementRequest.application.crn,
@@ -66,7 +66,7 @@ class Cas1ChangeRequestDomainEventService(
     val reason = changeRequest.requestReason
 
     cas1DomainEventService.savePlacementAppealCreated(
-      domainEvent = Cas1DomainEvent(
+      domainEvent = SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = changeRequest.placementRequest.application.id,
         crn = changeRequest.placementRequest.application.crn,
@@ -105,7 +105,7 @@ class Cas1ChangeRequestDomainEventService(
     val reason = changeRequest.rejectionReason!!
 
     cas1DomainEventService.savePlacementAppealRejected(
-      domainEvent = Cas1DomainEvent(
+      domainEvent = SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = changeRequest.placementRequest.application.id,
         crn = changeRequest.placementRequest.application.crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
@@ -486,7 +486,7 @@ class Cas1DomainEventDescriber(
   }
 
   @SuppressWarnings("TooGenericExceptionThrown")
-  private fun getSpaceBookingCancellationDetailForEvent(bookingId: UUID, event: Cas1DomainEvent<BookingCancelledEnvelope>): BookingCancellationDetail {
+  private fun getSpaceBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<BookingCancelledEnvelope>): BookingCancellationDetail {
     val spaceBooking = cas1SpaceBookingRepository.findByIdOrNull(bookingId)
       ?: throw RuntimeException("Space Booking ID $bookingId with cancellation not found")
     if (spaceBooking.cancellationReason == null) {
@@ -501,7 +501,7 @@ class Cas1DomainEventDescriber(
   }
 
   @SuppressWarnings("TooGenericExceptionThrown")
-  private fun getBookingCancellationDetailForEvent(bookingId: UUID, event: Cas1DomainEvent<BookingCancelledEnvelope>): BookingCancellationDetail {
+  private fun getBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<BookingCancelledEnvelope>): BookingCancellationDetail {
     val booking = bookingRepository.findByIdOrNull(bookingId)
       ?: throw RuntimeException("Booking ID $bookingId with cancellation not found")
     if (booking.cancellations.count() != 1) {
@@ -525,8 +525,8 @@ class Cas1DomainEventDescriber(
   }
 
   private fun DomainEventSummary.id(): UUID = UUID.fromString(this.id)
-  private fun <T> Cas1DomainEvent<T>?.describe(describe: (T) -> String?): String? = this?.let { describe(it.data) }
-  private fun <T> Cas1DomainEvent<T>?.toPayload(toPayload: (T) -> Cas1TimelineEventContentPayload): Cas1TimelineEventContentPayload? = this?.let { toPayload(it.data) }
+  private fun <T> GetCas1DomainEvent<T>?.describe(describe: (T) -> String?): String? = this?.let { describe(it.data) }
+  private fun <T> GetCas1DomainEvent<T>?.toPayload(toPayload: (T) -> Cas1TimelineEventContentPayload): Cas1TimelineEventContentPayload? = this?.let { toPayload(it.data) }
   private val StaffMember.name: String
     get() = "${this.forenames} ${this.surname}".trim()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -123,145 +123,145 @@ class Cas1DomainEventService(
   }
 
   @Transactional
-  fun saveApplicationSubmittedDomainEvent(domainEvent: Cas1DomainEvent<ApplicationSubmittedEnvelope>) = saveAndEmit(
+  fun saveApplicationSubmittedDomainEvent(domainEvent: SaveCas1DomainEvent<ApplicationSubmittedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
   )
 
   @Transactional
-  fun saveApplicationAssessedDomainEvent(domainEvent: Cas1DomainEvent<ApplicationAssessedEnvelope>) = saveAndEmit(
+  fun saveApplicationAssessedDomainEvent(domainEvent: SaveCas1DomainEvent<ApplicationAssessedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
   )
 
   @Transactional
-  fun saveBookingMadeDomainEvent(domainEvent: Cas1DomainEvent<BookingMadeEnvelope>) = saveAndEmit(
+  fun saveBookingMadeDomainEvent(domainEvent: SaveCas1DomainEvent<BookingMadeEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
   )
 
   @Transactional
-  fun saveEmergencyTransferCreatedEvent(domainEvent: Cas1DomainEvent<EmergencyTransferCreatedEnvelope>) = saveAndEmit(
+  fun saveEmergencyTransferCreatedEvent(domainEvent: SaveCas1DomainEvent<EmergencyTransferCreatedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED,
   )
 
   @Transactional
-  fun savePersonArrivedEvent(domainEvent: Cas1DomainEvent<PersonArrivedEnvelope>) = saveAndEmit(
+  fun savePersonArrivedEvent(domainEvent: SaveCas1DomainEvent<PersonArrivedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
   )
 
   @Transactional
-  fun savePersonNotArrivedEvent(domainEvent: Cas1DomainEvent<PersonNotArrivedEnvelope>) = saveAndEmit(
+  fun savePersonNotArrivedEvent(domainEvent: SaveCas1DomainEvent<PersonNotArrivedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
   )
 
   @Transactional
-  fun savePersonDepartedEvent(domainEvent: Cas1DomainEvent<PersonDepartedEnvelope>) = saveAndEmit(
+  fun savePersonDepartedEvent(domainEvent: SaveCas1DomainEvent<PersonDepartedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
   )
 
   @Transactional
-  fun saveBookingNotMadeEvent(domainEvent: Cas1DomainEvent<BookingNotMadeEnvelope>) = saveAndEmit(
+  fun saveBookingNotMadeEvent(domainEvent: SaveCas1DomainEvent<BookingNotMadeEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE,
   )
 
   @Transactional
-  fun saveBookingCancelledEvent(domainEvent: Cas1DomainEvent<BookingCancelledEnvelope>) = saveAndEmit(
+  fun saveBookingCancelledEvent(domainEvent: SaveCas1DomainEvent<BookingCancelledEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
   )
 
   @Transactional
-  fun saveBookingChangedEvent(domainEvent: Cas1DomainEvent<BookingChangedEnvelope>) = saveAndEmit(
+  fun saveBookingChangedEvent(domainEvent: SaveCas1DomainEvent<BookingChangedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
   )
 
   @Transactional
-  fun saveApplicationWithdrawnEvent(domainEvent: Cas1DomainEvent<ApplicationWithdrawnEnvelope>) = saveAndEmit(
+  fun saveApplicationWithdrawnEvent(domainEvent: SaveCas1DomainEvent<ApplicationWithdrawnEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
   )
 
   @Transactional
-  fun saveAssessmentAppealedEvent(domainEvent: Cas1DomainEvent<AssessmentAppealedEnvelope>) = saveAndEmit(
+  fun saveAssessmentAppealedEvent(domainEvent: SaveCas1DomainEvent<AssessmentAppealedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED,
   )
 
   @Transactional
-  fun savePlacementAppealAccepted(domainEvent: Cas1DomainEvent<PlacementAppealAcceptedEnvelope>) = saveAndEmit(
+  fun savePlacementAppealAccepted(domainEvent: SaveCas1DomainEvent<PlacementAppealAcceptedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_ACCEPTED,
   )
 
   @Transactional
-  fun savePlacementAppealCreated(domainEvent: Cas1DomainEvent<PlacementAppealCreatedEnvelope>) = saveAndEmit(
+  fun savePlacementAppealCreated(domainEvent: SaveCas1DomainEvent<PlacementAppealCreatedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_CREATED,
   )
 
   @Transactional
-  fun savePlacementAppealRejected(domainEvent: Cas1DomainEvent<PlacementAppealRejectedEnvelope>) = saveAndEmit(
+  fun savePlacementAppealRejected(domainEvent: SaveCas1DomainEvent<PlacementAppealRejectedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_REJECTED,
   )
 
   @Transactional
-  fun savePlacementApplicationWithdrawnEvent(domainEvent: Cas1DomainEvent<PlacementApplicationWithdrawnEnvelope>) = saveAndEmit(
+  fun savePlacementApplicationWithdrawnEvent(domainEvent: SaveCas1DomainEvent<PlacementApplicationWithdrawnEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
   )
 
   @Transactional
-  fun savePlacementApplicationAllocatedEvent(domainEvent: Cas1DomainEvent<PlacementApplicationAllocatedEnvelope>) = saveAndEmit(
+  fun savePlacementApplicationAllocatedEvent(domainEvent: SaveCas1DomainEvent<PlacementApplicationAllocatedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED,
   )
 
   @Transactional
-  fun saveMatchRequestWithdrawnEvent(domainEvent: Cas1DomainEvent<MatchRequestWithdrawnEnvelope>) = saveAndEmit(
+  fun saveMatchRequestWithdrawnEvent(domainEvent: SaveCas1DomainEvent<MatchRequestWithdrawnEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
   )
 
   @Transactional
-  fun saveRequestForPlacementCreatedEvent(domainEvent: Cas1DomainEvent<RequestForPlacementCreatedEnvelope>) = saveAndEmit(
+  fun saveRequestForPlacementCreatedEvent(domainEvent: SaveCas1DomainEvent<RequestForPlacementCreatedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
   )
 
   @Transactional
-  fun saveRequestForPlacementAssessedEvent(domainEvent: Cas1DomainEvent<RequestForPlacementAssessedEnvelope>) = saveAndEmit(
+  fun saveRequestForPlacementAssessedEvent(domainEvent: SaveCas1DomainEvent<RequestForPlacementAssessedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED,
   )
 
   @Transactional
-  fun saveApplicationExpiredEvent(domainEvent: Cas1DomainEvent<ApplicationExpiredEnvelope>) = saveAndEmit(
+  fun saveApplicationExpiredEvent(domainEvent: SaveCas1DomainEvent<ApplicationExpiredEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED,
   )
 
   @Transactional
-  fun saveAssessmentAllocatedEvent(domainEvent: Cas1DomainEvent<AssessmentAllocatedEnvelope>) = saveAndEmit(
+  fun saveAssessmentAllocatedEvent(domainEvent: SaveCas1DomainEvent<AssessmentAllocatedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
   )
 
   @Transactional
-  fun saveFurtherInformationRequestedEvent(domainEvent: Cas1DomainEvent<FurtherInformationRequestedEnvelope>) = saveAndEmit(
+  fun saveFurtherInformationRequestedEvent(domainEvent: SaveCas1DomainEvent<FurtherInformationRequestedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
   )
 
   @Transactional
-  fun saveKeyWorkerAssignedEvent(domainEvent: Cas1DomainEvent<BookingKeyWorkerAssignedEnvelope>) = saveAndEmit(
+  fun saveKeyWorkerAssignedEvent(domainEvent: SaveCas1DomainEvent<BookingKeyWorkerAssignedEnvelope>) = saveAndEmit(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED,
   )
@@ -274,7 +274,7 @@ class Cas1DomainEventService(
 
   @Transactional
   fun saveAndEmit(
-    domainEvent: Cas1DomainEvent<*>,
+    domainEvent: SaveCas1DomainEvent<*>,
     eventType: DomainEventType,
   ) {
     val domainEventEntity = domainEventRepository.save(
@@ -364,7 +364,7 @@ data class GetCas1DomainEvent<T>(
   val schemaVersion: Int? = null,
 )
 
-data class Cas1DomainEvent<T>(
+data class SaveCas1DomainEvent<T>(
   val id: UUID,
   val applicationId: UUID? = null,
   val assessmentId: UUID? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -90,13 +90,13 @@ class Cas1DomainEventService(
   fun getRequestForPlacementAssessedEvent(id: UUID) = get(id, RequestForPlacementAssessedEnvelope::class)
   fun getFurtherInformationRequestMadeEvent(id: UUID) = get(id, FurtherInformationRequestedEnvelope::class)
 
-  private fun <T : Cas1DomainEventEnvelopeInterface<*>> get(id: UUID, envelopeType: KClass<T>): Cas1DomainEvent<T>? {
+  private fun <T : Cas1DomainEventEnvelopeInterface<*>> get(id: UUID, envelopeType: KClass<T>): GetCas1DomainEvent<T>? {
     val entity = domainEventRepository.findByIdOrNull(id) ?: return null
     return toDomainEvent(entity, envelopeType)
   }
 
   @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
-  fun <T : Cas1DomainEventEnvelopeInterface<*>> toDomainEvent(entity: DomainEventEntity, envelopeType: KClass<T>): Cas1DomainEvent<T> {
+  fun <T : Cas1DomainEventEnvelopeInterface<*>> toDomainEvent(entity: DomainEventEntity, envelopeType: KClass<T>): GetCas1DomainEvent<T> {
     checkNotNull(entity.applicationId) { "application id should not be null" }
 
     if (entity.type.cas1Info!!.envelopeType != envelopeType) {
@@ -115,14 +115,10 @@ class Cas1DomainEventService(
 
     val data = objectMapper.readValue(dataJson, envelopeType.java)
 
-    return Cas1DomainEvent(
+    return GetCas1DomainEvent(
       id = entity.id,
-      applicationId = entity.applicationId,
-      crn = entity.crn,
-      nomsNumber = entity.nomsNumber,
-      occurredAt = entity.occurredAt.toInstant(),
-      schemaVersion = entity.schemaVersion,
       data = data,
+      schemaVersion = entity.schemaVersion,
     )
   }
 
@@ -361,6 +357,12 @@ class Cas1DomainEventService(
     )
   }
 }
+
+data class GetCas1DomainEvent<T>(
+  val id: UUID,
+  val data: T,
+  val schemaVersion: Int? = null,
+)
 
 data class Cas1DomainEvent<T>(
   val id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -75,7 +75,7 @@ class Cas1PlacementApplicationDomainEventService(
     )
 
     domainEventService.saveRequestForPlacementCreatedEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
@@ -120,7 +120,7 @@ class Cas1PlacementApplicationDomainEventService(
     )
 
     domainEventService.savePlacementApplicationWithdrawnEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
@@ -167,7 +167,7 @@ class Cas1PlacementApplicationDomainEventService(
     )
 
     domainEventService.savePlacementApplicationAllocatedEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
@@ -216,7 +216,7 @@ class Cas1PlacementApplicationDomainEventService(
     )
 
     domainEventService.saveRequestForPlacementAssessedEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
@@ -62,7 +62,7 @@ class Cas1PlacementRequestDomainEventService(
     )
 
     domainEventService.saveRequestForPlacementCreatedEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,
@@ -121,7 +121,7 @@ class Cas1PlacementRequestDomainEventService(
     )
 
     domainEventService.saveMatchRequestWithdrawnEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = application.id,
         crn = application.crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import java.time.Instant
 import java.util.UUID
 
@@ -54,7 +54,7 @@ class Cas1ExpiredApplicationsScheduledJob(
         val domainEventId = UUID.randomUUID()
         val eventOccurredAt = Instant.now()
         domainEventService.saveApplicationExpiredEvent(
-          Cas1DomainEvent(
+          SaveCas1DomainEvent(
             id = domainEventId,
             applicationId = application.id,
             crn = application.crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
@@ -39,8 +39,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1BookingToSpaceBookingSeedCsvRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -509,7 +509,7 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
     val bookingId = booking.id
 
     cas1DomainEventService.saveBookingMadeDomainEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = domainEventId,
         applicationId = applicationId,
         crn = "irrelevant",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
@@ -38,8 +38,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateEventNumberSeedJobCsvRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -88,7 +88,7 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
     val staffUserDetails = StaffDetailFactory.staffDetail()
 
     domainEventService.saveApplicationAssessedDomainEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = UUID.randomUUID(),
         applicationId = application.id,
         assessmentId = UUID.randomUUID(),
@@ -145,7 +145,7 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
     val staffUserDetails = StaffDetailFactory.staffDetail()
 
     domainEventService.saveApplicationSubmittedDomainEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = UUID.randomUUID(),
         applicationId = application.id,
         crn = application.crn,
@@ -203,7 +203,7 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
     val staffUserDetails = StaffDetailFactory.staffDetail()
 
     domainEventService.saveBookingMadeDomainEvent(
-      Cas1DomainEvent(
+      SaveCas1DomainEvent(
         id = UUID.randomUUID(),
         applicationId = application.id,
         crn = application.crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AppealCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AppealCas1DomainEventServiceTest.kt
@@ -21,8 +21,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealDomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.withinSeconds
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.LocalDate
@@ -135,7 +135,7 @@ class Cas1AppealCas1DomainEventServiceTest {
     }
   }
 
-  fun Cas1DomainEvent<AssessmentAppealedEnvelope>.matches() = this.applicationId == application.id &&
+  fun SaveCas1DomainEvent<AssessmentAppealedEnvelope>.matches() = this.applicationId == application.id &&
     this.assessmentId == null &&
     this.bookingId == null &&
     this.crn == application.crn &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -44,8 +44,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentDomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.Clock
 import java.time.LocalDate
@@ -241,7 +241,7 @@ class Cas1AssessmentDomainEventServiceTest {
         apDeliusContextApiClient.getStaffDetail(user.deliusUsername)
       }
 
-      val domainEventArgument = slot<Cas1DomainEvent<ApplicationAssessedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<ApplicationAssessedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveApplicationAssessedDomainEvent(
@@ -341,7 +341,7 @@ class Cas1AssessmentDomainEventServiceTest {
         user,
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<ApplicationAssessedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<ApplicationAssessedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveApplicationAssessedDomainEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
@@ -39,8 +39,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.Instant
@@ -134,7 +134,7 @@ class Cas1BookingCas1DomainEventServiceTest {
     fun `bookingMade saves domain event`() {
       service.spaceBookingMade(application, spaceBooking, user, placementRequest)
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingMadeEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingMadeEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveBookingMadeDomainEvent(
@@ -253,7 +253,7 @@ class Cas1BookingCas1DomainEventServiceTest {
     fun `bookingMade saves domain event`() {
       service.bookingMade(application, booking, user, placementRequest)
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingMadeEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingMadeEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveBookingMadeDomainEvent(
@@ -355,7 +355,7 @@ class Cas1BookingCas1DomainEventServiceTest {
         previousDepartureDateIfChanged = null,
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingChangedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingChangedEnvelope>>()
       verify(exactly = 1) {
         domainEventService.saveBookingChangedEvent(
           capture(domainEventArgument),
@@ -440,7 +440,7 @@ class Cas1BookingCas1DomainEventServiceTest {
         previousDepartureDateIfChanged = LocalDate.of(2099, 11, 10),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingChangedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingChangedEnvelope>>()
       verify(exactly = 1) {
         domainEventService.saveBookingChangedEvent(
           capture(domainEventArgument),
@@ -547,7 +547,7 @@ class Cas1BookingCas1DomainEventServiceTest {
         notes = "the notes",
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingNotMadeEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingNotMadeEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveBookingNotMadeEvent(
@@ -633,7 +633,7 @@ class Cas1BookingCas1DomainEventServiceTest {
           .produce(),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingCancelledEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingCancelledEnvelope>>()
       verify(exactly = 1) {
         domainEventService.saveBookingCancelledEvent(
           capture(domainEventArgument),
@@ -723,7 +723,7 @@ class Cas1BookingCas1DomainEventServiceTest {
           .produce(),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingCancelledEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingCancelledEnvelope>>()
       verify(exactly = 1) {
         domainEventService.saveBookingCancelledEvent(
           capture(domainEventArgument),
@@ -817,7 +817,7 @@ class Cas1BookingCas1DomainEventServiceTest {
           .produce(),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingCancelledEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingCancelledEnvelope>>()
       verify(exactly = 1) {
         domainEventService.saveBookingCancelledEvent(
           capture(domainEventArgument),
@@ -906,7 +906,7 @@ class Cas1BookingCas1DomainEventServiceTest {
           .produce(),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingCancelledEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingCancelledEnvelope>>()
       verify(exactly = 1) {
         domainEventService.saveBookingCancelledEvent(
           capture(domainEventArgument),
@@ -974,7 +974,7 @@ class Cas1BookingCas1DomainEventServiceTest {
 
     val staffUserDetails = StaffDetailFactory.staffDetail()
 
-    val domainEventArgument = slot<Cas1DomainEvent<BookingChangedEnvelope>>()
+    val domainEventArgument = slot<SaveCas1DomainEvent<BookingChangedEnvelope>>()
 
     val createdAt = OffsetDateTime.now()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementDomainEventServiceTest.kt
@@ -33,10 +33,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventServiceConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
@@ -143,7 +143,7 @@ class Cas1BookingManagementDomainEventServiceTest {
         ),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<PersonArrivedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<PersonArrivedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.savePersonArrivedEvent(
@@ -195,7 +195,7 @@ class Cas1BookingManagementDomainEventServiceTest {
         ),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<PersonArrivedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<PersonArrivedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.savePersonArrivedEvent(
@@ -300,7 +300,7 @@ class Cas1BookingManagementDomainEventServiceTest {
         ),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<PersonDepartedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<PersonDepartedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.savePersonDepartedEvent(capture(domainEventArgument))
@@ -360,7 +360,7 @@ class Cas1BookingManagementDomainEventServiceTest {
         ),
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<PersonDepartedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<PersonDepartedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.savePersonDepartedEvent(capture(domainEventArgument))
@@ -449,7 +449,7 @@ class Cas1BookingManagementDomainEventServiceTest {
         previousKeyWorkerName = null,
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveKeyWorkerAssignedEvent(
@@ -480,7 +480,7 @@ class Cas1BookingManagementDomainEventServiceTest {
         previousKeyWorkerName = previousKeyWorkerName,
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveKeyWorkerAssignedEvent(
@@ -509,7 +509,7 @@ class Cas1BookingManagementDomainEventServiceTest {
         previousKeyWorkerName = previousKeyWorkerName,
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveKeyWorkerAssignedEvent(
@@ -526,7 +526,7 @@ class Cas1BookingManagementDomainEventServiceTest {
     }
 
     private fun checkDomainEventBookingProperties(
-      domainEvent: Cas1DomainEvent<BookingKeyWorkerAssignedEnvelope>,
+      domainEvent: SaveCas1DomainEvent<BookingKeyWorkerAssignedEnvelope>,
       spaceBooking: Cas1SpaceBookingEntity,
       applicationId: UUID,
     ) {
@@ -600,7 +600,7 @@ class Cas1BookingManagementDomainEventServiceTest {
         to = to,
       )
 
-      val domainEventArgument = slot<Cas1DomainEvent<EmergencyTransferCreatedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<EmergencyTransferCreatedEnvelope>>()
 
       verify(exactly = 1) {
         domainEventService.saveEmergencyTransferCreatedEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestDomainEventServiceTest.kt
@@ -25,8 +25,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestRejectionReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeRequestDomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
 
@@ -68,7 +68,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
 
       service.placementAppealAccepted(changeRequest)
 
-      val domainEventArgument = slot<Cas1DomainEvent<PlacementAppealAcceptedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<PlacementAppealAcceptedEnvelope>>()
 
       verify(exactly = 1) {
         cas1DomainEventService.savePlacementAppealAccepted(
@@ -119,7 +119,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
 
       service.placementAppealCreated(changeRequest, requestingUser)
 
-      val domainEventArgument = slot<Cas1DomainEvent<PlacementAppealCreatedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<PlacementAppealCreatedEnvelope>>()
 
       verify(exactly = 1) {
         cas1DomainEventService.savePlacementAppealCreated(
@@ -175,7 +175,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
 
       service.placementAppealRejected(changeRequest, requestingUser)
 
-      val domainEventArgument = slot<Cas1DomainEvent<PlacementAppealRejectedEnvelope>>()
+      val domainEventArgument = slot<SaveCas1DomainEvent<PlacementAppealRejectedEnvelope>>()
 
       verify(exactly = 1) {
         cas1DomainEventService.savePlacementAppealRejected(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
@@ -95,9 +95,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventDescriber
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toInstant
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiDateTimeFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
@@ -1392,21 +1392,16 @@ class Cas1DomainEventDescriberTest {
   private fun <T> buildDomainEvent(
     builder: (UUID) -> T,
     schemaVersion: Int? = null,
-  ): Cas1DomainEvent<T> {
+  ): GetCas1DomainEvent<T> {
     val id = UUID.randomUUID()
-    val applicationId = UUID.randomUUID()
-    return Cas1DomainEvent(
+    return GetCas1DomainEvent(
       id = id,
-      applicationId = applicationId,
-      crn = "SOME-CRN",
-      nomsNumber = "theNomsNumber",
-      occurredAt = Instant.now(),
       data = builder(id),
       schemaVersion = schemaVersion,
     )
   }
 
-  private fun <T> buildDomainEvent(builder: (UUID) -> T): Cas1DomainEvent<T> = buildDomainEvent(builder, null)
+  private fun <T> buildDomainEvent(builder: (UUID) -> T): GetCas1DomainEvent<T> = buildDomainEvent(builder, null)
 }
 
 data class DomainEventSummaryImpl(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -65,10 +65,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ConfiguredDomainEventWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventMigrationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Cas1DomainEventsFactory
 import java.time.Instant
@@ -220,7 +220,7 @@ class Cas1DomainEventServiceTest {
 
       every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
-      val domainEventToSave = Cas1DomainEvent(
+      val domainEventToSave = SaveCas1DomainEvent(
         id = id,
         applicationId = applicationId,
         crn = crn,
@@ -290,7 +290,7 @@ class Cas1DomainEventServiceTest {
 
       every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
-      val domainEventToSave = Cas1DomainEvent(
+      val domainEventToSave = SaveCas1DomainEvent(
         id = id,
         applicationId = applicationId,
         crn = crn,
@@ -341,7 +341,7 @@ class Cas1DomainEventServiceTest {
 
       every { domainEventRepositoryMock.save(any()) } answers { it.invocation.args[0] as DomainEventEntity }
 
-      val domainEventToSave = Cas1DomainEvent(
+      val domainEventToSave = SaveCas1DomainEvent(
         id = id,
         applicationId = applicationId,
         crn = crn,
@@ -387,7 +387,7 @@ class Cas1DomainEventServiceTest {
 
       every { domainEventRepositoryMock.save(any()) } throws RuntimeException("A database exception")
 
-      val domainEventToSave = Cas1DomainEvent(
+      val domainEventToSave = SaveCas1DomainEvent(
         id = id,
         applicationId = applicationId,
         crn = crn,
@@ -519,7 +519,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = ApplicationSubmittedFactory().produce()
       val domainEventEnvelope = mockk<ApplicationSubmittedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<ApplicationSubmittedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<ApplicationSubmittedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -545,7 +545,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = ApplicationAssessedFactory().produce()
       val domainEventEnvelope = mockk<ApplicationAssessedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<ApplicationAssessedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<ApplicationAssessedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -571,7 +571,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = BookingMadeFactory().produce()
       val domainEventEnvelope = mockk<BookingMadeEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<BookingMadeEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<BookingMadeEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -597,7 +597,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = PersonArrivedFactory().produce()
       val domainEventEnvelope = mockk<PersonArrivedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<PersonArrivedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<PersonArrivedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -623,7 +623,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = PersonNotArrivedFactory().produce()
       val domainEventEnvelope = mockk<PersonNotArrivedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<PersonNotArrivedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<PersonNotArrivedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -649,7 +649,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = PersonDepartedFactory().produce()
       val domainEventEnvelope = mockk<PersonDepartedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<PersonDepartedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<PersonDepartedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -675,7 +675,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = BookingNotMadeFactory().produce()
       val domainEventEnvelope = mockk<BookingNotMadeEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<BookingNotMadeEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<BookingNotMadeEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -701,7 +701,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = BookingCancelledFactory().produce()
       val domainEventEnvelope = mockk<BookingCancelledEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<BookingCancelledEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<BookingCancelledEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -727,7 +727,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = BookingChangedFactory().produce()
       val domainEventEnvelope = mockk<BookingChangedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<BookingChangedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<BookingChangedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -753,7 +753,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = BookingKeyWorkerAssignedFactory().produce()
       val domainEventEnvelope = mockk<BookingKeyWorkerAssignedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<BookingKeyWorkerAssignedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -779,7 +779,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = ApplicationWithdrawnFactory().produce()
       val domainEventEnvelope = mockk<ApplicationWithdrawnEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<ApplicationWithdrawnEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<ApplicationWithdrawnEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -805,7 +805,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = ApplicationExpiredFactory().produce()
       val domainEventEnvelope = mockk<ApplicationExpiredEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<ApplicationExpiredEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<ApplicationExpiredEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -831,7 +831,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = AssessmentAppealedFactory().produce()
       val domainEventEnvelope = mockk<AssessmentAppealedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<AssessmentAppealedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<AssessmentAppealedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -857,7 +857,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = PlacementApplicationWithdrawnFactory().produce()
       val domainEventEnvelope = mockk<PlacementApplicationWithdrawnEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<PlacementApplicationWithdrawnEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<PlacementApplicationWithdrawnEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -883,7 +883,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = PlacementApplicationAllocatedFactory().produce()
       val domainEventEnvelope = mockk<PlacementApplicationAllocatedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<PlacementApplicationAllocatedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<PlacementApplicationAllocatedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -909,7 +909,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = RequestForPlacementAssessedFactory().produce()
       val domainEventEnvelope = mockk<RequestForPlacementAssessedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<RequestForPlacementAssessedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<RequestForPlacementAssessedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -935,7 +935,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = MatchRequestWithdrawnFactory().produce()
       val domainEventEnvelope = mockk<MatchRequestWithdrawnEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<MatchRequestWithdrawnEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<MatchRequestWithdrawnEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -961,7 +961,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = RequestForPlacementCreatedFactory().produce()
       val domainEventEnvelope = mockk<RequestForPlacementCreatedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<RequestForPlacementCreatedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<RequestForPlacementCreatedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -987,7 +987,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = AssessmentAllocatedFactory().produce()
       val domainEventEnvelope = mockk<AssessmentAllocatedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<AssessmentAllocatedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<AssessmentAllocatedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope
@@ -1013,7 +1013,7 @@ class Cas1DomainEventServiceTest {
 
       val eventDetails = FurtherInformationRequestedFactory().produce()
       val domainEventEnvelope = mockk<FurtherInformationRequestedEnvelope>()
-      val domainEvent = mockk<Cas1DomainEvent<FurtherInformationRequestedEnvelope>>()
+      val domainEvent = mockk<SaveCas1DomainEvent<FurtherInformationRequestedEnvelope>>()
 
       every { domainEvent.id } returns id
       every { domainEvent.data } returns domainEventEnvelope

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -68,6 +68,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventMigrationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.Cas1DomainEventsFactory
 import java.time.Instant
@@ -167,19 +168,15 @@ class Cas1DomainEventServiceTest {
       val event = method.invoke(id)
 
       assertThat(event).isEqualTo(
-        Cas1DomainEvent(
+        GetCas1DomainEvent(
           id = id,
-          applicationId = applicationId,
-          crn = crn,
-          nomsNumber = nomsNumber,
-          occurredAt = occurredAt.toInstant(),
           data = domainEventAndJson.envelope,
           schemaVersion = domainEventAndJson.schemaVersion.versionNo,
         ),
       )
     }
 
-    private fun fetchGetterForType(type: DomainEventType): (UUID) -> Cas1DomainEvent<out Any>? = mapOf(
+    private fun fetchGetterForType(type: DomainEventType): (UUID) -> GetCas1DomainEvent<out Any>? = mapOf(
       DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED to domainEventService::getApplicationSubmittedDomainEvent,
       DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED to domainEventService::getApplicationAssessedDomainEvent,
       DomainEventType.APPROVED_PREMISES_BOOKING_MADE to domainEventService::getBookingMadeEvent,


### PR DESCRIPTION
The `Cas1DomainEvent` data class was being used when both saving and retrieving domain events, but most of the parameters were not being used when getting the domain event. 

This PR splits the class into separate get/save versions.