### PR TITLE
Allow duplicate entries for domain event metadata

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -1,16 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import io.hypersistence.utils.hibernate.type.json.JsonType
-import jakarta.persistence.CollectionTable
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
-import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.MapKeyColumn
-import jakarta.persistence.MapKeyEnumerated
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.annotations.Type
 import org.springframework.data.jpa.repository.JpaRepository
@@ -163,12 +161,9 @@ data class DomainEventEntity(
   val triggerSource: TriggerSourceType? = null,
   val triggeredByUserId: UUID?,
   val nomsNumber: String?,
-  @ElementCollection
-  @MapKeyColumn(name = "name")
-  @MapKeyEnumerated(EnumType.STRING)
-  @Column(name = "value")
-  @CollectionTable(name = "domain_events_metadata", joinColumns = [ JoinColumn(name = "domain_event_id") ])
-  val metadata: Map<MetaDataName, String?> = emptyMap(),
+  @OneToMany(cascade = [CascadeType.ALL])
+  @JoinColumn(name = "domain_event_id", nullable = false)
+  val metadata: List<DomainEventMetadataEntity> = emptyList(),
   /**
    * Use to track the schema version used for the [data] property. The schema version
    * will be specific to the corresponding [type]. This version number relates to
@@ -185,16 +180,6 @@ data class DomainEventEntity(
 )
 
 enum class TriggerSourceType { USER, SYSTEM }
-
-enum class MetaDataName {
-  CAS1_APP_REASON_FOR_SHORT_NOTICE,
-  CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER,
-  CAS1_PLACEMENT_APPLICATION_ID,
-  CAS1_REQUESTED_AP_TYPE,
-  CAS1_PLACEMENT_REQUEST_ID,
-  CAS1_CANCELLATION_ID,
-  CAS1_SPACE_BOOKING_ID,
-}
 
 enum class DomainEventCas {
   CAS1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventMetadataEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventMetadataEntity.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "domain_events_metadata")
+data class DomainEventMetadataEntity(
+  @Id
+  val id: UUID,
+  @Enumerated(EnumType.STRING)
+  val name: MetaDataName,
+  val value: String?,
+)
+
+enum class MetaDataName {
+  CAS1_APP_REASON_FOR_SHORT_NOTICE,
+  CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER,
+  CAS1_PLACEMENT_APPLICATION_ID,
+  CAS1_REQUESTED_AP_TYPE,
+  CAS1_PLACEMENT_REQUEST_ID,
+  CAS1_CANCELLATION_ID,
+  CAS1_SPACE_BOOKING_ID,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksSer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapOfNonNullValues
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -104,11 +103,15 @@ class Cas1ApplicationDomainEventService(
             caseDetail,
           ),
         ),
-        metadata = mapOfNonNullValues(
-          MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE to submitApplication.reasonForShortNotice,
-          MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER to submitApplication.reasonForShortNoticeOther,
-          MetaDataName.CAS1_REQUESTED_AP_TYPE to application.apType.name,
-        ),
+        metadata = buildMap {
+          submitApplication.reasonForShortNotice?.let {
+            put(MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE, listOf(it))
+          }
+          submitApplication.reasonForShortNoticeOther?.let {
+            put(MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER, listOf(it))
+          }
+          put(MetaDataName.CAS1_REQUESTED_AP_TYPE, listOf(application.apType.name))
+        },
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -198,7 +198,7 @@ class Cas1AssessmentDomainEventService(
           ),
         ),
         metadata = mapOf(
-          MetaDataName.CAS1_REQUESTED_AP_TYPE to apType?.asApprovedPremisesType()?.name,
+          MetaDataName.CAS1_REQUESTED_AP_TYPE to listOf(apType?.asApprovedPremisesType()?.name),
         ),
         schemaVersion = 2,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -33,7 +33,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapOfNonNullValues
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -132,8 +131,8 @@ class Cas1BookingDomainEventService(
             failureDescription = notes,
           ),
         ),
-        metadata = mapOfNonNullValues(
-          MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequest.id.toString(),
+        metadata = mapOf(
+          MetaDataName.CAS1_PLACEMENT_REQUEST_ID to listOf(placementRequest.id.toString()),
         ),
         cas1PlacementRequestId = placementRequest.id,
       ),
@@ -381,9 +380,11 @@ class Cas1BookingDomainEventService(
             characteristics = bookingInfo.characteristics,
           ),
         ),
-        metadata = mapOfNonNullValues(
-          MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequestId?.toString(),
-        ),
+        metadata = buildMap {
+          placementRequestId?.toString()?.let {
+            put(MetaDataName.CAS1_PLACEMENT_REQUEST_ID, listOf(it))
+          }
+        },
         cas1PlacementRequestId = placementRequestId,
       ),
     )
@@ -457,9 +458,11 @@ class Cas1BookingDomainEventService(
             cancellationRecordedAt = now.toInstant(),
           ),
         ),
-        metadata = mapOfNonNullValues(
-          MetaDataName.CAS1_CANCELLATION_ID to cancellationInfo.cancellationId?.toString(),
-        ),
+        metadata = buildMap {
+          cancellationInfo.cancellationId?.toString()?.let {
+            put(MetaDataName.CAS1_CANCELLATION_ID, listOf(it))
+          }
+        },
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -54,6 +54,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Re
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.DomainEventUrlConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventMetadataEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
@@ -338,7 +339,17 @@ class Cas1DomainEventService(
         triggerSource = domainEvent.triggerSource,
         triggeredByUserId = userService.getUserForRequestOrNull()?.id,
         nomsNumber = domainEvent.nomsNumber,
-        metadata = domainEvent.metadata,
+        metadata = domainEvent.metadata.entries.flatMap {
+          val key = it.key
+          val values = it.value
+          values.map { value ->
+            DomainEventMetadataEntity(
+              id = UUID.randomUUID(),
+              name = key,
+              value = value,
+            )
+          }
+        },
         schemaVersion = domainEvent.schemaVersion,
       ),
     )
@@ -420,7 +431,7 @@ data class SaveCas1DomainEvent<T>(
   val nomsNumber: String?,
   val occurredAt: Instant,
   val data: T,
-  val metadata: Map<MetaDataName, String?> = emptyMap(),
+  val metadata: Map<MetaDataName, List<String?>> = emptyMap(),
   val schemaVersion: Int? = null,
   val triggerSource: TriggerSourceType? = null,
   val emit: Boolean = true,
@@ -438,7 +449,7 @@ data class SaveCas1DomainEventWithPayload<T : Cas1DomainEventPayload>(
   val nomsNumber: String?,
   val occurredAt: Instant,
   val data: T,
-  val metadata: Map<MetaDataName, String?> = emptyMap(),
+  val metadata: Map<MetaDataName, List<String?>> = emptyMap(),
   val schemaVersion: Int? = null,
   val triggerSource: TriggerSourceType? = null,
   val emit: Boolean = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -133,7 +133,7 @@ class Cas1PlacementApplicationDomainEventService(
           eventDetails = eventDetails,
         ),
         metadata = mapOf(
-          MetaDataName.CAS1_PLACEMENT_APPLICATION_ID to placementApplication.id.toString(),
+          MetaDataName.CAS1_PLACEMENT_APPLICATION_ID to listOf(placementApplication.id.toString()),
         ),
       ),
     )
@@ -229,7 +229,7 @@ class Cas1PlacementApplicationDomainEventService(
           eventDetails = requestPlacementApplicationAssessed,
         ),
         metadata = mapOf(
-          MetaDataName.CAS1_PLACEMENT_APPLICATION_ID to placementApplication.id.toString(),
+          MetaDataName.CAS1_PLACEMENT_APPLICATION_ID to listOf(placementApplication.id.toString()),
         ),
       ),
     )

--- a/src/main/resources/db/migration/all/20250430153115__add_generated_id_to_domain_event_metadata.sql
+++ b/src/main/resources/db/migration/all/20250430153115__add_generated_id_to_domain_event_metadata.sql
@@ -1,0 +1,4 @@
+ALTER TABLE domain_events_metadata ADD id uuid NOT NULL DEFAULT gen_random_uuid();
+ALTER TABLE domain_events_metadata ADD CONSTRAINT domain_events_metadata_pk PRIMARY KEY (id);
+
+ALTER TABLE domain_events_metadata DROP CONSTRAINT domain_events_metadata_unique;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -6,6 +6,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventMetadataEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
@@ -31,7 +32,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var triggerSource: Yielded<TriggerSourceType?> = { null }
   private var triggeredByUserId: Yielded<UUID?> = { null }
   private var nomsNumber: Yielded<String?> = { randomStringMultiCaseWithNumbers(8) }
-  private var metadata: Yielded<Map<MetaDataName, String?>> = { emptyMap() }
+  private var metadata: Yielded<List<DomainEventMetadataEntity>> = { emptyList() }
   private var schemaVersion: Yielded<Int?> = { null }
   private var applicationOrigin: Yielded<ApplicationOrigin?> = { null }
 
@@ -102,8 +103,19 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     this.nomsNumber = { nomsNumber }
   }
 
-  fun withMetadata(metadata: Map<MetaDataName, String>) = apply {
-    this.metadata = { metadata }
+  fun withMetadata(metadata: Map<MetaDataName, List<String>>) = apply {
+    this.metadata = {
+      metadata.entries.flatMap {
+        val key = it.key
+        it.value.map { value ->
+          DomainEventMetadataEntity(
+            id = UUID.randomUUID(),
+            name = key,
+            value = value,
+          )
+        }
+      }
+    }
   }
 
   fun withSchemaVersion(schemaVersion: Int?) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
@@ -419,7 +419,7 @@ open class SubjectAccessRequestServiceTestBase : Cas2v2IntegrationTestBase() {
       withTriggeredByUserId(userId)
       withMetadata(
         mapOf(
-          MetaDataName.CAS1_REQUESTED_AP_TYPE to ApprovedPremisesType.NORMAL.toString(),
+          MetaDataName.CAS1_REQUESTED_AP_TYPE to listOf(ApprovedPremisesType.NORMAL.toString()),
         ),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCasUpdateEventNumberTest.kt
@@ -180,7 +180,6 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
             sentenceLengthInMonths = null,
           ),
         ),
-        metadata = mapOf(),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ld
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Region
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Team
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
@@ -40,7 +39,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -101,6 +99,7 @@ class Cas1ApplicationCas1DomainEventServiceTest {
         .withCrn("THECRN")
         .withCreatedByUser(user)
         .withSubmittedAt(null)
+        .withApType(ApprovedPremisesType.NORMAL)
         .produce()
         .apply {
           schemaUpToDate = true
@@ -215,10 +214,9 @@ class Cas1ApplicationCas1DomainEventServiceTest {
               data.mappa == "CAT C1/LEVEL L1" &&
               data.sentenceLengthInMonths == null &&
               data.offenceId == application.offenceId &&
-              it.metadata[MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE].equals("reason for short notice") &&
-              it.metadata[MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER].equals("reason for short notice other") &&
-              enumValueOf<ApprovedPremisesType>(it.metadata[MetaDataName.CAS1_REQUESTED_AP_TYPE].toString()).asApiType()
-                .toString() == ApType.normal.value
+              it.metadata[MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE]!!.contains("reason for short notice") &&
+              it.metadata[MetaDataName.CAS1_APP_REASON_FOR_SHORT_NOTICE_OTHER]!!.contains("reason for short notice other") &&
+              it.metadata[MetaDataName.CAS1_REQUESTED_AP_TYPE]!!.contains(ApprovedPremisesType.NORMAL.name)
           },
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentDomainEventServiceTest.kt
@@ -275,7 +275,7 @@ class Cas1AssessmentDomainEventServiceTest {
       assertThat(eventDetails.assessedBy).isEqualTo(expectedAssessor)
       assertThat(eventDetails.decision).isEqualTo("ACCEPTED")
       assertThat(eventDetails.decisionRationale).isNull()
-      assertThat(domainEvent.metadata).containsEntry(MetaDataName.CAS1_REQUESTED_AP_TYPE, "NORMAL")
+      assertThat(domainEvent.metadata).containsEntry(MetaDataName.CAS1_REQUESTED_AP_TYPE, listOf("NORMAL"))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
@@ -175,7 +175,7 @@ class Cas1BookingCas1DomainEventServiceTest {
       assertThat(data.situation).isEqualTo(application.situation)
       assertThat(data.characteristics).isEqualTo(listOf(SpaceCharacteristic.hasEnSuite))
 
-      assertThat(domainEvent.metadata).isEqualTo(mapOf(MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequest.id.toString()))
+      assertThat(domainEvent.metadata).isEqualTo(mapOf(MetaDataName.CAS1_PLACEMENT_REQUEST_ID to listOf(placementRequest.id.toString())))
     }
   }
 
@@ -293,7 +293,7 @@ class Cas1BookingCas1DomainEventServiceTest {
       assertThat(data.situation).isEqualTo(application.situation)
       assertThat(data.characteristics).isNull()
 
-      assertThat(domainEvent.metadata).isEqualTo(mapOf(MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequest.id.toString()))
+      assertThat(domainEvent.metadata).isEqualTo(mapOf(MetaDataName.CAS1_PLACEMENT_REQUEST_ID to listOf(placementRequest.id.toString())))
     }
   }
 
@@ -572,7 +572,7 @@ class Cas1BookingCas1DomainEventServiceTest {
       assertThat(data.attemptedBy.staffMember!!.staffCode).isEqualTo("the staff code")
       assertThat(data.failureDescription).isEqualTo("the notes")
 
-      assertThat(domainEvent.metadata).isEqualTo(mapOf(MetaDataName.CAS1_PLACEMENT_REQUEST_ID to placementRequest.id.toString()))
+      assertThat(domainEvent.metadata).isEqualTo(mapOf(MetaDataName.CAS1_PLACEMENT_REQUEST_ID to listOf(placementRequest.id.toString())))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationCas1DomainEventServiceTest.kt
@@ -196,7 +196,7 @@ class Cas1PlacementApplicationCas1DomainEventServiceTest {
             assertThat(it.crn).isEqualTo(CRN)
             assertThat(it.nomsNumber).isEqualTo(application.nomsNumber)
             assertThat(it.occurredAt).isWithinTheLastMinute()
-            assertThat(it.metadata).containsEntry(MetaDataName.CAS1_PLACEMENT_APPLICATION_ID, placementApplication.id.toString())
+            assertThat(it.metadata).containsEntry(MetaDataName.CAS1_PLACEMENT_APPLICATION_ID, listOf(placementApplication.id.toString()))
 
             val eventDetails = it.data.eventDetails
             assertThat(eventDetails.applicationId).isEqualTo(application.id)
@@ -406,7 +406,7 @@ class Cas1PlacementApplicationCas1DomainEventServiceTest {
             assertThat(it.crn).isEqualTo(CRN)
             assertThat(it.nomsNumber).isEqualTo(application.nomsNumber)
             assertThat(it.occurredAt).isWithinTheLastMinute()
-            assertThat(it.metadata).containsEntry(MetaDataName.CAS1_PLACEMENT_APPLICATION_ID, placementApplication.id.toString())
+            assertThat(it.metadata).containsEntry(MetaDataName.CAS1_PLACEMENT_APPLICATION_ID, listOf(placementApplication.id.toString()))
 
             val eventDetails = it.data.eventDetails
             assertThat(eventDetails.applicationId).isEqualTo(application.id)


### PR DESCRIPTION
We have a requirement to be able to link a single domain event to multiple space bookings (e.g. ‘placement transferred’).

This commit modifies the domain event to metadata relationship to allow multiple entries to be stored against a given metadata name.

Subsequent commits will then make use of this to store multiple space bookings against a single entity, and add required indexes to ensure retrieving such domain events is efficient