### PR TITLE
APS-2250 remove reason for shortening a booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -41,7 +41,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementService.DepartureInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.ShortenBookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.SpaceBookingFilterCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingUpdateService.UpdateBookingDetails
@@ -222,12 +221,12 @@ class Cas1SpaceBookingController(
 
     ensureEntityFromCasResultIsSuccess(
       cas1SpaceBookingService.shortenBooking(
-        ShortenBookingDetails(
+        UpdateBookingDetails(
           bookingId = bookingId,
           premisesId = premisesId,
           departureDate = cas1ShortenSpaceBooking.departureDate,
-          reason = cas1ShortenSpaceBooking.reason,
           updatedBy = userService.getUserForRequest(),
+          updateType = UpdateType.SHORTENING,
         ),
       ),
     )

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -212,12 +212,8 @@ components:
           type: string
           format: date
           example: 2022-09-30
-        reason:
-          description: Reason for shortening a placement
-          type: string
       required:
         - departureDate
-        - reason
     Cas1SpaceSearchRequirements:
       deprecated: true
       type: object

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6983,12 +6983,8 @@ components:
           type: string
           format: date
           example: 2022-09-30
-        reason:
-          description: Reason for shortening a placement
-          type: string
       required:
         - departureDate
-        - reason
     Cas1SpaceSearchRequirements:
       deprecated: true
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -22,7 +22,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewPlanned
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBookingCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NonArrival
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ShortenSpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
@@ -2644,9 +2643,8 @@ class Cas1SpaceBookingTest {
         .uri("/cas1/premises/${spaceBooking.premises.id}/space-bookings/${spaceBooking.id}/shorten")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
-          Cas1ShortenSpaceBooking(
+          Cas1UpdateSpaceBooking(
             departureDate = LocalDate.now(),
-            reason = "valid reason",
           ),
         )
         .exchange()
@@ -2664,9 +2662,8 @@ class Cas1SpaceBookingTest {
         .uri("/cas1/premises/${spaceBooking.premises.id}/space-bookings/${spaceBooking.id}/shorten")
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
-          Cas1ShortenSpaceBooking(
+          Cas1UpdateSpaceBooking(
             departureDate = today,
-            reason = "valid reason",
           ),
         )
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -55,7 +55,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingCreateService.CreateBookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.ShortenBookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingUpdateService.UpdateBookingDetails
@@ -785,12 +784,12 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
       val result = service.shortenBooking(
-        ShortenBookingDetails(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           departureDate = LocalDate.now().minusDays(1),
-          reason = "valid reason",
           updatedBy = user,
+          updateType = UpdateType.SHORTENING,
         ),
       )
 
@@ -805,12 +804,12 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
       val result = service.shortenBooking(
-        ShortenBookingDetails(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           departureDate = LocalDate.now().plusDays(8),
-          reason = "valid reason",
           updatedBy = user,
+          updateType = UpdateType.SHORTENING,
         ),
       )
 
@@ -825,12 +824,12 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
       val result = service.shortenBooking(
-        ShortenBookingDetails(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           departureDate = LocalDate.now().plusDays(7),
-          reason = "valid reason",
           updatedBy = user,
+          updateType = UpdateType.SHORTENING,
         ),
       )
 
@@ -861,12 +860,12 @@ class Cas1SpaceBookingServiceTest {
 
       every { cas1SpaceBookingUpdateService.validate(updateDetails) } returns validationResult
 
-      val shortenBookingDetails = ShortenBookingDetails(
+      val shortenBookingDetails = UpdateBookingDetails(
         bookingId = existingSpaceBooking.id,
         premisesId = PREMISES_ID,
         departureDate = LocalDate.now().plusDays(1),
-        reason = "valid reason",
         updatedBy = user,
+        updateType = UpdateType.SHORTENING,
       )
 
       val result = service.shortenBooking(shortenBookingDetails)
@@ -889,12 +888,12 @@ class Cas1SpaceBookingServiceTest {
       every { cas1SpaceBookingUpdateService.validate(updateDetails) } returns CasResult.Success(Unit)
       every { cas1SpaceBookingUpdateService.update(updateDetails) } returns existingSpaceBooking
 
-      val shortenBookingDetails = ShortenBookingDetails(
+      val shortenBookingDetails = UpdateBookingDetails(
         bookingId = existingSpaceBooking.id,
         premisesId = PREMISES_ID,
         departureDate = LocalDate.now().plusDays(1),
-        reason = "valid reason",
         updatedBy = user,
+        updateType = UpdateType.SHORTENING,
       )
 
       val result = service.shortenBooking(shortenBookingDetails)
@@ -919,12 +918,12 @@ class Cas1SpaceBookingServiceTest {
       every { cas1SpaceBookingUpdateService.validate(updateDetails) } returns CasResult.Success(Unit)
       every { cas1SpaceBookingUpdateService.update(updateDetails) } returns existingSpaceBooking
 
-      val shortenBookingDetails = ShortenBookingDetails(
+      val shortenBookingDetails = UpdateBookingDetails(
         bookingId = existingSpaceBooking.id,
         premisesId = PREMISES_ID,
         departureDate = LocalDate.now(),
-        reason = "valid reason",
         updatedBy = user,
+        updateType = UpdateType.SHORTENING,
       )
 
       val result = service.shortenBooking(shortenBookingDetails)


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2250

- ~~send booking changed domain event when booking is shortened~~
- remove "reason" from API type and associated logic since it is [no longer required](https://mojdt.slack.com/archives/C03K0HB0LBE/p1746523751781129?thread_ts=1745998375.954829&cid=C03K0HB0LBE)
- ~~refactor common update/shorten email logic~~

_NB. Previous PRs already merged have added in the feature to send a domain event when a booking is shortened, therefore this PR and ticket scope is reduced to removing reason for shortening a booking only._