### PR TITLE
Migrate booking domain events describers to new model

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
@@ -63,6 +63,7 @@ class Cas1DomainEventDescriber(
     }
 
     // Do _not_ add to this list! Instead, create an implementation of [TimelineFactory]
+    // If migrating code from here into a [TimelineFactory], use a [LegacyTimelineFactory]
     return when (domainEventSummary.type) {
       DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> EventDescriptionAndPayload(
         "The application was submitted",
@@ -70,7 +71,6 @@ class Cas1DomainEventDescriber(
       )
 
       DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> buildApplicationAssessedDescription(domainEventSummary)
-      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> buildBookingMadeDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> buildPersonArrivedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> buildPersonNotArrivedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> buildPersonDepartedDescription(domainEventSummary)
@@ -127,17 +127,6 @@ class Cas1DomainEventDescriber(
   private fun buildApplicationAssessedDescription(domainEventSummary: DomainEventSummary): EventDescriptionAndPayload<*> {
     val event = domainEventService.getApplicationAssessedDomainEvent(domainEventSummary.id())
     return EventDescriptionAndPayload(event.describe { "The application was assessed and ${it.eventDetails.decision.lowercase()}" }, null)
-  }
-
-  private fun buildBookingMadeDescription(domainEventSummary: DomainEventSummary): EventDescriptionAndPayload<*> {
-    val event = domainEventService.getBookingMadeEvent(domainEventSummary.id())
-    val description = event.describe {
-      "A placement at ${it.eventDetails.premises.name} was booked for " +
-        "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()} " +
-        "against Delius Event Number ${it.eventDetails.deliusEventNumber}"
-    }
-
-    return EventDescriptionAndPayload(description, null)
   }
 
   private fun buildBookingKeyWorkerAssignedDescription(domainEventSummary: DomainEventSummary): EventDescriptionAndPayload<*> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingChangedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingChangedTimelineFactory.kt
@@ -94,8 +94,6 @@ class BookingChangedTimelineFactory(val domainEventService: Cas1DomainEventServi
     )
   }
 
-  private fun <T> GetCas1DomainEvent<T>?.describe(describe: (T) -> String?): String? = this?.let { describe(it.data) }
-
   private fun convertToCas1SpaceCharacteristics(spaceCharacteristics: List<SpaceCharacteristic>?): List<Cas1SpaceCharacteristic>? = spaceCharacteristics?.map { spaceCharacteristic ->
     Cas1SpaceCharacteristic.valueOf(spaceCharacteristic.value)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingMadeTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingMadeTimelineFactory.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BookingMadeContentPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventPayloadBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventDescriber
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
+import java.util.UUID
+
+@Service
+class BookingMadeTimelineFactory(val domainEventService: Cas1DomainEventService) : LegacyTimelineFactory<Cas1BookingMadeContentPayload> {
+  override fun produce(domainEventId: UUID): Cas1DomainEventDescriber.EventDescriptionAndPayload<Cas1BookingMadeContentPayload> {
+    val event = domainEventService.get(domainEventId, BookingMade::class)!!
+
+    val eventDetails = event.data.eventDetails
+
+    return Cas1DomainEventDescriber.EventDescriptionAndPayload(
+      buildDescription(event),
+      Cas1BookingMadeContentPayload(
+        type = Cas1TimelineEventType.bookingMade,
+        booking = Cas1TimelineEventPayloadBookingSummary(
+          bookingId = eventDetails.bookingId,
+          premises = NamedId(
+            eventDetails.premises.id,
+            eventDetails.premises.name,
+          ),
+          arrivalDate = eventDetails.arrivalOn,
+          departureDate = eventDetails.departureOn,
+        ),
+      ),
+    )
+  }
+
+  private fun buildDescription(event: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingMade>>) = event.describe {
+    "A placement at ${it.eventDetails.premises.name} was booked for " +
+      "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()} " +
+      "against Delius Event Number ${it.eventDetails.deliusEventNumber}"
+  }
+
+  override fun forType() = DomainEventType.APPROVED_PREMISES_BOOKING_MADE
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/DomainEventUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/DomainEventUtils.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEv
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.DomainEventUtils.mapApprovedPremisesEntityToPremises
 
 object DomainEventUtils {
@@ -36,3 +37,5 @@ fun Premises.toNamedId() = NamedId(
   id = this.id,
   name = this.name,
 )
+
+fun <T> GetCas1DomainEvent<T>?.describe(describe: (T) -> String?): String? = this?.let { describe(it.data) }

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1198,6 +1198,7 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
+          booking_made: '#/components/schemas/Cas1BookingMadeContentPayload'
           booking_changed: '#/components/schemas/Cas1BookingChangedContentPayload'
           emergency_transfer_created: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayload'
           placement_change_request_accepted: '#/components/schemas/Cas1PlacementChangeRequestAcceptedPayload'
@@ -1241,6 +1242,15 @@ components:
         - premises
         - expectedArrival
         - expectedDeparture
+    Cas1BookingMadeContentPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+      required:
+        - booking
     Cas1PlacementChangeRequestCreatedPayload:
       type: object
       allOf:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7969,6 +7969,7 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
+          booking_made: '#/components/schemas/Cas1BookingMadeContentPayload'
           booking_changed: '#/components/schemas/Cas1BookingChangedContentPayload'
           emergency_transfer_created: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayload'
           placement_change_request_accepted: '#/components/schemas/Cas1PlacementChangeRequestAcceptedPayload'
@@ -8012,6 +8013,15 @@ components:
         - premises
         - expectedArrival
         - expectedDeparture
+    Cas1BookingMadeContentPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+      required:
+        - booking
     Cas1PlacementChangeRequestCreatedPayload:
       type: object
       allOf:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Assessmen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAppealedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingKeyWorkerAssignedFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.FurtherInformationRequestedFactory
@@ -113,35 +112,6 @@ class Cas1DomainEventDescriberTest {
     val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
 
     assertThat(result.description).isEqualTo("The application was assessed and $decision")
-  }
-
-  @Test
-  fun `Returns expected description for booking made event`() {
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_MADE)
-    val arrivalDate = LocalDate.of(2024, 1, 1)
-    val departureDate = LocalDate.of(2024, 4, 1)
-
-    every { mockDomainEventService.getBookingMadeEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingMade,
-        eventDetails = BookingMadeFactory()
-          .withArrivalOn(arrivalDate)
-          .withDepartureOn(departureDate)
-          .withPremises(
-            EventPremisesFactory()
-              .withName("The Premises Name")
-              .produce(),
-          )
-          .withDeliusEventNumber("989")
-          .produce(),
-      )
-    }
-
-    val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-
-    assertThat(result.description).isEqualTo("A placement at The Premises Name was booked for Monday 1 January 2024 to Monday 1 April 2024 against Delius Event Number 989")
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingMadeTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingMadeTimelineFactoryTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.domainevents
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.BookingMadeTimelineFactory
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class BookingMadeTimelineFactoryTest {
+
+  @MockK
+  lateinit var domainEventService: Cas1DomainEventService
+
+  @InjectMockKs
+  lateinit var service: BookingMadeTimelineFactory
+
+  val id: UUID = UUID.randomUUID()
+
+  @Test
+  fun success() {
+    val bookingId = UUID.randomUUID()
+    val arrivalDate = LocalDate.of(2024, 1, 1)
+    val departureDate = LocalDate.of(2024, 4, 1)
+
+    every { domainEventService.get(id, BookingMade::class) } returns buildDomainEvent(
+      data = BookingMadeFactory()
+        .withBookingId(bookingId)
+        .withArrivalOn(arrivalDate)
+        .withDepartureOn(departureDate)
+        .withPremises(
+          EventPremisesFactory()
+            .withName("The Premises Name")
+            .produce(),
+        )
+        .withDeliusEventNumber("989")
+        .produce(),
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.description).isEqualTo(
+      "A placement at The Premises Name was booked for " +
+        "Monday 1 January 2024 to Monday 1 April 2024 against Delius Event Number 989",
+    )
+
+    val payload = result.payload!!
+
+    assertThat(payload.booking.bookingId).isEqualTo(bookingId)
+    assertThat(payload.booking.premises.name).isEqualTo("The Premises Name")
+    assertThat(payload.booking.arrivalDate).isEqualTo(LocalDate.of(2024, 1, 1))
+    assertThat(payload.booking.departureDate).isEqualTo(LocalDate.of(2024, 4, 1))
+  }
+}


### PR DESCRIPTION
Move logic to build a description for the ‘booking made’ and 'booking cancelled' timeline entries into a `LegacyTimelineFactory`, adding payloads for the data