### PR TITLE
APS-2227 - Send emergency transfer emails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -48,6 +48,8 @@ object Cas1NotifyTemplates {
   const val PLACEMENT_REQUEST_SUBMITTED = "deb11bc6-d424-4370-bbe5-41f6a823d292"
   const val PLACEMENT_REQUEST_SUBMITTED_V2 = "e7e5b481-aca8-4930-bf4e-b3098834e840"
   const val PLACEMENT_REQUEST_WITHDRAWN_V2 = "58bda3a6-c091-4d78-a533-de5991777300"
+  const val TRANSFER_COMPLETE = "cf813a40-8135-4123-b9bb-2234d10f01ae"
+  const val TRANSFER_COMPLETE_EMERGENCY_FOR_CRU = "dae982a8-6afe-413e-b23d-12e195c2d947"
 }
 
 class NotifyTemplates {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementEmailService.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas1NotifyTemplates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TransferType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.ArrivalRecorded
+
+@Service
+class Cas1BookingManagementEmailService(
+  private val emailNotifier: Cas1EmailNotifier,
+) {
+  @EventListener
+  fun arrivalRecorded(arrivalRecorded: ArrivalRecorded) = arrivalRecorded(arrivalRecorded.spaceBooking)
+
+  fun arrivalRecorded(spaceBooking: Cas1SpaceBookingEntity) {
+    if (spaceBooking.transferType == TransferType.EMERGENCY) {
+      val application = spaceBooking.application!!
+      val recipientEmailAddresses = spaceBooking.placementRequest!!.requestingUsersEmailAddresses()
+
+      val toPersonalisation = spaceBooking.toEmailBookingInfo(spaceBooking.application!!).personalisationValues()
+      val fromPersonalisation = spaceBooking.transferredFrom!!.toEmailBookingInfo(spaceBooking.application!!).personalisationValues()
+
+      val personalisation = mapOf(
+        "crn" to application.crn,
+        "fromPremisesName" to fromPersonalisation.premisesName,
+        "toPremisesName" to toPersonalisation.premisesName,
+        "startDate" to toPersonalisation.startDate,
+        "endDate" to toPersonalisation.endDate,
+        "lengthStay" to toPersonalisation.lengthOfStay,
+        "lengthStayUnit" to toPersonalisation.lengthOfStayUnit,
+      )
+
+      emailNotifier.sendEmails(
+        recipientEmailAddresses = recipientEmailAddresses,
+        templateId = Cas1NotifyTemplates.TRANSFER_COMPLETE,
+        personalisation = personalisation,
+        application = application,
+      )
+
+      emailNotifier.sendEmails(
+        recipientEmailAddresses = setOfNotNull(application.cruManagementArea?.emailAddress),
+        templateId = Cas1NotifyTemplates.TRANSFER_COMPLETE_EMERGENCY_FOR_CRU,
+        personalisation = personalisation,
+        application = application,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
@@ -83,8 +83,6 @@ class Cas1BookingManagementService(
 
     val updatedSpaceBooking = cas1SpaceBookingRepository.save(existingCas1SpaceBooking)
 
-    cas1ChangeRequestService.spaceBookingHasArrival(updatedSpaceBooking)
-
     cas1SpaceBookingManagementDomainEventService.arrivalRecorded(
       Cas1SpaceBookingManagementDomainEventService.ArrivalInfo(
         updatedSpaceBooking,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.DepartureInfo
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.ArrivalRecorded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.time.LocalDate
 import java.time.LocalTime
@@ -37,6 +39,7 @@ class Cas1BookingManagementService(
   private val lockableCas1SpaceBookingEntityRepository: LockableCas1SpaceBookingEntityRepository,
   private val userService: UserService,
   private val cas1ChangeRequestService: Cas1ChangeRequestService,
+  private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
 
   @Transactional
@@ -78,20 +81,22 @@ class Cas1BookingManagementService(
     existingCas1SpaceBooking.actualArrivalDate = arrivalDate
     existingCas1SpaceBooking.actualArrivalTime = arrivalTime
 
-    val result = cas1SpaceBookingRepository.save(existingCas1SpaceBooking)
+    val updatedSpaceBooking = cas1SpaceBookingRepository.save(existingCas1SpaceBooking)
 
-    cas1ChangeRequestService.spaceBookingHasArrival(existingCas1SpaceBooking)
+    cas1ChangeRequestService.spaceBookingHasArrival(updatedSpaceBooking)
 
     cas1SpaceBookingManagementDomainEventService.arrivalRecorded(
       Cas1SpaceBookingManagementDomainEventService.ArrivalInfo(
-        existingCas1SpaceBooking,
+        updatedSpaceBooking,
         actualArrivalDate = arrivalDate,
         actualArrivalTime = arrivalTime,
         recordedBy = userService.getUserForRequest(),
       ),
     )
 
-    success(result)
+    applicationEventPublisher.publishEvent(ArrivalRecorded(updatedSpaceBooking))
+
+    success(updatedSpaceBooking)
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import jakarta.transaction.Transactional
+import org.springframework.context.event.EventListener
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ChangeRequestSortField
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.GeneralValidationError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Success
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.ArrivalRecorded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -216,7 +218,8 @@ class Cas1ChangeRequestService(
 
   fun spaceBookingWithdrawn(spaceBooking: Cas1SpaceBookingEntity) = resolveAllChangeRequestsForSpaceBookingAndType(spaceBooking, ChangeRequestType.entries.toList())
 
-  fun spaceBookingHasArrival(spaceBooking: Cas1SpaceBookingEntity) = resolveAllChangeRequestsForSpaceBookingAndType(spaceBooking, listOf(ChangeRequestType.PLACEMENT_APPEAL))
+  @EventListener
+  fun spaceBookingHasArrival(arrivalRecorded: ArrivalRecorded) = resolveAllChangeRequestsForSpaceBookingAndType(arrivalRecorded.spaceBooking, listOf(ChangeRequestType.PLACEMENT_APPEAL))
 
   fun spaceBookingMarkedAsNonArrival(spaceBooking: Cas1SpaceBookingEntity) = resolveAllChangeRequestsForSpaceBookingAndType(spaceBooking, listOf(ChangeRequestType.PLACEMENT_APPEAL))
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1EmailUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1EmailUtils.kt
@@ -1,7 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Constants.DAYS_IN_WEEK
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
+import java.time.LocalDate
+import java.util.UUID
 
 fun ApprovedPremisesApplicationEntity.interestedPartiesEmailAddresses(): Set<String> = setOfNotNull(
   createdByUser.email,
@@ -14,3 +21,60 @@ fun ApprovedPremisesApplicationEntity.interestedPartiesEmailAddresses(): Set<Str
 
 fun PlacementApplicationEntity.interestedPartiesEmailAddresses(): Set<String> = application.interestedPartiesEmailAddresses() +
   setOfNotNull(createdByUser.email)
+
+
+fun Cas1SpaceBookingEntity.toEmailBookingInfo(
+  application: ApprovedPremisesApplicationEntity,
+) = EmailBookingInfo(
+  bookingId = id,
+  arrivalDate = canonicalArrivalDate,
+  departureDate = canonicalDepartureDate,
+  premises = premises,
+  application = application,
+  placementApplication = placementRequest?.placementApplication,
+)
+
+fun BookingEntity.toEmailBookingInfo(
+  application: ApprovedPremisesApplicationEntity,
+  placementApplication: PlacementApplicationEntity?,
+) = EmailBookingInfo(
+  bookingId = id,
+  arrivalDate = arrivalDate,
+  departureDate = departureDate,
+  premises = premises as ApprovedPremisesEntity,
+  application = application,
+  placementApplication = placementApplication,
+)
+
+data class EmailBookingInfo(
+  val bookingId: UUID,
+  val arrivalDate: LocalDate,
+  val departureDate: LocalDate,
+  val premises: ApprovedPremisesEntity,
+  val application: ApprovedPremisesApplicationEntity,
+  val placementApplication: PlacementApplicationEntity?,
+) {
+  fun personalisationValues(): BookingEmailPersonalisationValues {
+    val lengthOfStayDays = arrivalDate.getDaysUntilInclusive(departureDate).size
+    val lengthOfStayWeeks = lengthOfStayDays.toDouble() / DAYS_IN_WEEK
+    val lengthOfStayWeeksWholeNumber = (lengthOfStayDays.toDouble() % DAYS_IN_WEEK) == 0.0
+
+    return BookingEmailPersonalisationValues(
+      crn = application.crn,
+      startDate = arrivalDate.toString(),
+      endDate = departureDate.toString(),
+      premisesName = premises.name,
+      lengthOfStay = if (lengthOfStayWeeksWholeNumber) lengthOfStayWeeks.toInt() else lengthOfStayDays,
+      lengthOfStayUnit = if (lengthOfStayWeeksWholeNumber) "weeks" else "days",
+    )
+  }
+}
+
+data class BookingEmailPersonalisationValues(
+  val crn: String,
+  val startDate: String,
+  val endDate: String,
+  val premisesName: String,
+  val lengthOfStay: Int,
+  val lengthOfStayUnit: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1EmailUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1EmailUtils.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Constants.DAYS_IN_WEEK
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
 import java.time.LocalDate
@@ -22,6 +23,8 @@ fun ApprovedPremisesApplicationEntity.interestedPartiesEmailAddresses(): Set<Str
 fun PlacementApplicationEntity.interestedPartiesEmailAddresses(): Set<String> = application.interestedPartiesEmailAddresses() +
   setOfNotNull(createdByUser.email)
 
+fun PlacementRequestEntity.requestingUsersEmailAddresses() = application.interestedPartiesEmailAddresses() +
+  (placementApplication?.interestedPartiesEmailAddresses() ?: emptySet())
 
 fun Cas1SpaceBookingEntity.toEmailBookingInfo(
   application: ApprovedPremisesApplicationEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/springevent/ArrivalRecorded.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/springevent/ArrivalRecorded.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+
+data class ArrivalRecorded(val spaceBooking: Cas1SpaceBookingEntity)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -207,6 +207,14 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.transferredTo = { transferredBooking }
   }
 
+  fun withTransferredFrom(transferredBooking: Cas1SpaceBookingEntity?) = apply {
+    this.transferredFrom = { transferredBooking }
+  }
+
+  fun withTransferType(transferType: TransferType?) = apply {
+    this.transferType = { transferType }
+  }
+
   override fun produce() = Cas1SpaceBookingEntity(
     id = this.id(),
     premises = this.premises(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ChangeRequestTest.kt
@@ -16,11 +16,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas1NotifyTemplates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1ChangeRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1CruManagementArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASubmittedCas1Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
@@ -255,7 +255,7 @@ class Cas1ChangeRequestTest {
 
       val placementRequest1 = givenAPlacementRequest(
         createdByUser = user,
-        application = givenACas1Application(
+        application = givenASubmittedCas1Application(
           createdByUser = user,
           offender = givenAnOffender(
             offenderDetailsConfigBlock = {
@@ -298,7 +298,7 @@ class Cas1ChangeRequestTest {
 
       val placementRequest2 = givenAPlacementRequest(
         createdByUser = user,
-        application = givenACas1Application(
+        application = givenASubmittedCas1Application(
           createdByUser = user,
           offender = givenAnOffender(
             offenderDetailsConfigBlock = {
@@ -326,7 +326,7 @@ class Cas1ChangeRequestTest {
 
       val placementRequest3 = givenAPlacementRequest(
         createdByUser = user,
-        application = givenACas1Application(
+        application = givenASubmittedCas1Application(
           createdByUser = user,
           offender = givenAnOffender(
             offenderDetailsConfigBlock = {
@@ -603,7 +603,7 @@ class Cas1ChangeRequestTest {
 
       cruManagementArea = givenACas1CruManagementArea(emailAddress = "cru@test.com")
 
-      application = givenACas1Application(
+      application = givenASubmittedCas1Application(
         createdByUser = user,
         offender = givenAnOffender(
           offenderDetailsConfigBlock = {
@@ -636,7 +636,7 @@ class Cas1ChangeRequestTest {
 
       placementRequest2 = givenAPlacementRequest(
         createdByUser = user,
-        application = givenACas1Application(
+        application = givenASubmittedCas1Application(
           createdByUser = user,
           offender = givenAnOffender(
             offenderDetailsConfigBlock = {
@@ -772,7 +772,7 @@ class Cas1ChangeRequestTest {
 
       placementRequest1 = givenAPlacementRequest(
         createdByUser = user,
-        application = givenACas1Application(
+        application = givenASubmittedCas1Application(
           createdByUser = user,
           offender = givenAnOffender(
             offenderDetailsConfigBlock = {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
@@ -31,6 +31,7 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
   actualArrivalDate: LocalDate? = null,
   caseManager: Cas1ApplicationUserDetailsEntity? = null,
   cruManagementArea: Cas1CruManagementAreaEntity? = null,
+  transferredTo: Cas1SpaceBookingEntity? = null,
 ): Cas1SpaceBookingEntity {
   val (user) = givenAUser()
   val placementRequestToUse = placementRequest ?: if (offlineApplication == null) {
@@ -62,5 +63,6 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
     withCriteria(criteria?.toMutableList() ?: emptyList<CharacteristicEntity>().toMutableList())
     withNonArrivalConfirmedAt(nonArrivalConfirmedAt)
     withCancellationOccurredAt(cancellationOccurredAt)
+    withTransferredTo(transferredTo)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
@@ -36,6 +37,7 @@ fun IntegrationTestBase.givenAPlacementApplication(
   noticeType: Cas1ApplicationTimelinessCategory? = null,
   isWithdrawn: Boolean = false,
   placementDates: List<PlacementDateEntity> = mutableListOf(),
+  application: ApprovedPremisesApplicationEntity? = null,
 ): PlacementApplicationEntity {
   val userApArea = givenAnApArea()
 
@@ -52,7 +54,7 @@ fun IntegrationTestBase.givenAPlacementApplication(
     withApArea(userApArea)
   }
 
-  val (_, application) = givenAnAssessmentForApprovedPremises(
+  val application = application ?: givenAnAssessmentForApprovedPremises(
     decision = assessmentDecision,
     submittedAt = OffsetDateTime.now(),
     crn = crn,
@@ -63,7 +65,7 @@ fun IntegrationTestBase.givenAPlacementApplication(
     name = name,
     requiredQualification = requiredQualification,
     noticeType = noticeType,
-  )
+  ).second
 
   return placementApplicationFactory.produceAndPersist {
     withCreatedByUser(createdByUser)
@@ -90,7 +92,7 @@ fun IntegrationTestBase.givenAPlacementApplication(
 @SuppressWarnings("LongParameterList")
 fun IntegrationTestBase.givenAPlacementApplication(
   assessmentDecision: AssessmentDecision = AssessmentDecision.ACCEPTED,
-  createdByUser: UserEntity,
+  createdByUser: UserEntity = givenAUser().first,
   schema: ApprovedPremisesPlacementApplicationJsonSchemaEntity? = null,
   crn: String = randomStringMultiCaseWithNumbers(8),
   allocatedToUser: UserEntity? = null,
@@ -100,7 +102,8 @@ fun IntegrationTestBase.givenAPlacementApplication(
   placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
   dueAt: OffsetDateTime? = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
   placementDates: MutableList<PlacementDateEntity> = mutableListOf(),
-  block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit,
+  application: ApprovedPremisesApplicationEntity? = null,
+  block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit = { },
 ): PlacementApplicationEntity {
   val placementApplication = givenAPlacementApplication(
     assessmentDecision = assessmentDecision,
@@ -116,6 +119,8 @@ fun IntegrationTestBase.givenAPlacementApplication(
     placementType = placementType,
     dueAt = dueAt,
     placementDates = placementDates,
+    application = application,
+    isWithdrawn = false,
   )
   block(placementApplication)
   return placementApplication

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -33,7 +33,7 @@ import java.time.OffsetDateTime
 fun IntegrationTestBase.givenAPlacementRequest(
   placementRequestAllocatedTo: UserEntity? = null,
   assessmentAllocatedTo: UserEntity? = null,
-  createdByUser: UserEntity,
+  createdByUser: UserEntity = givenAUser().first,
   crn: String? = null,
   name: String? = null,
   reallocated: Boolean = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
@@ -15,22 +16,25 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCa
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
-fun IntegrationTestBase.givenACas1Application(
-  createdByUser: UserEntity,
+fun IntegrationTestBase.givenASubmittedCas1Application(
+  createdByUser: UserEntity = givenAUser().first,
   offender: CaseSummary,
   cruManagementArea: Cas1CruManagementAreaEntity? = null,
   tier: String? = null,
+  caseManager: Cas1ApplicationUserDetailsEntity? = null,
 ) = givenACas1Application(
   createdByUser = createdByUser,
   crn = offender.crn,
   cruManagementArea = cruManagementArea,
   name = "${offender.name.forename} ${offender.name.surname}",
   tier = tier,
+  caseManager = caseManager,
+  submittedAt = OffsetDateTime.now(),
 )
 
 @Suppress("LongParameterList")
 fun IntegrationTestBase.givenACas1Application(
-  createdByUser: UserEntity,
+  createdByUser: UserEntity = givenAUser().first,
   crn: String = randomStringMultiCaseWithNumbers(8),
   submittedAt: OffsetDateTime? = null,
   eventNumber: String = randomInt(1, 9).toString(),
@@ -38,8 +42,20 @@ fun IntegrationTestBase.givenACas1Application(
   cruManagementArea: Cas1CruManagementAreaEntity? = null,
   name: String = "${randomStringUpperCase(4)} ${randomStringUpperCase(6)}",
   tier: String? = null,
+  caseManager: Cas1ApplicationUserDetailsEntity? = null,
   block: (application: ApplicationEntity) -> Unit = {},
-) = givenAnApplication(createdByUser, crn, submittedAt, eventNumber, isWomensApplication, cruManagementArea, name, tier, block)
+) = givenAnApplication(
+  createdByUser,
+  crn,
+  submittedAt,
+  eventNumber,
+  isWomensApplication,
+  cruManagementArea,
+  name,
+  tier,
+  caseManager,
+  block,
+)
 
 @Suppress("LongParameterList")
 fun IntegrationTestBase.givenAnApplication(
@@ -51,6 +67,7 @@ fun IntegrationTestBase.givenAnApplication(
   cruManagementArea: Cas1CruManagementAreaEntity? = null,
   name: String = "${randomStringUpperCase(4)} ${randomStringUpperCase(6)}",
   tier: String? = null,
+  caseManager: Cas1ApplicationUserDetailsEntity? = null,
   block: (application: ApplicationEntity) -> Unit = {},
 ): ApprovedPremisesApplicationEntity {
   val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -71,6 +88,8 @@ fun IntegrationTestBase.givenAnApplication(
     withIsWomensApplication(isWomensApplication)
     withName(name)
     withRiskRatings(riskRatings)
+    withCaseManagerUserDetails(caseManager)
+    withCaseManagerIsNotApplicant(caseManager != null)
   }
 
   block(application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementEmailServiceTest.kt
@@ -1,0 +1,129 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas1NotifyTemplates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1ApplicationUserDetailsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TransferType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.MockCas1EmailNotificationService
+import java.time.LocalDate
+
+class Cas1BookingManagementEmailServiceTest {
+
+  private val mockEmailNotificationService = MockCas1EmailNotificationService()
+
+  private val service = Cas1BookingManagementEmailService(mockEmailNotificationService)
+
+  companion object TestConstants {
+    const val CRU_MANAGEMENT_AREA_EMAIL = "apAreaEmail@test.com"
+    const val APPLICANT_EMAIL = "applicantEmail@test.com"
+    const val PLACEMENT_APPLICATION_CREATOR_EMAIL = "placementAppCreatorEmail@test.com"
+    const val CRN = "CRN123"
+    const val FROM_PREMISES_NAME = "From Premises Name"
+    const val TO_PREMISES_NAME = "To Premises Name"
+    const val CASE_MANAGER_EMAIL = "caseManager@test.com"
+  }
+
+  @Nested
+  inner class ArrivalRecorded {
+
+    @Test
+    fun `not transfer, do nothing`() {
+      service.arrivalRecorded(
+        Cas1SpaceBookingEntityFactory()
+          .withTransferType(null)
+          .produce(),
+      )
+
+      mockEmailNotificationService.assertNoEmailsRequested()
+    }
+
+    @Test
+    fun `not emergency transfer, do nothing`() {
+      service.arrivalRecorded(
+        Cas1SpaceBookingEntityFactory()
+          .withTransferType(TransferType.PLANNED)
+          .produce(),
+      )
+
+      mockEmailNotificationService.assertNoEmailsRequested()
+    }
+
+    @Test
+    fun `emergency transfer, send email to applicant(s)`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withDefaults()
+        .withCrn(CRN)
+        .withCreatedByUser(UserEntityFactory().withDefaults().withEmail(APPLICANT_EMAIL).produce())
+        .withCaseManagerIsNotApplicant(true)
+        .withCaseManagerUserDetails(Cas1ApplicationUserDetailsEntityFactory().withEmailAddress(CASE_MANAGER_EMAIL).produce())
+        .withCruManagementArea(Cas1CruManagementAreaEntityFactory().withEmailAddress(CRU_MANAGEMENT_AREA_EMAIL).produce())
+        .produce()
+
+      val fromSpaceBooking = Cas1SpaceBookingEntityFactory()
+        .withApplication(application)
+        .withPremises(ApprovedPremisesEntityFactory().withDefaults().withName(FROM_PREMISES_NAME).produce())
+        .produce()
+
+      val toSpaceBooking = Cas1SpaceBookingEntityFactory()
+        .withApplication(application)
+        .withPremises(ApprovedPremisesEntityFactory().withDefaults().withName(TO_PREMISES_NAME).produce())
+        .withTransferType(TransferType.EMERGENCY)
+        .withPlacementRequest(
+          PlacementRequestEntityFactory()
+            .withDefaults()
+            .withApplication(application)
+            .withPlacementApplication(
+              PlacementApplicationEntityFactory()
+                .withDefaults()
+                .withApplication(application)
+                .withCreatedByUser(UserEntityFactory().withDefaults().withEmail(PLACEMENT_APPLICATION_CREATOR_EMAIL).produce())
+                .produce(),
+            )
+            .produce(),
+        )
+        .withTransferredFrom(fromSpaceBooking)
+        .withCanonicalArrivalDate(LocalDate.of(2025, 1, 2))
+        .withCanonicalDepartureDate(LocalDate.of(2025, 2, 1))
+        .produce()
+
+      service.arrivalRecorded(toSpaceBooking)
+
+      mockEmailNotificationService.assertEmailRequestCount(4)
+
+      mockEmailNotificationService.assertEmailsRequested(
+        setOf(APPLICANT_EMAIL, CASE_MANAGER_EMAIL, PLACEMENT_APPLICATION_CREATOR_EMAIL),
+        Cas1NotifyTemplates.TRANSFER_COMPLETE,
+        personalisationSubSet = mapOf(
+          "crn" to CRN,
+          "fromPremisesName" to FROM_PREMISES_NAME,
+          "toPremisesName" to TO_PREMISES_NAME,
+          "startDate" to "2025-01-02",
+          "endDate" to "2025-02-01",
+          "lengthStay" to 31,
+          "lengthStayUnit" to "days",
+        ),
+        application,
+      )
+
+      mockEmailNotificationService.assertEmailRequested(
+        CRU_MANAGEMENT_AREA_EMAIL,
+        Cas1NotifyTemplates.TRANSFER_COMPLETE_EMERGENCY_FOR_CRU,
+        personalisationSubSet = mapOf(
+          "crn" to CRN,
+          "fromPremisesName" to FROM_PREMISES_NAME,
+          "toPremisesName" to TO_PREMISES_NAME,
+        ),
+        application,
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
@@ -290,8 +290,6 @@ class Cas1BookingManagementServiceTest {
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
 
       val arrivalInfoCaptor = slot<Cas1SpaceBookingManagementDomainEventService.ArrivalInfo>()
-      every { cas1ChangeRequestService.spaceBookingHasArrival(capture(updatedSpaceBookingCaptor)) } returns Unit
-
       every { cas1SpaceBookingManagementDomainEventService.arrivalRecorded(capture(arrivalInfoCaptor)) } returns Unit
       every { userService.getUserForRequest() } returns user
 
@@ -304,8 +302,6 @@ class Cas1BookingManagementServiceTest {
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
       result as CasResult.Success
-
-      verify { cas1ChangeRequestService.spaceBookingHasArrival(any()) }
 
       val updatedSpaceBooking = updatedSpaceBookingCaptor.captured
       assertThat(updatedSpaceBooking.expectedArrivalDate).isEqualTo(existingSpaceBooking.expectedArrivalDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 
+import io.mockk.Runs
 import io.mockk.every
-import io.mockk.mockk
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
@@ -9,9 +13,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssignKeyWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NonArrival
@@ -40,6 +46,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.DepartureInfo
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.ArrivalRecorded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -47,31 +54,46 @@ import java.time.LocalTime
 import java.time.ZoneOffset
 import java.util.UUID
 import java.util.stream.Stream
+import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType
 
+@ExtendWith(MockKExtension::class)
 class Cas1BookingManagementServiceTest {
-  private val cas1PremisesService = mockk<Cas1PremisesService>()
-  private val spaceBookingRepository = mockk<Cas1SpaceBookingRepository>()
-  private val cas1SpaceBookingManagementDomainEventService = mockk<Cas1SpaceBookingManagementDomainEventService>()
-  private val moveOnCategoryRepository = mockk<MoveOnCategoryRepository>()
-  private val departureReasonRepository = mockk<DepartureReasonRepository>()
-  private val staffMemberService = mockk<StaffMemberService>()
-  private val nonArrivalReasonRepository = mockk<NonArrivalReasonRepository>()
-  private val lockableCas1SpaceBookingRepository = mockk<LockableCas1SpaceBookingEntityRepository>()
-  private val userService = mockk<UserService>()
-  private val cas1ChangeRequestService = mockk<Cas1ChangeRequestService>()
 
-  private val service = Cas1BookingManagementService(
-    cas1PremisesService,
-    spaceBookingRepository,
-    cas1SpaceBookingManagementDomainEventService,
-    departureReasonRepository,
-    moveOnCategoryRepository,
-    staffMemberService,
-    nonArrivalReasonRepository,
-    lockableCas1SpaceBookingRepository,
-    userService,
-    cas1ChangeRequestService,
-  )
+  @MockK
+  lateinit var cas1PremisesService: Cas1PremisesService
+
+  @MockK
+  lateinit var spaceBookingRepository: Cas1SpaceBookingRepository
+
+  @MockK
+  lateinit var cas1SpaceBookingManagementDomainEventService: Cas1SpaceBookingManagementDomainEventService
+
+  @MockK
+  lateinit var moveOnCategoryRepository: MoveOnCategoryRepository
+
+  @MockK
+  lateinit var departureReasonRepository: DepartureReasonRepository
+
+  @MockK
+  lateinit var staffMemberService: StaffMemberService
+
+  @MockK
+  lateinit var nonArrivalReasonRepository: NonArrivalReasonRepository
+
+  @MockK
+  lateinit var lockableCas1SpaceBookingRepository: LockableCas1SpaceBookingEntityRepository
+
+  @MockK
+  lateinit var userService: UserService
+
+  @MockK
+  lateinit var cas1ChangeRequestService: Cas1ChangeRequestService
+
+  @MockK
+  lateinit var applicationEventPublisher: ApplicationEventPublisher
+
+  @InjectMockKs
+  lateinit var service: Cas1BookingManagementService
 
   @Nested
   inner class RecordArrival {
@@ -86,6 +108,11 @@ class Cas1BookingManagementServiceTest {
     private val premises = ApprovedPremisesEntityFactory()
       .withDefaults()
       .produce()
+
+    @BeforeEach
+    fun before() {
+      every { applicationEventPublisher.publishEvent(any(JvmType.Object::class)) } just Runs
+    }
 
     @Test
     fun `Returns validation error if no premises with the given premisesId exists`() {
@@ -249,7 +276,7 @@ class Cas1BookingManagementServiceTest {
     }
 
     @Test
-    fun `Updates space booking with arrival information and raises domain event`() {
+    fun `Updates space booking with arrival information, raises domain event and email`() {
       val user = UserEntityFactory().withDefaults().produce()
 
       every { cas1PremisesService.findPremiseById(any()) } returns premises
@@ -291,6 +318,8 @@ class Cas1BookingManagementServiceTest {
       assertThat(arrivalInfo.actualArrivalDate).isEqualTo(LocalDate.of(2024, 1, 2))
       assertThat(arrivalInfo.actualArrivalTime).isEqualTo(LocalTime.of(3, 4, 5))
       assertThat(arrivalInfo.recordedBy).isEqualTo(user)
+
+      verify { applicationEventPublisher.publishEvent(ArrivalRecorded(updatedSpaceBooking)) }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/MockCas1EmailNotificationService.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/MockCas1EmailNotificationService.kt
@@ -39,6 +39,20 @@ class MockCas1EmailNotificationService : Cas1EmailNotifier {
     assertThat(requestedEmails).hasSize(expectedCount)
   }
 
+  fun assertEmailsRequested(
+    recipientEmailAddresses: Set<String>,
+    templateId: String,
+    personalisationSubSet: Map<String, Any>,
+    application: ApprovedPremisesApplicationEntity,
+  ) = recipientEmailAddresses.forEach { recipientEmailAddress ->
+    assertEmailRequested(
+      recipientEmailAddress,
+      templateId,
+      personalisationSubSet,
+      application,
+    )
+  }
+
   fun assertEmailRequested(
     recipientEmailAddress: String,
     templateId: String,


### PR DESCRIPTION
Emails are sent on arrival for any space booking that was created for an emergency transfer.

This commit introduces the user of spring events to ‘notify’ the email service that an arrival event has occurred. This minimises the amount of mocking required in the main service functions and better decouples services, simplifying unit testing