### PR TITLE
Use Spring Events for Change Request Logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/SpringEventPublisher.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+/**
+ * A wrap around spring's [ApplicationEventPublisher] that is simpler to mock
+ * as it uses kotlin's [Any] type
+ */
+@Service
+class SpringEventPublisher(
+  val applicationEventPublisher: ApplicationEventPublisher,
+) {
+
+  fun publishEvent(event: Any) {
+    applicationEventPublisher.publishEvent(event)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalRea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.DepartureInfo
@@ -39,7 +39,7 @@ class Cas1BookingManagementService(
   private val lockableCas1SpaceBookingEntityRepository: LockableCas1SpaceBookingEntityRepository,
   private val userService: UserService,
   private val cas1ChangeRequestService: Cas1ChangeRequestService,
-  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val springEventPublisher: SpringEventPublisher,
 ) {
 
   @Transactional
@@ -92,7 +92,7 @@ class Cas1BookingManagementService(
       ),
     )
 
-    applicationEventPublisher.publishEvent(ArrivalRecorded(updatedSpaceBooking))
+    springEventPublisher.publishEvent(ArrivalRecorded(updatedSpaceBooking))
 
     success(updatedSpaceBooking)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestDomainEventService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventCodedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventPayload
@@ -14,6 +15,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ChangeRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.domainevent.toEventBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealRejected
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlannedTransferRequestAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlannedTransferRequestCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlannedTransferRequestRejected
 import java.time.OffsetDateTime
 
 @Service
@@ -21,31 +28,23 @@ class Cas1ChangeRequestDomainEventService(
   private val cas1DomainEventService: Cas1DomainEventService,
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
 ) {
-  fun placementAppealAccepted(
-    changeRequest: Cas1ChangeRequestEntity,
-  ) = saveChangeRequestAcceptedDomainEvent(changeRequest)
+  @EventListener
+  fun placementAppealAccepted(placementAppealAccepted: PlacementAppealAccepted) = saveChangeRequestAcceptedDomainEvent(placementAppealAccepted.changeRequest)
 
-  fun placementAppealCreated(
-    changeRequest: Cas1ChangeRequestEntity,
-    requestingUser: UserEntity,
-  ) = saveChangeRequestCreated(changeRequest, requestingUser)
+  @EventListener
+  fun placementAppealCreated(placementAppealCreated: PlacementAppealCreated) = saveChangeRequestCreated(placementAppealCreated.changeRequest, placementAppealCreated.requestingUser)
 
-  fun placementAppealRejected(
-    changeRequest: Cas1ChangeRequestEntity,
-    rejectingUser: UserEntity,
-  ) = saveChangeRequestRejected(changeRequest, rejectingUser)
+  @EventListener
+  fun placementAppealRejected(placementAppealRejected: PlacementAppealRejected) = saveChangeRequestRejected(placementAppealRejected.changeRequest, placementAppealRejected.rejectingUser)
 
-  fun plannedTransferRequestCreated(
-    changeRequest: Cas1ChangeRequestEntity,
-    requestingUser: UserEntity,
-  ) = saveChangeRequestCreated(changeRequest, requestingUser)
+  @EventListener
+  fun plannedTransferRequestCreated(plannedTransferRequestCreated: PlannedTransferRequestCreated) = saveChangeRequestCreated(plannedTransferRequestCreated.changeRequest, plannedTransferRequestCreated.requestingUser)
 
-  fun plannedTransferRequestRejected(
-    changeRequest: Cas1ChangeRequestEntity,
-    rejectingUser: UserEntity,
-  ) = saveChangeRequestRejected(changeRequest, rejectingUser)
+  @EventListener
+  fun plannedTransferRequestRejected(plannedTransferRequestRejected: PlannedTransferRequestRejected) = saveChangeRequestRejected(plannedTransferRequestRejected.changeRequest, plannedTransferRequestRejected.rejectingUser)
 
-  fun plannedTransferRequestAccepted(changeRequest: Cas1ChangeRequestEntity) = saveChangeRequestAcceptedDomainEvent(changeRequest)
+  @EventListener
+  fun plannedTransferRequestAccepted(plannedTransferRequestAccepted: PlannedTransferRequestAccepted) = saveChangeRequestAcceptedDomainEvent(plannedTransferRequestAccepted.changeRequest)
 
   fun saveChangeRequestCreated(
     changeRequest: Cas1ChangeRequestEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ChangeRequestEmailService.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas1NotifyTemplates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealRejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 
 @Service
@@ -13,7 +17,9 @@ class Cas1ChangeRequestEmailService(
   @Value("\${url-templates.frontend.cas1.cru-dashboard}") private val cruDashboardUrlTemplate: UrlTemplate,
 ) {
 
-  fun placementAppealCreated(changeRequest: Cas1ChangeRequestEntity) {
+  @EventListener
+  fun placementAppealCreated(placementAppealCreated: PlacementAppealCreated) {
+    val changeRequest = placementAppealCreated.changeRequest
     val application = changeRequest.placementRequest.application
 
     emailNotifier.sendEmails(
@@ -24,7 +30,9 @@ class Cas1ChangeRequestEmailService(
     )
   }
 
-  fun placementAppealAccepted(changeRequest: Cas1ChangeRequestEntity) {
+  @EventListener
+  fun placementAppealAccepted(placementAppealAccepted: PlacementAppealAccepted) {
+    val changeRequest = placementAppealAccepted.changeRequest
     val application = changeRequest.placementRequest.application
 
     val personalisation = commonPersonalisation(changeRequest)
@@ -48,7 +56,9 @@ class Cas1ChangeRequestEmailService(
     )
   }
 
-  fun placementAppealRejected(changeRequest: Cas1ChangeRequestEntity) {
+  @EventListener
+  fun placementAppealRejected(placementAppealRejected: PlacementAppealRejected) {
+    val changeRequest = placementAppealRejected.changeRequest
     val application = changeRequest.placementRequest.application
 
     emailNotifier.sendEmails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/springevent/ChangeRequestSpringEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/springevent/ChangeRequestSpringEvents.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
+
+data class PlacementAppealAccepted(
+  val changeRequest: Cas1ChangeRequestEntity,
+)
+
+data class PlacementAppealCreated(
+  val changeRequest: Cas1ChangeRequestEntity,
+  val requestingUser: UserEntity,
+)
+
+data class PlacementAppealRejected(
+  val changeRequest: Cas1ChangeRequestEntity,
+  val rejectingUser: UserEntity,
+)
+
+data class PlannedTransferRequestCreated(
+  val changeRequest: Cas1ChangeRequestEntity,
+  val requestingUser: UserEntity,
+)
+
+data class PlannedTransferRequestRejected(
+  val changeRequest: Cas1ChangeRequestEntity,
+  val rejectingUser: UserEntity,
+)
+
+data class PlannedTransferRequestAccepted(
+  val changeRequest: Cas1ChangeRequestEntity,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 
-import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.just
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
@@ -17,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssignKeyWorker
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NonArrival
@@ -39,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryRepository.Constants.MOVE_ON_CATEGORY_NOT_APPLICABLE_ID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementService
@@ -54,7 +52,6 @@ import java.time.LocalTime
 import java.time.ZoneOffset
 import java.util.UUID
 import java.util.stream.Stream
-import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType
 
 @ExtendWith(MockKExtension::class)
 class Cas1BookingManagementServiceTest {
@@ -90,7 +87,7 @@ class Cas1BookingManagementServiceTest {
   lateinit var cas1ChangeRequestService: Cas1ChangeRequestService
 
   @MockK
-  lateinit var applicationEventPublisher: ApplicationEventPublisher
+  lateinit var springEventPublisher: SpringEventPublisher
 
   @InjectMockKs
   lateinit var service: Cas1BookingManagementService
@@ -111,7 +108,7 @@ class Cas1BookingManagementServiceTest {
 
     @BeforeEach
     fun before() {
-      every { applicationEventPublisher.publishEvent(any(JvmType.Object::class)) } just Runs
+      every { springEventPublisher.publishEvent(any()) } returns Unit
     }
 
     @Test
@@ -315,7 +312,7 @@ class Cas1BookingManagementServiceTest {
       assertThat(arrivalInfo.actualArrivalTime).isEqualTo(LocalTime.of(3, 4, 5))
       assertThat(arrivalInfo.recordedBy).isEqualTo(user)
 
-      verify { applicationEventPublisher.publishEvent(ArrivalRecorded(updatedSpaceBooking)) }
+      verify { springEventPublisher.publishEvent(ArrivalRecorded(updatedSpaceBooking)) }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestDomainEventServiceTest.kt
@@ -28,6 +28,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ChangeRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEventWithPayload
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealRejected
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlannedTransferRequestAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlannedTransferRequestCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlannedTransferRequestRejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
 
@@ -44,7 +50,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
   lateinit var service: Cas1ChangeRequestDomainEventService
 
   @Nested
-  inner class PlacementAppealAccepted {
+  inner class PlacementAppealAcceptedTest {
 
     @Test
     fun success() {
@@ -68,7 +74,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
         .withSpaceBooking(spaceBooking)
         .produce()
 
-      service.placementAppealAccepted(changeRequest)
+      service.placementAppealAccepted(PlacementAppealAccepted(changeRequest))
 
       val domainEventArgument = slot<SaveCas1DomainEventWithPayload<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementChangeRequestAccepted>>()
 
@@ -100,7 +106,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
   }
 
   @Nested
-  inner class PlacementAppealCreated {
+  inner class PlacementAppealCreatedTest {
 
     @Test
     fun success() {
@@ -122,7 +128,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
         .produce()
       val requestingUser = UserEntityFactory().withDefaults().withDeliusUsername("theusername").produce()
 
-      service.placementAppealCreated(changeRequest, requestingUser)
+      service.placementAppealCreated(PlacementAppealCreated(changeRequest, requestingUser))
 
       val domainEventArgument = slot<SaveCas1DomainEventWithPayload<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementChangeRequestCreated>>()
 
@@ -155,7 +161,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
   }
 
   @Nested
-  inner class PlacementAppealRejected {
+  inner class PlacementAppealRejectedTest {
 
     @Test
     fun success() {
@@ -179,7 +185,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
 
       val requestingUser = UserEntityFactory().withDefaults().withDeliusUsername("theusername").produce()
 
-      service.placementAppealRejected(changeRequest, requestingUser)
+      service.placementAppealRejected(PlacementAppealRejected(changeRequest, requestingUser))
 
       val domainEventArgument = slot<SaveCas1DomainEventWithPayload<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementChangeRequestRejected>>()
 
@@ -212,7 +218,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
   }
 
   @Nested
-  inner class PlannedTransferRequestAccepted {
+  inner class PlannedTransferRequestAcceptedTest {
 
     @Test
     fun success() {
@@ -237,7 +243,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
         .withSpaceBooking(spaceBooking)
         .produce()
 
-      service.plannedTransferRequestAccepted(changeRequest)
+      service.plannedTransferRequestAccepted(PlannedTransferRequestAccepted(changeRequest))
 
       val domainEvent = getSavedDomainEvent<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementChangeRequestAccepted>()
 
@@ -264,7 +270,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
   }
 
   @Nested
-  inner class PlannedTransferRequestCreated {
+  inner class PlannedTransferRequestCreatedTest {
 
     @Test
     fun success() {
@@ -286,7 +292,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
         .produce()
       val requestingUser = UserEntityFactory().withDefaults().withDeliusUsername("theusername").produce()
 
-      service.plannedTransferRequestCreated(changeRequest, requestingUser)
+      service.plannedTransferRequestCreated(PlannedTransferRequestCreated(changeRequest, requestingUser))
 
       val domainEvent = getSavedDomainEvent<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementChangeRequestCreated>()
 
@@ -314,7 +320,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
   }
 
   @Nested
-  inner class PlannedTransferRequestRejected {
+  inner class PlannedTransferRequestRejectedTest {
 
     @Test
     fun success() {
@@ -338,7 +344,7 @@ class Cas1ChangeRequestDomainEventServiceTest {
 
       val requestingUser = UserEntityFactory().withDefaults().withDeliusUsername("theusername").produce()
 
-      service.plannedTransferRequestRejected(changeRequest, requestingUser)
+      service.plannedTransferRequestRejected(PlannedTransferRequestRejected(changeRequest, requestingUser))
 
       val domainEvent = getSavedDomainEvent<uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PlacementChangeRequestRejected>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ChangeRequestEmailServiceTest.kt
@@ -14,6 +14,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeRequestEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealAccepted
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealCreated
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.PlacementAppealRejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.MockCas1EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 
@@ -60,7 +63,7 @@ class Cas1ChangeRequestEmailServiceTest {
     .withName(PREMISES_NAME).produce()
 
   @Nested
-  inner class PlacementAppealCreated {
+  inner class PlacementAppealCreatedTest {
 
     @Test
     fun `sends emails to CRU`() {
@@ -78,7 +81,7 @@ class Cas1ChangeRequestEmailServiceTest {
         )
         .produce()
 
-      service.placementAppealCreated(changeRequest)
+      service.placementAppealCreated(PlacementAppealCreated(changeRequest, UserEntityFactory().withDefaults().produce()))
 
       mockEmailNotificationService.assertEmailRequestCount(1)
       mockEmailNotificationService.assertEmailRequested(
@@ -95,7 +98,7 @@ class Cas1ChangeRequestEmailServiceTest {
   }
 
   @Nested
-  inner class PlacementAppealAccepted {
+  inner class PlacementAppealAcceptedTest {
 
     @Test
     fun `sends email to premises and applicants`() {
@@ -121,7 +124,7 @@ class Cas1ChangeRequestEmailServiceTest {
         )
         .produce()
 
-      service.placementAppealAccepted(changeRequest)
+      service.placementAppealAccepted(PlacementAppealAccepted(changeRequest))
 
       mockEmailNotificationService.assertEmailRequestCount(4)
 
@@ -168,7 +171,7 @@ class Cas1ChangeRequestEmailServiceTest {
   }
 
   @Nested
-  inner class PlacementAppealRejected {
+  inner class PlacementAppealRejectedTest {
 
     @Test
     fun `sends emails to CRU and Premises`() {
@@ -186,7 +189,7 @@ class Cas1ChangeRequestEmailServiceTest {
         )
         .produce()
 
-      service.placementAppealRejected(changeRequest)
+      service.placementAppealRejected(PlacementAppealRejected(changeRequest, UserEntityFactory().withDefaults().produce()))
 
       mockEmailNotificationService.assertEmailRequestCount(2)
 


### PR DESCRIPTION
Update logic that triggers domain events and emails related to change requests to use spring events. This helps reduce the amount of mocking in unit tests and decouples code
