### PR TITLE
updated isTransferredApplication logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -138,6 +138,7 @@ data class Cas2ApplicationEntity(
   val mostRecentPomUserId: UUID
     get() = applicationAssignments.first { it.allocatedPomUser?.id != null }.allocatedPomUser?.id!!
 
+  fun isTransferredApplication() = applicationAssignments.map { it.prisonCode }.distinct().size > 1
   fun createApplicationAssignment(prisonCode: String, allocatedPomUser: NomisUserEntity?) {
     this.applicationAssignments.add(
       Cas2ApplicationAssignmentEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2UserAccessService.kt
@@ -11,7 +11,7 @@ class Cas2UserAccessService {
     in CAS-1598.
     For now, we'll only use the new logic if the application has been transferred (so more than one assignment), otherwise use existing.
      */
-    if (application.applicationAssignments.size > 1) {
+    if (application.isTransferredApplication()) {
       return user.id == application.currentPomUserId ||
         // user is currently assigned POM
         (user.activeCaseloadId != null && user.activeCaseloadId == application.currentPrisonCode) // user is in same prison

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/ApplicationsTransformer.kt
@@ -47,7 +47,7 @@ class ApplicationsTransformer(
       allocatedPomName = currentUser?.name,
       allocatedPomEmailAddress = currentUser?.email,
       currentPrisonName = omu?.prisonName ?: jpa.currentPrisonCode,
-      isTransferredApplication = jpa.currentPrisonCode != jpa.referringPrisonCode,
+      isTransferredApplication = jpa.isTransferredApplication(),
       assignmentDate = jpa.currentAssignmentDate,
       omuEmailAddress = omu?.email,
     )


### PR DESCRIPTION
this would return false positives when an application was transferred out and then back into the first prison, the first POM details were  displayed despite not being allocated