### PR TITLE
APS-2249 Send emails when space booking is shortened.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -123,6 +123,13 @@ class Cas1BookingEmailService(
     spaceBooking.toBookingInfo(application),
   )
 
+  fun spaceBookingShortened(
+    spaceBooking: Cas1SpaceBookingEntity,
+    application: ApprovedPremisesApplicationEntity,
+  ) = bookingShortened(
+    spaceBooking.toBookingInfo(application),
+  )
+
   fun bookingAmended(
     application: ApprovedPremisesApplicationEntity,
     booking: BookingEntity,
@@ -139,6 +146,26 @@ class Cas1BookingEmailService(
       (
         application.interestedPartiesEmailAddresses() +
           setOfNotNull(bookingInfo.premises.emailAddress)
+        ).toSet()
+
+    emailNotifier.sendEmails(
+      recipientEmailAddresses = interestedParties,
+      templateId = Cas1NotifyTemplates.BOOKING_AMENDED,
+      personalisation = emailPersonalisation,
+      application = application,
+    )
+  }
+
+  private fun bookingShortened(bookingInfo: BookingInfo) {
+    val application = bookingInfo.application
+    val emailPersonalisation = buildCommonPersonalisation(bookingInfo)
+
+    val interestedParties =
+      (
+        application.interestedPartiesEmailAddresses() +
+          setOfNotNull(bookingInfo.premises.emailAddress) +
+          setOfNotNull(application.cruManagementArea?.emailAddress) +
+          setOfNotNull(bookingInfo.placementApplication?.createdByUser?.email)
         ).toSet()
 
     emailNotifier.sendEmails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -328,7 +328,16 @@ class Cas1SpaceBookingService(
 
     if (validationErrors.any()) return fieldValidationError
 
+    val previousDepartureDate = existingBooking!!.expectedDepartureDate
+
     val updatedBooking = updateExistingSpaceBooking(existingBooking!!, updateSpaceBookingDetails)
+
+    updatedBooking.application?.let { application ->
+      cas1BookingEmailService.spaceBookingShortened(
+        spaceBooking = updatedBooking,
+        application = application,
+      )
+    }
 
     success(updatedBooking)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas1SpaceBooking.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
@@ -27,6 +29,8 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
   nonArrivalConfirmedAt: Instant? = null,
   cancellationOccurredAt: LocalDate? = null,
   actualArrivalDate: LocalDate? = null,
+  caseManager: Cas1ApplicationUserDetailsEntity? = null,
+  cruManagementArea: Cas1CruManagementAreaEntity? = null,
 ): Cas1SpaceBookingEntity {
   val (user) = givenAUser()
   val placementRequestToUse = placementRequest ?: if (offlineApplication == null) {
@@ -35,6 +39,8 @@ fun IntegrationTestBase.givenACas1SpaceBooking(
       assessmentAllocatedTo = user,
       createdByUser = user,
       application = application,
+      caseManager = caseManager,
+      cruManagementArea = cruManagementArea,
     ).first
   } else {
     null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -1520,7 +1520,7 @@ class Cas1SpaceBookingServiceTest {
     }
 
     @Test
-    fun `should update departure date when status is hasArrival`() {
+    fun `should update departure date when status is hasArrival and send emails`() {
       val shortenSpaceBookingDetails = ShortenSpaceBookingDetails(
         bookingId = UUID.randomUUID(),
         premisesId = PREMISES_ID,
@@ -1534,6 +1534,7 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
+      every { cas1BookingEmailService.spaceBookingShortened(any(), any()) } returns Unit
 
       val result = service.shortenSpaceBooking(shortenSpaceBookingDetails)
 
@@ -1544,6 +1545,13 @@ class Cas1SpaceBookingServiceTest {
       assertThat(updatedSpaceBooking.canonicalArrivalDate).isEqualTo(existingSpaceBooking.canonicalArrivalDate)
       assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
       assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
+
+      verify(exactly = 1) {
+        cas1BookingEmailService.spaceBookingShortened(
+          spaceBooking = updatedSpaceBookingCaptor.captured,
+          application = updatedSpaceBookingCaptor.captured.application!!,
+        )
+      }
     }
 
     @Test
@@ -1563,6 +1571,7 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
+      every { cas1BookingEmailService.spaceBookingShortened(any(), any()) } returns Unit
 
       val result = service.shortenSpaceBooking(shortenSpaceBookingDetails)
 
@@ -1573,6 +1582,13 @@ class Cas1SpaceBookingServiceTest {
       assertThat(updatedSpaceBooking.canonicalArrivalDate).isEqualTo(existingSpaceBooking.canonicalArrivalDate)
       assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
       assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
+
+      verify(exactly = 1) {
+        cas1BookingEmailService.spaceBookingShortened(
+          spaceBooking = updatedSpaceBookingCaptor.captured,
+          application = updatedSpaceBookingCaptor.captured.application!!,
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2249

API: Create a new Cas1SpaceBookingService.shortenSpaceBooking method in the service, if the departure date for the existing booking is after the departure date supplied in the Cas1ShortenSpaceBooking supplied then send the “[Booking Amendment](https://docs.google.com/spreadsheets/d/1vRzoK0NDLjmWT6p6DWAEbhV5kBudgRveTyEWJnT1PjE/edit?gid=1424773734#gid=1424773734)” email.

Recipients:

1. The probation practitioner who created the application
2. Application case manager
3. AP manager
4. The person who created the corresponding placement application (if applicable - this might not be the same person who created the application)
5. CRU inbox