### PR TITLE
CAS-1552 added bedspaces array to cas3/premises/summaries endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3PremisesSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3PremisesSummaryTransformer.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3BedspaceSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3PremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TemporaryAccommodationPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.FlatTemporaryAccommodationPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PremisesSummary as ApiPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesSummary as DomainTemporaryAccommodationPremisesSummary
 
@@ -31,5 +33,24 @@ class Cas3PremisesSummaryTransformer {
     bedspaceCount = domain.bedCount,
     pdu = domain.pdu,
     localAuthorityAreaName = domain.localAuthorityAreaName,
+  )
+
+  fun transformFlatDomainToCas3PremisesSummary(domain: FlatTemporaryAccommodationPremisesSummary, bedspaces: List<Cas3BedspaceSummary>): Cas3PremisesSummary = Cas3PremisesSummary(
+    id = domain.id,
+    name = domain.name,
+    addressLine1 = domain.addressLine1,
+    addressLine2 = domain.addressLine2,
+    postcode = domain.postcode,
+    status = domain.status,
+    bedspaces = bedspaces,
+    bedspaceCount = bedspaces.count { it.status == Cas3BedspaceSummary.Status.online },
+    pdu = domain.pdu,
+    localAuthorityAreaName = domain.localAuthorityAreaName,
+  )
+
+  fun transformFlatDomainToCas3BedspaceSummary(domain: FlatTemporaryAccommodationPremisesSummary): Cas3BedspaceSummary = Cas3BedspaceSummary(
+    id = domain.bedspacesId!!,
+    reference = domain.bedspacesReference!!,
+    status = domain.bedspacesStatus!!,
   )
 }

--- a/src/main/resources/static/cas3-schemas.yml
+++ b/src/main/resources/static/cas3-schemas.yml
@@ -333,6 +333,10 @@ components:
           type: string
         localAuthorityAreaName:
           type: string
+        bedspaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3BedspaceSummary'
         bedspaceCount:
           type: integer
           example: 22
@@ -344,7 +348,23 @@ components:
         - addressLine1
         - postcode
         - pdu
-        - bedCount
+        - bedspaceCount
+        - status
+    Cas3BedspaceSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        reference:
+          type: string
+        status:
+          enum:
+            - online
+            - archived
+      required:
+        - id
+        - reference
         - status
     Cas3Departure:
       type: object

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -5170,6 +5170,10 @@ components:
           type: string
         localAuthorityAreaName:
           type: string
+        bedspaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3BedspaceSummary'
         bedspaceCount:
           type: integer
           example: 22
@@ -5181,7 +5185,23 @@ components:
         - addressLine1
         - postcode
         - pdu
-        - bedCount
+        - bedspaceCount
+        - status
+    Cas3BedspaceSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        reference:
+          type: string
+        status:
+          enum:
+            - online
+            - archived
+      required:
+        - id
+        - reference
         - status
     Cas3Departure:
       type: object


### PR DESCRIPTION
bedspaces obtained from flat query and then premises summaries formed by grouping them by id and adding the bedspaces array

left old queries and types (TemporaryAccommodationPremisesSummary) untouched and created new as they are going to be deleted in PR: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3380