### PR TITLE
APS-2267 introduce internal booking events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapOfNonNullValues
 import java.time.LocalDate
@@ -47,10 +48,9 @@ class Cas1BookingDomainEventService(
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
 ) {
 
-  fun spaceBookingMade(
-    booking: Cas1SpaceBookingEntity,
-    user: UserEntity,
-  ) {
+  fun spaceBookingMade(cas1BookingCreatedEvent: Cas1BookingCreatedEvent) {
+    val booking = cas1BookingCreatedEvent.booking
+    val user = cas1BookingCreatedEvent.createdBy
     val placementRequest = booking.placementRequest!!
     val application = placementRequest.application
     bookingMade(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingChangedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.mapOfNonNullValues
@@ -141,27 +142,22 @@ class Cas1BookingDomainEventService(
   }
 
   fun spaceBookingChanged(
-    booking: Cas1SpaceBookingEntity,
-    changedBy: UserEntity,
-    bookingChangedAt: OffsetDateTime,
-    previousArrivalDateIfChanged: LocalDate?,
-    previousDepartureDateIfChanged: LocalDate?,
-    previousCharacteristicsIfChanged: List<CharacteristicEntity>?,
+    bookingChanged: Cas1BookingChangedEvent,
   ) = bookingChanged(
     BookingChangedInfo(
-      bookingId = booking.id,
-      crn = booking.crn,
-      arrivalDate = booking.expectedArrivalDate,
-      departureDate = booking.expectedDepartureDate,
-      applicationFacade = booking.applicationFacade,
-      approvedPremises = booking.premises,
-      changedAt = bookingChangedAt,
-      changedBy = changedBy,
-      previousArrivalDateIfChanged = previousArrivalDateIfChanged,
-      previousDepartureDateIfChanged = previousDepartureDateIfChanged,
+      bookingId = bookingChanged.booking.id,
+      crn = bookingChanged.booking.crn,
+      arrivalDate = bookingChanged.booking.expectedArrivalDate,
+      departureDate = bookingChanged.booking.expectedDepartureDate,
+      applicationFacade = bookingChanged.booking.applicationFacade,
+      approvedPremises = bookingChanged.booking.premises,
+      changedAt = bookingChanged.bookingChangedAt,
+      changedBy = bookingChanged.changedBy,
+      previousArrivalDateIfChanged = bookingChanged.previousArrivalDateIfChanged,
+      previousDepartureDateIfChanged = bookingChanged.previousDepartureDateIfChanged,
       isSpaceBooking = true,
-      characteristics = booking.criteria.toSpaceCharacteristics(),
-      previousCharacteristics = previousCharacteristicsIfChanged?.toSpaceCharacteristics(),
+      characteristics = bookingChanged.booking.criteria.toSpaceCharacteristics(),
+      previousCharacteristics = bookingChanged.previousCharacteristicsIfChanged?.toSpaceCharacteristics(),
     ),
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualifica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ApplicationFacade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCancelledEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingChangedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
@@ -279,20 +280,16 @@ class Cas1BookingDomainEventService(
     ),
   )
 
-  fun spaceBookingCancelled(
-    spaceBooking: Cas1SpaceBookingEntity,
-    user: UserEntity,
-    reason: CancellationReasonEntity,
-  ) = bookingCancelled(
+  fun spaceBookingCancelled(bookingCancelled: Cas1BookingCancelledEvent) = bookingCancelled(
     CancellationInfo(
-      bookingId = spaceBooking.id,
-      applicationFacade = spaceBooking.applicationFacade,
+      bookingId = bookingCancelled.booking.id,
+      applicationFacade = bookingCancelled.booking.applicationFacade,
       cancellationId = null,
-      crn = spaceBooking.crn,
-      cancelledAt = spaceBooking.cancellationOccurredAt!!,
-      reason = reason,
-      cancelledBy = user,
-      premises = spaceBooking.premises,
+      crn = bookingCancelled.booking.crn,
+      cancelledAt = bookingCancelled.booking.cancellationOccurredAt!!,
+      reason = bookingCancelled.reason,
+      cancelledBy = bookingCancelled.user,
+      premises = bookingCancelled.booking.premises,
       isSpaceBooking = true,
     ),
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Confli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.GeneralValidationError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Success
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCancelledEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingChangedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
@@ -234,7 +235,7 @@ class Cas1SpaceBookingService(
     }
 
     cas1ChangeRequestService.spaceBookingWithdrawn(spaceBooking)
-    cas1BookingDomainEventService.spaceBookingCancelled(spaceBooking, user, reason)
+    cas1BookingDomainEventService.spaceBookingCancelled(Cas1BookingCancelledEvent(spaceBooking, user, reason))
     cas1ApplicationStatusService.spaceBookingCancelled(
       spaceBooking,
       isUserRequestedWithdrawal = withdrawalContext.triggeringEntityType == WithdrawableEntityType.SpaceBooking,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Confli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.GeneralValidationError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Success
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingChangedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
@@ -288,12 +289,14 @@ class Cas1SpaceBookingService(
     val previousCharacteristicsIfChanged = if (previousCharacteristics.sortedBy { it.id } != updatedBooking.criteria.sortedBy { it.id }) previousCharacteristics else null
 
     cas1BookingDomainEventService.spaceBookingChanged(
-      booking = updatedBooking,
-      changedBy = updateSpaceBookingDetails.updatedBy,
-      bookingChangedAt = OffsetDateTime.now(),
-      previousArrivalDateIfChanged = previousArrivalDateIfChanged,
-      previousDepartureDateIfChanged = previousDepartureDateIfChanged,
-      previousCharacteristicsIfChanged = previousCharacteristicsIfChanged,
+      Cas1BookingChangedEvent(
+        booking = updatedBooking,
+        changedBy = updateSpaceBookingDetails.updatedBy,
+        bookingChangedAt = OffsetDateTime.now(clock),
+        previousArrivalDateIfChanged = previousArrivalDateIfChanged,
+        previousDepartureDateIfChanged = previousDepartureDateIfChanged,
+        previousCharacteristicsIfChanged = previousCharacteristicsIfChanged,
+      ),
     )
 
     if (previousArrivalDateIfChanged != null || previousDepartureDateIfChanged != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Confli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.GeneralValidationError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Success
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import java.time.Clock
@@ -649,7 +650,7 @@ class Cas1SpaceBookingService(
 
     beforeBookingMadeDomainEvent(spaceBooking)
 
-    cas1BookingDomainEventService.spaceBookingMade(spaceBooking, createdBy)
+    cas1BookingDomainEventService.spaceBookingMade(Cas1BookingCreatedEvent(spaceBooking, createdBy))
     cas1BookingEmailService.spaceBookingMade(spaceBooking, application)
 
     return spaceBooking

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/springevent/BookingSpringEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/springevent/BookingSpringEvents.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -18,4 +19,10 @@ data class Cas1BookingChangedEvent(
   val previousArrivalDateIfChanged: LocalDate?,
   val previousDepartureDateIfChanged: LocalDate?,
   val previousCharacteristicsIfChanged: List<CharacteristicEntity>?,
+)
+
+data class Cas1BookingCancelledEvent(
+  val booking: Cas1SpaceBookingEntity,
+  val user: UserEntity,
+  val reason: CancellationReasonEntity,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/springevent/BookingSpringEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/springevent/BookingSpringEvents.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+data class Cas1BookingCreatedEvent(
+  val booking: Cas1SpaceBookingEntity,
+  val createdBy: UserEntity,
+)
+
+data class Cas1BookingChangedEvent(
+  val booking: Cas1SpaceBookingEntity,
+  val changedBy: UserEntity,
+  val bookingChangedAt: OffsetDateTime,
+  val previousArrivalDateIfChanged: LocalDate?,
+  val previousDepartureDateIfChanged: LocalDate?,
+  val previousCharacteristicsIfChanged: List<CharacteristicEntity>?,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -109,8 +109,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.Dom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.EmailNotificationAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.IntegrationTestDbManager
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.TestPropertiesInitializer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.ClockConfiguration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MockFeatureFlagService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MutableClockConfiguration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.NoOpSentryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
@@ -567,7 +567,7 @@ abstract class IntegrationTestBase {
   lateinit var domainEventAsserter: DomainEventAsserter
 
   @Autowired
-  lateinit var clock: MutableClockConfiguration.MutableClock
+  lateinit var clock: ClockConfiguration.MutableClock
 
   @Autowired
   lateinit var mockSentryService: NoOpSentryService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/ClockConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/ClockConfiguration.kt
@@ -12,7 +12,7 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 
 @Configuration
-class MutableClockConfiguration {
+class ClockConfiguration {
 
   val clock: MutableClock
     @Bean
@@ -24,7 +24,9 @@ class MutableClockConfiguration {
     clock.reset()
   }
 
-  class MutableClock(time: Instant? = null) : Clock() {
+  class FixedClock : MutableClock(Instant.now())
+
+  open class MutableClock(time: Instant? = null) : Clock() {
     var fixedTime: Instant? = time
 
     fun reset() = run { fixedTime = null }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.Instant
@@ -134,7 +135,7 @@ class Cas1BookingCas1DomainEventServiceTest {
 
     @Test
     fun `bookingMade saves domain event`() {
-      service.spaceBookingMade(spaceBooking, user)
+      service.spaceBookingMade(Cas1BookingCreatedEvent(spaceBooking, user))
 
       val domainEventArgument = slot<SaveCas1DomainEvent<BookingMadeEnvelope>>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCancelledEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingChangedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
@@ -814,11 +815,13 @@ class Cas1BookingCas1DomainEventServiceTest {
       )
 
       service.spaceBookingCancelled(
-        spaceBooking = spaceBooking,
-        user = user,
-        reason = CancellationReasonEntityFactory()
-          .withName("the reason name")
-          .produce(),
+        Cas1BookingCancelledEvent(
+          booking = spaceBooking,
+          user = user,
+          reason = CancellationReasonEntityFactory()
+            .withName("the reason name")
+            .produce(),
+        ),
       )
 
       val domainEventArgument = slot<SaveCas1DomainEvent<BookingCancelledEnvelope>>()
@@ -903,11 +906,13 @@ class Cas1BookingCas1DomainEventServiceTest {
       )
 
       service.spaceBookingCancelled(
-        spaceBooking = spaceBooking,
-        user = user,
-        reason = CancellationReasonEntityFactory()
-          .withName("the reason name")
-          .produce(),
+        Cas1BookingCancelledEvent(
+          booking = spaceBooking,
+          user = user,
+          reason = CancellationReasonEntityFactory()
+            .withName("the reason name")
+            .produce(),
+        ),
       )
 
       val domainEventArgument = slot<SaveCas1DomainEvent<BookingCancelledEnvelope>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingCas1DomainEventServiceTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingChangedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
@@ -1001,12 +1002,14 @@ class Cas1BookingCas1DomainEventServiceTest {
       )
 
       service.spaceBookingChanged(
-        booking,
-        changedBy,
-        bookingChangedAt = createdAt,
-        previousArrivalDateIfChanged = LocalDate.of(2025, 2, 12),
-        previousDepartureDateIfChanged = null,
-        previousCharacteristicsIfChanged = null,
+        Cas1BookingChangedEvent(
+          booking,
+          changedBy,
+          bookingChangedAt = createdAt,
+          previousArrivalDateIfChanged = LocalDate.of(2025, 2, 12),
+          previousDepartureDateIfChanged = null,
+          previousCharacteristicsIfChanged = null,
+        ),
       )
 
       verify(exactly = 1) {
@@ -1077,12 +1080,14 @@ class Cas1BookingCas1DomainEventServiceTest {
       )
 
       service.spaceBookingChanged(
-        booking,
-        changedBy,
-        bookingChangedAt = createdAt,
-        previousArrivalDateIfChanged = LocalDate.of(2025, 2, 12),
-        previousDepartureDateIfChanged = LocalDate.of(2025, 4, 11),
-        previousCharacteristicsIfChanged = listOf(previousRoomCharacteristic),
+        Cas1BookingChangedEvent(
+          booking,
+          changedBy,
+          bookingChangedAt = createdAt,
+          previousArrivalDateIfChanged = LocalDate.of(2025, 2, 12),
+          previousDepartureDateIfChanged = LocalDate.of(2025, 4, 11),
+          previousCharacteristicsIfChanged = listOf(previousRoomCharacteristic),
+        ),
       )
 
       verify(exactly = 1) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -64,6 +64,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SpaceBookin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCancelledEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingChangedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
@@ -774,7 +775,7 @@ class Cas1SpaceBookingServiceTest {
 
       every { cas1ChangeRequestService.spaceBookingWithdrawn(spaceBooking) } returns Unit
       every { cas1BookingEmailService.spaceBookingWithdrawn(spaceBooking, application, WithdrawalTriggeredByUser(user)) } returns Unit
-      every { cas1BookingDomainEventService.spaceBookingCancelled(spaceBooking, user, reason) } returns Unit
+      every { cas1BookingDomainEventService.spaceBookingCancelled(any()) } returns Unit
       every { cas1ApplicationStatusService.spaceBookingCancelled(spaceBooking) } returns Unit
 
       val result = service.withdraw(
@@ -798,7 +799,7 @@ class Cas1SpaceBookingServiceTest {
       assertThat(persistedBooking.cancellationReasonNotes).isEqualTo("the user provided notes")
 
       verify { cas1ChangeRequestService.spaceBookingWithdrawn(spaceBooking) }
-      verify { cas1BookingDomainEventService.spaceBookingCancelled(spaceBooking, user, reason) }
+      verify { cas1BookingDomainEventService.spaceBookingCancelled(Cas1BookingCancelledEvent(spaceBooking, user, reason)) }
       verify { cas1ApplicationStatusService.spaceBookingCancelled(spaceBooking) }
       verify { cas1BookingEmailService.spaceBookingWithdrawn(spaceBooking, application, WithdrawalTriggeredByUser(user)) }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -63,12 +63,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SpaceBookin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingCreatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -316,7 +316,7 @@ class Cas1SpaceBookingServiceTest {
         LockablePlacementRequestEntity(placementRequest.id)
 
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
-      every { cas1BookingDomainEventService.spaceBookingMade(any(), any()) } returns Unit
+      every { cas1BookingDomainEventService.spaceBookingMade(any()) } returns Unit
       every { cas1BookingEmailService.spaceBookingMade(any(), any()) } returns Unit
 
       val persistedBookingCaptor = slot<Cas1SpaceBookingEntity>()
@@ -361,7 +361,7 @@ class Cas1SpaceBookingServiceTest {
       assertThat(persistedBooking.deliusEventNumber).isEqualTo("42")
 
       verify { cas1ApplicationStatusService.spaceBookingMade(persistedBooking) }
-      verify { cas1BookingDomainEventService.spaceBookingMade(persistedBooking, user) }
+      verify { cas1BookingDomainEventService.spaceBookingMade(Cas1BookingCreatedEvent(persistedBooking, user)) }
       verify { cas1BookingEmailService.spaceBookingMade(persistedBooking, application) }
     }
 
@@ -410,12 +410,7 @@ class Cas1SpaceBookingServiceTest {
         LockablePlacementRequestEntity(placementRequest.id)
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
 
-      every {
-        cas1BookingDomainEventService.spaceBookingMade(
-          any(),
-          user,
-        )
-      } returns Unit
+      every { cas1BookingDomainEventService.spaceBookingMade(any()) } returns Unit
 
       every { cas1BookingEmailService.spaceBookingMade(any(), any()) } returns Unit
 
@@ -1799,7 +1794,7 @@ class Cas1SpaceBookingServiceTest {
       every { cas1SpaceBookingManagementDomainEventService.emergencyTransferCreated(any(), any(), any()) } returns Unit
 
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
-      every { cas1BookingDomainEventService.spaceBookingMade(any(), any()) } returns Unit
+      every { cas1BookingDomainEventService.spaceBookingMade(any()) } returns Unit
       every { cas1BookingEmailService.spaceBookingMade(any(), any()) } returns Unit
 
       assertThat(existingSpaceBooking.transferredTo).isNull()
@@ -1847,7 +1842,7 @@ class Cas1SpaceBookingServiceTest {
       val placementRequest = existingSpaceBooking.placementRequest!!
       val application = placementRequest.application
       verify { cas1ApplicationStatusService.spaceBookingMade(emergencyBooking) }
-      verify { cas1BookingDomainEventService.spaceBookingMade(emergencyBooking, user) }
+      verify { cas1BookingDomainEventService.spaceBookingMade(Cas1BookingCreatedEvent(emergencyBooking, user)) }
       verify { cas1BookingEmailService.spaceBookingMade(emergencyBooking, application) }
     }
   }
@@ -2113,7 +2108,7 @@ class Cas1SpaceBookingServiceTest {
       every { characteristicService.getCharacteristicsByPropertyNames(any(), ServiceName.approvedPremises) } returns emptyList()
 
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
-      every { cas1BookingDomainEventService.spaceBookingMade(any(), any()) } returns Unit
+      every { cas1BookingDomainEventService.spaceBookingMade(any()) } returns Unit
       every { cas1BookingEmailService.spaceBookingMade(any(), any()) } returns Unit
 
       val capturedBookings = mutableListOf<Cas1SpaceBookingEntity>()
@@ -2164,19 +2159,8 @@ class Cas1SpaceBookingServiceTest {
       val placementRequest = existingSpaceBooking.placementRequest!!
       val application = placementRequest.application
       verify { cas1ApplicationStatusService.spaceBookingMade(transferredBooking) }
-      verify { cas1BookingDomainEventService.spaceBookingMade(transferredBooking, user) }
+      verify { cas1BookingDomainEventService.spaceBookingMade(Cas1BookingCreatedEvent(transferredBooking, user)) }
       verify { cas1BookingEmailService.spaceBookingMade(transferredBooking, application) }
     }
   }
-
-  data class TestCaseForDeparture(
-    val newReasonId: UUID,
-    val newMoveOnCategoryId: UUID,
-    val newDepartureDate: LocalDate,
-    val newDepartureTime: LocalTime,
-    val existingReasonId: UUID,
-    val existingMoveOnCategoryId: UUID,
-    val existingDepartureDate: LocalDate,
-    val existingDepartureTime: LocalTime,
-  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/allocations/rules/EmergencyAndShortNoticeAssessmentRuleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/allocations/rules/EmergencyAndShortNoticeAssessmentRuleTest.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MutableClockConfiguration
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.ClockConfiguration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AutoAllocationDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.allocations.UserAllocatorRuleOutcome
@@ -55,7 +55,7 @@ class EmergencyAndShortNoticeAssessmentRuleTest {
       expectedAllocation: String,
     ) {
       val assessmentRule = EmergencyAndShortNoticeAssessmentRule(
-        MutableClockConfiguration.MutableClock(
+        ClockConfiguration.MutableClock(
           date.atTime(12, 0, 0).toInstant(ZoneOffset.UTC),
         ),
       )
@@ -200,7 +200,7 @@ class EmergencyAndShortNoticeAssessmentRuleTest {
     @EnumSource(Cas1ApplicationTimelinessCategory::class, names = ["emergency", "shortNotice"])
     fun `Returns Skip with when no user is configured for the cru management area on the given day`(noticeType: Cas1ApplicationTimelinessCategory) {
       val assessmentRule = EmergencyAndShortNoticeAssessmentRule(
-        MutableClockConfiguration.MutableClock(
+        ClockConfiguration.MutableClock(
           // Wednesday
           LocalDate.parse("2024-07-03").atTime(12, 0, 0).toInstant(ZoneOffset.UTC),
         ),


### PR DESCRIPTION
Add internal event data classes when creating, amending or cancelling a space booking, in preparation for using spring events for 'intra service' communication, and in preparation for adding additional fields to these calls