### PR TITLE
Refactor booking changed domain event describer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingChangedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingChangedTimelineFactory.kt
@@ -1,0 +1,96 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChanged
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BookingChangedContentPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventDescriber.EventDescriptionAndPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class BookingChangedTimelineFactory(val domainEventService: Cas1DomainEventService) : LegacyTimelineFactory<Cas1BookingChangedContentPayload> {
+
+  override fun produce(domainEventId: UUID): EventDescriptionAndPayload<Cas1BookingChangedContentPayload> {
+    val event = domainEventService.get(domainEventId, BookingChanged::class)!!
+
+    return buildBookingChangedDescription(event)
+  }
+
+  private fun buildBookingChangedDescription(domainEvent: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingChanged>>): EventDescriptionAndPayload<Cas1BookingChangedContentPayload> {
+    if (domainEvent.schemaVersion == null) {
+      val description = domainEvent.describe {
+        "A placement at ${it.eventDetails.premises.name} had its arrival and/or departure date changed to " +
+          "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()}"
+      }
+
+      return EventDescriptionAndPayload(description, null)
+    }
+
+    if (domainEvent.schemaVersion == 2) {
+      val eventDetails = domainEvent.data.eventDetails
+      val previousArrival = eventDetails.previousArrivalOn
+      val previousDeparture = eventDetails.previousDepartureOn
+      val changes = mutableListOf<String>()
+
+      fun addDateChangeMessage(previousDate: LocalDate, newDate: LocalDate, changeType: String) {
+        changes.add(
+          "its $changeType date changed from ${previousDate.toUiFormat()} to ${newDate.toUiFormat()}",
+        )
+      }
+
+      if (previousArrival != null) {
+        addDateChangeMessage(previousArrival, eventDetails.arrivalOn, "arrival")
+      }
+
+      if (previousDeparture != null) {
+        addDateChangeMessage(previousDeparture, eventDetails.departureOn, "departure")
+      }
+
+      val description = if (changes.isNotEmpty()) {
+        domainEvent.describe {
+          "A placement at ${it.eventDetails.premises.name} had ${changes.joinToString(", ")}"
+        }
+      } else {
+        null
+      }
+      return EventDescriptionAndPayload(description, getBookingChangedContentPayLoad(domainEvent))
+    }
+
+    return EventDescriptionAndPayload(null, null)
+  }
+
+  fun getBookingChangedContentPayLoad(domainEvent: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingChanged>>): Cas1BookingChangedContentPayload? {
+    val eventDetails = domainEvent.data.eventDetails
+    return Cas1BookingChangedContentPayload(
+      type = Cas1TimelineEventType.bookingChanged,
+      premises = NamedId(
+        id = eventDetails.premises.id,
+        name = eventDetails.premises.name,
+      ),
+      schemaVersion = domainEvent.schemaVersion!!,
+      previousExpectedArrival = domainEvent.data.eventDetails.previousArrivalOn,
+      expectedArrival = eventDetails.arrivalOn,
+      previousExpectedDeparture = eventDetails.previousDepartureOn,
+      expectedDeparture = eventDetails.departureOn,
+      characteristics = convertToCas1SpaceCharacteristics(eventDetails.characteristics),
+      previousCharacteristics = convertToCas1SpaceCharacteristics(eventDetails.previousCharacteristics),
+    )
+  }
+
+  private fun <T> GetCas1DomainEvent<T>?.describe(describe: (T) -> String?): String? = this?.let { describe(it.data) }
+
+  private fun convertToCas1SpaceCharacteristics(spaceCharacteristics: List<SpaceCharacteristic>?): List<Cas1SpaceCharacteristic>? = spaceCharacteristics?.map { spaceCharacteristic ->
+    Cas1SpaceCharacteristic.valueOf(spaceCharacteristic.value)
+  }
+
+  override fun forType() = DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/LegacyTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/LegacyTimelineFactory.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventContentPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventDescriber.EventDescriptionAndPayload
+import java.util.UUID
+
+/**
+ * Used when migrating 'description' based timeline entries to 'content payload based' timeline entries
+ *
+ * Once the UI has started using the content payload, the factory should be converted into a regular
+ * [TimelineFactory]
+ */
+interface LegacyTimelineFactory<T : Cas1TimelineEventContentPayload> {
+  fun produce(domainEventId: UUID): EventDescriptionAndPayload<T>
+
+  fun forType(): DomainEventType
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingChangedTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingChangedTimelineFactoryTest.kt
@@ -1,0 +1,173 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.domainevents
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChanged
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BookingChangedContentPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingChangedFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.BookingChangedTimelineFactory
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class BookingChangedTimelineFactoryTest {
+  @MockK
+  lateinit var domainEventService: Cas1DomainEventService
+
+  @InjectMockKs
+  lateinit var service: BookingChangedTimelineFactory
+
+  val id: UUID = UUID.randomUUID()
+
+  @Test
+  fun `Schema version is null`() {
+    val arrivalDate = LocalDate.of(2024, 1, 1)
+    val departureDate = LocalDate.of(2024, 4, 1)
+
+    every { domainEventService.get(id, BookingChanged::class) } returns buildDomainEvent(
+      data = BookingChangedFactory()
+        .withArrivalOn(arrivalDate)
+        .withDepartureOn(departureDate)
+        .withPremises(
+          EventPremisesFactory()
+            .withName("The Premises Name")
+            .produce(),
+        )
+        .produce(),
+      schemaVersion = null,
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.description)
+      .isEqualTo("A placement at The Premises Name had its arrival and/or departure date changed to Monday 1 January 2024 to Monday 1 April 2024")
+    assertThat(result.payload).isNull()
+  }
+
+  @Test
+  fun `Schema version is 2 and only previous arrival date is present`() {
+    val arrivalDate = LocalDate.of(2025, 4, 5)
+    val departureDate = LocalDate.of(2025, 6, 1)
+    val previousArrivalOn = LocalDate.of(2025, 4, 1)
+
+    every { domainEventService.get(id, BookingChanged::class) } returns buildDomainEvent(
+      data = BookingChangedFactory()
+        .withArrivalOn(arrivalDate)
+        .withPreviousArrivalOn(null)
+        .withDepartureOn(departureDate)
+        .withPreviousArrivalOn(previousArrivalOn)
+        .withPremises(
+          EventPremisesFactory()
+            .withName("The Premises Name")
+            .produce(),
+        )
+        .withCharacteristics(listOf(SpaceCharacteristic.hasEnSuite))
+        .withPreviousCharacteristics(null)
+        .produce(),
+      schemaVersion = 2,
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.description)
+      .isEqualTo("A placement at The Premises Name had its arrival date changed from Tuesday 1 April 2025 to Saturday 5 April 2025")
+
+    val contentPayload = result.payload as Cas1BookingChangedContentPayload
+    assertThat(contentPayload.premises.name).isEqualTo("The Premises Name")
+    assertThat(contentPayload.expectedArrival).isEqualTo(arrivalDate)
+    assertThat(contentPayload.previousExpectedArrival).isEqualTo(previousArrivalOn)
+    assertThat(contentPayload.expectedDeparture).isEqualTo(departureDate)
+    assertThat(contentPayload.previousExpectedDeparture).isNull()
+    assertThat(contentPayload.characteristics).isEqualTo(listOf(Cas1SpaceCharacteristic.hasEnSuite))
+    assertThat(contentPayload.previousCharacteristics).isNull()
+  }
+
+  @Test
+  fun `Schema version is 2 and only previous departure date is present`() {
+    val arrivalDate = LocalDate.of(2025, 4, 5)
+    val departureDate = LocalDate.of(2025, 6, 10)
+    val previousDepartureOn = LocalDate.of(2025, 6, 1)
+
+    every { domainEventService.get(id, BookingChanged::class) } returns buildDomainEvent(
+      data = BookingChangedFactory()
+        .withArrivalOn(arrivalDate)
+        .withPreviousArrivalOn(null)
+        .withDepartureOn(departureDate)
+        .withPreviousDepartureOn(previousDepartureOn)
+        .withPremises(
+          EventPremisesFactory()
+            .withName("The Premises Name")
+            .produce(),
+        )
+        .withCharacteristics(listOf(SpaceCharacteristic.hasEnSuite))
+        .withPreviousCharacteristics(null)
+        .produce(),
+      schemaVersion = 2,
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.description)
+      .isEqualTo("A placement at The Premises Name had its departure date changed from Sunday 1 June 2025 to Tuesday 10 June 2025")
+
+    val contentPayload = result.payload as Cas1BookingChangedContentPayload
+    assertThat(contentPayload.premises.name).isEqualTo("The Premises Name")
+    assertThat(contentPayload.expectedArrival).isEqualTo(arrivalDate)
+    assertThat(contentPayload.previousExpectedArrival).isNull()
+    assertThat(contentPayload.expectedDeparture).isEqualTo(departureDate)
+    assertThat(contentPayload.previousExpectedDeparture).isEqualTo(previousDepartureOn)
+    assertThat(contentPayload.characteristics).containsExactly(Cas1SpaceCharacteristic.hasEnSuite)
+    assertThat(contentPayload.previousCharacteristics).isNull()
+  }
+
+  @Test
+  fun `Schema version is 2 and previous arrival, departure dates and characteristics are present`() {
+    val arrivalDate = LocalDate.of(2025, 4, 5)
+    val departureDate = LocalDate.of(2025, 6, 10)
+    val previousArrivalOn = LocalDate.of(2025, 4, 1)
+    val previousDepartureOn = LocalDate.of(2025, 6, 1)
+
+    every { domainEventService.get(id, BookingChanged::class) } returns buildDomainEvent(
+      data = BookingChangedFactory()
+        .withArrivalOn(arrivalDate)
+        .withDepartureOn(departureDate)
+        .withPreviousArrivalOn(previousArrivalOn)
+        .withPreviousDepartureOn(previousDepartureOn)
+        .withCharacteristics(listOf(SpaceCharacteristic.hasEnSuite))
+        .withPreviousCharacteristics(listOf(SpaceCharacteristic.isArsonSuitable))
+        .withPremises(
+          EventPremisesFactory()
+            .withName("The Premises Name")
+            .produce(),
+        )
+        .produce(),
+      schemaVersion = 2,
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.description)
+      .isEqualTo(
+        "A placement at The Premises Name had its arrival date changed from Tuesday 1 April 2025 to Saturday 5 April 2025, " +
+          "its departure date changed from Sunday 1 June 2025 to Tuesday 10 June 2025",
+      )
+
+    val contentPayload = result.payload as Cas1BookingChangedContentPayload
+    assertThat(contentPayload.premises.name).isEqualTo("The Premises Name")
+    assertThat(contentPayload.expectedArrival).isEqualTo(arrivalDate)
+    assertThat(contentPayload.previousExpectedArrival).isEqualTo(previousArrivalOn)
+    assertThat(contentPayload.expectedDeparture).isEqualTo(departureDate)
+    assertThat(contentPayload.previousExpectedDeparture).isEqualTo(previousDepartureOn)
+    assertThat(contentPayload.characteristics).containsExactly(Cas1SpaceCharacteristic.hasEnSuite)
+    assertThat(contentPayload.previousCharacteristics).containsExactly(Cas1SpaceCharacteristic.isArsonSuitable)
+  }
+}


### PR DESCRIPTION
Extract logic from the `DomainEventDescriber` class and put it into a standalone `LegacyTimelineFactory`. This is in preparation for making changes to the logic.

Both versions of the timeline rendering still work after this change:

![Screenshot 2025-05-01 at 15 08 44](https://github.com/user-attachments/assets/41ceb817-d131-4d1a-87d8-bd8e2a6d2a03)

![Screenshot 2025-05-01 at 15 08 31](https://github.com/user-attachments/assets/1da04572-41e0-4277-bdb4-3616c085da05)
