### PR TITLE
Add Space Booking Actions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -28,10 +28,12 @@ class UserAccessService(
   private val requestContextService: RequestContextService,
 ) {
   fun ensureCurrentUserHasPermission(permission: UserPermission) {
-    if (!userService.getUserForRequest().hasPermission(permission)) {
+    if (!currentUserHasPermission(permission)) {
       throw ForbiddenProblem("Permission ${permission.name} is required")
     }
   }
+
+  fun currentUserHasPermission(permission: UserPermission) = userService.getUserForRequest().hasPermission(permission)
 
   fun currentUserCanAccessRegion(service: ServiceName, probationRegionId: UUID?) = userCanAccessRegion(userService.getUserForRequest(), service, probationRegionId)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingActionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingActionsService.kt
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingAction
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.ActionOutcome.Available
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.ActionOutcome.Unavailable
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SpaceBookingAction.APPEAL_CREATE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SpaceBookingAction.TRANSFER_CREATE
+
+@Service
+class Cas1SpaceBookingActionsService(
+  val userAccessService: UserAccessService,
+) {
+  fun determineActions(spaceBooking: Cas1SpaceBookingEntity): ActionsResult {
+    val outcomes = listOf(
+      appealCreate(spaceBooking),
+      transferCreate(spaceBooking),
+    )
+
+    return ActionsResult(outcomes)
+  }
+
+  private fun appealCreate(spaceBooking: Cas1SpaceBookingEntity): ActionOutcome {
+    val requiredPermission = UserPermission.CAS1_PLACEMENT_APPEAL_CREATE
+    return if (!userAccessService.currentUserHasPermission(requiredPermission)) {
+      Unavailable(APPEAL_CREATE, "User must have permission '$requiredPermission'")
+    } else if (spaceBooking.hasArrival()) {
+      Unavailable(APPEAL_CREATE, "Space booking has been marked as arrived")
+    } else if (spaceBooking.hasNonArrival()) {
+      Unavailable(APPEAL_CREATE, "Space booking has been marked as non arrived")
+    } else if (spaceBooking.isCancelled()) {
+      Unavailable(APPEAL_CREATE, "Space booking has been cancelled")
+    } else {
+      Available(APPEAL_CREATE)
+    }
+  }
+
+  private fun transferCreate(spaceBooking: Cas1SpaceBookingEntity): ActionOutcome {
+    val requiredPermission = UserPermission.CAS1_TRANSFER_CREATE
+    return if (!userAccessService.currentUserHasPermission(requiredPermission)) {
+      Unavailable(TRANSFER_CREATE, "User must have permission '$requiredPermission'")
+    } else if (!spaceBooking.hasArrival()) {
+      Unavailable(TRANSFER_CREATE, "Space booking has not been marked as arrived")
+    } else if (spaceBooking.hasNonArrival()) {
+      Unavailable(TRANSFER_CREATE, "Space booking has been marked as non arrived")
+    } else if (spaceBooking.hasDeparted()) {
+      Unavailable(TRANSFER_CREATE, "Space booking has been marked as departed")
+    } else if (spaceBooking.isCancelled()) {
+      Unavailable(TRANSFER_CREATE, "Space booking has been cancelled")
+    } else {
+      Available(TRANSFER_CREATE)
+    }
+  }
+}
+
+class ActionsResult(
+  private val outcomes: List<ActionOutcome>,
+) {
+  companion object {
+    fun forAllowedAction(action: SpaceBookingAction) = ActionsResult(listOf(Available(action)))
+    fun forUnavailableAction(action: SpaceBookingAction, message: String) = ActionsResult(listOf(Unavailable(action, message)))
+  }
+
+  fun available() = outcomes.filterIsInstance<Available>().map { it.action }
+
+  fun unavailable() = outcomes.filterIsInstance<Unavailable>()
+
+  fun unavailableReason(action: SpaceBookingAction) = unavailable().firstOrNull { it.action == action }?.reason
+}
+
+sealed interface ActionOutcome {
+  val action: SpaceBookingAction
+
+  data class Available(override val action: SpaceBookingAction) : ActionOutcome
+  data class Unavailable(override val action: SpaceBookingAction, val reason: String) : ActionOutcome
+}
+
+enum class SpaceBookingAction(
+  val apiType: Cas1SpaceBookingAction,
+) {
+  APPEAL_CREATE(Cas1SpaceBookingAction.APPEAL_CREATE),
+  TRANSFER_CREATE(Cas1SpaceBookingAction.APPEAL_CREATE),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Chan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ChangeRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingActionsService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
@@ -36,6 +37,7 @@ class Cas1SpaceBookingTransformer(
   private val userTransformer: UserTransformer,
   private val spaceBookingStatusTransformer: Cas1SpaceBookingStatusTransformer,
   private val cas1ChangeRequestRepository: Cas1ChangeRequestRepository,
+  private val cas1SpaceBookingActionsService: Cas1SpaceBookingActionsService,
 ) {
   fun transformJpaToApi(
     person: PersonInfoResult,
@@ -92,6 +94,7 @@ class Cas1SpaceBookingTransformer(
       departure = jpa.extractDeparture(),
       status = status,
       characteristics = jpa.criteria.toCas1SpaceCharacteristics(),
+      allowedActions = cas1SpaceBookingActionsService.determineActions(jpa).available().map { it.apiType },
     )
   }
 

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -394,6 +394,9 @@ components:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
+        allowedActions:
+          items:
+            $ref: '#/components/schemas/Cas1SpaceBookingAction'
       required:
         - id
         - applicationId
@@ -407,6 +410,7 @@ components:
         - createdAt
         - otherBookingsInPremisesForCrn
         - characteristics
+        - allowedActions
     Cas1SpaceBookingDates:
       type: object
       properties:
@@ -425,6 +429,14 @@ components:
         - id
         - canonicalArrivalDate
         - canonicalDepartureDate
+    Cas1SpaceBookingAction:
+      type: string
+      enum:
+        - appealCreate
+        - transferCreate
+      x-enum-varnames:
+        - APPEAL_CREATE
+        - TRANSFER_CREATE
     Cas1SpaceBookingSummarySortField:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7063,6 +7063,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+        allowedActions:
+          items:
+            $ref: '#/components/schemas/Cas1SpaceBookingAction'
       required:
         - id
         - applicationId
@@ -7076,6 +7079,7 @@ components:
         - createdAt
         - otherBookingsInPremisesForCrn
         - characteristics
+        - allowedActions
     Cas1SpaceBookingDates:
       type: object
       properties:
@@ -7094,6 +7098,14 @@ components:
         - id
         - canonicalArrivalDate
         - canonicalDepartureDate
+    Cas1SpaceBookingAction:
+      type: string
+      enum:
+        - appealCreate
+        - transferCreate
+      x-enum-varnames:
+        - APPEAL_CREATE
+        - TRANSFER_CREATE
     Cas1SpaceBookingSummarySortField:
       type: string
       enum:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingsActionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingsActionsServiceTest.kt
@@ -1,0 +1,178 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.ActionsResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingActionsService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SpaceBookingAction
+import java.time.Instant
+import java.time.LocalDate
+
+@ExtendWith(MockKExtension::class)
+class Cas1SpaceBookingsActionsServiceTest {
+
+  @MockK
+  private lateinit var userAccessService: UserAccessService
+
+  @InjectMockKs
+  private lateinit var service: Cas1SpaceBookingActionsService
+
+  @BeforeEach
+  fun before() {
+    every { userAccessService.currentUserHasPermission(any()) } returns true
+  }
+
+  @Nested
+  inner class AppealCreate {
+
+    val spaceBooking = Cas1SpaceBookingEntityFactory()
+      .withActualArrivalDate(null)
+      .withNonArrivalConfirmedAt(null)
+      .withCancellationOccurredAt(null)
+      .produce()
+
+    @Test
+    fun success() {
+      service.determineActions(spaceBooking).assertAvailable(SpaceBookingAction.APPEAL_CREATE)
+    }
+
+    @Test
+    fun `unavailable if user does not have correct permission`() {
+      userDoesntHavePermission(UserPermission.CAS1_PLACEMENT_APPEAL_CREATE)
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.APPEAL_CREATE,
+          message = "User must have permission 'CAS1_PLACEMENT_APPEAL_CREATE'",
+        )
+    }
+
+    @Test
+    fun `unavailable if has arrival`() {
+      spaceBooking.actualArrivalDate = LocalDate.now()
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.APPEAL_CREATE,
+          message = "Space booking has been marked as arrived",
+        )
+    }
+
+    @Test
+    fun `unavailable if has non arrival`() {
+      spaceBooking.nonArrivalConfirmedAt = Instant.now()
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.APPEAL_CREATE,
+          message = "Space booking has been marked as non arrived",
+        )
+    }
+
+    @Test
+    fun `unavailable if has cancellation`() {
+      spaceBooking.cancellationOccurredAt = LocalDate.now()
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.APPEAL_CREATE,
+          message = "Space booking has been cancelled",
+        )
+    }
+  }
+
+  @Nested
+  inner class TransferCreate {
+
+    val spaceBooking = Cas1SpaceBookingEntityFactory()
+      .withActualArrivalDate(LocalDate.now())
+      .withActualDepartureDate(null)
+      .withNonArrivalConfirmedAt(null)
+      .withCancellationOccurredAt(null)
+      .produce()
+
+    @Test
+    fun success() {
+      service.determineActions(spaceBooking).assertAvailable(SpaceBookingAction.TRANSFER_CREATE)
+    }
+
+    @Test
+    fun `unavailable if user does not have correct permission`() {
+      userDoesntHavePermission(UserPermission.CAS1_TRANSFER_CREATE)
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.TRANSFER_CREATE,
+          message = "User must have permission 'CAS1_TRANSFER_CREATE'",
+        )
+    }
+
+    @Test
+    fun `unavailable if does not have arrival`() {
+      spaceBooking.actualArrivalDate = null
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.TRANSFER_CREATE,
+          message = "Space booking has not been marked as arrived",
+        )
+    }
+
+    @Test
+    fun `unavailable if has non arrival`() {
+      spaceBooking.nonArrivalConfirmedAt = Instant.now()
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.TRANSFER_CREATE,
+          message = "Space booking has been marked as non arrived",
+        )
+    }
+
+    @Test
+    fun `unavailable if has departure`() {
+      spaceBooking.actualDepartureDate = LocalDate.now()
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.TRANSFER_CREATE,
+          message = "Space booking has been marked as departed",
+        )
+    }
+
+    @Test
+    fun `unavailable if has cancellation`() {
+      spaceBooking.cancellationOccurredAt = LocalDate.now()
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.TRANSFER_CREATE,
+          message = "Space booking has been cancelled",
+        )
+    }
+  }
+
+  private fun userDoesntHavePermission(permission: UserPermission) {
+    every { userAccessService.currentUserHasPermission(permission) } returns false
+  }
+
+  private fun ActionsResult.assertAvailable(action: SpaceBookingAction) {
+    assertThat(this.available()).contains(action)
+    assertThat(this.unavailable().map { it.action }).doesNotContain(action)
+  }
+
+  private fun ActionsResult.assertUnavailable(action: SpaceBookingAction, message: String) {
+    assertThat(this.available()).doesNotContain(action)
+    assertThat(this.unavailableReason(action)).isEqualTo(message)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingAction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummaryStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonSummaryDiscriminator
@@ -40,6 +41,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.ActionsResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingActionsService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SpaceBookingAction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
@@ -71,6 +75,9 @@ class Cas1SpaceBookingTransformerTest {
 
   @MockK
   private lateinit var cas1ChangeRequestRepository: Cas1ChangeRequestRepository
+
+  @MockK
+  private lateinit var cas1SpaceBookingActionsService: Cas1SpaceBookingActionsService
 
   @InjectMockKs
   private lateinit var transformer: Cas1SpaceBookingTransformer
@@ -182,6 +189,9 @@ class Cas1SpaceBookingTransformerTest {
         )
       } returns expectedUser
       every { cancellationReasonTransformer.transformJpaToApi(cancellationReason) } returns expectedCancellationReason
+      every { cas1SpaceBookingActionsService.determineActions(spaceBooking) } returns ActionsResult.forAllowedAction(
+        SpaceBookingAction.APPEAL_CREATE,
+      )
 
       val result = transformer.transformJpaToApi(personInfo, spaceBooking, otherBookings)
 
@@ -241,6 +251,8 @@ class Cas1SpaceBookingTransformerTest {
         Cas1SpaceCharacteristic.isCatered,
         Cas1SpaceCharacteristic.hasEnSuite,
       )
+
+      assertThat(result.allowedActions).containsExactly(Cas1SpaceBookingAction.APPEAL_CREATE)
     }
 
     @Test
@@ -306,6 +318,9 @@ class Cas1SpaceBookingTransformerTest {
           ServiceName.approvedPremises,
         )
       } returns expectedUser
+      every { cas1SpaceBookingActionsService.determineActions(spaceBooking) } returns ActionsResult.forAllowedAction(
+        SpaceBookingAction.APPEAL_CREATE,
+      )
 
       val result = transformer.transformJpaToApi(personInfo, spaceBooking, emptyList())
 


### PR DESCRIPTION
This commit adds the concept of actions, which are used to determine if a user can do something on a given entity (in this case space bookings). Actions have two purposes:

1. To provide the UI a list of available actions, allowing it to selectively render options
2. To check that a given action is allowed when it is attempted by a given user

This allows us to remove duplication of logic across the API and UI and change this logic in the API without needing UI changes.

Actions have been added for creating change requests