### PR TITLE
APS-2269 Update transfer action logic and reuse

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -487,6 +487,7 @@ data class Cas1SpaceBookingEntity(
   @Deprecated("The definition of active is ambiguous, use !isCancelled() instead")
   fun isActive() = !isCancelled()
   fun isCancelled() = cancellationOccurredAt != null
+  fun isNotCancelled() = !isCancelled()
   fun hasDeparted() = actualDepartureDate != null
   fun hasNonArrival() = nonArrivalConfirmedAt != null
   fun hasArrival() = actualArrivalDate != null
@@ -495,6 +496,7 @@ data class Cas1SpaceBookingEntity(
     canonicalArrivalDate <= day &&
     canonicalDepartureDate > day
   fun hasBeenTransferred() = transferredTo != null
+  fun hasNonCancelledTransfer() = transferredTo?.isNotCancelled() ?: false
   fun isEligibleForEmergencyTransfer(): Boolean = !(
     this.hasDeparted() ||
       this.hasBeenTransferred() ||

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -495,14 +495,7 @@ data class Cas1SpaceBookingEntity(
     !hasNonArrival() &&
     canonicalArrivalDate <= day &&
     canonicalDepartureDate > day
-  fun hasBeenTransferred() = transferredTo != null
   fun hasNonCancelledTransfer() = transferredTo?.isNotCancelled() ?: false
-  fun isEligibleForEmergencyTransfer(): Boolean = !(
-    this.hasDeparted() ||
-      this.hasBeenTransferred() ||
-      this.isCancelled() ||
-      this.hasNonArrival()
-    )
 
   override fun toString() = "Cas1SpaceBookingEntity:$id"
   val applicationFacade: Cas1ApplicationFacade

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingActionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingActionsService.kt
@@ -25,14 +25,16 @@ class Cas1SpaceBookingActionsService(
 
   private fun appealCreate(spaceBooking: Cas1SpaceBookingEntity): ActionOutcome {
     val requiredPermission = UserPermission.CAS1_PLACEMENT_APPEAL_CREATE
+    fun unavailable(reason: String) = Unavailable(APPEAL_CREATE, reason)
+
     return if (!userAccessService.currentUserHasPermission(requiredPermission)) {
-      Unavailable(APPEAL_CREATE, "User must have permission '$requiredPermission'")
+      unavailable("User must have permission '$requiredPermission'")
     } else if (spaceBooking.hasArrival()) {
-      Unavailable(APPEAL_CREATE, "Space booking has been marked as arrived")
+      unavailable("Space booking has been marked as arrived")
     } else if (spaceBooking.hasNonArrival()) {
-      Unavailable(APPEAL_CREATE, "Space booking has been marked as non arrived")
+      unavailable("Space booking has been marked as non arrived")
     } else if (spaceBooking.isCancelled()) {
-      Unavailable(APPEAL_CREATE, "Space booking has been cancelled")
+      unavailable("Space booking has been cancelled")
     } else {
       Available(APPEAL_CREATE)
     }
@@ -40,16 +42,18 @@ class Cas1SpaceBookingActionsService(
 
   private fun transferCreate(spaceBooking: Cas1SpaceBookingEntity): ActionOutcome {
     val requiredPermission = UserPermission.CAS1_TRANSFER_CREATE
+    fun unavailable(reason: String) = Unavailable(TRANSFER_CREATE, reason)
+
     return if (!userAccessService.currentUserHasPermission(requiredPermission)) {
-      Unavailable(TRANSFER_CREATE, "User must have permission '$requiredPermission'")
+      unavailable("User must have permission '$requiredPermission'")
     } else if (!spaceBooking.hasArrival()) {
-      Unavailable(TRANSFER_CREATE, "Space booking has not been marked as arrived")
+      unavailable("Space booking has not been marked as arrived")
     } else if (spaceBooking.hasNonArrival()) {
-      Unavailable(TRANSFER_CREATE, "Space booking has been marked as non arrived")
+      unavailable("Space booking has been marked as non arrived")
     } else if (spaceBooking.hasDeparted()) {
-      Unavailable(TRANSFER_CREATE, "Space booking has been marked as departed")
+      unavailable("Space booking has been marked as departed")
     } else if (spaceBooking.isCancelled()) {
-      Unavailable(TRANSFER_CREATE, "Space booking has been cancelled")
+      unavailable("Space booking has been cancelled")
     } else {
       Available(TRANSFER_CREATE)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingActionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingActionsService.kt
@@ -54,6 +54,8 @@ class Cas1SpaceBookingActionsService(
       unavailable("Space booking has been marked as departed")
     } else if (spaceBooking.isCancelled()) {
       unavailable("Space booking has been cancelled")
+    } else if (spaceBooking.hasNonCancelledTransfer()) {
+      unavailable("Space booking has already been transferred")
     } else {
       Available(TRANSFER_CREATE)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -2658,6 +2658,7 @@ class Cas1SpaceBookingTest {
         withApplication(placementRequest.application)
         withCreatedBy(user)
         withExpectedArrivalDate(LocalDate.parse("2025-02-05"))
+        withActualArrivalDate(LocalDate.parse("2025-02-05"))
         withExpectedDepartureDate(LocalDate.parse("2025-06-29"))
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingsActionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingsActionsServiceTest.kt
@@ -107,6 +107,15 @@ class Cas1SpaceBookingsActionsServiceTest {
     }
 
     @Test
+    fun `success if has existing cancelled transfer`() {
+      spaceBooking.transferredTo = Cas1SpaceBookingEntityFactory()
+        .withCancellationOccurredAt(LocalDate.now())
+        .produce()
+
+      service.determineActions(spaceBooking).assertAvailable(SpaceBookingAction.TRANSFER_CREATE)
+    }
+
+    @Test
     fun `unavailable if user does not have correct permission`() {
       userDoesntHavePermission(UserPermission.CAS1_TRANSFER_CREATE)
 
@@ -158,6 +167,19 @@ class Cas1SpaceBookingsActionsServiceTest {
         .assertUnavailable(
           action = SpaceBookingAction.TRANSFER_CREATE,
           message = "Space booking has been cancelled",
+        )
+    }
+
+    @Test
+    fun `unavailable if has a non cancelled transfer already`() {
+      spaceBooking.transferredTo = Cas1SpaceBookingEntityFactory()
+        .withCancellationOccurredAt(null)
+        .produce()
+
+      service.determineActions(spaceBooking)
+        .assertUnavailable(
+          action = SpaceBookingAction.TRANSFER_CREATE,
+          message = "Space booking has already been transferred",
         )
     }
   }


### PR DESCRIPTION
* Update actions to block transfer if an active transfer exists
* The validation logic in the emergency transfer function duplicates that `Cas1SpaceBookingActions`. This commit updates the function to reuse the actions logic.