### PR TITLE
Upgrade data frame

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
 
   implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.9.3")
 
-  implementation("org.jetbrains.kotlinx:dataframe:0.13.1") {
+  implementation("org.jetbrains.kotlinx:dataframe:0.15.0") {
     exclude(group = "org.jetbrains.kotlinx", module = "dataframe-openapi")
   }
 
@@ -67,7 +67,7 @@ dependencies {
 
   implementation("net.javacrumbs.shedlock:shedlock-spring:5.16.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0")
-  implementation("org.jetbrains.kotlinx:dataframe-excel:0.13.1")
+  implementation("org.jetbrains.kotlinx:dataframe-excel:0.15.0")
 
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.13.17")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -20,7 +20,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
@@ -71,8 +70,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Transiti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.properties.BookingsReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toShortBase58
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.toYesNo
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3ReportService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -88,12 +85,6 @@ import java.time.ZoneOffset
 import java.util.UUID
 
 class Cas3ReportsTest : IntegrationTestBase() {
-  @Autowired
-  lateinit var bookingTransformer: BookingTransformer
-
-  @Autowired
-  lateinit var cas3ReportService: Cas3ReportService
-
   @ParameterizedTest
   @EnumSource(value = Cas3ReportType::class)
   fun `Get report for all regions returns 403 Forbidden if user does not have all regions access`(reportType: Cas3ReportType) {


### PR DESCRIPTION
This also upgrades POI, resolving CVE CVE-2025-31672

A change was made in POI that meant it no longer observed the ordering of columns as provided to to the `toDataFrame` function. To fix this we explicitly call the `reorderColumnsBy` function on the dataframe