### PR TITLE
Add createdBySummary to timeline events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1ApplicationTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1ApplicationTimelineTransformer.kt
@@ -37,6 +37,7 @@ class Cas1ApplicationTimelineTransformer(
       content = descriptionAndPayload.description,
       payload = descriptionAndPayload.payload,
       createdBy = domainEventSummary.triggeredByUser?.let { userTransformer.transformJpaToApi(it, ServiceName.approvedPremises) },
+      createdBySummary = domainEventSummary.triggeredByUser?.let { userTransformer.transformJpaToSummaryApi(it) },
       triggerSource = when (domainEventSummary.triggerSource) {
         uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType.USER -> Cas1TriggerSourceType.user
         uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType.SYSTEM -> Cas1TriggerSourceType.system

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1068,7 +1068,11 @@ components:
         content:
           type: string
         createdBy:
+          deprecated: true
+          description: Use createdBySummary
           $ref: '_shared.yml#/components/schemas/User'
+        createdBySummary:
+          $ref: '_shared.yml#/components/schemas/UserSummary'
         payload:
           $ref: '#/components/schemas/Cas1TimelineEventContentPayload'
         associatedUrls:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7839,7 +7839,11 @@ components:
         content:
           type: string
         createdBy:
+          deprecated: true
+          description: Use createdBySummary
           $ref: '#/components/schemas/User'
+        createdBySummary:
+          $ref: '#/components/schemas/UserSummary'
         payload:
           $ref: '#/components/schemas/Cas1TimelineEventContentPayload'
         associatedUrls:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1ApplicationTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1ApplicationTimelineTransformerTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEv
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventUrlType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
@@ -81,6 +82,8 @@ class Cas1ApplicationTimelineTransformerTest {
 
     val userApi = mockk<ApprovedPremisesUser>()
     every { mockUserTransformer.transformJpaToApi(userJpa, ServiceName.approvedPremises) } returns userApi
+    val userSummaryApi = mockk<UserSummary>()
+    every { mockUserTransformer.transformJpaToSummaryApi(userJpa) } returns userSummaryApi
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", null)
 
     val result = applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)
@@ -91,6 +94,7 @@ class Cas1ApplicationTimelineTransformerTest {
     assertThat(result.associatedUrls).isEmpty()
     assertThat(result.content).isEqualTo("Some event")
     assertThat(result.createdBy).isEqualTo(userApi)
+    assertThat(result.createdBySummary).isEqualTo(userSummaryApi)
     assertThat(result.triggerSource).isEqualTo(null)
     assertThat(result.schemaVersion).isEqualTo(1)
   }
@@ -457,7 +461,6 @@ class Cas1ApplicationTimelineTransformerTest {
       schemaVersion = null,
     )
 
-    val userApi = mockk<ApprovedPremisesUser>()
     val payload = Cas1BookingChangedContentPayload(
       expectedArrival = LocalDate.now(),
       expectedDeparture = LocalDate.now(),
@@ -468,7 +471,10 @@ class Cas1ApplicationTimelineTransformerTest {
       previousCharacteristics = listOf(Cas1SpaceCharacteristic.isGroundFloor),
     )
 
+    val userApi = mockk<ApprovedPremisesUser>()
     every { mockUserTransformer.transformJpaToApi(userJpa, ServiceName.approvedPremises) } returns userApi
+    val userSummaryApi = mockk<UserSummary>()
+    every { mockUserTransformer.transformJpaToSummaryApi(userJpa) } returns userSummaryApi
     every { mockCas1DomainEventDescriber.getDescriptionAndPayload(domainEvent) } returns EventDescriptionAndPayload("Some event", payload)
 
     val result = applicationTimelineTransformer.transformDomainEventSummaryToTimelineEvent(domainEvent)
@@ -479,6 +485,7 @@ class Cas1ApplicationTimelineTransformerTest {
     assertThat(result.associatedUrls).isEmpty()
     assertThat(result.content).isEqualTo("Some event")
     assertThat(result.createdBy).isEqualTo(userApi)
+    assertThat(result.createdBySummary).isEqualTo(userSummaryApi)
     assertThat(result.triggerSource).isEqualTo(null)
     assertThat(result.payload).isInstanceOf(Cas1BookingChangedContentPayload::class.java)
     assertThat(payload.premises.id).isEqualTo(premisesId)


### PR DESCRIPTION
Before this commit we only provided a complete descritpion of the user that created a timeline event. This is overkill as the UI only needs the username. This commit deprecates the existing `createdBy` value and adds a new simpler `createdBySummary` value
