### PR TITLE
APS-2267 add content payloads to booking domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
@@ -2,16 +2,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelled
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventContentPayload
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEventSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.LegacyTimelineFactory
@@ -31,13 +26,9 @@ import java.util.UUID
 class Cas1DomainEventDescriber(
   private val domainEventService: Cas1DomainEventService,
   private val assessmentClarificationNoteRepository: AssessmentClarificationNoteRepository,
-  private val bookingRepository: BookingRepository,
-  private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
   private val payloadFactories: List<TimelineFactory<*>>,
   private val legacyPayloadFactories: List<LegacyTimelineFactory<*>>,
 ) {
-
-  data class BookingCancellationDetail(val premisesName: String, val cancellationReason: String, val arrivalDate: String, val departureDate: String)
 
   /**
    * For any new domain event only payload should be defined, as the
@@ -75,7 +66,6 @@ class Cas1DomainEventDescriber(
       DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> buildPersonNotArrivedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> buildPersonDepartedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_BOOKING_NOT_MADE -> buildBookingNotMadeDescription(domainEventSummary)
-      DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED -> buildBookingCancelledDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_BOOKING_KEYWORKER_ASSIGNED -> buildBookingKeyWorkerAssignedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_APPLICATION_WITHDRAWN -> buildApplicationWithdrawnDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_APPLICATION_EXPIRED -> buildApplicationExpiredDescription(domainEventSummary)
@@ -167,22 +157,6 @@ class Cas1DomainEventDescriber(
       " The reason was: $it"
     } ?: ""
     return EventDescriptionAndPayload(event.describe { "A placement was not made for the placement request.$failureReason" }, null)
-  }
-
-  private fun buildBookingCancelledDescription(domainEventSummary: DomainEventSummary): EventDescriptionAndPayload<*> {
-    val event = domainEventService.getBookingCancelledEvent(domainEventSummary.id())
-    val bookingId = event!!.data.eventDetails.bookingId
-
-    val bookingDetail: BookingCancellationDetail = if (domainEventSummary.cas1SpaceBookingId != null) {
-      getSpaceBookingCancellationDetailForEvent(bookingId, event)
-    } else {
-      getBookingCancellationDetailForEvent(bookingId, event)
-    }
-
-    val description = "A placement at ${bookingDetail.premisesName} booked for " +
-      "${bookingDetail.arrivalDate} to ${bookingDetail.departureDate} " +
-      "was cancelled. The reason was: ${bookingDetail.cancellationReason}"
-    return EventDescriptionAndPayload(description, null)
   }
 
   private fun buildAssessmentAppealedDescription(domainEventSummary: DomainEventSummary): EventDescriptionAndPayload<*> {
@@ -303,45 +277,6 @@ class Cas1DomainEventDescriber(
   private fun buildRequestForPlacementDescription(expectedArrival: LocalDate, duration: Int, rejected: Boolean = false): String {
     val endDate = expectedArrival.plusDays(duration.toLong())
     return "The placement request ${if (rejected) "was" else "is"} for ${expectedArrival.toUiFormat()} to ${endDate.toUiFormat()} (${toWeekAndDayDurationString(duration)})"
-  }
-
-  @SuppressWarnings("TooGenericExceptionThrown")
-  private fun getSpaceBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingCancelled>>): BookingCancellationDetail {
-    val spaceBooking = cas1SpaceBookingRepository.findByIdOrNull(bookingId)
-      ?: throw RuntimeException("Space Booking ID $bookingId with cancellation not found")
-    if (spaceBooking.cancellationReason == null) {
-      throw RuntimeException("Space Booking ID $bookingId does not have a cancellation")
-    }
-    return BookingCancellationDetail(
-      premisesName = spaceBooking.premises.name,
-      cancellationReason = "'${event.data.eventDetails.cancellationReason}'",
-      arrivalDate = spaceBooking.canonicalArrivalDate.toUiFormat(),
-      departureDate = spaceBooking.canonicalDepartureDate.toUiFormat(),
-    )
-  }
-
-  @SuppressWarnings("TooGenericExceptionThrown")
-  private fun getBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingCancelled>>): BookingCancellationDetail {
-    val booking = bookingRepository.findByIdOrNull(bookingId)
-      ?: throw RuntimeException("Booking ID $bookingId with cancellation not found")
-    if (booking.cancellations.count() != 1) {
-      throw RuntimeException("Booking ID $bookingId does not have one cancellation")
-    }
-    val cancellation = booking.cancellations.first()
-    val otherReasonText =
-      if (cancellation.reason.id == CancellationReasonRepository.CAS1_RELATED_OTHER_ID &&
-        !cancellation.otherReason.isNullOrEmpty()
-      ) {
-        ": ${cancellation.otherReason}."
-      } else {
-        ""
-      }
-    return BookingCancellationDetail(
-      premisesName = booking.premises.name,
-      cancellationReason = "'${event.data.eventDetails.cancellationReason}'$otherReasonText",
-      arrivalDate = booking.arrivalDate.toUiFormat(),
-      departureDate = booking.departureDate.toUiFormat(),
-    )
   }
 
   private fun DomainEventSummary.id(): UUID = UUID.fromString(this.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventDescriber.kt
@@ -63,6 +63,7 @@ class Cas1DomainEventDescriber(
     }
 
     // Do _not_ add to this list! Instead, create an implementation of [TimelineFactory]
+    // If migrating code from here into a [TimelineFactory], use a [LegacyTimelineFactory]
     return when (domainEventSummary.type) {
       DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED -> EventDescriptionAndPayload(
         "The application was submitted",
@@ -70,7 +71,6 @@ class Cas1DomainEventDescriber(
       )
 
       DomainEventType.APPROVED_PREMISES_APPLICATION_ASSESSED -> buildApplicationAssessedDescription(domainEventSummary)
-      DomainEventType.APPROVED_PREMISES_BOOKING_MADE -> buildBookingMadeDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_PERSON_ARRIVED -> buildPersonArrivedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_PERSON_NOT_ARRIVED -> buildPersonNotArrivedDescription(domainEventSummary)
       DomainEventType.APPROVED_PREMISES_PERSON_DEPARTED -> buildPersonDepartedDescription(domainEventSummary)
@@ -127,17 +127,6 @@ class Cas1DomainEventDescriber(
   private fun buildApplicationAssessedDescription(domainEventSummary: DomainEventSummary): EventDescriptionAndPayload<*> {
     val event = domainEventService.getApplicationAssessedDomainEvent(domainEventSummary.id())
     return EventDescriptionAndPayload(event.describe { "The application was assessed and ${it.eventDetails.decision.lowercase()}" }, null)
-  }
-
-  private fun buildBookingMadeDescription(domainEventSummary: DomainEventSummary): EventDescriptionAndPayload<*> {
-    val event = domainEventService.getBookingMadeEvent(domainEventSummary.id())
-    val description = event.describe {
-      "A placement at ${it.eventDetails.premises.name} was booked for " +
-        "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()} " +
-        "against Delius Event Number ${it.eventDetails.deliusEventNumber}"
-    }
-
-    return EventDescriptionAndPayload(description, null)
   }
 
   private fun buildBookingKeyWorkerAssignedDescription(domainEventSummary: DomainEventSummary): EventDescriptionAndPayload<*> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -140,6 +140,7 @@ class Cas1DomainEventService(
       id = entity.id,
       data = data,
       schemaVersion = entity.schemaVersion,
+      spaceBookingId = entity.cas1SpaceBookingId,
     )
   }
 
@@ -399,7 +400,8 @@ class Cas1DomainEventService(
 data class GetCas1DomainEvent<T>(
   val id: UUID,
   val data: T,
-  val schemaVersion: Int? = null,
+  val schemaVersion: Int?,
+  val spaceBookingId: UUID?,
 )
 
 @Deprecated("Use [SaveCas1DomainEventWithPayload]")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingCancelledTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingCancelledTimelineFactory.kt
@@ -1,0 +1,113 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelled
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BookingCancelledContentPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventPayloadBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventDescriber
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class BookingCancelledTimelineFactory(
+  val domainEventService: Cas1DomainEventService,
+  private val bookingRepository: BookingRepository,
+  private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
+) : LegacyTimelineFactory<Cas1BookingCancelledContentPayload> {
+  override fun produce(domainEventId: UUID): Cas1DomainEventDescriber.EventDescriptionAndPayload<Cas1BookingCancelledContentPayload> {
+    val event = domainEventService.get(domainEventId, BookingCancelled::class)!!
+
+    val bookingId = event.data.eventDetails.bookingId
+
+    val bookingDetail: BookingCancellationDetail = if (event.spaceBookingId != null) {
+      getSpaceBookingCancellationDetailForEvent(bookingId, event)
+    } else {
+      getBookingCancellationDetailForEvent(bookingId, event)
+    }
+
+    val eventDetails = event.data.eventDetails
+
+    return Cas1DomainEventDescriber.EventDescriptionAndPayload(
+      buildDescription(bookingDetail),
+      Cas1BookingCancelledContentPayload(
+        type = Cas1TimelineEventType.bookingCancelled,
+        booking = Cas1TimelineEventPayloadBookingSummary(
+          bookingId = bookingId,
+          premises = NamedId(
+            bookingDetail.premisesId,
+            bookingDetail.premisesName,
+          ),
+          arrivalDate = bookingDetail.arrivalDate,
+          departureDate = bookingDetail.departureDate,
+        ),
+        cancellationReason = bookingDetail.cancellationReason,
+      ),
+    )
+  }
+
+  private fun buildDescription(bookingDetail: BookingCancellationDetail) = "A placement at ${bookingDetail.premisesName} booked for " +
+    "${bookingDetail.arrivalDate.toUiFormat()} to ${bookingDetail.departureDate.toUiFormat()} " +
+    "was cancelled. The reason was: ${bookingDetail.cancellationReason}"
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  private fun getSpaceBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingCancelled>>): BookingCancellationDetail {
+    val spaceBooking = cas1SpaceBookingRepository.findByIdOrNull(bookingId)
+      ?: throw RuntimeException("Space Booking ID $bookingId with cancellation not found")
+    if (spaceBooking.cancellationReason == null) {
+      throw RuntimeException("Space Booking ID $bookingId does not have a cancellation")
+    }
+    return BookingCancellationDetail(
+      premisesName = spaceBooking.premises.name,
+      premisesId = spaceBooking.premises.id,
+      cancellationReason = "'${event.data.eventDetails.cancellationReason}'",
+      arrivalDate = spaceBooking.canonicalArrivalDate,
+      departureDate = spaceBooking.canonicalDepartureDate,
+    )
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  private fun getBookingCancellationDetailForEvent(bookingId: UUID, event: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingCancelled>>): BookingCancellationDetail {
+    val booking = bookingRepository.findByIdOrNull(bookingId)
+      ?: throw RuntimeException("Booking ID $bookingId with cancellation not found")
+    if (booking.cancellations.count() != 1) {
+      throw RuntimeException("Booking ID $bookingId does not have one cancellation")
+    }
+    val cancellation = booking.cancellations.first()
+    val otherReasonText =
+      if (cancellation.reason.id == CancellationReasonRepository.CAS1_RELATED_OTHER_ID &&
+        !cancellation.otherReason.isNullOrEmpty()
+      ) {
+        ": ${cancellation.otherReason}."
+      } else {
+        ""
+      }
+    return BookingCancellationDetail(
+      premisesName = booking.premises.name,
+      premisesId = booking.premises.id,
+      cancellationReason = "'${event.data.eventDetails.cancellationReason}'$otherReasonText",
+      arrivalDate = booking.arrivalDate,
+      departureDate = booking.departureDate,
+    )
+  }
+
+  private data class BookingCancellationDetail(
+    val premisesName: String,
+    val premisesId: UUID,
+    val cancellationReason: String,
+    val arrivalDate: LocalDate,
+    val departureDate: LocalDate,
+  )
+
+  override fun forType() = DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingChangedTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingChangedTimelineFactory.kt
@@ -94,8 +94,6 @@ class BookingChangedTimelineFactory(val domainEventService: Cas1DomainEventServi
     )
   }
 
-  private fun <T> GetCas1DomainEvent<T>?.describe(describe: (T) -> String?): String? = this?.let { describe(it.data) }
-
   private fun convertToCas1SpaceCharacteristics(spaceCharacteristics: List<SpaceCharacteristic>?): List<Cas1SpaceCharacteristic>? = spaceCharacteristics?.map { spaceCharacteristic ->
     Cas1SpaceCharacteristic.valueOf(spaceCharacteristic.value)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingMadeTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingMadeTimelineFactory.kt
@@ -34,6 +34,7 @@ class BookingMadeTimelineFactory(val domainEventService: Cas1DomainEventService)
           arrivalDate = eventDetails.arrivalOn,
           departureDate = eventDetails.departureOn,
         ),
+        eventNumber = eventDetails.deliusEventNumber,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingMadeTimelineFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/BookingMadeTimelineFactory.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1BookingMadeContentPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventPayloadBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventDescriber
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toUiFormat
+import java.util.UUID
+
+@Service
+class BookingMadeTimelineFactory(val domainEventService: Cas1DomainEventService) : LegacyTimelineFactory<Cas1BookingMadeContentPayload> {
+  override fun produce(domainEventId: UUID): Cas1DomainEventDescriber.EventDescriptionAndPayload<Cas1BookingMadeContentPayload> {
+    val event = domainEventService.get(domainEventId, BookingMade::class)!!
+
+    val eventDetails = event.data.eventDetails
+
+    return Cas1DomainEventDescriber.EventDescriptionAndPayload(
+      buildDescription(event),
+      Cas1BookingMadeContentPayload(
+        type = Cas1TimelineEventType.bookingMade,
+        booking = Cas1TimelineEventPayloadBookingSummary(
+          bookingId = eventDetails.bookingId,
+          premises = NamedId(
+            eventDetails.premises.id,
+            eventDetails.premises.name,
+          ),
+          arrivalDate = eventDetails.arrivalOn,
+          departureDate = eventDetails.departureOn,
+        ),
+      ),
+    )
+  }
+
+  private fun buildDescription(event: GetCas1DomainEvent<Cas1DomainEventEnvelope<BookingMade>>) = event.describe {
+    "A placement at ${it.eventDetails.premises.name} was booked for " +
+      "${it.eventDetails.arrivalOn.toUiFormat()} to ${it.eventDetails.departureOn.toUiFormat()} " +
+      "against Delius Event Number ${it.eventDetails.deliusEventNumber}"
+  }
+
+  override fun forType() = DomainEventType.APPROVED_PREMISES_BOOKING_MADE
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/DomainEventUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/domainevent/DomainEventUtils.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEv
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.GetCas1DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.DomainEventUtils.mapApprovedPremisesEntityToPremises
 
 object DomainEventUtils {
@@ -36,3 +37,5 @@ fun Premises.toNamedId() = NamedId(
   id = this.id,
   name = this.name,
 )
+
+fun <T> GetCas1DomainEvent<T>?.describe(describe: (T) -> String?): String? = this?.let { describe(it.data) }

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1202,6 +1202,7 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
+          booking_made: '#/components/schemas/Cas1BookingMadeContentPayload'
           booking_changed: '#/components/schemas/Cas1BookingChangedContentPayload'
           emergency_transfer_created: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayload'
           placement_change_request_accepted: '#/components/schemas/Cas1PlacementChangeRequestAcceptedPayload'
@@ -1245,6 +1246,15 @@ components:
         - premises
         - expectedArrival
         - expectedDeparture
+    Cas1BookingMadeContentPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+      required:
+        - booking
     Cas1PlacementChangeRequestCreatedPayload:
       type: object
       allOf:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1266,8 +1266,11 @@ components:
       properties:
         booking:
           $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        eventNumber:
+          type: string
       required:
         - booking
+        - eventNumber
     Cas1PlacementChangeRequestCreatedPayload:
       type: object
       allOf:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1202,8 +1202,9 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
-          booking_made: '#/components/schemas/Cas1BookingMadeContentPayload'
+          booking_cancelled: '#/components/schemas/Cas1BookingCancelledContentPayload'
           booking_changed: '#/components/schemas/Cas1BookingChangedContentPayload'
+          booking_made: '#/components/schemas/Cas1BookingMadeContentPayload'
           emergency_transfer_created: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayload'
           placement_change_request_accepted: '#/components/schemas/Cas1PlacementChangeRequestAcceptedPayload'
           placement_change_request_created: '#/components/schemas/Cas1PlacementChangeRequestCreatedPayload'
@@ -1246,6 +1247,18 @@ components:
         - premises
         - expectedArrival
         - expectedDeparture
+    Cas1BookingCancelledContentPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        cancellationReason:
+          type: string
+      required:
+        - booking
+        - cancellationReason
     Cas1BookingMadeContentPayload:
       type: object
       allOf:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7973,8 +7973,9 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
-          booking_made: '#/components/schemas/Cas1BookingMadeContentPayload'
+          booking_cancelled: '#/components/schemas/Cas1BookingCancelledContentPayload'
           booking_changed: '#/components/schemas/Cas1BookingChangedContentPayload'
+          booking_made: '#/components/schemas/Cas1BookingMadeContentPayload'
           emergency_transfer_created: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayload'
           placement_change_request_accepted: '#/components/schemas/Cas1PlacementChangeRequestAcceptedPayload'
           placement_change_request_created: '#/components/schemas/Cas1PlacementChangeRequestCreatedPayload'
@@ -8017,6 +8018,18 @@ components:
         - premises
         - expectedArrival
         - expectedDeparture
+    Cas1BookingCancelledContentPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        cancellationReason:
+          type: string
+      required:
+        - booking
+        - cancellationReason
     Cas1BookingMadeContentPayload:
       type: object
       allOf:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7973,6 +7973,7 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
+          booking_made: '#/components/schemas/Cas1BookingMadeContentPayload'
           booking_changed: '#/components/schemas/Cas1BookingChangedContentPayload'
           emergency_transfer_created: '#/components/schemas/Cas1EmergencyTransferCreatedContentPayload'
           placement_change_request_accepted: '#/components/schemas/Cas1PlacementChangeRequestAcceptedPayload'
@@ -8016,6 +8017,15 @@ components:
         - premises
         - expectedArrival
         - expectedDeparture
+    Cas1BookingMadeContentPayload:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cas1TimelineEventContentPayload"
+      properties:
+        booking:
+          $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+      required:
+        - booking
     Cas1PlacementChangeRequestCreatedPayload:
       type: object
       allOf:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -8037,8 +8037,11 @@ components:
       properties:
         booking:
           $ref: '#/components/schemas/Cas1TimelineEventPayloadBookingSummary'
+        eventNumber:
+          type: string
       required:
         - booking
+        - eventNumber
     Cas1PlacementChangeRequestCreatedPayload:
       type: object
       allOf:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Assessmen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAppealedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingKeyWorkerAssignedFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.FurtherInformationRequestedFactory
@@ -113,35 +112,6 @@ class Cas1DomainEventDescriberTest {
     val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
 
     assertThat(result.description).isEqualTo("The application was assessed and $decision")
-  }
-
-  @Test
-  fun `Returns expected description for booking made event`() {
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_MADE)
-    val arrivalDate = LocalDate.of(2024, 1, 1)
-    val departureDate = LocalDate.of(2024, 4, 1)
-
-    every { mockDomainEventService.getBookingMadeEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingMade,
-        eventDetails = BookingMadeFactory()
-          .withArrivalOn(arrivalDate)
-          .withDepartureOn(departureDate)
-          .withPremises(
-            EventPremisesFactory()
-              .withName("The Premises Name")
-              .produce(),
-          )
-          .withDeliusEventNumber("989")
-          .produce(),
-      )
-    }
-
-    val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-
-    assertThat(result.description).isEqualTo("A placement at The Premises Name was booked for Monday 1 January 2024 to Monday 1 April 2024 against Delius Event Number 989")
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventDescriberTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
@@ -15,22 +14,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Da
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApplicationWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAllocatedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.AssessmentAppealedFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingKeyWorkerAssignedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingNotMadeFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
@@ -46,10 +34,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestFo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.StaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
@@ -72,14 +56,10 @@ import java.util.UUID
 class Cas1DomainEventDescriberTest {
   private val mockDomainEventService = mockk<Cas1DomainEventService>()
   private val mockAssessmentClarificationNoteRepository = mockk<AssessmentClarificationNoteRepository>()
-  private val mockBookingRepository = mockk<BookingRepository>()
-  private val mockSpaceBookingRepository = mockk<Cas1SpaceBookingRepository>()
 
   private val cas1DomainEventDescriber = Cas1DomainEventDescriber(
     mockDomainEventService,
     mockAssessmentClarificationNoteRepository,
-    mockBookingRepository,
-    mockSpaceBookingRepository,
     emptyList(),
     emptyList(),
   )
@@ -214,265 +194,6 @@ class Cas1DomainEventDescriberTest {
     val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
 
     assertThat(result.description).isEqualTo("A placement was not made for the placement request.")
-  }
-
-  @Test
-  fun `Throws exception for booking cancelled event when booking is not found`() {
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
-    val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
-
-    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingCancelled,
-        eventDetails = BookingCancelledFactory()
-          .withBookingId(bookingId)
-          .produce(),
-      )
-    }
-    every { mockBookingRepository.findByIdOrNull(any()) } returns null
-
-    val exception = assertThrows<RuntimeException> {
-      cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-    }
-    assertThat(exception.message).isEqualTo("Booking ID $bookingId with cancellation not found")
-  }
-
-  @Test
-  fun `Throws exception for booking cancelled event when booking does not have one cancellation`() {
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
-    val bookingEntity = getBookingEntity()
-
-    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingCancelled,
-        eventDetails = BookingCancelledFactory()
-          .withBookingId(bookingEntity.id)
-          .produce(),
-      )
-    }
-
-    every { mockBookingRepository.findByIdOrNull(any()) } returns bookingEntity
-
-    val exception = assertThrows<RuntimeException> {
-      cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-    }
-    assertThat(exception.message).isEqualTo("Booking ID ${bookingEntity.id} does not have one cancellation")
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = ["Reason A", "Reason B"])
-  fun `Returns expected description for booking cancelled event`(reason: String) {
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
-    val bookingEntity = getBookingEntity()
-    val cancellation = CancellationEntityFactory()
-      .withDefaultReason()
-      .withBooking(bookingEntity)
-      .produce()
-
-    bookingEntity.cancellations += cancellation
-
-    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingCancelled,
-        eventDetails = BookingCancelledFactory()
-          .withBookingId(bookingEntity.id)
-          .withCancellationReason(reason)
-          .produce(),
-      )
-    }
-    every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
-
-    val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-
-    assertThat(result.description).isEqualTo("A placement at ${bookingEntity.premises.name} booked for Thursday 15 August 2024 to Sunday 18 August 2024 was cancelled. The reason was: '$reason'")
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = ["narrative A", "narrative B"])
-  fun `Returns expected description for booking cancelled event when reason is other with text narrative`(otherReasonText: String) {
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
-    val bookingEntity = getBookingEntity()
-    val cancellationOtherReason = CancellationReasonEntityFactory()
-      .withServiceScope(ServiceName.approvedPremises.value)
-      .withName("Other")
-      .withId(CancellationReasonRepository.CAS1_RELATED_OTHER_ID)
-      .produce()
-
-    val cancellation = CancellationEntityFactory()
-      .withReason(cancellationOtherReason)
-      .withOtherReason(otherReasonText)
-      .withBooking(bookingEntity)
-      .produce()
-
-    bookingEntity.cancellations += cancellation
-
-    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingCancelled,
-        eventDetails = BookingCancelledFactory()
-          .withBookingId(bookingEntity.id)
-          .withCancellationReason(cancellationOtherReason.name)
-          .produce(),
-      )
-    }
-    every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
-
-    val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-
-    assertThat(result.description).isEqualTo("A placement at ${bookingEntity.premises.name} booked for Thursday 15 August 2024 to Sunday 18 August 2024 was cancelled. The reason was: 'Other': $otherReasonText.")
-  }
-
-  @Test
-  fun `Returns expected description for booking cancelled event when reason is other without text narrative`() {
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
-    val bookingEntity = getBookingEntity()
-    val cancellationOtherReason = CancellationReasonEntityFactory()
-      .withServiceScope(ServiceName.approvedPremises.value)
-      .withName("Other")
-      .withId(CancellationReasonRepository.CAS1_RELATED_OTHER_ID)
-      .produce()
-    val cancellation = CancellationEntityFactory()
-      .withReason(cancellationOtherReason)
-      .withBooking(bookingEntity)
-      .produce()
-
-    bookingEntity.cancellations += cancellation
-
-    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingCancelled,
-        eventDetails = BookingCancelledFactory()
-          .withBookingId(bookingEntity.id)
-          .withCancellationReason(cancellationOtherReason.name)
-          .produce(),
-      )
-    }
-    every { mockBookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
-
-    val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-
-    assertThat(result.description).isEqualTo("A placement at ${bookingEntity.premises.name} booked for Thursday 15 August 2024 to Sunday 18 August 2024 was cancelled. The reason was: 'Other'")
-  }
-
-  @Test
-  fun `Returns expected description for space booking cancelled event`() {
-    val spaceBookingId = UUID.randomUUID()
-    val premises = ApprovedPremisesEntityFactory()
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea { ApAreaEntityFactory().produce() }
-          .produce()
-      }
-      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-      .produce()
-
-    val cancellationReason = "reason for cancellation"
-
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
-      .copy(cas1SpaceBookingId = spaceBookingId)
-
-    val spaceBooking = Cas1SpaceBookingEntityFactory()
-      .withId(spaceBookingId)
-      .withPremises(premises)
-      .withActualArrivalDate(null)
-      .withCancellationOccurredAt(null)
-      .withCancellationReason(CancellationReasonEntityFactory().produce())
-      .produce()
-
-    every { mockSpaceBookingRepository.findByIdOrNull(any()) } returns spaceBooking
-
-    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingCancelled,
-        eventDetails = BookingCancelledFactory()
-          .withBookingId(spaceBookingId)
-          .withCancellationReason(cancellationReason)
-          .produce(),
-      )
-    }
-
-    val result = cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-    assertThat(result.description).isEqualTo(
-      "A placement at ${premises.name} booked for ${spaceBooking.canonicalArrivalDate.toUiFormat()} " +
-        "to ${spaceBooking.canonicalDepartureDate.toUiFormat()} was cancelled. The reason was: '$cancellationReason'",
-    )
-  }
-
-  @Test
-  fun `Throws exception for space booking cancelled event when space booking is not found`() {
-    val spaceBookingId = UUID.randomUUID()
-
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
-      .copy(cas1SpaceBookingId = spaceBookingId)
-
-    every { mockSpaceBookingRepository.findByIdOrNull(any()) } returns null
-
-    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingCancelled,
-        eventDetails = BookingCancelledFactory()
-          .withBookingId(spaceBookingId)
-          .produce(),
-      )
-    }
-    val exception = assertThrows<RuntimeException> {
-      cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-    }
-    assertThat(exception.message).isEqualTo("Space Booking ID $spaceBookingId with cancellation not found")
-  }
-
-  @Test
-  fun `Throws exception for space booking cancelled event when booking does not have a cancelled reason`() {
-    val spaceBookingId = UUID.randomUUID()
-    val premises = ApprovedPremisesEntityFactory()
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea { ApAreaEntityFactory().produce() }
-          .produce()
-      }
-      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-      .produce()
-
-    val domainEventSummary = DomainEventSummaryImpl.ofType(DomainEventType.APPROVED_PREMISES_BOOKING_CANCELLED)
-      .copy(cas1SpaceBookingId = spaceBookingId)
-
-    every { mockSpaceBookingRepository.findByIdOrNull(any()) } returns
-      Cas1SpaceBookingEntityFactory()
-        .withId(spaceBookingId)
-        .withPremises(premises)
-        .withActualArrivalDate(null)
-        .withCancellationOccurredAt(null)
-        .produce()
-
-    every { mockDomainEventService.getBookingCancelledEvent(any()) } returns buildDomainEvent {
-      Cas1DomainEventEnvelope(
-        id = it,
-        timestamp = Instant.now(),
-        eventType = EventType.bookingCancelled,
-        eventDetails = BookingCancelledFactory()
-          .withBookingId(spaceBookingId)
-          .produce(),
-      )
-    }
-
-    val exception = assertThrows<RuntimeException> {
-      cas1DomainEventDescriber.getDescriptionAndPayload(domainEventSummary)
-    }
-    assertThat(exception.message).isEqualTo("Space Booking ID $spaceBookingId does not have a cancellation")
   }
 
   @Test
@@ -927,33 +648,6 @@ class Cas1DomainEventDescriberTest {
     )
   }
 
-  private fun getBookingEntity(): BookingEntity {
-    val premisesId = UUID.randomUUID()
-    val bookingId = UUID.randomUUID()
-    val premisesName = "premisesName"
-
-    val keyWorker = ContextStaffMemberFactory().produce()
-
-    val premisesEntity = ApprovedPremisesEntityFactory()
-      .withId(premisesId)
-      .withName(premisesName)
-      .withYieldedProbationRegion {
-        ProbationRegionEntityFactory()
-          .withYieldedApArea { ApAreaEntityFactory().produce() }
-          .produce()
-      }
-      .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
-      .produce()
-
-    return BookingEntityFactory()
-      .withId(bookingId)
-      .withPremises(premisesEntity)
-      .withArrivalDate(LocalDate.parse("2024-08-15"))
-      .withDepartureDate(LocalDate.parse("2024-08-18"))
-      .withStaffKeyWorkerCode(keyWorker.code)
-      .produce()
-  }
-
   private fun <T> buildDomainEvent(
     builder: (UUID) -> T,
   ): GetCas1DomainEvent<T> {
@@ -962,6 +656,7 @@ class Cas1DomainEventDescriberTest {
       id = id,
       data = builder(id),
       schemaVersion = null,
+      spaceBookingId = null,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -177,6 +177,8 @@ class Cas1DomainEventServiceTest {
         occurredAt = occurredAt.toInstant(),
       )
 
+      val spaceBookingId = UUID.randomUUID()
+
       every { domainEventRepositoryMock.findByIdOrNull(id) } returns DomainEventEntityFactory()
         .withId(id)
         .withApplicationId(applicationId)
@@ -186,6 +188,7 @@ class Cas1DomainEventServiceTest {
         .withData(domainEventAndJson.persistedJson)
         .withOccurredAt(occurredAt)
         .withSchemaVersion(domainEventAndJson.schemaVersion.versionNo)
+        .withCas1SpaceBookingId(spaceBookingId)
         .produce()
 
       val event = method.invoke(id)
@@ -195,6 +198,7 @@ class Cas1DomainEventServiceTest {
           id = id,
           data = domainEventAndJson.envelope,
           schemaVersion = domainEventAndJson.schemaVersion.versionNo,
+          spaceBookingId = spaceBookingId,
         ),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingCancelledTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingCancelledTimelineFactoryTest.kt
@@ -1,0 +1,323 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.domainevents
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingCancelled
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ContextStaffMemberFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingCancelledFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.BookingCancelledTimelineFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.seed.cas1.Cas1LinkedBookingToPlacementRequestSeedJobTest.Companion.bookingId
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class BookingCancelledTimelineFactoryTest {
+
+  @MockK
+  lateinit var domainEventService: Cas1DomainEventService
+
+  @MockK
+  lateinit var bookingRepository: BookingRepository
+
+  @MockK
+  lateinit var spaceBookingRepository: Cas1SpaceBookingRepository
+
+  @InjectMockKs
+  lateinit var service: BookingCancelledTimelineFactory
+
+  val id: UUID = UUID.randomUUID()
+
+  @Nested
+  inner class Booking {
+
+    @Test
+    fun `Throws exception for booking cancelled event when booking is not found`() {
+      val bookingId = UUID.fromString("75ed7091-1767-4901-8c2b-371dd0f5864c")
+
+      every { domainEventService.get(id, BookingCancelled::class) } returns buildDomainEvent(
+        data = BookingCancelledFactory()
+          .withBookingId(bookingId)
+          .produce(),
+      )
+
+      every { bookingRepository.findByIdOrNull(any()) } returns null
+
+      val exception = assertThrows<RuntimeException> {
+        service.produce(id)
+      }
+      assertThat(exception.message).isEqualTo("Booking ID $bookingId with cancellation not found")
+    }
+
+    @Test
+    fun `Throws exception for booking cancelled event when booking does not have one cancellation`() {
+      val bookingEntity = getBookingEntity()
+
+      every { domainEventService.get(id, BookingCancelled::class) } returns buildDomainEvent(
+        data = BookingCancelledFactory()
+          .withBookingId(bookingEntity.id)
+          .produce(),
+      )
+
+      every { bookingRepository.findByIdOrNull(any()) } returns bookingEntity
+
+      val exception = assertThrows<RuntimeException> {
+        service.produce(id)
+      }
+      assertThat(exception.message).isEqualTo("Booking ID ${bookingEntity.id} does not have one cancellation")
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = ["Reason A", "Reason B"])
+    fun `Returns expected description and payload`(reason: String) {
+      val bookingEntity = getBookingEntity()
+      val cancellation = CancellationEntityFactory()
+        .withDefaultReason()
+        .withBooking(bookingEntity)
+        .produce()
+
+      bookingEntity.cancellations += cancellation
+
+      every { domainEventService.get(id, BookingCancelled::class) } returns buildDomainEvent(
+        data = BookingCancelledFactory()
+          .withBookingId(bookingEntity.id)
+          .withCancellationReason(reason)
+          .produce(),
+      )
+
+      every { bookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
+
+      val result = service.produce(id)
+
+      assertThat(result.description).isEqualTo("A placement at premisesName booked for Thursday 15 August 2024 to Sunday 18 August 2024 was cancelled. The reason was: '$reason'")
+
+      val payload = result.payload!!
+      assertThat(payload.booking.bookingId).isEqualTo(bookingId)
+      assertThat(payload.booking.premises.name).isEqualTo("premisesName")
+      assertThat(payload.booking.arrivalDate).isEqualTo(LocalDate.of(2024, 8, 15))
+      assertThat(payload.booking.departureDate).isEqualTo(LocalDate.of(2024, 8, 18))
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = ["narrative A", "narrative B"])
+    fun `Returns expected description and payload when reason is other with text narrative`(
+      otherReasonText: String,
+    ) {
+      val bookingEntity = getBookingEntity()
+      val cancellationOtherReason = CancellationReasonEntityFactory()
+        .withServiceScope(ServiceName.approvedPremises.value)
+        .withName("Other")
+        .withId(CancellationReasonRepository.CAS1_RELATED_OTHER_ID)
+        .produce()
+
+      val cancellation = CancellationEntityFactory()
+        .withReason(cancellationOtherReason)
+        .withOtherReason(otherReasonText)
+        .withBooking(bookingEntity)
+        .produce()
+
+      bookingEntity.cancellations += cancellation
+
+      every { domainEventService.get(id, BookingCancelled::class) } returns buildDomainEvent(
+        data = BookingCancelledFactory()
+          .withBookingId(bookingEntity.id)
+          .withCancellationReason(cancellationOtherReason.name)
+          .produce(),
+      )
+
+      every { bookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
+
+      val result = service.produce(id)
+
+      assertThat(result.description).isEqualTo("A placement at premisesName booked for Thursday 15 August 2024 to Sunday 18 August 2024 was cancelled. The reason was: 'Other': $otherReasonText.")
+
+      val payload = result.payload!!
+      assertThat(payload.booking.bookingId).isEqualTo(bookingId)
+      assertThat(payload.booking.premises.name).isEqualTo("premisesName")
+      assertThat(payload.booking.arrivalDate).isEqualTo(LocalDate.of(2024, 8, 15))
+      assertThat(payload.booking.departureDate).isEqualTo(LocalDate.of(2024, 8, 18))
+    }
+
+    @Test
+    fun `Returns expected description and payload when reason is other without text narrative`() {
+      val bookingEntity = getBookingEntity()
+      val cancellationOtherReason = CancellationReasonEntityFactory()
+        .withServiceScope(ServiceName.approvedPremises.value)
+        .withName("Other")
+        .withId(CancellationReasonRepository.CAS1_RELATED_OTHER_ID)
+        .produce()
+      val cancellation = CancellationEntityFactory()
+        .withReason(cancellationOtherReason)
+        .withBooking(bookingEntity)
+        .produce()
+
+      bookingEntity.cancellations += cancellation
+
+      every { domainEventService.get(id, BookingCancelled::class) } returns buildDomainEvent(
+        data = BookingCancelledFactory()
+          .withBookingId(bookingEntity.id)
+          .withCancellationReason(cancellationOtherReason.name)
+          .produce(),
+      )
+
+      every { bookingRepository.findByIdOrNull(bookingEntity.id) } returns bookingEntity
+
+      val result = service.produce(id)
+
+      assertThat(result.description).isEqualTo("A placement at premisesName booked for Thursday 15 August 2024 to Sunday 18 August 2024 was cancelled. The reason was: 'Other'")
+
+      val payload = result.payload!!
+      assertThat(payload.booking.bookingId).isEqualTo(bookingId)
+      assertThat(payload.booking.premises.name).isEqualTo("premisesName")
+      assertThat(payload.booking.arrivalDate).isEqualTo(LocalDate.of(2024, 8, 15))
+      assertThat(payload.booking.departureDate).isEqualTo(LocalDate.of(2024, 8, 18))
+    }
+
+    private fun getBookingEntity(): BookingEntity {
+      val premisesId = UUID.randomUUID()
+      val premisesName = "premisesName"
+
+      val keyWorker = ContextStaffMemberFactory().produce()
+
+      val premisesEntity = ApprovedPremisesEntityFactory()
+        .withId(premisesId)
+        .withName(premisesName)
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
+        .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+        .produce()
+
+      return BookingEntityFactory()
+        .withId(bookingId)
+        .withPremises(premisesEntity)
+        .withArrivalDate(LocalDate.parse("2024-08-15"))
+        .withDepartureDate(LocalDate.parse("2024-08-18"))
+        .withStaffKeyWorkerCode(keyWorker.code)
+        .produce()
+    }
+  }
+
+  @Nested
+  inner class SpaceBooking {
+
+    @Test
+    fun `Returns expected description and payload`() {
+      val spaceBookingId = UUID.randomUUID()
+      val premises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .withName("The Premises Name")
+        .produce()
+
+      val spaceBooking = Cas1SpaceBookingEntityFactory()
+        .withId(spaceBookingId)
+        .withPremises(premises)
+        .withActualArrivalDate(null)
+        .withCanonicalArrivalDate(LocalDate.of(2024, 1, 1))
+        .withCanonicalDepartureDate(LocalDate.of(2024, 4, 1))
+        .withCancellationOccurredAt(null)
+        .withCancellationReason(CancellationReasonEntityFactory().produce())
+        .produce()
+
+      every { spaceBookingRepository.findByIdOrNull(any()) } returns spaceBooking
+
+      every { domainEventService.get(id, BookingCancelled::class) } returns buildDomainEvent(
+        data = BookingCancelledFactory()
+          .withBookingId(spaceBookingId)
+          .withCancellationReason("reason for cancellation")
+          .produce(),
+        spaceBookingId = spaceBookingId,
+      )
+
+      val result = service.produce(id)
+      assertThat(result.description).isEqualTo(
+        "A placement at The Premises Name booked for Monday 1 January 2024 to Monday 1 April 2024 was cancelled. " +
+          "The reason was: 'reason for cancellation'",
+      )
+
+      val payload = result.payload!!
+
+      assertThat(payload.booking.bookingId).isEqualTo(spaceBookingId)
+      assertThat(payload.booking.premises.name).isEqualTo("The Premises Name")
+      assertThat(payload.booking.arrivalDate).isEqualTo(LocalDate.of(2024, 1, 1))
+      assertThat(payload.booking.departureDate).isEqualTo(LocalDate.of(2024, 4, 1))
+    }
+
+    @Test
+    fun `Throws exception for space booking cancelled event when space booking is not found`() {
+      val spaceBookingId = UUID.randomUUID()
+
+      every { spaceBookingRepository.findByIdOrNull(any()) } returns null
+
+      every { domainEventService.get(id, BookingCancelled::class) } returns buildDomainEvent(
+        data = BookingCancelledFactory()
+          .withBookingId(spaceBookingId)
+          .produce(),
+        spaceBookingId = spaceBookingId,
+      )
+
+      val exception = assertThrows<RuntimeException> {
+        service.produce(id)
+      }
+      assertThat(exception.message).isEqualTo("Space Booking ID $spaceBookingId with cancellation not found")
+    }
+
+    @Test
+    fun `Throws exception for space booking cancelled event when booking does not have a cancelled reason`() {
+      val spaceBookingId = UUID.randomUUID()
+      val premises = ApprovedPremisesEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
+        .withYieldedLocalAuthorityArea { LocalAuthorityEntityFactory().produce() }
+        .produce()
+
+      every { spaceBookingRepository.findByIdOrNull(any()) } returns
+        Cas1SpaceBookingEntityFactory()
+          .withId(spaceBookingId)
+          .withPremises(premises)
+          .withActualArrivalDate(null)
+          .withCancellationOccurredAt(null)
+          .produce()
+
+      every { domainEventService.get(id, BookingCancelled::class) } returns buildDomainEvent(
+        data = BookingCancelledFactory()
+          .withBookingId(spaceBookingId)
+          .produce(),
+        spaceBookingId = spaceBookingId,
+      )
+
+      val exception = assertThrows<RuntimeException> {
+        service.produce(id)
+      }
+      assertThat(exception.message).isEqualTo("Space Booking ID $spaceBookingId does not have a cancellation")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingMadeTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingMadeTimelineFactoryTest.kt
@@ -59,5 +59,6 @@ class BookingMadeTimelineFactoryTest {
     assertThat(payload.booking.premises.name).isEqualTo("The Premises Name")
     assertThat(payload.booking.arrivalDate).isEqualTo(LocalDate.of(2024, 1, 1))
     assertThat(payload.booking.departureDate).isEqualTo(LocalDate.of(2024, 4, 1))
+    assertThat(payload.eventNumber).isEqualTo("989")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingMadeTimelineFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/BookingMadeTimelineFactoryTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.domainevents
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.BookingMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.BookingMadeFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.EventPremisesFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.BookingMadeTimelineFactory
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class BookingMadeTimelineFactoryTest {
+
+  @MockK
+  lateinit var domainEventService: Cas1DomainEventService
+
+  @InjectMockKs
+  lateinit var service: BookingMadeTimelineFactory
+
+  val id: UUID = UUID.randomUUID()
+
+  @Test
+  fun success() {
+    val bookingId = UUID.randomUUID()
+    val arrivalDate = LocalDate.of(2024, 1, 1)
+    val departureDate = LocalDate.of(2024, 4, 1)
+
+    every { domainEventService.get(id, BookingMade::class) } returns buildDomainEvent(
+      data = BookingMadeFactory()
+        .withBookingId(bookingId)
+        .withArrivalOn(arrivalDate)
+        .withDepartureOn(departureDate)
+        .withPremises(
+          EventPremisesFactory()
+            .withName("The Premises Name")
+            .produce(),
+        )
+        .withDeliusEventNumber("989")
+        .produce(),
+    )
+
+    val result = service.produce(id)
+
+    assertThat(result.description).isEqualTo(
+      "A placement at The Premises Name was booked for " +
+        "Monday 1 January 2024 to Monday 1 April 2024 against Delius Event Number 989",
+    )
+
+    val payload = result.payload!!
+
+    assertThat(payload.booking.bookingId).isEqualTo(bookingId)
+    assertThat(payload.booking.premises.name).isEqualTo("The Premises Name")
+    assertThat(payload.booking.arrivalDate).isEqualTo(LocalDate.of(2024, 1, 1))
+    assertThat(payload.booking.departureDate).isEqualTo(LocalDate.of(2024, 4, 1))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/Cas1DomainEventTestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/domainevents/Cas1DomainEventTestUtils.kt
@@ -9,11 +9,13 @@ import java.util.UUID
 fun <T : Cas1DomainEventPayload> buildDomainEvent(
   data: T,
   schemaVersion: Int? = null,
+  spaceBookingId: UUID? = null,
 ): GetCas1DomainEvent<Cas1DomainEventEnvelope<T>> {
   val id = UUID.randomUUID()
   return GetCas1DomainEvent(
     id = id,
     data = Cas1DomainEventEnvelopeFactory<T>().withDetails(data).produce(),
     schemaVersion = schemaVersion,
+    spaceBookingId = spaceBookingId,
   )
 }


### PR DESCRIPTION
Move logic to build a timeline description for the ‘booking made’ and 'booking cancelled' timeline entries into a `LegacyTimelineFactory`, adding a payload to allow the UI to build the description going forward

timeline entries shown for a booking below (space bookings rendered similarily)

![Screenshot 2025-05-07 at 14 35 33](https://github.com/user-attachments/assets/c5657a21-bb51-46dc-bed7-1bcadaab7b59)