### PR TITLE
APS-2246 - Add a list of open change request types to booking summary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -83,20 +83,6 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
           WHERE sbc.space_booking_id = b.id 
           GROUP BY sbc.space_booking_id
         ) AS characteristicsPropertyNamesCsv,
-        EXISTS (
-              SELECT 1
-              FROM cas1_change_requests c1
-              WHERE c1.cas1_space_booking_id = b.id
-                AND c1.type = 'PLANNED_TRANSFER'
-                AND c1.resolved = false
-        ) AS plannedTransferRequested,
-        EXISTS (
-              SELECT 1
-              FROM cas1_change_requests c2
-              WHERE c2.cas1_space_booking_id = b.id
-                AND c2.type = 'PLACEMENT_APPEAL'
-                AND c2.resolved = false
-        ) AS appealRequested,
         (
           SELECT STRING_AGG(DISTINCT change_requests.type, ',')
           FROM cas1_change_requests change_requests
@@ -321,8 +307,6 @@ interface Cas1SpaceBookingSearchResult {
   val characteristicsPropertyNamesCsv: String?
   val deliusEventNumber: String?
   val cancelled: Boolean
-  val plannedTransferRequested: Boolean
-  val appealRequested: Boolean
   val openChangeRequestTypeNamesCsv: String?
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -460,7 +460,7 @@ class Cas1SpaceBookingService(
       ),
     )
 
-    return CasResult.Success(
+    return Success(
       SearchResultContainer(
         results = page.toList(),
         paginationMetadata = getMetadata(page, pageCriteria),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1ChangeRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1ChangeRequestTransformer.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ChangeRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRepository.FindOpenChangeRequestResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ChangeRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
@@ -39,7 +40,7 @@ class Cas1ChangeRequestTransformer(
     entity: Cas1ChangeRequestEntity,
   ) = Cas1ChangeRequest(
     id = entity.id,
-    type = Cas1ChangeRequestType.valueOf(entity.type.name),
+    type = entity.type.toApiType(),
     createdAt = entity.createdAt.toInstant(),
     requestReason = NamedId(
       id = entity.requestReason.id,
@@ -79,3 +80,5 @@ class Cas1ChangeRequestTransformer(
     }
   }
 }
+
+fun ChangeRequestType.toApiType() = Cas1ChangeRequestType.valueOf(this.name)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ChangeRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.getCharacteristicPropertyNames
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.getOpenChangeRequestTypes
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -206,8 +205,8 @@ class Cas1SpaceBookingTransformer(
       },
       deliusEventNumber = spaceBooking.deliusEventNumber,
       isCancelled = spaceBooking.isCancelled(),
-      plannedTransferRequested = openChangeRequestsForBooking.any { it.type == ChangeRequestType.PLANNED_TRANSFER },
-      appealRequested = openChangeRequestsForBooking.any { it.type == ChangeRequestType.PLACEMENT_APPEAL },
+      plannedTransferRequested = false,
+      appealRequested = false,
       openChangeRequestTypes = openChangeRequestsForBooking.map { it.type.toApiType() },
     )
   }
@@ -259,8 +258,8 @@ class Cas1SpaceBookingTransformer(
     },
     deliusEventNumber = searchResult.deliusEventNumber,
     isCancelled = searchResult.cancelled,
-    plannedTransferRequested = searchResult.plannedTransferRequested,
-    appealRequested = searchResult.appealRequested,
+    plannedTransferRequested = false,
+    appealRequested = false,
     openChangeRequestTypes = searchResult.getOpenChangeRequestTypes().map { it.toApiType() },
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/StringHelpers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/StringHelpers.kt
@@ -10,3 +10,5 @@ fun String.kebabCaseToPascalCase(): String {
 fun String.javaConstantNameToSentence(): String = replace("_", " ")
   .lowercase()
   .replaceFirstChar { it.uppercase() }
+
+fun String?.commaSeparatedToList() = this?.split(",")?.filter { it.isNotBlank() } ?: emptyList()

--- a/src/main/resources/db/migration/all/20250501171254__add_change_request_space_booking_index.sql
+++ b/src/main/resources/db/migration/all/20250501171254__add_change_request_space_booking_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX cas1_change_requests_cas1_space_booking_id_idx ON cas1_change_requests (cas1_space_booking_id);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4415,9 +4415,17 @@ components:
         isCancelled:
           type: boolean
         plannedTransferRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
         appealRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
+        openChangeRequestTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1ChangeRequestType'
       required:
         - id
         - person
@@ -4430,6 +4438,17 @@ components:
         - isCancelled
         - plannedTransferRequested
         - appealRequested
+        - openChangeRequestTypes
+    Cas1ChangeRequestType:
+      type: string
+      enum:
+        - placementAppeal
+        - placementExtension
+        - plannedTransfer
+      x-enum-varnames:
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
+        - PLANNED_TRANSFER
     Cas1KeyWorkerAllocation:
       type: object
       properties:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4436,8 +4436,6 @@ components:
         - expectedArrivalDate
         - expectedDepartureDate
         - isCancelled
-        - plannedTransferRequested
-        - appealRequested
         - openChangeRequestTypes
     Cas1ChangeRequestType:
       type: string

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1389,7 +1389,7 @@ components:
           type: string
           format: uuid
         type:
-          $ref: '#/components/schemas/Cas1ChangeRequestType'
+          $ref: '_shared.yml#/components/schemas/Cas1ChangeRequestType'
         requestJson:
           type: object
           $ref: '_shared.yml#/components/schemas/Unit'
@@ -1409,16 +1409,6 @@ components:
       x-enum-varnames:
         - APPROVED
         - REJECTED
-    Cas1ChangeRequestType:
-      type: string
-      enum:
-        - placementAppeal
-        - placementExtension
-        - plannedTransfer
-      x-enum-varnames:
-        - PLACEMENT_APPEAL
-        - PLACEMENT_EXTENSION
-        - PLANNED_TRANSFER
     Cas1ChangeRequest:
       type: object
       properties:
@@ -1426,7 +1416,7 @@ components:
           type: string
           format: uuid
         type:
-          $ref: '#/components/schemas/Cas1ChangeRequestType'
+          $ref: '_shared.yml#/components/schemas/Cas1ChangeRequestType'
         createdAt:
           type: string
           format: date-time
@@ -1469,7 +1459,7 @@ components:
         person:
           $ref: "_shared.yml#/components/schemas/PersonSummary"
         type:
-          $ref: '#/components/schemas/Cas1ChangeRequestType'
+          $ref: '_shared.yml#/components/schemas/Cas1ChangeRequestType'
         createdAt:
           type: string
           format: date-time

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7756,8 +7756,6 @@ components:
         - expectedArrivalDate
         - expectedDepartureDate
         - isCancelled
-        - plannedTransferRequested
-        - appealRequested
         - openChangeRequestTypes
     Cas1ChangeRequestType:
       type: string

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -7735,9 +7735,17 @@ components:
         isCancelled:
           type: boolean
         plannedTransferRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
         appealRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
+        openChangeRequestTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1ChangeRequestType'
       required:
         - id
         - person
@@ -7750,6 +7758,17 @@ components:
         - isCancelled
         - plannedTransferRequested
         - appealRequested
+        - openChangeRequestTypes
+    Cas1ChangeRequestType:
+      type: string
+      enum:
+        - placementAppeal
+        - placementExtension
+        - plannedTransfer
+      x-enum-varnames:
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
+        - PLANNED_TRANSFER
     Cas1KeyWorkerAllocation:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6736,8 +6736,6 @@ components:
         - expectedArrivalDate
         - expectedDepartureDate
         - isCancelled
-        - plannedTransferRequested
-        - appealRequested
         - openChangeRequestTypes
     Cas1ChangeRequestType:
       type: string

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6715,9 +6715,17 @@ components:
         isCancelled:
           type: boolean
         plannedTransferRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
         appealRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
+        openChangeRequestTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1ChangeRequestType'
       required:
         - id
         - person
@@ -6730,6 +6738,17 @@ components:
         - isCancelled
         - plannedTransferRequested
         - appealRequested
+        - openChangeRequestTypes
+    Cas1ChangeRequestType:
+      type: string
+      enum:
+        - placementAppeal
+        - placementExtension
+        - plannedTransfer
+      x-enum-varnames:
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
+        - PLANNED_TRANSFER
     Cas1KeyWorkerAllocation:
       type: object
       properties:
@@ -8163,16 +8182,6 @@ components:
       x-enum-varnames:
         - APPROVED
         - REJECTED
-    Cas1ChangeRequestType:
-      type: string
-      enum:
-        - placementAppeal
-        - placementExtension
-        - plannedTransfer
-      x-enum-varnames:
-        - PLACEMENT_APPEAL
-        - PLACEMENT_EXTENSION
-        - PLANNED_TRANSFER
     Cas1ChangeRequest:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4939,9 +4939,17 @@ components:
         isCancelled:
           type: boolean
         plannedTransferRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
         appealRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
+        openChangeRequestTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1ChangeRequestType'
       required:
         - id
         - person
@@ -4954,6 +4962,17 @@ components:
         - isCancelled
         - plannedTransferRequested
         - appealRequested
+        - openChangeRequestTypes
+    Cas1ChangeRequestType:
+      type: string
+      enum:
+        - placementAppeal
+        - placementExtension
+        - plannedTransfer
+      x-enum-varnames:
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
+        - PLANNED_TRANSFER
     Cas1KeyWorkerAllocation:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4960,8 +4960,6 @@ components:
         - expectedArrivalDate
         - expectedDepartureDate
         - isCancelled
-        - plannedTransferRequested
-        - appealRequested
         - openChangeRequestTypes
     Cas1ChangeRequestType:
       type: string

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -4971,8 +4971,6 @@ components:
         - expectedArrivalDate
         - expectedDepartureDate
         - isCancelled
-        - plannedTransferRequested
-        - appealRequested
         - openChangeRequestTypes
     Cas1ChangeRequestType:
       type: string

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -4950,9 +4950,17 @@ components:
         isCancelled:
           type: boolean
         plannedTransferRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
         appealRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
+        openChangeRequestTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1ChangeRequestType'
       required:
         - id
         - person
@@ -4965,6 +4973,17 @@ components:
         - isCancelled
         - plannedTransferRequested
         - appealRequested
+        - openChangeRequestTypes
+    Cas1ChangeRequestType:
+      type: string
+      enum:
+        - placementAppeal
+        - placementExtension
+        - plannedTransfer
+      x-enum-varnames:
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
+        - PLANNED_TRANSFER
     Cas1KeyWorkerAllocation:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4802,8 +4802,6 @@ components:
         - expectedArrivalDate
         - expectedDepartureDate
         - isCancelled
-        - plannedTransferRequested
-        - appealRequested
         - openChangeRequestTypes
     Cas1ChangeRequestType:
       type: string

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -4781,9 +4781,17 @@ components:
         isCancelled:
           type: boolean
         plannedTransferRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
         appealRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
           type: boolean
+        openChangeRequestTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1ChangeRequestType'
       required:
         - id
         - person
@@ -4796,6 +4804,17 @@ components:
         - isCancelled
         - plannedTransferRequested
         - appealRequested
+        - openChangeRequestTypes
+    Cas1ChangeRequestType:
+      type: string
+      enum:
+        - placementAppeal
+        - placementExtension
+        - plannedTransfer
+      x-enum-varnames:
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
+        - PLANNED_TRANSFER
     Cas1KeyWorkerAllocation:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -591,13 +591,13 @@ class Cas1SpaceBookingTest {
       assertThat(response[1].person.crn).isEqualTo("CRN_LEGACY_NO_ARRIVAL")
       assertThat(response[2].person.crn).isEqualTo("CRN_DEPARTED")
       assertThat(response[3].person.crn).isEqualTo("CRN_CURRENT1")
-      assertThat(response[3].appealRequested).isTrue
+      assertThat(response[3].appealRequested).isFalse
       assertThat(response[3].plannedTransferRequested).isFalse
       assertThat(response[3].openChangeRequestTypes).containsExactly(Cas1ChangeRequestType.PLACEMENT_APPEAL)
       assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
       assertThat(response[5].person.crn).isEqualTo("CRN_CURRENT3")
       assertThat(response[5].appealRequested).isFalse
-      assertThat(response[5].plannedTransferRequested).isTrue
+      assertThat(response[5].plannedTransferRequested).isFalse
       assertThat(response[5].openChangeRequestTypes).containsExactly(Cas1ChangeRequestType.PLANNED_TRANSFER)
       assertThat(response[6].person.crn).isEqualTo("CRN_CURRENT4")
       assertThat(response[6].appealRequested).isFalse

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApprovedPlacementAppeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssignKeyWorker
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ChangeRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewDeparture
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewEmergencyTransfer
@@ -592,13 +593,16 @@ class Cas1SpaceBookingTest {
       assertThat(response[3].person.crn).isEqualTo("CRN_CURRENT1")
       assertThat(response[3].appealRequested).isTrue
       assertThat(response[3].plannedTransferRequested).isFalse
+      assertThat(response[3].openChangeRequestTypes).containsExactly(Cas1ChangeRequestType.PLACEMENT_APPEAL)
       assertThat(response[4].person.crn).isEqualTo("CRN_CURRENT2_OFFLINE")
       assertThat(response[5].person.crn).isEqualTo("CRN_CURRENT3")
       assertThat(response[5].appealRequested).isFalse
       assertThat(response[5].plannedTransferRequested).isTrue
+      assertThat(response[5].openChangeRequestTypes).containsExactly(Cas1ChangeRequestType.PLANNED_TRANSFER)
       assertThat(response[6].person.crn).isEqualTo("CRN_CURRENT4")
       assertThat(response[6].appealRequested).isFalse
       assertThat(response[6].plannedTransferRequested).isFalse
+      assertThat(response[6].openChangeRequestTypes).isEmpty()
       assertThat(response[7].person.crn).isEqualTo("CRN_UPCOMING")
       assertThat(response[8].person.crn).isEqualTo("CRN_NONARRIVAL")
     }
@@ -1075,7 +1079,7 @@ class Cas1SpaceBookingTest {
     }
 
     @Test
-    fun `Success`() {
+    fun success() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
 
       val response = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -458,7 +458,7 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.deliusEventNumber).isEqualTo("event8")
       assertThat(result.isCancelled).isEqualTo(cancelled)
       assertThat(result.plannedTransferRequested).isFalse()
-      assertThat(result.appealRequested).isTrue()
+      assertThat(result.appealRequested).isFalse()
       assertThat(result.openChangeRequestTypes).containsExactly(Cas1ChangeRequestType.PLACEMENT_APPEAL)
     }
   }
@@ -501,8 +501,6 @@ class Cas1SpaceBookingTransformerTest {
           characteristicsPropertyNamesCsv = "hasTurningSpace,isCatered",
           deliusEventNumber = "event8",
           cancelled = true,
-          plannedTransferRequested = true,
-          appealRequested = false,
           openChangeRequestTypeNamesCsv = "PLANNED_TRANSFER,PLACEMENT_EXTENSION",
         ),
         premises,
@@ -531,7 +529,7 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.status).isEqualTo(Cas1SpaceBookingSummaryStatus.departed)
       assertThat(result.deliusEventNumber).isEqualTo("event8")
       assertThat(result.isCancelled).isTrue()
-      assertThat(result.plannedTransferRequested).isTrue()
+      assertThat(result.plannedTransferRequested).isFalse()
       assertThat(result.appealRequested).isFalse()
       assertThat(result.openChangeRequestTypes).containsExactly(
         Cas1ChangeRequestType.PLANNED_TRANSFER,
@@ -572,8 +570,6 @@ class Cas1SpaceBookingTransformerTest {
           characteristicsPropertyNamesCsv = null,
           deliusEventNumber = "event8",
           cancelled = false,
-          plannedTransferRequested = false,
-          appealRequested = true,
           openChangeRequestTypeNamesCsv = "",
         ),
         premises = ApprovedPremisesEntityFactory().withDefaults().produce(),
@@ -584,7 +580,7 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.keyWorkerAllocation).isNull()
       assertThat(result.isCancelled).isFalse()
       assertThat(result.plannedTransferRequested).isFalse()
-      assertThat(result.appealRequested).isTrue()
+      assertThat(result.appealRequested).isFalse()
     }
   }
 }
@@ -608,8 +604,6 @@ data class Cas1SpaceBookingSearchResultImpl(
   override val characteristicsPropertyNamesCsv: String?,
   override val deliusEventNumber: String?,
   override val cancelled: Boolean,
-  override val plannedTransferRequested: Boolean,
-  override val appealRequested: Boolean,
   override val openChangeRequestTypeNamesCsv: String,
 ) : Cas1SpaceBookingSearchResult
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -368,7 +368,7 @@ class Cas1SpaceBookingTransformerTest {
   }
 
   @Nested
-  inner class TransformToSummary {
+  inner class TransformJpaToSummary {
 
     @ParameterizedTest
     @CsvSource("true,false")
@@ -459,6 +459,7 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.isCancelled).isEqualTo(cancelled)
       assertThat(result.plannedTransferRequested).isFalse()
       assertThat(result.appealRequested).isTrue()
+      assertThat(result.openChangeRequestTypes).containsExactly(Cas1ChangeRequestType.PLACEMENT_APPEAL)
     }
   }
 
@@ -497,11 +498,12 @@ class Cas1SpaceBookingTransformerTest {
           keyWorkerStaffCode = "the staff code",
           keyWorkerAssignedAt = LocalDateTime.of(2023, 12, 12, 0, 0, 0).toInstant(ZoneOffset.UTC),
           keyWorkerName = "the keyworker name",
-          characteristicsPropertyNames = "hasTurningSpace,isCatered",
+          characteristicsPropertyNamesCsv = "hasTurningSpace,isCatered",
           deliusEventNumber = "event8",
           cancelled = true,
           plannedTransferRequested = true,
           appealRequested = false,
+          openChangeRequestTypeNamesCsv = "PLANNED_TRANSFER,PLACEMENT_EXTENSION",
         ),
         premises,
         personSummaryInfo,
@@ -531,6 +533,10 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.isCancelled).isTrue()
       assertThat(result.plannedTransferRequested).isTrue()
       assertThat(result.appealRequested).isFalse()
+      assertThat(result.openChangeRequestTypes).containsExactly(
+        Cas1ChangeRequestType.PLANNED_TRANSFER,
+        Cas1ChangeRequestType.PLACEMENT_EXTENSION,
+      )
     }
 
     @Test
@@ -563,11 +569,12 @@ class Cas1SpaceBookingTransformerTest {
           keyWorkerStaffCode = null,
           keyWorkerAssignedAt = null,
           keyWorkerName = null,
-          characteristicsPropertyNames = null,
+          characteristicsPropertyNamesCsv = null,
           deliusEventNumber = "event8",
           cancelled = false,
           plannedTransferRequested = false,
           appealRequested = true,
+          openChangeRequestTypeNamesCsv = "",
         ),
         premises = ApprovedPremisesEntityFactory().withDefaults().produce(),
         personSummaryInfo,
@@ -598,11 +605,12 @@ data class Cas1SpaceBookingSearchResultImpl(
   override val keyWorkerStaffCode: String?,
   override val keyWorkerAssignedAt: Instant?,
   override val keyWorkerName: String?,
-  override val characteristicsPropertyNames: String?,
+  override val characteristicsPropertyNamesCsv: String?,
   override val deliusEventNumber: String?,
   override val cancelled: Boolean,
   override val plannedTransferRequested: Boolean,
   override val appealRequested: Boolean,
+  override val openChangeRequestTypeNamesCsv: String,
 ) : Cas1SpaceBookingSearchResult
 
 data class Cas1SpaceBookingAtPremisesImpl(


### PR DESCRIPTION
Update `Cas1SpaceBookingSummary` to include a list of open change request types, replacing the current booleans `plannedTransferRequested` and `appealRequested`