### PR TITLE
Improve OOSB Report Integration Test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1OutOfServiceBedsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1OutOfServiceBedsReportTest.kt
@@ -1,25 +1,25 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.reporting
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns
 import org.jetbrains.kotlinx.dataframe.api.convertTo
 import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.toList
 import org.jetbrains.kotlinx.dataframe.io.readExcel
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS1_REPORT_VIEWER
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1OutOfServiceBedsReportGenerator.Cas1BedIdentifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.Cas1OutOfServiceBedReportRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ReportService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -34,10 +34,10 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
   fun `Get out-of-service beds report returns OK with correct body`() {
     givenAUser(roles = listOf(CAS1_REPORT_VIEWER)) { userEntity, jwt ->
       givenAnOffender { _, _ ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withProbationRegion(userEntity.probationRegion)
-        }
+        val premises = givenAnApprovedPremises(
+          name = "ap name",
+          region = givenAProbationRegion(name = "the region"),
+        )
 
         val bed1 = bedEntityFactory.produceAndPersist {
           withName("bed1")
@@ -79,35 +79,41 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
           )
         }
 
-        cas1OutOfServiceBedEntityFactory.produceAndPersist {
+        val oosbRecordBed1 = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
           withBed(bed1)
         }.apply {
           this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
             withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
             withCreatedBy(userEntity)
+            withReferenceNumber("ref1")
             withOutOfServiceBed(this@apply)
             withStartDate(LocalDate.of(2023, 4, 5))
             withEndDate(LocalDate.of(2023, 7, 8))
-            withYieldedReason {
-              cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
-            }
+            withReason(
+              cas1OutOfServiceBedReasonEntityFactory.produceAndPersist {
+                withName("Reason1")
+              },
+            )
           }
         }
 
-        cas1OutOfServiceBedEntityFactory.produceAndPersist {
+        val oosbRecordBed2 = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
           withBed(bed2)
         }.apply {
           this.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
             withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
             withCreatedBy(userEntity)
+            withReferenceNumber("ref2")
             withOutOfServiceBed(this@apply)
             withStartDate(LocalDate.of(2023, 4, 12))
             withEndDate(LocalDate.of(2023, 7, 5))
-            withYieldedReason {
-              cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
-            }
+            withReason(
+              cas1OutOfServiceBedReasonEntityFactory.produceAndPersist {
+                withName("Reason2")
+              },
+            )
           }
         }
 
@@ -146,20 +152,6 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
           }
         }
 
-        /*
-        Note - this test is mostly redundant because it calls the report generator directly to determine
-        what the endpoint should be returning. So it's only checking that the controller is calling
-        the report generator, not that it returns an expected result
-
-        This is better tested by [Cas1OutOfServiceBedReportGeneratorTest] which could be merged
-        with this test
-         */
-        val expectedDataFrame = Cas1OutOfServiceBedsReportGenerator(realOutOfServiceBedRepository)
-          .createReport(
-            listOf(Cas1BedIdentifier(bed1.id), Cas1BedIdentifier(bed2.id)),
-            Cas1ReportService.MonthSpecificReportParams(2023, 4),
-          ).sortBy { row -> row["bedName"] }
-
         webTestClient.get()
           .uri("$outOfServiceBedsEndpoint?year=2023&month=4")
           .header("Authorization", "Bearer $jwt")
@@ -171,10 +163,31 @@ class Cas1OutOfServiceBedsReportTest : IntegrationTestBase() {
           .consumeWith {
             val actual = DataFrame
               .readExcel(it.responseBody!!.inputStream())
-              .convertTo<Cas1OutOfServiceBedReportRow>(ExcessiveColumns.Remove)
+              .convertTo<Cas1OutOfServiceBedReportRow>(ExcessiveColumns.Fail)
               .sortBy { row -> row["bedName"] }
 
-            Assertions.assertThat(actual).isEqualTo(expectedDataFrame)
+            val actualRows = actual.toList()
+            assertThat(actualRows).hasSize(2)
+            assertThat(actualRows[0].roomName).isEqualTo("room1")
+            assertThat(actualRows[0].bedName).isEqualTo("bed1")
+            assertThat(actualRows[0].id).isEqualTo(oosbRecordBed1.id.toString())
+            assertThat(actualRows[0].workOrderId).isEqualTo("ref1")
+            assertThat(actualRows[0].region).isEqualTo("the region")
+            assertThat(actualRows[0].ap).isEqualTo("ap name")
+            assertThat(actualRows[0].reason).isEqualTo("Reason1")
+            assertThat(actualRows[0].startDate).isEqualTo(LocalDate.of(2023, 4, 5))
+            assertThat(actualRows[0].endDate).isEqualTo(LocalDate.of(2023, 7, 8))
+            assertThat(actualRows[0].lengthDays).isEqualTo(26)
+
+            assertThat(actualRows[1].roomName).isEqualTo("room2")
+            assertThat(actualRows[1].bedName).isEqualTo("bed2")
+            assertThat(actualRows[1].id).isEqualTo(oosbRecordBed2.id.toString())
+            assertThat(actualRows[1].workOrderId).isEqualTo("ref2")
+            assertThat(actualRows[1].ap).isEqualTo("ap name")
+            assertThat(actualRows[1].reason).isEqualTo("Reason2")
+            assertThat(actualRows[1].startDate).isEqualTo(LocalDate.of(2023, 4, 12))
+            assertThat(actualRows[1].endDate).isEqualTo(LocalDate.of(2023, 7, 5))
+            assertThat(actualRows[1].lengthDays).isEqualTo(19)
           }
       }
     }


### PR DESCRIPTION
This commit updates the out of service bed report integration test to explicitly state assertions instead of deferring to a report generated by the code under test
