### PR TITLE
APS-2267 - Always set timeline payload for booking changed event regardless of schema version

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -67,6 +67,7 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
         d.assessmentId as assessmentId,
         d.bookingId as bookingId,
         d.triggerSource as triggerSource,
+        d.schemaVersion as schemaVersion,
         CASE
             WHEN b.id IS NOT NULL THEN b.premises.id
             WHEN sb.id IS NOT NULL THEN sb.premises.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/DomainEventSummary.kt
@@ -18,4 +18,5 @@ interface DomainEventSummary {
   val cas1SpaceBookingId: UUID?
   val triggerSource: TriggerSourceType?
   val triggeredByUser: UserEntity?
+  val schemaVersion: Int?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingChangedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingChangedTimelineFactory.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Sp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BookingChangedContentPayload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventDescriber.EventDescriptionAndPayload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
@@ -25,58 +24,67 @@ class BookingChangedTimelineFactory(val domainEventService: Cas1DomainEventServi
     return buildBookingChangedDescription(event)
   }
 
-  private fun buildBookingChangedDescription(domainEvent: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingChanged>>): EventDescriptionAndPayload<Cas1BookingChangedContentPayload> {
-    if (domainEvent.schemaVersion == null) {
-      val description = domainEvent.describe {
-        "A placement at ${it.eventDetails.premises.name} had its arrival and/or departure date changed to " +
-          "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()}"
-      }
-
-      return EventDescriptionAndPayload(description, null)
-    }
-
-    if (domainEvent.schemaVersion == 2) {
-      val eventDetails = domainEvent.data.eventDetails
-      val previousArrival = eventDetails.previousArrivalOn
-      val previousDeparture = eventDetails.previousDepartureOn
-      val changes = mutableListOf<String>()
-
-      fun addDateChangeMessage(previousDate: LocalDate, newDate: LocalDate, changeType: String) {
-        changes.add(
-          "its $changeType date changed from ${previousDate.toUiFormat()} to ${newDate.toUiFormat()}",
-        )
-      }
-
-      if (previousArrival != null) {
-        addDateChangeMessage(previousArrival, eventDetails.arrivalOn, "arrival")
-      }
-
-      if (previousDeparture != null) {
-        addDateChangeMessage(previousDeparture, eventDetails.departureOn, "departure")
-      }
-
-      val description = if (changes.isNotEmpty()) {
-        domainEvent.describe {
-          "A placement at ${it.eventDetails.premises.name} had ${changes.joinToString(", ")}"
-        }
-      } else {
-        null
-      }
-      return EventDescriptionAndPayload(description, getBookingChangedContentPayLoad(domainEvent))
-    }
-
-    return EventDescriptionAndPayload(null, null)
+  private fun buildBookingChangedDescription(domainEvent: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingChanged>>) = if (domainEvent.schemaVersion == 2) {
+    forSchemaVersion2(domainEvent)
+  } else {
+    forSchemaVersionNull(domainEvent)
   }
 
-  fun getBookingChangedContentPayLoad(domainEvent: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingChanged>>): Cas1BookingChangedContentPayload? {
+  private fun forSchemaVersionNull(domainEvent: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingChanged>>): EventDescriptionAndPayload<Cas1BookingChangedContentPayload> {
+    val description = domainEvent.describe {
+      "A placement at ${it.eventDetails.premises.name} had its arrival and/or departure date changed to " +
+        "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()}"
+    }
+
+    val eventDetails = domainEvent.data.eventDetails
+    val payload = Cas1BookingChangedContentPayload(
+      type = Cas1TimelineEventType.bookingChanged,
+      premises = eventDetails.premises.toNamedId(),
+      schemaVersion = null,
+      expectedArrival = eventDetails.arrivalOn,
+      expectedDeparture = eventDetails.departureOn,
+    )
+
+    return EventDescriptionAndPayload(description, payload)
+  }
+
+  private fun forSchemaVersion2(domainEvent: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingChanged>>): EventDescriptionAndPayload<Cas1BookingChangedContentPayload> {
+    val eventDetails = domainEvent.data.eventDetails
+    val previousArrival = eventDetails.previousArrivalOn
+    val previousDeparture = eventDetails.previousDepartureOn
+    val changes = mutableListOf<String>()
+
+    fun addDateChangeMessage(previousDate: LocalDate, newDate: LocalDate, changeType: String) {
+      changes.add(
+        "its $changeType date changed from ${previousDate.toUiFormat()} to ${newDate.toUiFormat()}",
+      )
+    }
+
+    if (previousArrival != null) {
+      addDateChangeMessage(previousArrival, eventDetails.arrivalOn, "arrival")
+    }
+
+    if (previousDeparture != null) {
+      addDateChangeMessage(previousDeparture, eventDetails.departureOn, "departure")
+    }
+
+    val description = if (changes.isNotEmpty()) {
+      domainEvent.describe {
+        "A placement at ${it.eventDetails.premises.name} had ${changes.joinToString(", ")}"
+      }
+    } else {
+      null
+    }
+
+    return EventDescriptionAndPayload(description, getVersion2BookingChangedContentPayLoad(domainEvent))
+  }
+
+  fun getVersion2BookingChangedContentPayLoad(domainEvent: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingChanged>>): Cas1BookingChangedContentPayload? {
     val eventDetails = domainEvent.data.eventDetails
     return Cas1BookingChangedContentPayload(
       type = Cas1TimelineEventType.bookingChanged,
-      premises = NamedId(
-        id = eventDetails.premises.id,
-        name = eventDetails.premises.name,
-      ),
-      schemaVersion = domainEvent.schemaVersion!!,
+      premises = eventDetails.premises.toNamedId(),
+      schemaVersion = domainEvent.schemaVersion,
       previousExpectedArrival = domainEvent.data.eventDetails.previousArrivalOn,
       expectedArrival = eventDetails.arrivalOn,
       previousExpectedDeparture = eventDetails.previousDepartureOn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/DomainEventUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/DomainEventUtils.kt
@@ -31,3 +31,8 @@ fun EventBookingSummary.toTimelinePayloadSummary() = Cas1TimelineEventPayloadBoo
   arrivalDate = this.arrivalDate,
   departureDate = this.departureDate,
 )
+
+fun Premises.toNamedId() = NamedId(
+  id = this.id,
+  name = this.name,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/EmergencyTransferCreatedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/EmergencyTransferCreatedTimelineFactory.kt
@@ -20,7 +20,6 @@ class EmergencyTransferCreatedTimelineFactory(val domainEventService: Cas1Domain
       type = Cas1TimelineEventType.emergencyTransferCreated,
       from = details.from.toTimelinePayloadSummary(),
       to = details.to.toTimelinePayloadSummary(),
-      schemaVersion = event.schemaVersion,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlacementAppealAcceptedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlacementAppealAcceptedTimelineFactory.kt
@@ -19,7 +19,6 @@ class PlacementAppealAcceptedTimelineFactory(val domainEventService: Cas1DomainE
     return Cas1PlacementAppealAcceptedPayload(
       type = Cas1TimelineEventType.placementAppealAccepted,
       booking = details.booking.toTimelinePayloadSummary(),
-      schemaVersion = event.schemaVersion,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlacementAppealCreatedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlacementAppealCreatedTimelineFactory.kt
@@ -22,7 +22,6 @@ class PlacementAppealCreatedTimelineFactory(val domainEventService: Cas1DomainEv
       type = Cas1TimelineEventType.placementAppealCreated,
       booking = details.booking.toTimelinePayloadSummary(),
       reason = NamedId(reason.id, reason.code),
-      schemaVersion = event.schemaVersion,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlacementAppealRejectedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlacementAppealRejectedTimelineFactory.kt
@@ -22,7 +22,6 @@ class PlacementAppealRejectedTimelineFactory(val domainEventService: Cas1DomainE
       type = Cas1TimelineEventType.placementAppealRejected,
       booking = details.booking.toTimelinePayloadSummary(),
       reason = NamedId(reason.id, reason.code),
-      schemaVersion = event.schemaVersion,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestAcceptedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestAcceptedTimelineFactory.kt
@@ -20,7 +20,6 @@ class PlannedTransferRequestAcceptedTimelineFactory(val domainEventService: Cas1
       type = Cas1TimelineEventType.plannedTransferRequestAccepted,
       from = details.from.toTimelinePayloadSummary(),
       to = details.to.toTimelinePayloadSummary(),
-      schemaVersion = event.schemaVersion,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestCreatedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestCreatedTimelineFactory.kt
@@ -22,7 +22,6 @@ class PlannedTransferRequestCreatedTimelineFactory(val domainEventService: Cas1D
       type = Cas1TimelineEventType.plannedTransferRequestCreated,
       booking = details.booking.toTimelinePayloadSummary(),
       reason = NamedId(reason.id, reason.code),
-      schemaVersion = event.schemaVersion,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestRejectedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/PlannedTransferRequestRejectedTimelineFactory.kt
@@ -22,7 +22,6 @@ class PlannedTransferRequestRejectedTimelineFactory(val domainEventService: Cas1
       type = Cas1TimelineEventType.plannedTransferRequestRejected,
       booking = details.booking.toTimelinePayloadSummary(),
       reason = NamedId(reason.id, reason.code),
-      schemaVersion = event.schemaVersion,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1ApplicationTimelineTransformer.kt
@@ -31,6 +31,7 @@ class Cas1ApplicationTimelineTransformer(
     return Cas1TimelineEvent(
       id = domainEventSummary.id,
       type = domainEventSummary.type.cas1Info?.timelineEventType ?: throw IllegalArgumentException("Cannot map ${domainEventSummary.type}, only CAS1 is currently supported"),
+      schemaVersion = domainEventSummary.schemaVersion,
       occurredAt = domainEventSummary.occurredAt.toInstant(),
       associatedUrls = associatedUrls,
       content = descriptionAndPayload.description,

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1078,6 +1078,8 @@ components:
         triggerSource:
           type: string
           $ref: '#/components/schemas/Cas1TriggerSourceType'
+        schemaVersion:
+          type: integer
       required:
         - type
         - id
@@ -1194,8 +1196,6 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/Cas1TimelineEventType'
-        schemaVersion:
-          type: integer
       required:
         - type
       discriminator:
@@ -1239,6 +1239,10 @@ components:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
+        schemaVersion:
+          description: This is deprecated, use the schema version information on the enclosing Cas1TimelineEvent
+          deprecated: true
+          type: integer
       required:
         - premises
         - expectedArrival

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7849,6 +7849,8 @@ components:
         triggerSource:
           type: string
           $ref: '#/components/schemas/Cas1TriggerSourceType'
+        schemaVersion:
+          type: integer
       required:
         - type
         - id
@@ -7965,8 +7967,6 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/Cas1TimelineEventType'
-        schemaVersion:
-          type: integer
       required:
         - type
       discriminator:
@@ -8010,6 +8010,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+        schemaVersion:
+          description: This is deprecated, use the schema version information on the enclosing Cas1TimelineEvent
+          deprecated: true
+          type: integer
       required:
         - premises
         - expectedArrival

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
@@ -986,17 +986,14 @@ class Cas1DomainEventDescriberTest {
 
   private fun <T> buildDomainEvent(
     builder: (UUID) -> T,
-    schemaVersion: Int? = null,
   ): GetCas1DomainEvent<T> {
     val id = UUID.randomUUID()
     return GetCas1DomainEvent(
       id = id,
       data = builder(id),
-      schemaVersion = schemaVersion,
+      schemaVersion = null,
     )
   }
-
-  private fun <T> buildDomainEvent(builder: (UUID) -> T): GetCas1DomainEvent<T> = buildDomainEvent(builder, null)
 }
 
 data class DomainEventSummaryImpl(
@@ -1011,6 +1008,7 @@ data class DomainEventSummaryImpl(
   override val cas1SpaceBookingId: UUID?,
   override val triggerSource: TriggerSourceType?,
   override val triggeredByUser: UserEntity?,
+  override val schemaVersion: Int? = null,
 ) : DomainEventSummary {
   companion object {
     fun ofType(type: DomainEventType) = DomainEventSummaryImpl(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingChangedTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingChangedTimelineFactoryTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingChanged
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.SpaceCharacteristic
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BookingChangedContentPayload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingChangedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
@@ -50,7 +49,15 @@ class BookingChangedTimelineFactoryTest {
 
     assertThat(result.description)
       .isEqualTo("A placement at The Premises Name had its arrival and/or departure date changed to Monday 1 January 2024 to Monday 1 April 2024")
-    assertThat(result.payload).isNull()
+
+    val contentPayload = result.payload!!
+    assertThat(contentPayload.premises.name).isEqualTo("The Premises Name")
+    assertThat(contentPayload.expectedArrival).isEqualTo(arrivalDate)
+    assertThat(contentPayload.previousExpectedArrival).isNull()
+    assertThat(contentPayload.expectedDeparture).isEqualTo(departureDate)
+    assertThat(contentPayload.previousExpectedDeparture).isNull()
+    assertThat(contentPayload.characteristics).isNull()
+    assertThat(contentPayload.previousCharacteristics).isNull()
   }
 
   @Test
@@ -81,7 +88,7 @@ class BookingChangedTimelineFactoryTest {
     assertThat(result.description)
       .isEqualTo("A placement at The Premises Name had its arrival date changed from Tuesday 1 April 2025 to Saturday 5 April 2025")
 
-    val contentPayload = result.payload as Cas1BookingChangedContentPayload
+    val contentPayload = result.payload!!
     assertThat(contentPayload.premises.name).isEqualTo("The Premises Name")
     assertThat(contentPayload.expectedArrival).isEqualTo(arrivalDate)
     assertThat(contentPayload.previousExpectedArrival).isEqualTo(previousArrivalOn)
@@ -119,7 +126,7 @@ class BookingChangedTimelineFactoryTest {
     assertThat(result.description)
       .isEqualTo("A placement at The Premises Name had its departure date changed from Sunday 1 June 2025 to Tuesday 10 June 2025")
 
-    val contentPayload = result.payload as Cas1BookingChangedContentPayload
+    val contentPayload = result.payload!!
     assertThat(contentPayload.premises.name).isEqualTo("The Premises Name")
     assertThat(contentPayload.expectedArrival).isEqualTo(arrivalDate)
     assertThat(contentPayload.previousExpectedArrival).isNull()
@@ -161,7 +168,7 @@ class BookingChangedTimelineFactoryTest {
           "its departure date changed from Sunday 1 June 2025 to Tuesday 10 June 2025",
       )
 
-    val contentPayload = result.payload as Cas1BookingChangedContentPayload
+    val contentPayload = result.payload!!
     assertThat(contentPayload.premises.name).isEqualTo("The Premises Name")
     assertThat(contentPayload.expectedArrival).isEqualTo(arrivalDate)
     assertThat(contentPayload.previousExpectedArrival).isEqualTo(previousArrivalOn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1ApplicationTimelineTransformerTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
 
 import io.mockk.every
 import io.mockk.mockk
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -57,6 +56,7 @@ class Cas1ApplicationTimelineTransformerTest {
     override val cas1SpaceBookingId: UUID?,
     override val triggerSource: TriggerSourceType?,
     override val triggeredByUser: UserEntity?,
+    override val schemaVersion: Int?,
   ) : DomainEventSummary
 
   @ParameterizedTest
@@ -76,6 +76,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = userJpa,
+      schemaVersion = 1,
     )
 
     val userApi = mockk<ApprovedPremisesUser>()
@@ -91,6 +92,7 @@ class Cas1ApplicationTimelineTransformerTest {
     assertThat(result.content).isEqualTo("Some event")
     assertThat(result.createdBy).isEqualTo(userApi)
     assertThat(result.triggerSource).isEqualTo(null)
+    assertThat(result.schemaVersion).isEqualTo(1)
   }
 
   @Test
@@ -108,13 +110,14 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = userJpa,
+      schemaVersion = null,
     )
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
 
     val exception = assertThrows<RuntimeException> {
       applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)
     }
-    Assertions.assertThat(exception.message).isEqualTo("Cannot map CAS2_APPLICATION_SUBMITTED, only CAS1 is currently supported")
+    assertThat(exception.message).isEqualTo("Cannot map CAS2_APPLICATION_SUBMITTED, only CAS1 is currently supported")
   }
 
   @Test
@@ -132,6 +135,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -166,6 +170,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -205,6 +210,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -238,6 +244,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = spaceBookingId,
       triggerSource = null,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -270,6 +277,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -304,6 +312,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -338,6 +347,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -379,6 +389,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -414,6 +425,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = triggerSource,
       triggeredByUser = null,
+      schemaVersion = null,
     )
 
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
@@ -442,6 +454,7 @@ class Cas1ApplicationTimelineTransformerTest {
       cas1SpaceBookingId = null,
       triggerSource = null,
       triggeredByUser = userJpa,
+      schemaVersion = null,
     )
 
     val userApi = mockk<ApprovedPremisesUser>()


### PR DESCRIPTION
Before this commit schemaVersion was part of the domain-event-specific content payload. Because all domain events have a schema version, this has been moved to the `Cas1TimelineEvent`, reducing the amount of copy-paste code. It has been temporarily retained for the Booking Amended payload type because this field is currently in use by the UI