### PR TITLE
APS-2269 Trigger booking email/domain event for transfers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -170,7 +170,7 @@ class Cas1SpaceBookingController(
   override fun getSpaceBookingByPremiseAndId(premisesId: UUID, bookingId: UUID): ResponseEntity<Cas1SpaceBooking> {
     userAccessService.ensureCurrentUserHasPermission(CAS1_SPACE_BOOKING_VIEW)
 
-    val booking = extractEntityFromCasResult(spaceBookingService.getBooking(premisesId, bookingId))
+    val booking = extractEntityFromCasResult(spaceBookingService.getBookingForPremisesAndId(premisesId, bookingId))
 
     return ResponseEntity
       .ok()
@@ -324,7 +324,7 @@ class Cas1SpaceBookingController(
     userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_SPACE_BOOKING_WITHDRAW)
 
     val spaceBooking = extractEntityFromCasResult(
-      cas1SpaceBookingService.getBooking(premisesId, bookingId),
+      cas1SpaceBookingService.getBookingForPremisesAndId(premisesId, bookingId),
     )
 
     return ResponseEntity
@@ -346,7 +346,7 @@ class Cas1SpaceBookingController(
   override fun appeal(premisesId: UUID, bookingId: UUID, body: Cas1ApprovedPlacementAppeal): ResponseEntity<Unit> {
     userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PLACEMENT_APPEAL_ASSESS)
     val spaceBooking = extractEntityFromCasResult(
-      cas1SpaceBookingService.getBooking(premisesId, bookingId),
+      cas1SpaceBookingService.getBookingForPremisesAndId(premisesId, bookingId),
     )
 
     ensureEntityFromCasResultIsSuccess(
@@ -401,7 +401,7 @@ class Cas1SpaceBookingController(
     val user = userService.getUserForRequest()
 
     ensureEntityFromCasResultIsSuccess(
-      cas1SpaceBookingService.emergencyTransfer(premisesId, bookingId, user, cas1NewEmergencyTransfer),
+      cas1SpaceBookingService.createEmergencyTransfer(premisesId, bookingId, user, cas1NewEmergencyTransfer),
     )
 
     return ResponseEntity(HttpStatus.OK)
@@ -417,7 +417,7 @@ class Cas1SpaceBookingController(
     val user = userService.getUserForRequest()
 
     ensureEntityFromCasResultIsSuccess(
-      cas1SpaceBookingService.plannedTransfer(bookingId, user, cas1NewPlannedTransfer),
+      cas1SpaceBookingService.createPlannedTransfer(bookingId, user, cas1NewPlannedTransfer),
     )
 
     return ResponseEntity(HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -92,7 +92,7 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
         )
     """,
   )
-  fun findAllTimelineEventsByIds(applicationId: UUID?, spaceBookingId: UUID?): List<DomainEventSummary>
+  fun findAllTimelineEventsByIds(applicationId: UUID?, spaceBookingId: UUID? = null): List<DomainEventSummary>
 
   @Query(
     "SELECT * FROM domain_events domain_event " +
@@ -102,7 +102,7 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
   )
   fun findAllCreatedInMonth(month: Int, year: Int): List<DomainEventEntity>
 
-  fun findByApplicationId(applicationId: UUID): List<DomainEventEntity>
+  fun findByApplicationIdOrderByCreatedAtAsc(applicationId: UUID): List<DomainEventEntity>
 
   fun findByType(type: DomainEventType): List<DomainEventEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UpdateEventNumberSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1UpdateEventNumberSeedJob.kt
@@ -96,7 +96,7 @@ class Cas1UpdateEventNumberSeedJob(
   }
 
   private fun updateDomainEvents(applicationId: UUID, updatedEventNumber: Int) {
-    val domainEvents = domainEventRepository.findByApplicationId(applicationId)
+    val domainEvents = domainEventRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId)
 
     domainEvents.filter {
       it.type == DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -48,11 +48,11 @@ class Cas1BookingDomainEventService(
 ) {
 
   fun spaceBookingMade(
-    application: ApprovedPremisesApplicationEntity,
     booking: Cas1SpaceBookingEntity,
     user: UserEntity,
-    placementRequest: PlacementRequestEntity,
   ) {
+    val placementRequest = booking.placementRequest!!
+    val application = placementRequest.application
     bookingMade(
       applicationId = application.id,
       eventNumber = application.eventNumber,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -136,10 +136,8 @@ class Cas1SpaceBookingService(
     cas1ApplicationStatusService.spaceBookingMade(spaceBooking)
 
     cas1BookingDomainEventService.spaceBookingMade(
-      application = application,
       booking = spaceBooking,
       user = createdBy,
-      placementRequest = placementRequest,
     )
 
     cas1BookingEmailService.spaceBookingMade(spaceBooking, application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooki
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummarySortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository.Constants.CAS1_RELATED_APP_WITHDRAWN_ID
@@ -126,7 +125,6 @@ class Cas1SpaceBookingService(
 
     val spaceBooking = createSpaceBookingEntity(
       premises = premises,
-      application = application,
       placementRequest = placementRequest,
       expectedArrivalDate = arrivalDate,
       expectedDepartureDate = departureDate,
@@ -475,7 +473,7 @@ class Cas1SpaceBookingService(
     val premises: ApprovedPremisesEntity,
   )
 
-  fun getBooking(premisesId: UUID, bookingId: UUID): CasResult<Cas1SpaceBookingEntity> {
+  fun getBookingForPremisesAndId(premisesId: UUID, bookingId: UUID): CasResult<Cas1SpaceBookingEntity> {
     if (!cas1PremisesService.premiseExistsById(premisesId)) return CasResult.NotFound("premises", premisesId.toString())
 
     return getBooking(bookingId)
@@ -484,7 +482,7 @@ class Cas1SpaceBookingService(
   fun getBooking(bookingId: UUID): CasResult<Cas1SpaceBookingEntity> {
     val booking = cas1SpaceBookingRepository.findByIdOrNull(bookingId) ?: return CasResult.NotFound("booking", bookingId.toString())
 
-    return CasResult.Success(booking)
+    return Success(booking)
   }
 
   fun getBookingsForPremisesAndCrn(premisesId: UUID, crn: String) = cas1SpaceBookingRepository.findByPremisesIdAndCrn(
@@ -516,7 +514,7 @@ class Cas1SpaceBookingService(
     withdrawalContext: WithdrawalContext,
   ): CasResult<Unit> {
     if (spaceBooking.isCancelled()) {
-      return CasResult.Success(Unit)
+      return Success(Unit)
     }
 
     val resolvedReasonId = toCas1CancellationReason(withdrawalContext, userProvidedReasonId)
@@ -554,7 +552,7 @@ class Cas1SpaceBookingService(
       )
     }
 
-    return CasResult.Success(Unit)
+    return Success(Unit)
   }
 
   data class SpaceBookingFilterCriteria(
@@ -643,7 +641,7 @@ class Cas1SpaceBookingService(
 
   @Transactional
   @Suppress("ReturnCount")
-  fun emergencyTransfer(
+  fun createEmergencyTransfer(
     premisesId: UUID,
     bookingId: UUID,
     user: UserEntity,
@@ -676,7 +674,6 @@ class Cas1SpaceBookingService(
 
     val emergencyTransferSpaceBooking = createSpaceBookingEntity(
       premises = destinationPremises,
-      application = placementRequest.application,
       placementRequest = placementRequest,
       expectedArrivalDate = cas1NewEmergencyTransfer.arrivalDate,
       expectedDepartureDate = cas1NewEmergencyTransfer.departureDate,
@@ -685,7 +682,7 @@ class Cas1SpaceBookingService(
       transferType = TransferType.EMERGENCY,
     )
 
-    updateSpaceBookingForTransfer(existingCas1SpaceBooking, emergencyTransferSpaceBooking, cas1NewEmergencyTransfer.arrivalDate)
+    updateTransferredSpaceBooking(existingCas1SpaceBooking, emergencyTransferSpaceBooking, cas1NewEmergencyTransfer.arrivalDate)
 
     cas1SpaceBookingManagementDomainEventService.emergencyTransferCreated(
       user,
@@ -697,7 +694,7 @@ class Cas1SpaceBookingService(
 
   @Transactional
   @Suppress("ReturnCount")
-  fun plannedTransfer(
+  fun createPlannedTransfer(
     bookingId: UUID,
     user: UserEntity,
     cas1NewPlannedTransfer: Cas1NewPlannedTransfer,
@@ -727,7 +724,6 @@ class Cas1SpaceBookingService(
 
     val plannedTransferSpaceBooking = createSpaceBookingEntity(
       premises = destinationPremises,
-      application = placementRequest.application,
       placementRequest = placementRequest,
       expectedArrivalDate = cas1NewPlannedTransfer.arrivalDate,
       expectedDepartureDate = cas1NewPlannedTransfer.departureDate,
@@ -736,7 +732,7 @@ class Cas1SpaceBookingService(
       transferType = TransferType.PLANNED,
     )
 
-    updateSpaceBookingForTransfer(existingCas1SpaceBooking, plannedTransferSpaceBooking, cas1NewPlannedTransfer.arrivalDate)
+    updateTransferredSpaceBooking(existingCas1SpaceBooking, plannedTransferSpaceBooking, cas1NewPlannedTransfer.arrivalDate)
 
     cas1ChangeRequestService.approvedPlannedTransfer(
       changeRequest = changeRequest,
@@ -748,7 +744,7 @@ class Cas1SpaceBookingService(
     return Success(Unit)
   }
 
-  private fun updateSpaceBookingForTransfer(
+  private fun updateTransferredSpaceBooking(
     existingSpaceBooking: Cas1SpaceBookingEntity,
     transferredSpaceBooking: Cas1SpaceBookingEntity,
     departureDate: LocalDate,
@@ -890,54 +886,57 @@ class Cas1SpaceBookingService(
     ServiceName.approvedPremises,
   )
 
-  fun createSpaceBookingEntity(
+  private fun createSpaceBookingEntity(
     premises: ApprovedPremisesEntity,
-    application: ApprovedPremisesApplicationEntity,
     placementRequest: PlacementRequestEntity,
     expectedArrivalDate: LocalDate,
     expectedDepartureDate: LocalDate,
     createdBy: UserEntity,
     characteristics: List<CharacteristicEntity>,
     transferType: TransferType?,
-  ): Cas1SpaceBookingEntity = cas1SpaceBookingRepository.saveAndFlush(
-    Cas1SpaceBookingEntity(
-      id = UUID.randomUUID(),
-      premises = premises,
-      application = application,
-      offlineApplication = null,
-      placementRequest = placementRequest,
-      createdBy = createdBy,
-      createdAt = OffsetDateTime.now(clock),
-      expectedArrivalDate = expectedArrivalDate,
-      expectedDepartureDate = expectedDepartureDate,
-      actualArrivalDate = null,
-      actualArrivalTime = null,
-      actualDepartureDate = null,
-      actualDepartureTime = null,
-      canonicalArrivalDate = expectedArrivalDate,
-      canonicalDepartureDate = expectedDepartureDate,
-      crn = placementRequest.application.crn,
-      keyWorkerStaffCode = null,
-      keyWorkerName = null,
-      keyWorkerAssignedAt = null,
-      cancellationOccurredAt = null,
-      cancellationRecordedAt = null,
-      cancellationReason = null,
-      cancellationReasonNotes = null,
-      departureMoveOnCategory = null,
-      departureReason = null,
-      departureNotes = null,
-      criteria = characteristics.toMutableList(),
-      nonArrivalConfirmedAt = null,
-      nonArrivalNotes = null,
-      nonArrivalReason = null,
-      deliusEventNumber = application.eventNumber,
-      migratedManagementInfoFrom = null,
-      transferredTo = null,
-      transferType = transferType,
-      deliusId = null,
-    ),
-  )
+  ): Cas1SpaceBookingEntity {
+    val application = placementRequest.application
+    val spaceBooking = cas1SpaceBookingRepository.saveAndFlush(
+      Cas1SpaceBookingEntity(
+        id = UUID.randomUUID(),
+        premises = premises,
+        application = application,
+        offlineApplication = null,
+        placementRequest = placementRequest,
+        createdBy = createdBy,
+        createdAt = OffsetDateTime.now(clock),
+        expectedArrivalDate = expectedArrivalDate,
+        expectedDepartureDate = expectedDepartureDate,
+        actualArrivalDate = null,
+        actualArrivalTime = null,
+        actualDepartureDate = null,
+        actualDepartureTime = null,
+        canonicalArrivalDate = expectedArrivalDate,
+        canonicalDepartureDate = expectedDepartureDate,
+        crn = placementRequest.application.crn,
+        keyWorkerStaffCode = null,
+        keyWorkerName = null,
+        keyWorkerAssignedAt = null,
+        cancellationOccurredAt = null,
+        cancellationRecordedAt = null,
+        cancellationReason = null,
+        cancellationReasonNotes = null,
+        departureMoveOnCategory = null,
+        departureReason = null,
+        departureNotes = null,
+        criteria = characteristics.toMutableList(),
+        nonArrivalConfirmedAt = null,
+        nonArrivalNotes = null,
+        nonArrivalReason = null,
+        deliusEventNumber = application.eventNumber,
+        migratedManagementInfoFrom = null,
+        transferredTo = null,
+        transferType = transferType,
+        deliusId = null,
+      ),
+    )
+    return spaceBooking
+  }
 
   data class UpdateSpaceBookingDetails(
     val bookingId: UUID,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -2712,7 +2712,15 @@ class Cas1SpaceBookingTest {
       assertThat(emergencyTransferredBooking.expectedArrivalDate).isEqualTo(LocalDate.now())
       assertThat(emergencyTransferredBooking.expectedDepartureDate).isEqualTo(LocalDate.now().plusMonths(1))
 
-      domainEventAsserter.assertDomainEventOfTypeStored(application.id, DomainEventType.APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED)
+      domainEventAsserter.assertDomainEventsStoredInSpecificOrder(
+        application.id,
+        DomainEventType.APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED,
+        DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
+      )
+
+      emailAsserter.assertEmailsRequestedCount(2)
+      emailAsserter.assertEmailRequested(applicant.email!!, Cas1NotifyTemplates.BOOKING_MADE)
+      emailAsserter.assertEmailRequested(destinationPremises.emailAddress!!, Cas1NotifyTemplates.BOOKING_MADE_FOR_PREMISES)
     }
   }
 
@@ -2853,7 +2861,15 @@ class Cas1SpaceBookingTest {
       assertThat(updatedChangedRequest.resolved).isTrue
       assertThat(updatedChangedRequest.decision).isEqualTo(ChangeRequestDecision.APPROVED)
 
-      domainEventAsserter.assertDomainEventOfTypeStored(application.id, DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_ACCEPTED)
+      domainEventAsserter.assertDomainEventsStoredInSpecificOrder(
+        application.id,
+        DomainEventType.APPROVED_PREMISES_PLANNED_TRANSFER_REQUEST_ACCEPTED,
+        DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
+      )
+
+      emailAsserter.assertEmailsRequestedCount(2)
+      emailAsserter.assertEmailRequested(applicant.email!!, Cas1NotifyTemplates.BOOKING_MADE)
+      emailAsserter.assertEmailRequested(destinationPremises.emailAddress!!, Cas1NotifyTemplates.BOOKING_MADE_FOR_PREMISES)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
@@ -91,17 +91,19 @@ class Cas1BookingCas1DomainEventServiceTest {
 
     val createdAt = OffsetDateTime.now()
 
+    val placementRequest = PlacementRequestEntityFactory()
+      .withDefaults()
+      .withApplication(application)
+      .produce()
+
     val spaceBooking = Cas1SpaceBookingEntityFactory()
       .withCrn("THEBOOKINGCRN")
+      .withPlacementRequest(placementRequest)
       .withCanonicalArrivalDate(LocalDate.of(2025, 12, 11))
       .withCanonicalDepartureDate(LocalDate.of(2025, 12, 12))
       .withPremises(premises)
       .withCreatedAt(createdAt)
       .withCriteria(CharacteristicEntityFactory().withModelScope("room").withPropertyName("hasEnSuite").produce())
-      .produce()
-
-    val placementRequest = PlacementRequestEntityFactory()
-      .withDefaults()
       .produce()
 
     @BeforeEach
@@ -132,7 +134,7 @@ class Cas1BookingCas1DomainEventServiceTest {
 
     @Test
     fun `bookingMade saves domain event`() {
-      service.spaceBookingMade(application, spaceBooking, user, placementRequest)
+      service.spaceBookingMade(spaceBooking, user)
 
       val domainEventArgument = slot<SaveCas1DomainEvent<BookingMadeEnvelope>>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -349,10 +349,8 @@ class Cas1SpaceBookingServiceTest {
 
       every {
         cas1BookingDomainEventService.spaceBookingMade(
-          application,
           any(),
           user,
-          placementRequest,
         )
       } returns Unit
 
@@ -450,10 +448,8 @@ class Cas1SpaceBookingServiceTest {
 
       every {
         cas1BookingDomainEventService.spaceBookingMade(
-          application,
           any(),
           user,
-          placementRequest,
         )
       } returns Unit
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -556,13 +556,13 @@ class Cas1SpaceBookingServiceTest {
   }
 
   @Nested
-  inner class GetBooking {
+  inner class GetBookingForPremisesAndId {
 
     @Test
     fun `Returns not found error if premises with the given ID doesn't exist`() {
       every { cas1PremisesService.premiseExistsById(any()) } returns false
 
-      val result = service.getBooking(UUID.randomUUID(), UUID.randomUUID())
+      val result = service.getBookingForPremisesAndId(UUID.randomUUID(), UUID.randomUUID())
 
       assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
       assertThat((result as CasResult.NotFound).entityType).isEqualTo("premises")
@@ -577,7 +577,7 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.premiseExistsById(premises.id) } returns true
       every { spaceBookingRepository.findByIdOrNull(any()) } returns null
 
-      val result = service.getBooking(premises.id, UUID.randomUUID())
+      val result = service.getBookingForPremisesAndId(premises.id, UUID.randomUUID())
 
       assertThat(result).isInstanceOf(CasResult.NotFound::class.java)
       assertThat((result as CasResult.NotFound).entityType).isEqualTo("booking")
@@ -595,7 +595,7 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.premiseExistsById(premises.id) } returns true
       every { spaceBookingRepository.findByIdOrNull(spaceBooking.id) } returns spaceBooking
 
-      val result = service.getBooking(premises.id, spaceBooking.id)
+      val result = service.getBookingForPremisesAndId(premises.id, spaceBooking.id)
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
       assertThat((result as CasResult.Success).value).isEqualTo(spaceBooking)
@@ -2665,7 +2665,7 @@ class Cas1SpaceBookingServiceTest {
   }
 
   @Nested
-  inner class EmergencyTransfer {
+  inner class CreateEmergencyTransfer {
 
     private val user = UserEntityFactory()
       .withDefaults()
@@ -2695,7 +2695,7 @@ class Cas1SpaceBookingServiceTest {
 
       val destinationPremisesId = UUID.randomUUID()
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         existingSpaceBooking.id,
         user,
@@ -2718,7 +2718,7 @@ class Cas1SpaceBookingServiceTest {
       )
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         existingSpaceBooking.id,
         user,
@@ -2741,7 +2741,7 @@ class Cas1SpaceBookingServiceTest {
       )
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         existingSpaceBooking.id,
         user,
@@ -2766,7 +2766,7 @@ class Cas1SpaceBookingServiceTest {
 
       val bookingId = UUID.randomUUID()
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         bookingId,
         user,
@@ -2790,7 +2790,7 @@ class Cas1SpaceBookingServiceTest {
       )
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         anotherPremisesId,
         existingSpaceBooking.id,
         user,
@@ -2817,7 +2817,7 @@ class Cas1SpaceBookingServiceTest {
       )
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         existingSpaceBooking.id,
         user,
@@ -2844,7 +2844,7 @@ class Cas1SpaceBookingServiceTest {
       )
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         existingSpaceBooking.id,
         user,
@@ -2871,7 +2871,7 @@ class Cas1SpaceBookingServiceTest {
       )
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         existingSpaceBooking.id,
         user,
@@ -2898,7 +2898,7 @@ class Cas1SpaceBookingServiceTest {
       )
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         existingSpaceBooking.id,
         user,
@@ -2931,7 +2931,7 @@ class Cas1SpaceBookingServiceTest {
 
       assertThat(existingSpaceBooking.transferredTo).isNull()
 
-      val result = service.emergencyTransfer(
+      val result = service.createEmergencyTransfer(
         PREMISES_ID,
         existingSpaceBooking.id,
         user,
@@ -2971,7 +2971,7 @@ class Cas1SpaceBookingServiceTest {
   }
 
   @Nested
-  inner class PlannedTransfer {
+  inner class CreatePlannedTransfer {
 
     private val user = UserEntityFactory()
       .withDefaults()
@@ -3006,7 +3006,7 @@ class Cas1SpaceBookingServiceTest {
 
       val destinationPremisesId = UUID.randomUUID()
 
-      val result = service.plannedTransfer(
+      val result = service.createPlannedTransfer(
         existingSpaceBooking.id,
         user,
         Cas1NewPlannedTransfer(
@@ -3032,7 +3032,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { cas1ChangeRequestService.findChangeRequest(any()) } returns existingChangeRequest
 
-      val result = service.plannedTransfer(
+      val result = service.createPlannedTransfer(
         existingSpaceBooking.id,
         user,
         Cas1NewPlannedTransfer(
@@ -3058,7 +3058,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { cas1ChangeRequestService.findChangeRequest(any()) } returns existingChangeRequest
 
-      val result = service.plannedTransfer(
+      val result = service.createPlannedTransfer(
         existingSpaceBooking.id,
         user,
         Cas1NewPlannedTransfer(
@@ -3084,7 +3084,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { cas1ChangeRequestService.findChangeRequest(any()) } returns existingChangeRequest
 
-      val result = service.plannedTransfer(
+      val result = service.createPlannedTransfer(
         existingSpaceBooking.id,
         user,
         Cas1NewPlannedTransfer(
@@ -3119,7 +3119,7 @@ class Cas1SpaceBookingServiceTest {
 
       val bookingId = UUID.randomUUID()
 
-      val result = service.plannedTransfer(
+      val result = service.createPlannedTransfer(
         bookingId,
         user,
         Cas1NewPlannedTransfer(
@@ -3161,7 +3161,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { cas1ChangeRequestService.approvedPlannedTransfer(any(), any(), any(), any()) } returns Unit
 
-      val result = service.plannedTransfer(
+      val result = service.createPlannedTransfer(
         existingSpaceBooking.id,
         user,
         Cas1NewPlannedTransfer(
@@ -3202,7 +3202,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { cas1ChangeRequestService.approvedPlannedTransfer(any(), any(), any(), any()) } returns Unit
 
-      val result = service.plannedTransfer(
+      val result = service.createPlannedTransfer(
         existingSpaceBooking.id,
         user,
         Cas1NewPlannedTransfer(
@@ -3238,7 +3238,7 @@ class Cas1SpaceBookingServiceTest {
 
       assertThat(existingSpaceBooking.transferredTo).isNull()
 
-      val result = service.plannedTransfer(
+      val result = service.createPlannedTransfer(
         existingSpaceBooking.id,
         user,
         Cas1NewPlannedTransfer(


### PR DESCRIPTION
This commit ensures the ‘booking made’ emails and domain events are triggered for emergency and planned transfers.