### PR TITLE
APS-2057 - Add Planned Transfer Domain Events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/Cas1DomainEventEnvelope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/Cas1DomainEventEnvelope.kt
@@ -4,8 +4,8 @@ import java.time.Instant
 import java.util.UUID
 
 data class Cas1DomainEventEnvelope<T : Cas1DomainEventPayload>(
-  val id: UUID,
-  val timestamp: Instant,
-  val eventType: EventType,
-  val eventDetails: T,
-)
+  override val id: UUID,
+  override val timestamp: Instant,
+  override val eventType: EventType,
+  override val eventDetails: T,
+) : Cas1DomainEventEnvelopeInterface<T>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/EmergencyTransferCreated.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/EmergencyTransferCreated.kt
@@ -7,13 +7,7 @@ data class EmergencyTransferCreated(
   val applicationId: UUID,
   val createdAt: Instant,
   val createdBy: StaffMember,
-  val from: TransferBooking,
-  val to: TransferBooking,
+  val from: EventBookingSummary,
+  val to: EventBookingSummary,
 ) : Cas1DomainEventPayload
 
-data class TransferBooking(
-  val bookingId: UUID,
-  val premises: Premises,
-  val arrivalOn: java.time.LocalDate,
-  val departureOn: java.time.LocalDate,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/EventBookingSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/EventBookingSummary.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
+
+import java.util.UUID
+
+data class EventBookingSummary(
+  val bookingId: UUID,
+  val premises: Premises,
+  val arrivalDate: java.time.LocalDate,
+  val departureDate: java.time.LocalDate,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/EventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/EventType.kt
@@ -31,6 +31,9 @@ enum class EventType(@get:JsonValue val value: kotlin.String) {
   placementApplicationWithdrawn("approved-premises.placement-application.withdrawn"),
   placementApplicationAllocated("approved-premises.placement-application.allocated"),
   matchRequestWithdrawn("approved-premises.match-request.withdrawn"),
+  plannedTransferRequestAccepted("approved-premises.planned-transfer-request.accepted"),
+  plannedTransferRequestCreated("approved-premises.planned-transfer-request.created"),
+  plannedTransferRequestRejected("approved-premises.planned-transfer-request.rejected"),
   requestForPlacementCreated("approved-premises.request-for-placement.created"),
   requestForPlacementAssessed("approved-premises.request-for-placement.assessed"),
   ;

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlannedTransferRequestAccepted.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlannedTransferRequestAccepted.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
+
+import java.util.UUID
+
+data class PlannedTransferRequestAccepted(
+  val changeRequestId: UUID,
+  val acceptedBy: StaffMember,
+  val from: EventBookingSummary,
+  val to: EventBookingSummary,
+) : Cas1DomainEventPayload

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlannedTransferRequestCreated.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlannedTransferRequestCreated.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
+
+import java.util.UUID
+
+data class PlannedTransferRequestCreated(
+  val changeRequestId: UUID,
+  val booking: EventBookingSummary,
+  val requestedBy: StaffMember,
+  val reason: Cas1DomainEventCodedId,
+) : Cas1DomainEventPayload

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlannedTransferRequestRejected.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas1/model/PlannedTransferRequestRejected.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model
+
+import java.time.LocalDate
+import java.util.UUID
+
+data class PlannedTransferRequestRejected(
+  val changeRequestId: UUID,
+  val booking: EventBookingSummary,
+  val rejectedBy: StaffMember,
+  val reason: Cas1DomainEventCodedId,
+) : Cas1DomainEventPayload

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -40,6 +40,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationAllocated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementApplicationWithdrawn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestRejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
@@ -484,6 +487,39 @@ enum class DomainEventType(
       emittable = false,
       apiType = Cas1EventType.placementAppealRejected,
       payloadType = PlacementAppealRejected::class,
+    ),
+  ),
+  APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_ACCEPTED(
+    DomainEventCas.CAS1,
+    Cas1EventType.plannedTransferRequestAccepted.value,
+    "A planned transfer request has been accepted",
+    cas1Info = Cas1DomainEventTypeInfo(
+      timelineEventType = Cas1TimelineEventType.plannedTransferRequestAccepted,
+      emittable = false,
+      payloadType = PlannedTransferRequestAccepted::class,
+      apiType = Cas1EventType.plannedTransferRequestAccepted,
+    ),
+  ),
+  APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_CREATED(
+    DomainEventCas.CAS1,
+    Cas1EventType.plannedTransferRequestCreated.value,
+    "A planned transfer request has been created",
+    cas1Info = Cas1DomainEventTypeInfo(
+      timelineEventType = Cas1TimelineEventType.plannedTransferRequestCreated,
+      emittable = false,
+      payloadType = PlannedTransferRequestCreated::class,
+      apiType = Cas1EventType.plannedTransferRequestCreated,
+    ),
+  ),
+  APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_REJECTED(
+    DomainEventCas.CAS1,
+    Cas1EventType.plannedTransferRequestRejected.value,
+    "A planned transfer request has been rejected",
+    cas1Info = Cas1DomainEventTypeInfo(
+      timelineEventType = Cas1TimelineEventType.plannedTransferRequestRejected,
+      emittable = false,
+      payloadType = PlannedTransferRequestRejected::class,
+      apiType = Cas1EventType.plannedTransferRequestRejected,
     ),
   ),
   CAS2_APPLICATION_SUBMITTED(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -358,7 +358,7 @@ enum class DomainEventType(
     cas1Info = Cas1DomainEventTypeInfo(
       Cas1TimelineEventType.applicationWithdrawn,
       payloadType = ApplicationWithdrawn::class,
-      apiType = Cas1EventType.bookingKeyWorkerAssigned,
+      apiType = Cas1EventType.applicationWithdrawn,
     ),
   ),
   APPROVED_PREMISES_ASSESSMENT_APPEALED(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementDomainEventService.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonNotArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.TransferBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
@@ -30,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Case
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.DomainEventUtils.mapApprovedPremisesEntityToPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.toEventBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toInstant
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
@@ -298,18 +298,8 @@ class Cas1SpaceBookingManagementDomainEventService(
             applicationId = application.id,
             createdAt = eventOccurredAt,
             createdBy = getStaffDetailsByUsername(createdBy.deliusUsername).toStaffMember(),
-            from = TransferBooking(
-              bookingId = from.id,
-              premises = mapApprovedPremisesEntityToPremises(from.premises),
-              arrivalOn = from.canonicalArrivalDate,
-              departureOn = from.canonicalDepartureDate,
-            ),
-            to = TransferBooking(
-              bookingId = to.id,
-              premises = mapApprovedPremisesEntityToPremises(to.premises),
-              arrivalOn = to.canonicalArrivalDate,
-              departureOn = to.canonicalDepartureDate,
-            ),
+            from = from.toEventBookingSummary(),
+            to = to.toEventBookingSummary(),
           ),
         ),
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestDomainEventService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventCodedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventPayload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealAccepted
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealAcceptedEnvelope
@@ -9,11 +10,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementAppealRejectedEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestRejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.DomainEventUtils.mapApprovedPremisesEntityToPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.toEventBookingSummary
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -130,6 +137,89 @@ class Cas1ChangeRequestDomainEventService(
             ),
           ),
         ),
+      ),
+    )
+  }
+
+  fun plannedTransferRequestCreated(
+    changeRequest: Cas1ChangeRequestEntity,
+    requestingUser: UserEntity,
+  ) {
+    val spaceBooking = changeRequest.spaceBooking
+    val reason = changeRequest.requestReason
+
+    save(
+      DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_CREATED,
+      changeRequest,
+      PlannedTransferRequestCreated(
+        changeRequestId = changeRequest.id,
+        booking = spaceBooking.toEventBookingSummary(),
+        requestedBy = getStaffDetailsByUsername(requestingUser.deliusUsername).toStaffMember(),
+        reason = Cas1DomainEventCodedId(
+          id = reason.id,
+          code = reason.code,
+        ),
+      ),
+    )
+  }
+
+  fun plannedTransferRequestRejected(
+    changeRequest: Cas1ChangeRequestEntity,
+    rejectingUser: UserEntity,
+  ) {
+    val spaceBooking = changeRequest.spaceBooking
+    val reason = changeRequest.rejectionReason!!
+
+    save(
+      DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_REJECTED,
+      changeRequest,
+      PlannedTransferRequestRejected(
+        changeRequestId = changeRequest.id,
+        booking = spaceBooking.toEventBookingSummary(),
+        rejectedBy = getStaffDetailsByUsername(rejectingUser.deliusUsername).toStaffMember(),
+        reason = Cas1DomainEventCodedId(
+          id = reason.id,
+          code = reason.code,
+        ),
+      ),
+    )
+  }
+
+  fun plannedTransferRequestAccepted(
+    changeRequest: Cas1ChangeRequestEntity,
+    acceptingUser: UserEntity,
+    from: Cas1SpaceBookingEntity,
+    to: Cas1SpaceBookingEntity,
+  ) {
+    save(
+      DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_ACCEPTED,
+      changeRequest,
+      PlannedTransferRequestAccepted(
+        changeRequestId = changeRequest.id,
+        acceptedBy = getStaffDetailsByUsername(acceptingUser.deliusUsername).toStaffMember(),
+        from = from.toEventBookingSummary(),
+        to = to.toEventBookingSummary(),
+      ),
+    )
+  }
+
+  private fun save(
+    type: DomainEventType,
+    changeRequest: Cas1ChangeRequestEntity,
+    payload: Cas1DomainEventPayload,
+  ) {
+    val spaceBooking = changeRequest.spaceBooking
+
+    cas1DomainEventService.save(
+      SaveCas1DomainEventWithPayload(
+        type = type,
+        applicationId = changeRequest.placementRequest.application.id,
+        crn = changeRequest.placementRequest.application.crn,
+        nomsNumber = changeRequest.placementRequest.application.nomsNumber,
+        occurredAt = OffsetDateTime.now().toInstant(),
+        cas1SpaceBookingId = spaceBooking.id,
+        schemaVersion = null,
+        data = payload,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -115,7 +115,7 @@ class Cas1DomainEventService(
   fun getRequestForPlacementAssessedEvent(id: UUID) = get(id, RequestForPlacementAssessed::class)
   fun getFurtherInformationRequestMadeEvent(id: UUID) = get(id, FurtherInformationRequested::class)
 
-  private fun <T : Cas1DomainEventPayload> get(id: UUID, payloadType: KClass<T>): GetCas1DomainEvent<Cas1DomainEventEnvelope<T>>? {
+  fun <T : Cas1DomainEventPayload> get(id: UUID, payloadType: KClass<T>): GetCas1DomainEvent<Cas1DomainEventEnvelope<T>>? {
     val entity = domainEventRepository.findByIdOrNull(id) ?: return null
     return toDomainEvent(entity, payloadType)
   }
@@ -303,7 +303,7 @@ class Cas1DomainEventService(
 
   private fun getAllDomainEventsById(applicationId: UUID? = null, spaceBookingId: UUID? = null) = domainEventRepository.findAllTimelineEventsByIds(applicationId, spaceBookingId).distinctBy { it.id }
 
-  fun <T : Cas1DomainEventPayload> save(saveWithPayload: SaveCas1DomainEventWithPayload<T>) {
+  fun save(saveWithPayload: SaveCas1DomainEventWithPayload) {
     val id = saveWithPayload.id
     val type = saveWithPayload.type
     val expectedPayloadType = type.cas1Info!!.payloadType
@@ -454,7 +454,7 @@ data class SaveCas1DomainEvent<T>(
   val emit: Boolean = true,
 )
 
-data class SaveCas1DomainEventWithPayload<T>(
+data class SaveCas1DomainEventWithPayload(
   val id: UUID = UUID.randomUUID(),
   val type: DomainEventType,
   val applicationId: UUID? = null,
@@ -465,7 +465,7 @@ data class SaveCas1DomainEventWithPayload<T>(
   val crn: String,
   val nomsNumber: String?,
   val occurredAt: Instant,
-  val data: T,
+  val data: Cas1DomainEventPayload,
   val metadata: Map<MetaDataName, String?> = emptyMap(),
   val schemaVersion: Int? = null,
   val triggerSource: TriggerSourceType? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -154,145 +154,145 @@ class Cas1DomainEventService(
   }
 
   @Transactional
-  fun saveApplicationSubmittedDomainEvent(domainEvent: SaveCas1DomainEvent<ApplicationSubmittedEnvelope>) = saveAndEmit(
+  fun saveApplicationSubmittedDomainEvent(domainEvent: SaveCas1DomainEvent<ApplicationSubmittedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED,
   )
 
   @Transactional
-  fun saveApplicationAssessedDomainEvent(domainEvent: SaveCas1DomainEvent<ApplicationAssessedEnvelope>) = saveAndEmit(
+  fun saveApplicationAssessedDomainEvent(domainEvent: SaveCas1DomainEvent<ApplicationAssessedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED,
   )
 
   @Transactional
-  fun saveBookingMadeDomainEvent(domainEvent: SaveCas1DomainEvent<BookingMadeEnvelope>) = saveAndEmit(
+  fun saveBookingMadeDomainEvent(domainEvent: SaveCas1DomainEvent<BookingMadeEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
   )
 
   @Transactional
-  fun saveEmergencyTransferCreatedEvent(domainEvent: SaveCas1DomainEvent<EmergencyTransferCreatedEnvelope>) = saveAndEmit(
+  fun saveEmergencyTransferCreatedEvent(domainEvent: SaveCas1DomainEvent<EmergencyTransferCreatedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED,
   )
 
   @Transactional
-  fun savePersonArrivedEvent(domainEvent: SaveCas1DomainEvent<PersonArrivedEnvelope>) = saveAndEmit(
+  fun savePersonArrivedEvent(domainEvent: SaveCas1DomainEvent<PersonArrivedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED,
   )
 
   @Transactional
-  fun savePersonNotArrivedEvent(domainEvent: SaveCas1DomainEvent<PersonNotArrivedEnvelope>) = saveAndEmit(
+  fun savePersonNotArrivedEvent(domainEvent: SaveCas1DomainEvent<PersonNotArrivedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED,
   )
 
   @Transactional
-  fun savePersonDepartedEvent(domainEvent: SaveCas1DomainEvent<PersonDepartedEnvelope>) = saveAndEmit(
+  fun savePersonDepartedEvent(domainEvent: SaveCas1DomainEvent<PersonDepartedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED,
   )
 
   @Transactional
-  fun saveBookingNotMadeEvent(domainEvent: SaveCas1DomainEvent<BookingNotMadeEnvelope>) = saveAndEmit(
+  fun saveBookingNotMadeEvent(domainEvent: SaveCas1DomainEvent<BookingNotMadeEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE,
   )
 
   @Transactional
-  fun saveBookingCancelledEvent(domainEvent: SaveCas1DomainEvent<BookingCancelledEnvelope>) = saveAndEmit(
+  fun saveBookingCancelledEvent(domainEvent: SaveCas1DomainEvent<BookingCancelledEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED,
   )
 
   @Transactional
-  fun saveBookingChangedEvent(domainEvent: SaveCas1DomainEvent<BookingChangedEnvelope>) = saveAndEmit(
+  fun saveBookingChangedEvent(domainEvent: SaveCas1DomainEvent<BookingChangedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
   )
 
   @Transactional
-  fun saveApplicationWithdrawnEvent(domainEvent: SaveCas1DomainEvent<ApplicationWithdrawnEnvelope>) = saveAndEmit(
+  fun saveApplicationWithdrawnEvent(domainEvent: SaveCas1DomainEvent<ApplicationWithdrawnEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN,
   )
 
   @Transactional
-  fun saveAssessmentAppealedEvent(domainEvent: SaveCas1DomainEvent<AssessmentAppealedEnvelope>) = saveAndEmit(
+  fun saveAssessmentAppealedEvent(domainEvent: SaveCas1DomainEvent<AssessmentAppealedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_APPEALED,
   )
 
   @Transactional
-  fun savePlacementAppealAccepted(domainEvent: SaveCas1DomainEvent<PlacementAppealAcceptedEnvelope>) = saveAndEmit(
+  fun savePlacementAppealAccepted(domainEvent: SaveCas1DomainEvent<PlacementAppealAcceptedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_ACCEPTED,
   )
 
   @Transactional
-  fun savePlacementAppealCreated(domainEvent: SaveCas1DomainEvent<PlacementAppealCreatedEnvelope>) = saveAndEmit(
+  fun savePlacementAppealCreated(domainEvent: SaveCas1DomainEvent<PlacementAppealCreatedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_CREATED,
   )
 
   @Transactional
-  fun savePlacementAppealRejected(domainEvent: SaveCas1DomainEvent<PlacementAppealRejectedEnvelope>) = saveAndEmit(
+  fun savePlacementAppealRejected(domainEvent: SaveCas1DomainEvent<PlacementAppealRejectedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_REJECTED,
   )
 
   @Transactional
-  fun savePlacementApplicationWithdrawnEvent(domainEvent: SaveCas1DomainEvent<PlacementApplicationWithdrawnEnvelope>) = saveAndEmit(
+  fun savePlacementApplicationWithdrawnEvent(domainEvent: SaveCas1DomainEvent<PlacementApplicationWithdrawnEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN,
   )
 
   @Transactional
-  fun savePlacementApplicationAllocatedEvent(domainEvent: SaveCas1DomainEvent<PlacementApplicationAllocatedEnvelope>) = saveAndEmit(
+  fun savePlacementApplicationAllocatedEvent(domainEvent: SaveCas1DomainEvent<PlacementApplicationAllocatedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_ALLOCATED,
   )
 
   @Transactional
-  fun saveMatchRequestWithdrawnEvent(domainEvent: SaveCas1DomainEvent<MatchRequestWithdrawnEnvelope>) = saveAndEmit(
+  fun saveMatchRequestWithdrawnEvent(domainEvent: SaveCas1DomainEvent<MatchRequestWithdrawnEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN,
   )
 
   @Transactional
-  fun saveRequestForPlacementCreatedEvent(domainEvent: SaveCas1DomainEvent<RequestForPlacementCreatedEnvelope>) = saveAndEmit(
+  fun saveRequestForPlacementCreatedEvent(domainEvent: SaveCas1DomainEvent<RequestForPlacementCreatedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_CREATED,
   )
 
   @Transactional
-  fun saveRequestForPlacementAssessedEvent(domainEvent: SaveCas1DomainEvent<RequestForPlacementAssessedEnvelope>) = saveAndEmit(
+  fun saveRequestForPlacementAssessedEvent(domainEvent: SaveCas1DomainEvent<RequestForPlacementAssessedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED,
   )
 
   @Transactional
-  fun saveApplicationExpiredEvent(domainEvent: SaveCas1DomainEvent<ApplicationExpiredEnvelope>) = saveAndEmit(
+  fun saveApplicationExpiredEvent(domainEvent: SaveCas1DomainEvent<ApplicationExpiredEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED,
   )
 
   @Transactional
-  fun saveAssessmentAllocatedEvent(domainEvent: SaveCas1DomainEvent<AssessmentAllocatedEnvelope>) = saveAndEmit(
+  fun saveAssessmentAllocatedEvent(domainEvent: SaveCas1DomainEvent<AssessmentAllocatedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_ALLOCATED,
   )
 
   @Transactional
-  fun saveFurtherInformationRequestedEvent(domainEvent: SaveCas1DomainEvent<FurtherInformationRequestedEnvelope>) = saveAndEmit(
+  fun saveFurtherInformationRequestedEvent(domainEvent: SaveCas1DomainEvent<FurtherInformationRequestedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED,
   )
 
   @Transactional
-  fun saveKeyWorkerAssignedEvent(domainEvent: SaveCas1DomainEvent<BookingKeyWorkerAssignedEnvelope>) = saveAndEmit(
+  fun saveKeyWorkerAssignedEvent(domainEvent: SaveCas1DomainEvent<BookingKeyWorkerAssignedEnvelope>) = saveAndEmitForEnvelope(
     domainEvent = domainEvent,
     eventType = DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED,
   )
@@ -303,8 +303,49 @@ class Cas1DomainEventService(
 
   private fun getAllDomainEventsById(applicationId: UUID? = null, spaceBookingId: UUID? = null) = domainEventRepository.findAllTimelineEventsByIds(applicationId, spaceBookingId).distinctBy { it.id }
 
+  fun <T : Cas1DomainEventPayload> save(saveWithPayload: SaveCas1DomainEventWithPayload<T>) {
+    val id = saveWithPayload.id
+    val type = saveWithPayload.type
+    val expectedPayloadType = type.cas1Info!!.payloadType
+    val actualPayloadType = saveWithPayload.data::class
+
+    if (actualPayloadType != expectedPayloadType) {
+      error("expected payload type of $expectedPayloadType, but got $actualPayloadType")
+    }
+
+    val envelope = Cas1DomainEventEnvelope(
+      id = id,
+      timestamp = saveWithPayload.occurredAt,
+      eventType = type.cas1Info.apiType,
+      eventDetails = saveWithPayload.data,
+    )
+
+    val saveWithEnvelope = SaveCas1DomainEvent(
+      id = id,
+      applicationId = saveWithPayload.applicationId,
+      assessmentId = saveWithPayload.assessmentId,
+      bookingId = saveWithPayload.bookingId,
+      cas1SpaceBookingId = saveWithPayload.cas1SpaceBookingId,
+      cas1PlacementRequestId = saveWithPayload.cas1PlacementRequestId,
+      crn = saveWithPayload.crn,
+      nomsNumber = saveWithPayload.nomsNumber,
+      occurredAt = saveWithPayload.occurredAt,
+      data = envelope,
+      metadata = saveWithPayload.metadata,
+      schemaVersion = saveWithPayload.schemaVersion,
+      triggerSource = saveWithPayload.triggerSource,
+      emit = saveWithPayload.emit,
+    )
+
+    saveAndEmitForEnvelope(
+      saveWithEnvelope,
+      type,
+    )
+  }
+
+  @Deprecated("Instead use [save]")
   @Transactional
-  fun saveAndEmit(
+  fun saveAndEmitForEnvelope(
     domainEvent: SaveCas1DomainEvent<*>,
     eventType: DomainEventType,
   ) {
@@ -395,8 +436,27 @@ data class GetCas1DomainEvent<T>(
   val schemaVersion: Int? = null,
 )
 
+@Deprecated("Use [SaveCas1DomainEventWithPayload]")
 data class SaveCas1DomainEvent<T>(
   val id: UUID,
+  val applicationId: UUID? = null,
+  val assessmentId: UUID? = null,
+  val bookingId: UUID? = null,
+  val cas1SpaceBookingId: UUID? = null,
+  val cas1PlacementRequestId: UUID? = null,
+  val crn: String,
+  val nomsNumber: String?,
+  val occurredAt: Instant,
+  val data: T,
+  val metadata: Map<MetaDataName, String?> = emptyMap(),
+  val schemaVersion: Int? = null,
+  val triggerSource: TriggerSourceType? = null,
+  val emit: Boolean = true,
+)
+
+data class SaveCas1DomainEventWithPayload<T>(
+  val id: UUID = UUID.randomUUID(),
+  val type: DomainEventType,
   val applicationId: UUID? = null,
   val assessmentId: UUID? = null,
   val bookingId: UUID? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -712,7 +712,12 @@ class Cas1SpaceBookingService(
 
     updateSpaceBookingForTransfer(existingCas1SpaceBooking, plannedTransferSpaceBooking, cas1NewPlannedTransfer.arrivalDate)
 
-    cas1ChangeRequestService.approveChangeRequest(changeRequest, user)
+    cas1ChangeRequestService.approvedPlannedTransfer(
+      changeRequest = changeRequest,
+      user = user,
+      from = existingCas1SpaceBooking,
+      to = plannedTransferSpaceBooking,
+    )
 
     return Success(Unit)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/DomainEventUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/DomainEventUtils.kt
@@ -1,7 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventPayloadBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.DomainEventUtils.mapApprovedPremisesEntityToPremises
 
 object DomainEventUtils {
   fun mapApprovedPremisesEntityToPremises(aPEntity: ApprovedPremisesEntity) = Premises(
@@ -12,3 +17,17 @@ object DomainEventUtils {
     localAuthorityAreaName = aPEntity.localAuthorityArea!!.name,
   )
 }
+
+fun Cas1SpaceBookingEntity.toEventBookingSummary() = EventBookingSummary(
+  bookingId = this.id,
+  premises = mapApprovedPremisesEntityToPremises(this.premises),
+  arrivalDate = this.canonicalArrivalDate,
+  departureDate = this.canonicalDepartureDate,
+)
+
+fun EventBookingSummary.toTimelinePayloadSummary() = Cas1TimelineEventPayloadBookingSummary(
+  bookingId = this.bookingId,
+  premises = NamedId(this.premises.id, this.premises.name),
+  arrivalDate = this.arrivalDate,
+  departureDate = this.departureDate,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestAcceptedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestAcceptedTimelineFactory.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PlannedTransferRequestAcceptedPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import java.util.UUID
+
+@Service
+class PlannedTransferRequestAcceptedTimelineFactory(val domainEventService: Cas1DomainEventService) : TimelineFactory<Cas1PlannedTransferRequestAcceptedPayload> {
+
+  override fun produce(domainEventId: UUID): Cas1PlannedTransferRequestAcceptedPayload {
+    val event = domainEventService.get(domainEventId, PlannedTransferRequestAccepted::class)!!
+
+    val details = event.data.eventDetails
+
+    return Cas1PlannedTransferRequestAcceptedPayload(
+      type = Cas1TimelineEventType.plannedTransferRequestAccepted,
+      from = details.from.toTimelinePayloadSummary(),
+      to = details.to.toTimelinePayloadSummary(),
+      schemaVersion = event.schemaVersion,
+    )
+  }
+
+  override fun forType() = DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_ACCEPTED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestCreatedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestCreatedTimelineFactory.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PlannedTransferRequestCreatedPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import java.util.UUID
+
+@Service
+class PlannedTransferRequestCreatedTimelineFactory(val domainEventService: Cas1DomainEventService) : TimelineFactory<Cas1PlannedTransferRequestCreatedPayload> {
+
+  override fun produce(domainEventId: UUID): Cas1PlannedTransferRequestCreatedPayload {
+    val event = domainEventService.get(domainEventId, PlannedTransferRequestCreated::class)!!
+
+    val details = event.data.eventDetails
+    val reason = details.reason
+
+    return Cas1PlannedTransferRequestCreatedPayload(
+      type = Cas1TimelineEventType.plannedTransferRequestCreated,
+      booking = details.booking.toTimelinePayloadSummary(),
+      reason = NamedId(reason.id, reason.code),
+      schemaVersion = event.schemaVersion,
+    )
+  }
+
+  override fun forType() = DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_CREATED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestRejectedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestRejectedTimelineFactory.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestRejected
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PlannedTransferRequestRejectedPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import java.util.UUID
+
+@Service
+class PlannedTransferRequestRejectedTimelineFactory(val domainEventService: Cas1DomainEventService) : TimelineFactory<Cas1PlannedTransferRequestRejectedPayload> {
+
+  override fun produce(domainEventId: UUID): Cas1PlannedTransferRequestRejectedPayload {
+    val event = domainEventService.get(domainEventId, PlannedTransferRequestRejected::class)!!
+
+    val details = event.data.eventDetails
+    val reason = details.reason
+
+    return Cas1PlannedTransferRequestRejectedPayload(
+      type = Cas1TimelineEventType.plannedTransferRequestRejected,
+      booking = details.booking.toTimelinePayloadSummary(),
+      reason = NamedId(reason.id, reason.code),
+      schemaVersion = event.schemaVersion,
+    )
+  }
+
+  override fun forType() = DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_REJECTED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/TimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/TimelineFactory.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventContentPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import java.util.UUID
+
+interface TimelineFactory<T : Cas1TimelineEventContentPayload> {
+  fun produce(domainEventId: UUID): T
+
+  fun forType(): DomainEventType
+}

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1100,6 +1100,9 @@ components:
         - placement_appeal_rejected
         - placement_application_withdrawn
         - placement_application_allocated
+        - planned_transfer_request_accepted
+        - planned_transfer_request_created
+        - planned_transfer_request_rejected
         - match_request_withdrawn
         - request_for_placement_created
         - request_for_placement_assessed
@@ -1187,6 +1190,9 @@ components:
           placement_appeal_accepted: '#/components/schemas/Cas1PlacementAppealAcceptedPayload'
           placement_appeal_created: '#/components/schemas/Cas1PlacementAppealCreatedPayload'
           placement_appeal_rejected: '#/components/schemas/Cas1PlacementAppealRejectedPayload'
+          planned_transfer_request_accepted: '#/components/schemas/Cas1PlannedTransferRequestAcceptedPayload'
+          planned_transfer_request_created: '#/components/schemas/Cas1PlannedTransferRequestCreatedPayload'
+          planned_transfer_request_rejected: '#/components/schemas/Cas1PlannedTransferRequestRejectedPayload'
     Cas1BookingChangedContentPayload:
       type: object
       allOf:
@@ -1278,19 +1284,55 @@ components:
         - expectedArrival
         - expectedDeparture
         - rejectionReason
+    Cas1PlannedTransferRequestCreatedPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        reason:
+          $ref: '_shared.yml#/components/schemas/NamedId'
+      required:
+        - booking
+        - reason
+    Cas1PlannedTransferRequestAcceptedPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        from:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        to:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+      required:
+        - from
+        - to
+    Cas1PlannedTransferRequestRejectedPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        reason:
+          $ref: '_shared.yml#/components/schemas/NamedId'
+      required:
+        - booking
+        - reason
     Cas1EmergencyTransferCreatedContentPayload:
       type: object
       allOf:
         - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
       properties:
         from:
-          $ref: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayloadBooking'
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
         to:
-          $ref: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayloadBooking'
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
       required:
         - from
         - to
-    Cas1EmergencyTransferCreatedContentPayloadBooking:
+    Cas1TimelineEventPayloadBookingSummary:
       type: object
       properties:
         bookingId:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7824,6 +7824,9 @@ components:
         - placement_appeal_rejected
         - placement_application_withdrawn
         - placement_application_allocated
+        - planned_transfer_request_accepted
+        - planned_transfer_request_created
+        - planned_transfer_request_rejected
         - match_request_withdrawn
         - request_for_placement_created
         - request_for_placement_assessed
@@ -7911,6 +7914,9 @@ components:
           placement_appeal_accepted: '#/components/schemas/Cas1PlacementAppealAcceptedPayload'
           placement_appeal_created: '#/components/schemas/Cas1PlacementAppealCreatedPayload'
           placement_appeal_rejected: '#/components/schemas/Cas1PlacementAppealRejectedPayload'
+          planned_transfer_request_accepted: '#/components/schemas/Cas1PlannedTransferRequestAcceptedPayload'
+          planned_transfer_request_created: '#/components/schemas/Cas1PlannedTransferRequestCreatedPayload'
+          planned_transfer_request_rejected: '#/components/schemas/Cas1PlannedTransferRequestRejectedPayload'
     Cas1BookingChangedContentPayload:
       type: object
       allOf:
@@ -8002,19 +8008,55 @@ components:
         - expectedArrival
         - expectedDeparture
         - rejectionReason
+    Cas1PlannedTransferRequestCreatedPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        reason:
+          $ref: '#/components/schemas/NamedId'
+      required:
+        - booking
+        - reason
+    Cas1PlannedTransferRequestAcceptedPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        from:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        to:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+      required:
+        - from
+        - to
+    Cas1PlannedTransferRequestRejectedPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        reason:
+          $ref: '#/components/schemas/NamedId'
+      required:
+        - booking
+        - reason
     Cas1EmergencyTransferCreatedContentPayload:
       type: object
       allOf:
         - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
       properties:
         from:
-          $ref: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayloadBooking'
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
         to:
-          $ref: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayloadBooking'
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
       required:
         - from
         - to
-    Cas1EmergencyTransferCreatedContentPayloadBooking:
+    Cas1TimelineEventPayloadBookingSummary:
       type: object
       properties:
         bookingId:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/Cas1DomainEventEnvelopeFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/Cas1DomainEventEnvelopeFactory.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
+import java.time.Instant
+import java.util.UUID
+
+class Cas1DomainEventEnvelopeFactory<T : Cas1DomainEventPayload> : Factory<Cas1DomainEventEnvelope<T>> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var timestamp: Yielded<Instant> = { Instant.now() }
+  private var type: Yielded<EventType> = { EventType.plannedTransferRequestCreated }
+  private var details: Yielded<T> = { PlannedTransferRequestCreatedFactory().produce() as T }
+
+  fun withDetails(details: T) = apply { this.details = { details } }
+
+  override fun produce() = Cas1DomainEventEnvelope<T>(
+    id = id(),
+    timestamp = timestamp(),
+    eventType = type(),
+    eventDetails = details(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/EmergencyTransferCreatedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/EmergencyTransferCreatedFactory.kt
@@ -2,25 +2,23 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
 
 import io.github.bluegroundltd.kfactory.Factory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EmergencyTransferCreated
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.TransferBooking
 import java.time.Instant
-import java.time.LocalDate
 import java.util.UUID
 
 class EmergencyTransferCreatedFactory : Factory<EmergencyTransferCreated> {
   private var applicationId = { UUID.randomUUID() }
   private var createdAt = { Instant.now() }
   private var createdBy = { StaffMemberFactory().produce() }
-  private var from = { TransferBookingFactory().produce() }
-  private var to = { TransferBookingFactory().produce() }
+  private var from = { EventBookingSummaryFactory().produce() }
+  private var to = { EventBookingSummaryFactory().produce() }
 
   fun withApplicationId(applicationId: UUID) = apply { this.applicationId = { applicationId } }
   fun withCreatedAt(createdAt: Instant) = apply { this.createdAt = { createdAt } }
   fun withCreatedBy(createdBy: StaffMember) = apply { this.createdBy = { createdBy } }
-  fun withFrom(from: TransferBooking) = apply { this.from = { from } }
-  fun withTo(to: TransferBooking) = apply { this.to = { to } }
+  fun withFrom(from: EventBookingSummary) = apply { this.from = { from } }
+  fun withTo(to: EventBookingSummary) = apply { this.to = { to } }
 
   override fun produce() = EmergencyTransferCreated(
     applicationId = applicationId(),
@@ -28,24 +26,5 @@ class EmergencyTransferCreatedFactory : Factory<EmergencyTransferCreated> {
     createdBy = createdBy(),
     from = from(),
     to = to(),
-  )
-}
-
-class TransferBookingFactory : Factory<TransferBooking> {
-  private var bookingId = { UUID.randomUUID() }
-  private var premises = { EventPremisesFactory().produce() }
-  private var arrivalOn = { LocalDate.now() }
-  private var departureOn = { LocalDate.now() }
-
-  fun withBookingId(bookingId: UUID) = apply { this.bookingId = { bookingId } }
-  fun withPremises(premises: Premises) = apply { this.premises = { premises } }
-  fun withArrivalOn(arrivalOn: LocalDate) = apply { this.arrivalOn = { arrivalOn } }
-  fun withDepartureOn(departureOn: LocalDate) = apply { this.departureOn = { departureOn } }
-
-  override fun produce() = TransferBooking(
-    bookingId = bookingId(),
-    premises = premises(),
-    arrivalOn = arrivalOn(),
-    departureOn = departureOn(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/EventBookingSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/EventBookingSummaryFactory.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Premises
+import java.time.LocalDate
+import java.util.UUID
+
+class EventBookingSummaryFactory : Factory<EventBookingSummary> {
+  private var bookingId = { UUID.randomUUID() }
+  private var premises = { EventPremisesFactory().produce() }
+  private var arrivalOn = { LocalDate.now() }
+  private var departureOn = { LocalDate.now() }
+
+  fun withBookingId(bookingId: UUID) = apply { this.bookingId = { bookingId } }
+  fun withPremises(premises: Premises) = apply { this.premises = { premises } }
+  fun withArrivalOn(arrivalOn: LocalDate) = apply { this.arrivalOn = { arrivalOn } }
+  fun withDepartureOn(departureOn: LocalDate) = apply { this.departureOn = { departureOn } }
+
+  override fun produce() = EventBookingSummary(
+    bookingId = bookingId(),
+    premises = premises(),
+    arrivalDate = arrivalOn(),
+    departureDate = departureOn(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlacementApplicationAllocatedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlacementApplicationAllocatedFactory.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.St
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.Instant
+import java.time.LocalDate
 import java.util.UUID
 
 class PlacementApplicationAllocatedFactory : Factory<PlacementApplicationAllocated> {
@@ -17,7 +18,7 @@ class PlacementApplicationAllocatedFactory : Factory<PlacementApplicationAllocat
   private var placementApplicationId: Yielded<UUID> = { UUID.randomUUID() }
   private var personReference: Yielded<PersonReference> = { PersonReferenceFactory().produce() }
   private var allocatedAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
-  private var placementDates: Yielded<List<DatePeriod>> = { emptyList() }
+  private var placementDates: Yielded<List<DatePeriod>> = { listOf(DatePeriod(startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1))) }
   private var allocatedTo: Yielded<StaffMember?> = { StaffMemberFactory().produce() }
   private var allocatedBy: Yielded<StaffMember?> = { StaffMemberFactory().produce() }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlannedTransferRequestAcceptedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlannedTransferRequestAcceptedFactory.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
+import java.util.UUID
+
+class PlannedTransferRequestAcceptedFactory : Factory<PlannedTransferRequestAccepted> {
+  private var changeRequestId = { UUID.randomUUID() }
+  private var acceptedBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var from = { EventBookingSummaryFactory().produce() }
+  private var to = { EventBookingSummaryFactory().produce() }
+
+  fun withAcceptedBy(acceptedBy: StaffMember) = apply { this.acceptedBy = { acceptedBy } }
+  fun withFrom(from: EventBookingSummary) = apply { this.from = { from } }
+  fun withTo(to: EventBookingSummary) = apply { this.to = { to } }
+
+  override fun produce() = PlannedTransferRequestAccepted(
+    changeRequestId = changeRequestId(),
+    acceptedBy = acceptedBy(),
+    from = from(),
+    to = to(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlannedTransferRequestCreatedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlannedTransferRequestCreatedFactory.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventCodedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
+import java.util.UUID
+
+class PlannedTransferRequestCreatedFactory : Factory<PlannedTransferRequestCreated> {
+  private var changeRequestId = { UUID.randomUUID() }
+  private var booking = { EventBookingSummaryFactory().produce() }
+  private var requestedBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var reason: Yielded<Cas1DomainEventCodedId> = { Cas1DomainEventCodedIdFactory().produce() }
+
+  fun withRequestedBy(requestedBy: StaffMember) = apply { this.requestedBy = { requestedBy } }
+  fun withReason(reason: Cas1DomainEventCodedId) = apply { this.reason = { reason } }
+  fun withBooking(booking: EventBookingSummary) = apply { this.booking = { booking } }
+
+  override fun produce() = PlannedTransferRequestCreated(
+    changeRequestId = changeRequestId(),
+    booking = booking(),
+    requestedBy = requestedBy(),
+    reason = reason(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlannedTransferRequestRejectedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlannedTransferRequestRejectedFactory.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventCodedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestRejected
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
+import java.util.UUID
+
+class PlannedTransferRequestRejectedFactory : Factory<PlannedTransferRequestRejected> {
+  private var changeRequestId = { UUID.randomUUID() }
+  private var booking = { EventBookingSummaryFactory().produce() }
+  private var rejectedBy: Yielded<StaffMember> = { StaffMemberFactory().produce() }
+  private var reason: Yielded<Cas1DomainEventCodedId> = { Cas1DomainEventCodedIdFactory().produce() }
+
+  fun withRejectedBy(rejectedBy: StaffMember) = apply { this.rejectedBy = { rejectedBy } }
+  fun withReason(reason: Cas1DomainEventCodedId) = apply { this.reason = { reason } }
+  fun withBooking(booking: EventBookingSummary) = apply { this.booking = { booking } }
+
+  override fun produce() = PlannedTransferRequestRejected(
+    changeRequestId = changeRequestId(),
+    booking = booking(),
+    rejectedBy = rejectedBy(),
+    reason = reason(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTimelineTest.kt
@@ -151,9 +151,9 @@ class Cas1ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
         withCreatedBy(userEntity)
       }
 
-      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type, clarificationNote.id)
+      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type = type, requestId = clarificationNote.id)
     } else {
-      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type)
+      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type = type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTimelineTest.kt
@@ -71,10 +71,12 @@ class Cas1ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
       withAssessmentSchema(assessmentSchema)
     }
 
-    domainEvents = DomainEventType.entries.filter { it.cas == DomainEventCas.CAS1 }.map {
-      createDomainEvent(it, otherApplication, otherAssessment, user)
-      return@map createDomainEvent(it, application, assessment, user)
-    }
+    domainEvents = DomainEventType.entries
+      .filter { it.cas == DomainEventCas.CAS1 }
+      .filter { it != DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED }.map {
+        createDomainEvent(it, otherApplication, otherAssessment, user)
+        return@map createDomainEvent(it, application, assessment, user)
+      }
 
     notes = createTimelineNotes(application, 5, isDeleted = false)
     createTimelineNotes(application, 2, isDeleted = true)
@@ -157,6 +159,7 @@ class Cas1ApplicationTimelineTest : InitialiseDatabasePerClassTestBase() {
     }
 
     return domainEventFactory.produceAndPersist {
+      withType(type)
       withApplicationId(applicationEntity.id)
       withData(data)
       withTriggeredByUserId(userEntity.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_CREATED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_REJECTED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_CREATED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_CHANGE_REQUEST_DEV
@@ -230,6 +231,8 @@ class Cas1ChangeRequestTest {
           assertThat(persistedChangeRequest.requestJson).isEqualTo("{}")
           assertThat(persistedChangeRequest.requestReason).isEqualTo(changeRequestReason)
           assertThat(persistedChangeRequest.spaceBooking.id).isEqualTo(spaceBooking.id)
+
+          domainEventAsserter.assertDomainEventOfTypeStored(placementRequest.application.id, APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_CREATED)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -2790,6 +2790,8 @@ class Cas1SpaceBookingTest {
 
       assertThat(updatedChangedRequest.resolved).isTrue
       assertThat(updatedChangedRequest.decision).isEqualTo(ChangeRequestDecision.APPROVED)
+
+      domainEventAsserter.assertDomainEventOfTypeStored(application.id, DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_ACCEPTED)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTimelineTest.kt
@@ -193,9 +193,9 @@ class Cas1SpaceBookingTimelineTest : InitialiseDatabasePerClassTestBase() {
         withAssessment(assessmentEntity)
         withCreatedBy(userEntity)
       }
-      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type, clarificationNote.id)
+      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type = type, requestId = clarificationNote.id)
     } else {
-      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type)
+      domainEventsFactory.createEnvelopeForLatestSchemaVersion(type = type)
     }
 
     return domainEventFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementDomainEventServiceTest.kt
@@ -623,12 +623,12 @@ class Cas1BookingManagementDomainEventServiceTest {
       assertThat(data.createdBy.username).isEqualTo("thecreator")
       assertThat(data.from.bookingId).isEqualTo(from.id)
       assertThat(data.from.premises.name).isEqualTo("frompremises")
-      assertThat(data.from.arrivalOn).isEqualTo(LocalDate.of(2019, 8, 7))
-      assertThat(data.from.departureOn).isEqualTo(LocalDate.of(2019, 8, 8))
+      assertThat(data.from.arrivalDate).isEqualTo(LocalDate.of(2019, 8, 7))
+      assertThat(data.from.departureDate).isEqualTo(LocalDate.of(2019, 8, 8))
       assertThat(data.to.bookingId).isEqualTo(to.id)
       assertThat(data.to.premises.name).isEqualTo("topremises")
-      assertThat(data.to.arrivalOn).isEqualTo(LocalDate.of(2019, 8, 8))
-      assertThat(data.to.departureOn).isEqualTo(LocalDate.of(2019, 8, 9))
+      assertThat(data.to.arrivalDate).isEqualTo(LocalDate.of(2019, 8, 8))
+      assertThat(data.to.departureDate).isEqualTo(LocalDate.of(2019, 8, 9))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
@@ -46,6 +46,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Cas1DomainEventCodedIdFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EmergencyTransferCreatedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventBookingSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.FurtherInformationRequestedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.MatchRequestWithdrawnFactory
@@ -60,7 +61,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Placement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementCreatedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.StaffMemberFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.TransferBookingFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
@@ -98,6 +98,7 @@ class Cas1DomainEventDescriberTest {
     mockAssessmentClarificationNoteRepository,
     mockBookingRepository,
     mockSpaceBookingRepository,
+    emptyList(),
   )
 
   @Test
@@ -842,7 +843,7 @@ class Cas1DomainEventDescriberTest {
             eventType = EventType.emergencyTransferCreated,
             eventDetails = EmergencyTransferCreatedFactory()
               .withFrom(
-                TransferBookingFactory()
+                EventBookingSummaryFactory()
                   .withPremises(
                     EventPremisesFactory()
                       .withName("from premises")
@@ -854,7 +855,7 @@ class Cas1DomainEventDescriberTest {
                   .produce(),
               )
               .withTo(
-                TransferBookingFactory()
+                EventBookingSummaryFactory()
                   .withPremises(
                     EventPremisesFactory()
                       .withName("to premises")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -2878,7 +2878,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { spaceBookingRepository.saveAndFlush(any()) } returns existingSpaceBooking
 
-      every { cas1ChangeRequestService.approveChangeRequest(any(), any()) } returns existingChangeRequest
+      every { cas1ChangeRequestService.approvedPlannedTransfer(any(), any(), any(), any()) } returns Unit
 
       val bookingId = UUID.randomUUID()
 
@@ -2922,7 +2922,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { spaceBookingRepository.saveAndFlush(any()) } returns existingSpaceBooking
 
-      every { cas1ChangeRequestService.approveChangeRequest(any(), any()) } returns existingChangeRequest
+      every { cas1ChangeRequestService.approvedPlannedTransfer(any(), any(), any(), any()) } returns Unit
 
       val result = service.plannedTransfer(
         existingSpaceBooking.id,
@@ -2963,7 +2963,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { spaceBookingRepository.saveAndFlush(any()) } returns existingSpaceBooking
 
-      every { cas1ChangeRequestService.approveChangeRequest(any(), any()) } returns existingChangeRequest
+      every { cas1ChangeRequestService.approvedPlannedTransfer(any(), any(), any(), any()) } returns Unit
 
       val result = service.plannedTransfer(
         existingSpaceBooking.id,
@@ -2997,7 +2997,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { spaceBookingRepository.saveAndFlush(capture(capturedBookings)) } answers { firstArg() }
 
-      every { cas1ChangeRequestService.approveChangeRequest(any(), any()) } returns existingChangeRequest
+      every { cas1ChangeRequestService.approvedPlannedTransfer(any(), any(), any(), any()) } returns Unit
 
       assertThat(existingSpaceBooking.transferredTo).isNull()
 
@@ -3016,7 +3016,6 @@ class Cas1SpaceBookingServiceTest {
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
 
       verify(exactly = 2) { spaceBookingRepository.saveAndFlush(any()) }
-      verify { cas1ChangeRequestService.approveChangeRequest(any(), any()) }
 
       assertEquals(2, capturedBookings.size)
 
@@ -3031,6 +3030,15 @@ class Cas1SpaceBookingServiceTest {
       assertThat(transferredBooking.expectedArrivalDate).isEqualTo(LocalDate.now().plusDays(2))
       assertThat(transferredBooking.expectedDepartureDate).isEqualTo(LocalDate.now().plusMonths(1))
       assertThat(transferredBooking.transferType).isEqualTo(TransferType.PLANNED)
+
+      verify {
+        cas1ChangeRequestService.approvedPlannedTransfer(
+          changeRequest = existingChangeRequest,
+          user = user,
+          from = existingSpaceBooking,
+          to = transferredBooking,
+        )
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/Cas1DomainEventTestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/Cas1DomainEventTestUtils.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.domainevents
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Cas1DomainEventEnvelopeFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
+import java.util.UUID
+
+fun <T : Cas1DomainEventPayload> buildDomainEvent(
+  data: T,
+  schemaVersion: Int? = null,
+): GetCas1DomainEvent<Cas1DomainEventEnvelope<T>> {
+  val id = UUID.randomUUID()
+  return GetCas1DomainEvent(
+    id = id,
+    data = Cas1DomainEventEnvelopeFactory<T>().withDetails(data).produce(),
+    schemaVersion = schemaVersion,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/PlannedTransferRequestAcceptedTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/PlannedTransferRequestAcceptedTimelineFactoryTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.domainevents
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventBookingSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlannedTransferRequestAcceptedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.PlannedTransferRequestAcceptedTimelineFactory
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class PlannedTransferRequestAcceptedTimelineFactoryTest {
+  @MockK
+  lateinit var domainEventService: Cas1DomainEventService
+
+  @InjectMockKs
+  lateinit var service: PlannedTransferRequestAcceptedTimelineFactory
+
+  @Test
+  fun produce() {
+    val id = UUID.randomUUID()
+
+    every {
+      domainEventService.get(id, PlannedTransferRequestAccepted::class)
+    } returns buildDomainEvent(
+      data = PlannedTransferRequestAcceptedFactory()
+        .withFrom(
+          EventBookingSummaryFactory()
+            .withPremises(EventPremisesFactory().withName("The Premises Name from").produce())
+            .withArrivalOn(LocalDate.of(2015, 12, 1))
+            .withDepartureOn(LocalDate.of(2015, 12, 2))
+            .produce(),
+        )
+        .withTo(
+          EventBookingSummaryFactory()
+            .withPremises(EventPremisesFactory().withName("The Premises Name to").produce())
+            .withArrivalOn(LocalDate.of(2016, 12, 1))
+            .withDepartureOn(LocalDate.of(2016, 12, 2))
+            .produce(),
+        )
+        .produce(),
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.type).isEqualTo(Cas1TimelineEventType.plannedTransferRequestAccepted)
+    assertThat(result.from.premises.name).isEqualTo("The Premises Name from")
+    assertThat(result.from.arrivalDate).isEqualTo(LocalDate.of(2015, 12, 1))
+    assertThat(result.from.departureDate).isEqualTo(LocalDate.of(2015, 12, 2))
+    assertThat(result.to.premises.name).isEqualTo("The Premises Name to")
+    assertThat(result.to.arrivalDate).isEqualTo(LocalDate.of(2016, 12, 1))
+    assertThat(result.to.departureDate).isEqualTo(LocalDate.of(2016, 12, 2))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/PlannedTransferRequestCreatedTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/PlannedTransferRequestCreatedTimelineFactoryTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.domainevents
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Cas1DomainEventCodedIdFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventBookingSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlannedTransferRequestCreatedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.PlannedTransferRequestCreatedTimelineFactory
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class PlannedTransferRequestCreatedTimelineFactoryTest {
+  @MockK
+  lateinit var domainEventService: Cas1DomainEventService
+
+  @InjectMockKs
+  lateinit var service: PlannedTransferRequestCreatedTimelineFactory
+
+  @Test
+  fun produce() {
+    val id = UUID.randomUUID()
+
+    every {
+      domainEventService.get(id, PlannedTransferRequestCreated::class)
+    } returns buildDomainEvent(
+      data = PlannedTransferRequestCreatedFactory()
+        .withBooking(
+          EventBookingSummaryFactory()
+            .withPremises(EventPremisesFactory().withName("The Premises Name").produce())
+            .withArrivalOn(LocalDate.of(2015, 12, 1))
+            .withDepartureOn(LocalDate.of(2015, 12, 2))
+            .produce(),
+        )
+        .withReason(Cas1DomainEventCodedIdFactory().withCode("The appeal name").produce())
+        .produce(),
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.type).isEqualTo(Cas1TimelineEventType.plannedTransferRequestCreated)
+    assertThat(result.booking.premises.name).isEqualTo("The Premises Name")
+    assertThat(result.booking.arrivalDate).isEqualTo(LocalDate.of(2015, 12, 1))
+    assertThat(result.booking.departureDate).isEqualTo(LocalDate.of(2015, 12, 2))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/PlannedTransferRequestRejectedTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/PlannedTransferRequestRejectedTimelineFactoryTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.domainevents
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlannedTransferRequestRejected
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Cas1DomainEventCodedIdFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventBookingSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlannedTransferRequestRejectedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.PlannedTransferRequestRejectedTimelineFactory
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class PlannedTransferRequestRejectedTimelineFactoryTest {
+  @MockK
+  lateinit var domainEventService: Cas1DomainEventService
+
+  @InjectMockKs
+  lateinit var service: PlannedTransferRequestRejectedTimelineFactory
+
+  @Test
+  fun produce() {
+    val id = UUID.randomUUID()
+
+    every {
+      domainEventService.get(id, PlannedTransferRequestRejected::class)
+    } returns buildDomainEvent(
+      data = PlannedTransferRequestRejectedFactory()
+        .withBooking(
+          EventBookingSummaryFactory()
+            .withPremises(EventPremisesFactory().withName("The Premises Name").produce())
+            .withArrivalOn(LocalDate.of(2015, 12, 1))
+            .withDepartureOn(LocalDate.of(2015, 12, 2))
+            .produce(),
+        )
+        .withReason(Cas1DomainEventCodedIdFactory().withCode("The appeal name").produce())
+        .produce(),
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.type).isEqualTo(Cas1TimelineEventType.plannedTransferRequestRejected)
+    assertThat(result.booking.premises.name).isEqualTo("The Premises Name")
+    assertThat(result.booking.arrivalDate).isEqualTo(LocalDate.of(2015, 12, 1))
+    assertThat(result.booking.departureDate).isEqualTo(LocalDate.of(2015, 12, 2))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
@@ -40,8 +40,10 @@ class Cas1DomainEventsFactory(val objectMapper: ObjectMapper) {
     type: DomainEventType,
     requestId: UUID = UUID.randomUUID(),
     occurredAt: Instant = Instant.now(),
+    id: UUID = UUID.randomUUID(),
   ): DomainEventEnvelopeAndPersistedJson {
     val envelope = createEnvelopeForLatestSchemaVersion(
+      id,
       type,
       requestId,
       occurredAt = occurredAt,
@@ -56,11 +58,11 @@ class Cas1DomainEventsFactory(val objectMapper: ObjectMapper) {
 
   @SuppressWarnings("CyclomaticComplexMethod", "TooGenericExceptionThrown")
   fun createEnvelopeForLatestSchemaVersion(
+    id: UUID = UUID.randomUUID(),
     type: DomainEventType,
     requestId: UUID = UUID.randomUUID(),
     occurredAt: Instant = Instant.now(),
-  ): Any {
-    val id = UUID.randomUUID()
+  ): Cas1DomainEventEnvelope<*> {
     val eventType = EventType.entries.find { it.value == type.typeName } ?: throw RuntimeException("Cannot find EventType for $type")
 
     val eventDetails = when (type) {
@@ -109,7 +111,7 @@ class Cas1DomainEventsFactory(val objectMapper: ObjectMapper) {
 }
 
 data class DomainEventEnvelopeAndPersistedJson(
-  val envelope: Any,
+  val envelope: Cas1DomainEventEnvelope<*>,
   val persistedJson: String,
   val schemaVersion: DomainEventSchemaVersion,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/Cas1DomainEventsFactory.kt
@@ -27,6 +27,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Placement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementAppealRejectedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationAllocatedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationWithdrawnFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlannedTransferRequestAcceptedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlannedTransferRequestCreatedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlannedTransferRequestRejectedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementCreatedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventSchemaVersion
@@ -90,6 +93,9 @@ class Cas1DomainEventsFactory(val objectMapper: ObjectMapper) {
       DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_CREATED -> PlacementAppealCreatedFactory().produce()
       DomainEventType.APPROVED_PREMISES_PLACEMENT_APPEAL_REJECTED -> PlacementAppealRejectedFactory().produce()
       DomainEventType.APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED -> EmergencyTransferCreatedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_CREATED -> PlannedTransferRequestCreatedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_ACCEPTED -> PlannedTransferRequestAcceptedFactory().produce()
+      DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_REJECTED -> PlannedTransferRequestRejectedFactory().produce()
       else -> throw RuntimeException("Domain event type $type not supported")
     }
 


### PR DESCRIPTION
This commit is quite large because it applies some new approaches to creating and retreiving domain events that should minimise the code required going forward. Notably:

* Uses the generic `Cas1DomainEventEnvelope` instead of type-specific envelopes. Some new common code was required to support this
* Uses standalone domain event describers for the timeline. Making it easier to unit test describers. Some new common code was required to support this
* Uses a common `Booking` type for timeline content. Some new common code was required to support this