### PR TITLE
APS-2275 Add placement id to matching outcomes report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PlacementMatchingOutcomesV2ReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PlacementMatchingOutcomesV2ReportRepository.kt
@@ -46,6 +46,10 @@ class Cas1PlacementMatchingOutcomesV2ReportRepository(
         first_match_event.data -> 'eventDetails' -> 'premises' ->> 'name' as first_successful_match_attempt_premises_name,
         to_char(latest_match_event.occurred_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as last_successful_match_attempt_date_time,
         latest_match_event.data -> 'eventDetails' -> 'premises' ->> 'name' as last_successful_match_attempt_premises_name,
+        CASE
+          WHEN latest_match_attempt_event.type = 'APPROVED_PREMISES_BOOKING_MADE' THEN  latest_match_event.data -> 'eventDetails' ->> 'bookingId'
+          ELSE ''
+        END as last_successful_match_placement_id,
         
         rfp.* 
       FROM raw_requests_for_placements rfp

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcce
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentRejection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBookingCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewAppeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBookingNotMade
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
 import java.time.LocalDate
 import java.util.UUID
 
@@ -305,15 +307,14 @@ class Cas1SimpleApiClient {
     placementRequestId: UUID,
     managerJwt: String,
     body: Cas1NewSpaceBooking,
-  ) {
-    integrationTestBase.webTestClient.post()
-      .uri("/cas1/placement-requests/$placementRequestId/space-bookings")
-      .header("Authorization", "Bearer $managerJwt")
-      .bodyValue(body)
-      .exchange()
-      .expectStatus()
-      .isOk
-  }
+  ) = integrationTestBase.webTestClient.post()
+    .uri("/cas1/placement-requests/$placementRequestId/space-bookings")
+    .header("Authorization", "Bearer $managerJwt")
+    .bodyValue(body)
+    .exchange()
+    .expectStatus()
+    .isOk
+    .bodyAsObject<Cas1SpaceBooking>()
 
   fun spaceBookingCancel(
     integrationTestBase: IntegrationTestBase,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -251,6 +251,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.first_successful_match_attempt_premises_name).isNull()
       assertThat(row.last_successful_match_attempt_date_time).isNull()
       assertThat(row.last_successful_match_attempt_premises_name).isNull()
+      assertThat(row.last_successful_match_placement_id).isNull()
     }
   }
 
@@ -274,6 +275,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
   inner class StandardRFPMatched {
     lateinit var application: ApprovedPremisesApplicationEntity
+    lateinit var latestBookingId: UUID
 
     fun createRequestForPlacement() {
       application = createSubmitAndAssessedApplication(
@@ -283,7 +285,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       clock.setNow(LocalDateTime.of(2030, 1, 2, 3, 4, 5))
 
-      createBooking(
+      latestBookingId = createBooking(
         placementRequestId = application.placementRequests[0].id,
         matcherUsername = "MATCHER1",
         matcherApAreaName = "MATCHER1CRU",
@@ -308,6 +310,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.first_successful_match_attempt_premises_name).isEqualTo("StandardRFPMatched Premise")
       assertThat(row.last_successful_match_attempt_date_time).isEqualTo("2030-01-02T03:04:05Z")
       assertThat(row.last_successful_match_attempt_premises_name).isEqualTo("StandardRFPMatched Premise")
+      assertThat(row.last_successful_match_placement_id).isEqualTo(latestBookingId.toString())
     }
   }
 
@@ -352,6 +355,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
   inner class StandardRFPNotMatchedAndThenMatched {
     lateinit var application: ApprovedPremisesApplicationEntity
+    lateinit var latestBookingId: UUID
 
     fun createRequestForPlacement() {
       application = createSubmitAndAssessedApplication(
@@ -368,7 +372,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       clock.setNow(LocalDateTime.of(2030, 2, 3, 4, 5, 6))
 
-      createBooking(
+      latestBookingId = createBooking(
         placementRequestId = application.placementRequests[0].id,
         matcherUsername = "MATCHER13",
         matcherApAreaName = "MATCHER13CRU",
@@ -393,11 +397,13 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.first_successful_match_attempt_premises_name).isEqualTo("StandardRFPNotMatchedAndThenMatched premise")
       assertThat(row.last_successful_match_attempt_date_time).isEqualTo("2030-02-03T04:05:06Z")
       assertThat(row.last_successful_match_attempt_premises_name).isEqualTo("StandardRFPNotMatchedAndThenMatched premise")
+      assertThat(row.last_successful_match_placement_id).isEqualTo(latestBookingId.toString())
     }
   }
 
   inner class StandardRFPMultipleTransfers {
     lateinit var application: ApprovedPremisesApplicationEntity
+    lateinit var latestBookingId: UUID
 
     fun createRequestForPlacement() {
       application = createSubmitAndAssessedApplication(
@@ -428,7 +434,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       clock.setNow(LocalDateTime.of(2032, 1, 2, 3, 4, 5))
 
-      createBooking(
+      latestBookingId = createBooking(
         placementRequestId = application.placementRequests[0].id,
         matcherUsername = "MATCHER6",
         matcherApAreaName = "MATCHER6CRU",
@@ -452,11 +458,13 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.first_successful_match_attempt_premises_name).isEqualTo("StandardRFPMultipleTransfers premise 1")
       assertThat(row.last_successful_match_attempt_date_time).isEqualTo("2032-01-02T03:04:05Z")
       assertThat(row.last_successful_match_attempt_premises_name).isEqualTo("StandardRFPMultipleTransfers premise 3")
+      assertThat(row.last_successful_match_placement_id).isEqualTo(latestBookingId.toString())
     }
   }
 
   inner class PlacementAppMatched {
     lateinit var application: ApprovedPremisesApplicationEntity
+    lateinit var latestBookingId: UUID
 
     fun createRequestForPlacement() {
       application = createSubmitAndAssessedApplication(
@@ -477,7 +485,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       clock.setNow(LocalDateTime.of(2031, 8, 7, 6, 5, 6))
 
-      createBooking(
+      latestBookingId = createBooking(
         placementRequestId = application.placementRequests[0].id,
         matcherUsername = "MATCHER10",
         matcherApAreaName = "MATCHER10CRU",
@@ -501,6 +509,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       assertThat(row.first_successful_match_attempt_premises_name).isEqualTo("PlacementAppMatched Premise")
       assertThat(row.last_successful_match_attempt_date_time).isEqualTo("2031-08-07T06:05:06Z")
       assertThat(row.last_successful_match_attempt_premises_name).isEqualTo("PlacementAppMatched Premise")
+      assertThat(row.last_successful_match_placement_id).isEqualTo(latestBookingId.toString())
     }
   }
 
@@ -565,7 +574,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
     matcherUsername: String,
     matcherApAreaName: String,
     premisesName: String = randomStringMultiCaseWithNumbers(8),
-  ) {
+  ): UUID {
     val managerJwt = givenAUser(
       roles = listOf(UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA),
       staffDetail = StaffDetailFactory.staffDetail(name = PersonName(forename = "Jeff", surname = "Jefferson"), deliusUsername = matcherUsername),
@@ -579,7 +588,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       withSupportsSpaceBookings(true)
     }
 
-    cas1SimpleApiClient.spaceBookingForPlacementRequest(
+    return cas1SimpleApiClient.spaceBookingForPlacementRequest(
       integrationTestBase = this,
       placementRequestId = placementRequestId,
       managerJwt = managerJwt,
@@ -589,7 +598,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
         premisesId = premises.id,
         characteristics = emptyList(),
       ),
-    )
+    ).id
   }
 
   private fun createBookingNotMade(
@@ -827,5 +836,6 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
     val first_successful_match_attempt_premises_name: String?,
     val last_successful_match_attempt_date_time: String?,
     val last_successful_match_attempt_premises_name: String?,
+    val last_successful_match_placement_id: String?,
   )
 }


### PR DESCRIPTION
This is being temporarily added until the placement report can report on all placements (i.e. once all regions have migrated to space bookings)