### PR TITLE
APS-2267 - Raise Common Domain Events and Emails for Shortened, Emergency Transfer & Planned Transfer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -38,12 +38,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementService.DepartureInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.DepartureInfo
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.ShortenSpaceBookingDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.ShortenBookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.SpaceBookingFilterCriteria
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateSpaceBookingDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateBookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
@@ -196,8 +196,8 @@ class Cas1SpaceBookingController(
       .filter { it.isModelScopeRoom() }
 
     ensureEntityFromCasResultIsSuccess(
-      cas1SpaceBookingService.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      cas1SpaceBookingService.updateBooking(
+        UpdateBookingDetails(
           bookingId = bookingId,
           premisesId = premisesId,
           arrivalDate = cas1UpdateSpaceBooking.arrivalDate,
@@ -220,8 +220,8 @@ class Cas1SpaceBookingController(
     userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_SPACE_BOOKING_SHORTEN)
 
     ensureEntityFromCasResultIsSuccess(
-      cas1SpaceBookingService.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      cas1SpaceBookingService.shortenBooking(
+        ShortenBookingDetails(
           bookingId = bookingId,
           premisesId = premisesId,
           departureDate = cas1ShortenSpaceBooking.departureDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.ShortenBookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.SpaceBookingFilterCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateBookingDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
@@ -204,7 +205,7 @@ class Cas1SpaceBookingController(
           departureDate = cas1UpdateSpaceBooking.departureDate,
           characteristics = characteristics,
           updatedBy = user,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -204,6 +204,7 @@ class Cas1SpaceBookingController(
           departureDate = cas1UpdateSpaceBooking.departureDate,
           characteristics = characteristics,
           updatedBy = user,
+          shortened = false,
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
@@ -43,4 +43,9 @@ class CasResultValidatedScope<EntityType> {
   infix fun UUID.hasConflictError(message: String) = CasResult.ConflictError<EntityType>(this, message)
 }
 
+fun CasResultValidatedScope<Unit>.successOrErrors(): CasResult<Unit> = if (hasErrors()) {
+  errors()
+} else {
+  success(Unit)
+}
 inline fun <EntityType> validatedCasResult(scope: CasResultValidatedScope<EntityType>.() -> CasResult<EntityType>): CasResult<EntityType> = scope(CasResultValidatedScope())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ValidationErrors.kt
@@ -31,6 +31,9 @@ inline fun <EntityType> validated(scope: ValidatedScope<EntityType>.() -> Valida
 class CasResultValidatedScope<EntityType> {
   val validationErrors = ValidationErrors()
 
+  fun hasErrors() = validationErrors.any()
+  fun errors() = fieldValidationError
+
   val fieldValidationError: CasResult.FieldValidationError<EntityType> = CasResult.FieldValidationError(validationErrors)
 
   infix fun success(entity: EntityType) = CasResult.Success(entity)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/CasResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/CasResult.kt
@@ -34,3 +34,9 @@ sealed interface CasResult<SuccessType> {
   data class Unauthorised<SuccessType>(val message: String? = null) : Error<SuccessType>
   data class NotFound<SuccessType>(val entityType: String, val id: String) : Error<SuccessType>
 }
+
+inline fun <T> CasResult<T>.ifError(block: (CasResult.Error<T>) -> Unit) {
+  if (this is CasResult.Error) {
+    block(this)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/CasResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/results/CasResult.kt
@@ -15,11 +15,18 @@ import java.util.UUID
  * down into the contained values.
  */
 sealed interface CasResult<SuccessType> {
-  data class Success<SuccessType>(val value: SuccessType) : CasResult<SuccessType>
+
+  fun isError(): Boolean
+
+  data class Success<SuccessType>(val value: SuccessType) : CasResult<SuccessType> {
+    override fun isError() = false
+  }
   sealed interface Error<SuccessType> : CasResult<SuccessType> {
     // This is safe as the generic is irrelevant on Error types
     @Suppress("UNCHECKED_CAST")
     fun <R> reviseType(): CasResult<R> = this as Error<R>
+
+    override fun isError() = true
   }
   data class FieldValidationError<SuccessType>(val validationMessages: Map<String, String>) : Error<SuccessType>
   data class GeneralValidationError<SuccessType>(val message: String) : Error<SuccessType>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -114,10 +114,10 @@ class Cas1BookingEmailService(
   fun spaceBookingAmended(
     spaceBooking: Cas1SpaceBookingEntity,
     application: ApprovedPremisesApplicationEntity,
-    shortened: Boolean,
+    updateType: Cas1SpaceBookingService.UpdateType,
   ) = bookingAmended(
     spaceBooking.toEmailBookingInfo(application),
-    shortened = shortened,
+    shortened = updateType == Cas1SpaceBookingService.UpdateType.SHORTENING,
   )
 
   fun bookingAmended(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -114,15 +114,10 @@ class Cas1BookingEmailService(
   fun spaceBookingAmended(
     spaceBooking: Cas1SpaceBookingEntity,
     application: ApprovedPremisesApplicationEntity,
+    shortened: Boolean,
   ) = bookingAmended(
     spaceBooking.toEmailBookingInfo(application),
-  )
-
-  fun spaceBookingShortened(
-    spaceBooking: Cas1SpaceBookingEntity,
-    application: ApprovedPremisesApplicationEntity,
-  ) = bookingShortened(
-    spaceBooking.toEmailBookingInfo(application),
+    shortened = shortened,
   )
 
   fun bookingAmended(
@@ -131,37 +126,24 @@ class Cas1BookingEmailService(
     placementApplication: PlacementApplicationEntity?,
   ) = bookingAmended(
     booking.toEmailBookingInfo(application, placementApplication),
+    shortened = false,
   )
 
-  private fun bookingAmended(emailBookingInfo: EmailBookingInfo) {
+  private fun bookingAmended(
+    emailBookingInfo: EmailBookingInfo,
+    shortened: Boolean,
+  ) {
     val application = emailBookingInfo.application
     val emailPersonalisation = buildCommonPersonalisation(emailBookingInfo)
 
-    val interestedParties =
-      (
-        application.interestedPartiesEmailAddresses() +
-          setOfNotNull(emailBookingInfo.premises.emailAddress)
-        ).toSet()
-
-    emailNotifier.sendEmails(
-      recipientEmailAddresses = interestedParties,
-      templateId = Cas1NotifyTemplates.BOOKING_AMENDED,
-      personalisation = emailPersonalisation,
-      application = application,
-    )
-  }
-
-  private fun bookingShortened(bookingInfo: EmailBookingInfo) {
-    val application = bookingInfo.application
-    val emailPersonalisation = buildCommonPersonalisation(bookingInfo)
-
-    val interestedParties =
-      (
-        application.interestedPartiesEmailAddresses() +
-          setOfNotNull(bookingInfo.premises.emailAddress) +
-          setOfNotNull(application.cruManagementArea?.emailAddress) +
-          setOfNotNull(bookingInfo.placementApplication?.createdByUser?.email)
-        ).toSet()
+    val interestedParties = buildSet {
+      addAll(application.interestedPartiesEmailAddresses())
+      emailBookingInfo.premises.emailAddress?.let { add(it) }
+      emailBookingInfo.placementApplication?.createdByUser?.email?.let { add(it) }
+      if (shortened) {
+        application.cruManagementArea?.emailAddress?.let { add(it) }
+      }
+    }
 
     emailNotifier.sendEmails(
       recipientEmailAddresses = interestedParties,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.DepartureInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.ArrivalRecorded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.time.LocalDate
@@ -320,4 +319,12 @@ class Cas1BookingManagementService(
     date: LocalDate,
     time: LocalTime,
   ) = actualArrivalDate == date && actualArrivalTime == time
+
+  data class DepartureInfo(
+    val departureDate: LocalDate,
+    val departureTime: LocalTime,
+    val reasonId: UUID,
+    val moveOnCategoryId: UUID? = null,
+    val notes: String? = null,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -240,7 +240,7 @@ class Cas1SpaceBookingService(
       premisesId = shortenedBookingDetails.premisesId,
       departureDate = shortenedBookingDetails.departureDate,
       updatedBy = shortenedBookingDetails.updatedBy,
-      shortened = true,
+      updateType = UpdateType.SHORTENING,
     )
     validateUpdateBookingCommon(updateBookingDetails).ifError { return it.reviseType() }
 
@@ -269,6 +269,7 @@ class Cas1SpaceBookingService(
       premisesId = premisesId,
       departureDate = arrivalDate,
       updatedBy = user,
+      updateType = UpdateType.TRANSFER,
     )
     validateUpdateBookingCommon(updateExistingBookingDetails).ifError { return it.reviseType() }
 
@@ -358,6 +359,7 @@ class Cas1SpaceBookingService(
       premisesId = existingCas1SpaceBooking.premises.id,
       departureDate = arrivalDate,
       updatedBy = user,
+      updateType = UpdateType.TRANSFER,
     )
     validateUpdateBookingCommon(updateExistingBookingDetails).ifError { return it.reviseType() }
 
@@ -599,7 +601,7 @@ class Cas1SpaceBookingService(
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedBooking,
           application = application,
-          shortened = details.shortened,
+          updateType = details.updateType,
         )
       }
     }
@@ -641,9 +643,15 @@ class Cas1SpaceBookingService(
     val departureDate: LocalDate? = null,
     val characteristics: List<CharacteristicEntity>? = null,
     val updatedBy: UserEntity,
-    val shortened: Boolean = false,
+    val updateType: UpdateType,
     val transferredTo: Cas1SpaceBookingEntity? = null,
   )
+
+  enum class UpdateType {
+    AMENDMENT,
+    SHORTENING,
+    TRANSFER,
+  }
 
   data class ShortenBookingDetails(
     val bookingId: UUID,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/DomainEventAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/DomainEventAsserter.kt
@@ -36,11 +36,8 @@ class DomainEventAsserter(
   }
 
   fun assertDomainEventsStoredInSpecificOrder(applicationId: UUID, vararg eventTypes: DomainEventType) {
-    val allDomainEvents = domainEventRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId)
-    allDomainEvents.forEachIndexed { index, actualDomainEvent ->
-      val expectedType = eventTypes[index]
-      assertThat(actualDomainEvent.type).isEqualTo(eventTypes[index]).withFailMessage("Expected event of type $expectedType as index $index, was ${actualDomainEvent.type}")
-    }
+    val allDomainEventsTypes = domainEventRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId).map { it.type }
+    assertThat(allDomainEventsTypes).isEqualTo(eventTypes.toList())
   }
 
   fun assertDomainEventsOfTypeStored(applicationId: UUID, eventType: DomainEventType, expectedCount: Int) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/EmailNotificationAsserter.kt
@@ -56,6 +56,6 @@ class EmailNotificationAsserter {
   fun formatRequestedEmails() = "\n" + requestedEmails.map { "\n $it" }
 
   fun assertEmailsRequestedCount(expectedCount: Int) {
-    assertThat(requestedEmails.size).isEqualTo(expectedCount)
+    assertThat(requestedEmails.size).withFailMessage("Emails are $requestedEmails").isEqualTo(expectedCount)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -2824,11 +2824,14 @@ class Cas1SpaceBookingTest {
         application.id,
         DomainEventType.APPROVED_PREMISES_EMERGENCY_TRANSFER_CREATED,
         DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
+        DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
       )
 
-      emailAsserter.assertEmailsRequestedCount(2)
+      emailAsserter.assertEmailsRequestedCount(4)
       emailAsserter.assertEmailRequested(applicant.email!!, Cas1NotifyTemplates.BOOKING_MADE)
       emailAsserter.assertEmailRequested(destinationPremises.emailAddress!!, Cas1NotifyTemplates.BOOKING_MADE_FOR_PREMISES)
+      emailAsserter.assertEmailRequested(applicant.email!!, Cas1NotifyTemplates.BOOKING_AMENDED)
+      emailAsserter.assertEmailRequested(existingSpaceBooking.premises.emailAddress!!, Cas1NotifyTemplates.BOOKING_AMENDED)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -2976,11 +2976,14 @@ class Cas1SpaceBookingTest {
         application.id,
         DomainEventType.APPROVED_PREMISES_PLACEMENT_CHANGE_REQUEST_ACCEPTED,
         DomainEventType.APPROVED_PREMISES_BOOKING_MADE,
+        DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
       )
 
-      emailAsserter.assertEmailsRequestedCount(2)
+      emailAsserter.assertEmailsRequestedCount(4)
       emailAsserter.assertEmailRequested(applicant.email!!, Cas1NotifyTemplates.BOOKING_MADE)
       emailAsserter.assertEmailRequested(destinationPremises.emailAddress!!, Cas1NotifyTemplates.BOOKING_MADE_FOR_PREMISES)
+      emailAsserter.assertEmailRequested(applicant.email!!, Cas1NotifyTemplates.BOOKING_AMENDED)
+      emailAsserter.assertEmailRequested(existingSpaceBooking.premises.emailAddress!!, Cas1NotifyTemplates.BOOKING_AMENDED)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -2698,6 +2698,11 @@ class Cas1SpaceBookingTest {
         spaceBooking.application!!.cruManagementArea!!.emailAddress!!,
         Cas1NotifyTemplates.BOOKING_AMENDED,
       )
+
+      domainEventAsserter.assertDomainEventOfTypeStored(
+        spaceBooking.application!!.id,
+        DomainEventType.APPROVED_PREMISES_BOOKING_CHANGED,
+      )
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredBySeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1BookingEmailServiceTest.TestConstants.APPLICANT_EMAIL
@@ -677,7 +678,7 @@ class Cas1BookingEmailServiceTest {
       service.spaceBookingAmended(
         spaceBooking = booking,
         application = application,
-        shortened = false,
+        updateType = Cas1SpaceBookingService.UpdateType.AMENDMENT,
       )
 
       val expectedPersonalisation = mapOf(
@@ -710,7 +711,7 @@ class Cas1BookingEmailServiceTest {
       service.spaceBookingAmended(
         spaceBooking = booking,
         application = application,
-        shortened = true,
+        updateType = Cas1SpaceBookingService.UpdateType.SHORTENING,
       )
 
       val expectedPersonalisation = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -640,31 +640,44 @@ class Cas1BookingEmailServiceTest {
 
   @Nested
   inner class SpaceBookingAmended {
-    @Test
-    fun `spaceBookingAmended sends email to applicant, premises, case manager when emails are defined`() {
-      val applicant = UserEntityFactory()
-        .withUnitTestControlProbationRegion()
-        .withEmail(APPLICANT_EMAIL)
-        .produce()
+    val applicant = UserEntityFactory()
+      .withDefaults()
+      .withEmail(APPLICANT_EMAIL)
+      .withCruManagementArea(Cas1CruManagementAreaEntityFactory().withEmailAddress(CRU_MANAGEMENT_AREA_EMAIL).produce())
+      .produce()
 
-      val application = createApplication(
-        applicant = applicant,
-        caseManagerNotApplicant = true,
-        cruManagementArea = Cas1CruManagementAreaEntityFactory()
-          .withEmailAddress(CRU_MANAGEMENT_AREA_EMAIL)
+    val application = createApplication(
+      applicant = applicant,
+      caseManagerNotApplicant = true,
+      cruManagementArea = Cas1CruManagementAreaEntityFactory()
+        .withEmailAddress(CRU_MANAGEMENT_AREA_EMAIL)
+        .produce(),
+    )
+
+    val booking = Cas1SpaceBookingEntityFactory()
+      .withApplication(application)
+      .withPremises(premises)
+      .withCanonicalArrivalDate(LocalDate.of(2023, 2, 1))
+      .withCanonicalDepartureDate(LocalDate.of(2023, 2, 14))
+      .withPlacementRequest(
+        PlacementRequestEntityFactory()
+          .withPlacementApplication(
+            PlacementApplicationEntityFactory()
+              .withDefaults()
+              .withCreatedByUser(UserEntityFactory().withDefaults().withEmail(PLACEMENT_APPLICATION_CREATOR_EMAIL).produce())
+              .produce(),
+          )
+          .withDefaults()
           .produce(),
       )
+      .produce()
 
-      val booking = createSpaceBooking(
-        application,
-        premises,
-        arrivalDate = LocalDate.of(2023, 2, 1),
-        departureDate = LocalDate.of(2023, 2, 14),
-      )
-
+    @Test
+    fun `spaceBookingAmended sends email to applicant(s), premises, case manager when emails are defined`() {
       service.spaceBookingAmended(
         spaceBooking = booking,
         application = application,
+        shortened = false,
       )
 
       val expectedPersonalisation = mapOf(
@@ -678,23 +691,48 @@ class Cas1BookingEmailServiceTest {
         "lengthStayUnit" to "weeks",
       )
 
-      mockEmailNotificationService.assertEmailRequestCount(3)
-      mockEmailNotificationService.assertEmailRequested(
-        APPLICANT_EMAIL,
+      mockEmailNotificationService.assertEmailRequestCount(4)
+      mockEmailNotificationService.assertEmailsRequested(
+        setOf(
+          APPLICANT_EMAIL,
+          CASE_MANAGER_EMAIL,
+          PLACEMENT_APPLICATION_CREATOR_EMAIL,
+          PREMISES_EMAIL,
+        ),
         Cas1NotifyTemplates.BOOKING_AMENDED,
         expectedPersonalisation,
         application,
       )
+    }
 
-      mockEmailNotificationService.assertEmailRequested(
-        CASE_MANAGER_EMAIL,
-        Cas1NotifyTemplates.BOOKING_AMENDED,
-        expectedPersonalisation,
-        application,
+    @Test
+    fun `spaceBookingAmended for shortened space booking sends email to applicant(s), premises, case manager and CRU when emails are defined`() {
+      service.spaceBookingAmended(
+        spaceBooking = booking,
+        application = application,
+        shortened = true,
       )
 
-      mockEmailNotificationService.assertEmailRequested(
-        PREMISES_EMAIL,
+      val expectedPersonalisation = mapOf(
+        "apName" to PREMISES_NAME,
+        "applicationUrl" to "http://frontend/applications/${application.id}",
+        "applicationTimelineUrl" to "http://frontend/applications/${application.id}?tab=timeline",
+        "crn" to CRN,
+        "startDate" to "2023-02-01",
+        "endDate" to "2023-02-14",
+        "lengthStay" to 2,
+        "lengthStayUnit" to "weeks",
+      )
+
+      mockEmailNotificationService.assertEmailRequestCount(5)
+      mockEmailNotificationService.assertEmailsRequested(
+        setOf(
+          APPLICANT_EMAIL,
+          CASE_MANAGER_EMAIL,
+          PLACEMENT_APPLICATION_CREATOR_EMAIL,
+          PREMISES_EMAIL,
+          CRU_MANAGEMENT_AREA_EMAIL,
+        ),
         Cas1NotifyTemplates.BOOKING_AMENDED,
         expectedPersonalisation,
         application,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
@@ -40,10 +40,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SpringEventPubli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.StaffMemberService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementService.DepartureInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.DepartureInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.ArrivalRecorded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -1842,6 +1842,8 @@ class Cas1SpaceBookingServiceTest {
         cas1SpaceBookingActionsService.determineActions(existingSpaceBooking)
       } returns ActionsResult.forAllowedAction(SpaceBookingAction.PLANNED_TRANSFER_REQUEST)
 
+      every { placementRequestService.getPlacementRequestOrNull(any()) } returns existingSpaceBooking.placementRequest
+
       every { spaceBookingRepository.saveAndFlush(capture(capturedBookings)) } answers { firstArg() }
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
       every { cas1SpaceBookingManagementDomainEventService.emergencyTransferCreated(any(), any(), any()) } returns Unit
@@ -2159,6 +2161,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1ChangeRequestService.findChangeRequest(any()) } returns existingChangeRequest
 
       every { characteristicService.getCharacteristicsByPropertyNames(any(), ServiceName.approvedPremises) } returns emptyList()
+
+      every { placementRequestService.getPlacementRequestOrNull(any()) } returns existingSpaceBooking.placementRequest
 
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
       every { cas1BookingDomainEventService.spaceBookingMade(any()) } returns Unit

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -58,8 +58,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Premise
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingActionsService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.ShortenSpaceBookingDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateSpaceBookingDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.ShortenBookingDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateBookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SpaceBookingAction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
@@ -828,8 +828,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns null
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           arrivalDate = newArrivalDate,
@@ -853,8 +853,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns null
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           arrivalDate = newArrivalDate,
@@ -878,8 +878,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           arrivalDate = newArrivalDate,
@@ -903,8 +903,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           arrivalDate = newArrivalDate,
@@ -928,8 +928,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           arrivalDate = newArrivalDate,
@@ -948,8 +948,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           arrivalDate = newArrivalDate,
@@ -971,8 +971,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           arrivalDate = LocalDate.of(2025, 6, 17),
@@ -996,8 +996,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           arrivalDate = null,
@@ -1021,8 +1021,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           arrivalDate = LocalDate.of(2025, 6, 16),
@@ -1047,8 +1047,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.updateSpaceBooking(
-        UpdateSpaceBookingDetails(
+      val result = service.updateBooking(
+        UpdateBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           arrivalDate = null,
@@ -1068,7 +1068,7 @@ class Cas1SpaceBookingServiceTest {
     fun `should update only departure dates when booking status is hasArrival`() {
       existingSpaceBooking.actualArrivalDate = LocalDate.of(2025, 3, 5)
       existingSpaceBooking.expectedDepartureDate = LocalDate.of(2025, 1, 10)
-      val updateSpaceBookingDetails = UpdateSpaceBookingDetails(
+      val updateBookingDetails = UpdateBookingDetails(
         bookingId = UUID.randomUUID(),
         premisesId = PREMISES_ID,
         arrivalDate = newArrivalDate,
@@ -1086,15 +1086,15 @@ class Cas1SpaceBookingServiceTest {
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } just Runs
       every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
-      val result = service.updateSpaceBooking(updateSpaceBookingDetails)
+      val result = service.updateBooking(updateBookingDetails)
 
       assertThatCasResult(result).isSuccess()
 
       val updatedSpaceBooking = updatedSpaceBookingCaptor.captured
       assertThat(updatedSpaceBooking.expectedArrivalDate).isEqualTo(existingSpaceBooking.expectedArrivalDate)
       assertThat(updatedSpaceBooking.canonicalArrivalDate).isEqualTo(existingSpaceBooking.canonicalArrivalDate)
-      assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(updateSpaceBookingDetails.departureDate)
-      assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(updateSpaceBookingDetails.departureDate)
+      assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(updateBookingDetails.departureDate)
+      assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(updateBookingDetails.departureDate)
 
       verify(exactly = 1) {
         cas1BookingDomainEventService.spaceBookingChanged(
@@ -1125,7 +1125,7 @@ class Cas1SpaceBookingServiceTest {
       val originalRoomCharacteristic = CharacteristicEntityFactory().withModelScope("room").withPropertyName("IsArsenCapable").produce()
       existingSpaceBooking.criteria = mutableListOf(originalRoomCharacteristic)
 
-      val updateSpaceBookingDetails = UpdateSpaceBookingDetails(
+      val updateBookingDetails = UpdateBookingDetails(
         bookingId = UUID.randomUUID(),
         premisesId = PREMISES_ID,
         arrivalDate = newArrivalDate,
@@ -1150,15 +1150,15 @@ class Cas1SpaceBookingServiceTest {
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } just Runs
       every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
-      val result = service.updateSpaceBooking(updateSpaceBookingDetails)
+      val result = service.updateBooking(updateBookingDetails)
 
       assertThatCasResult(result).isSuccess()
 
       val updatedSpaceBooking = updatedSpaceBookingCaptor.captured
-      assertThat(updatedSpaceBooking.expectedArrivalDate).isEqualTo(updateSpaceBookingDetails.arrivalDate)
-      assertThat(updatedSpaceBooking.canonicalArrivalDate).isEqualTo(updateSpaceBookingDetails.arrivalDate)
-      assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(updateSpaceBookingDetails.departureDate)
-      assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(updateSpaceBookingDetails.departureDate)
+      assertThat(updatedSpaceBooking.expectedArrivalDate).isEqualTo(updateBookingDetails.arrivalDate)
+      assertThat(updatedSpaceBooking.canonicalArrivalDate).isEqualTo(updateBookingDetails.arrivalDate)
+      assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(updateBookingDetails.departureDate)
+      assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(updateBookingDetails.departureDate)
 
       verify(exactly = 1) {
         cas1BookingDomainEventService.spaceBookingChanged(
@@ -1189,7 +1189,7 @@ class Cas1SpaceBookingServiceTest {
       val originalRoomCharacteristic = CharacteristicEntityFactory().withModelScope("room").withPropertyName("IsArsenCapable").produce()
       existingSpaceBooking.criteria = mutableListOf(originalRoomCharacteristic)
 
-      val updateSpaceBookingDetails = UpdateSpaceBookingDetails(
+      val updateBookingDetails = UpdateBookingDetails(
         bookingId = UUID.randomUUID(),
         premisesId = PREMISES_ID,
         arrivalDate = newArrivalDate,
@@ -1209,7 +1209,7 @@ class Cas1SpaceBookingServiceTest {
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } just Runs
       every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
-      val result = service.updateSpaceBooking(updateSpaceBookingDetails)
+      val result = service.updateBooking(updateBookingDetails)
 
       assertThatCasResult(result).isSuccess()
 
@@ -1245,7 +1245,7 @@ class Cas1SpaceBookingServiceTest {
       val originalRoomCharacteristic = CharacteristicEntityFactory().withModelScope("room").withPropertyName("IsArsenCapable").produce()
       existingSpaceBooking.criteria = mutableListOf(originalRoomCharacteristic)
 
-      val updateSpaceBookingDetails = UpdateSpaceBookingDetails(
+      val updateBookingDetails = UpdateBookingDetails(
         bookingId = UUID.randomUUID(),
         premisesId = PREMISES_ID,
         arrivalDate = null,
@@ -1264,7 +1264,7 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } just Runs
 
-      val result = service.updateSpaceBooking(updateSpaceBookingDetails)
+      val result = service.updateBooking(updateBookingDetails)
 
       assertThatCasResult(result).isSuccess()
 
@@ -1297,7 +1297,7 @@ class Cas1SpaceBookingServiceTest {
       val originalRoomCharacteristic = CharacteristicEntityFactory().withModelScope("room").withPropertyName("IsArsenCapable").produce()
       existingSpaceBooking.criteria = mutableListOf(originalRoomCharacteristic)
 
-      val updateSpaceBookingDetails = UpdateSpaceBookingDetails(
+      val updateBookingDetails = UpdateBookingDetails(
         bookingId = UUID.randomUUID(),
         premisesId = PREMISES_ID,
         arrivalDate = null,
@@ -1316,7 +1316,7 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } just Runs
 
-      val result = service.updateSpaceBooking(updateSpaceBookingDetails)
+      val result = service.updateBooking(updateBookingDetails)
 
       assertThatCasResult(result).isSuccess()
 
@@ -1367,8 +1367,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns null
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           departureDate = newDepartureDate,
@@ -1385,8 +1385,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns null
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           departureDate = newDepartureDate,
@@ -1405,8 +1405,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           departureDate = newDepartureDate,
@@ -1425,8 +1425,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           departureDate = newDepartureDate,
@@ -1445,8 +1445,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = PREMISES_ID,
           departureDate = newDepartureDate,
@@ -1463,8 +1463,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           departureDate = newDepartureDate,
@@ -1481,8 +1481,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           departureDate = LocalDate.now().minusDays(1),
@@ -1501,8 +1501,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           departureDate = LocalDate.now().plusDays(8),
@@ -1521,8 +1521,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
 
-      val result = service.shortenSpaceBooking(
-        ShortenSpaceBookingDetails(
+      val result = service.shortenBooking(
+        ShortenBookingDetails(
           bookingId = UUID.randomUUID(),
           premisesId = UUID.randomUUID(),
           departureDate = LocalDate.now().plusDays(7),
@@ -1538,7 +1538,7 @@ class Cas1SpaceBookingServiceTest {
 
     @Test
     fun `should update departure date when status is hasArrival and send emails`() {
-      val shortenSpaceBookingDetails = ShortenSpaceBookingDetails(
+      val shortenBookingDetails = ShortenBookingDetails(
         bookingId = UUID.randomUUID(),
         premisesId = PREMISES_ID,
         departureDate = LocalDate.now().plusDays(1),
@@ -1554,15 +1554,15 @@ class Cas1SpaceBookingServiceTest {
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } returns Unit
       every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
-      val result = service.shortenSpaceBooking(shortenSpaceBookingDetails)
+      val result = service.shortenBooking(shortenBookingDetails)
 
       assertThatCasResult(result).isSuccess()
 
       val updatedSpaceBooking = updatedSpaceBookingCaptor.captured
       assertThat(updatedSpaceBooking.expectedArrivalDate).isEqualTo(existingSpaceBooking.expectedArrivalDate)
       assertThat(updatedSpaceBooking.canonicalArrivalDate).isEqualTo(existingSpaceBooking.canonicalArrivalDate)
-      assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
-      assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
+      assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(shortenBookingDetails.departureDate)
+      assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(shortenBookingDetails.departureDate)
 
       verify(exactly = 1) {
         cas1BookingDomainEventService.spaceBookingChanged(
@@ -1590,7 +1590,7 @@ class Cas1SpaceBookingServiceTest {
     fun `should update departure date when status is hasArrival and new departure date and actual arrival date are today`() {
       existingSpaceBooking.actualArrivalDate = LocalDate.now()
 
-      val shortenSpaceBookingDetails = ShortenSpaceBookingDetails(
+      val shortenBookingDetails = ShortenBookingDetails(
         bookingId = UUID.randomUUID(),
         premisesId = PREMISES_ID,
         departureDate = LocalDate.now(),
@@ -1606,15 +1606,15 @@ class Cas1SpaceBookingServiceTest {
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } returns Unit
       every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
-      val result = service.shortenSpaceBooking(shortenSpaceBookingDetails)
+      val result = service.shortenBooking(shortenBookingDetails)
 
       assertThatCasResult(result).isSuccess()
 
       val updatedSpaceBooking = updatedSpaceBookingCaptor.captured
       assertThat(updatedSpaceBooking.expectedArrivalDate).isEqualTo(existingSpaceBooking.expectedArrivalDate)
       assertThat(updatedSpaceBooking.canonicalArrivalDate).isEqualTo(existingSpaceBooking.canonicalArrivalDate)
-      assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
-      assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
+      assertThat(updatedSpaceBooking.expectedDepartureDate).isEqualTo(shortenBookingDetails.departureDate)
+      assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(shortenBookingDetails.departureDate)
 
       verify(exactly = 1) {
         cas1BookingDomainEventService.spaceBookingChanged(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -837,6 +837,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -861,6 +862,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -885,6 +887,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -909,6 +912,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -933,6 +937,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -952,6 +957,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -974,6 +980,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = LocalDate.of(2025, 6, 16),
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -998,6 +1005,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = LocalDate.of(2025, 6, 4),
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -1022,6 +1030,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = null,
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -1047,6 +1056,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = LocalDate.of(2025, 6, 18),
           updatedBy = user,
           characteristics = null,
+          shortened = false,
         ),
       )
 
@@ -1066,6 +1076,7 @@ class Cas1SpaceBookingServiceTest {
         departureDate = LocalDate.of(2025, 4, 26),
         updatedBy = user,
         characteristics = null,
+        shortened = false,
       )
 
       val updatedSpaceBookingCaptor = slot<Cas1SpaceBookingEntity>()
@@ -1074,7 +1085,7 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } just Runs
-      every { cas1BookingEmailService.spaceBookingAmended(any(), any()) } returns Unit
+      every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
       val result = service.updateSpaceBooking(updateSpaceBookingDetails)
 
@@ -1103,6 +1114,7 @@ class Cas1SpaceBookingServiceTest {
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
+          shortened = false,
         )
       }
     }
@@ -1126,6 +1138,7 @@ class Cas1SpaceBookingServiceTest {
             .withModelScope("room")
             .produce(),
         ),
+        shortened = false,
       )
 
       existingSpaceBooking.actualArrivalDate = null
@@ -1136,7 +1149,7 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } just Runs
-      every { cas1BookingEmailService.spaceBookingAmended(any(), any()) } returns Unit
+      every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
       val result = service.updateSpaceBooking(updateSpaceBookingDetails)
 
@@ -1165,6 +1178,7 @@ class Cas1SpaceBookingServiceTest {
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
+          shortened = false,
         )
       }
     }
@@ -1183,6 +1197,7 @@ class Cas1SpaceBookingServiceTest {
         departureDate = newDepartureDate,
         updatedBy = user,
         characteristics = emptyList(),
+        shortened = false,
       )
 
       assertThat(existingSpaceBooking.criteria).isNotEmpty()
@@ -1193,7 +1208,7 @@ class Cas1SpaceBookingServiceTest {
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
       every { cas1BookingDomainEventService.spaceBookingChanged(any()) } just Runs
-      every { cas1BookingEmailService.spaceBookingAmended(any(), any()) } returns Unit
+      every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
       val result = service.updateSpaceBooking(updateSpaceBookingDetails)
 
@@ -1219,6 +1234,7 @@ class Cas1SpaceBookingServiceTest {
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
+          shortened = false,
         )
       }
     }
@@ -1237,6 +1253,7 @@ class Cas1SpaceBookingServiceTest {
         departureDate = null,
         updatedBy = user,
         characteristics = emptyList(),
+        shortened = false,
       )
 
       assertThat(existingSpaceBooking.criteria).isNotEmpty()
@@ -1288,6 +1305,7 @@ class Cas1SpaceBookingServiceTest {
         departureDate = null,
         updatedBy = user,
         characteristics = emptyList(),
+        shortened = false,
       )
 
       assertThat(existingSpaceBooking.criteria).isNotEmpty()
@@ -1326,6 +1344,7 @@ class Cas1SpaceBookingServiceTest {
   @Nested
   inner class ShortenSpaceBooking {
 
+    private val originalDepartureDate = LocalDate.now().plusDays(7)
     private val newDepartureDate = LocalDate.now().plusDays(1)
 
     private val user = UserEntityFactory()
@@ -1341,7 +1360,7 @@ class Cas1SpaceBookingServiceTest {
       .withPremises(premises)
       .withExpectedArrivalDate(LocalDate.now().minusDays(7))
       .withActualArrivalDate(LocalDate.now().minusDays(7))
-      .withExpectedDepartureDate(LocalDate.now().plusDays(7))
+      .withExpectedDepartureDate(originalDepartureDate)
       .produce()
 
     @Test
@@ -1382,10 +1401,7 @@ class Cas1SpaceBookingServiceTest {
 
     @Test
     fun `should return validation error when booking status is cancelled`() {
-      val existingSpaceBooking = Cas1SpaceBookingEntityFactory()
-        .withCancellationOccurredAt(LocalDate.now().minusWeeks(2))
-        .withPremises(premises)
-        .produce()
+      existingSpaceBooking.cancellationOccurredAt = LocalDate.now().minusWeeks(2)
 
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
@@ -1405,10 +1421,7 @@ class Cas1SpaceBookingServiceTest {
 
     @Test
     fun `should return validation error when booking status is departed`() {
-      val existingSpaceBooking = Cas1SpaceBookingEntityFactory()
-        .withActualDepartureDate(LocalDate.now().minusWeeks(2))
-        .withPremises(premises)
-        .produce()
+      existingSpaceBooking.actualDepartureDate = LocalDate.now().minusWeeks(2)
 
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
@@ -1428,10 +1441,7 @@ class Cas1SpaceBookingServiceTest {
 
     @Test
     fun `should return validation error when booking status is nonArrival`() {
-      val existingSpaceBooking = Cas1SpaceBookingEntityFactory()
-        .withNonArrivalConfirmedAt(Instant.now())
-        .withPremises(premises)
-        .produce()
+      existingSpaceBooking.nonArrivalConfirmedAt = Instant.now()
 
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
@@ -1542,7 +1552,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
-      every { cas1BookingEmailService.spaceBookingShortened(any(), any()) } returns Unit
+      every { cas1BookingDomainEventService.spaceBookingChanged(any()) } returns Unit
+      every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
       val result = service.shortenSpaceBooking(shortenSpaceBookingDetails)
 
@@ -1555,9 +1566,23 @@ class Cas1SpaceBookingServiceTest {
       assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
 
       verify(exactly = 1) {
-        cas1BookingEmailService.spaceBookingShortened(
+        cas1BookingDomainEventService.spaceBookingChanged(
+          Cas1BookingChangedEvent(
+            booking = updatedSpaceBookingCaptor.captured,
+            changedBy = user,
+            bookingChangedAt = OffsetDateTime.now(clock),
+            previousArrivalDateIfChanged = null,
+            previousDepartureDateIfChanged = originalDepartureDate,
+            previousCharacteristicsIfChanged = null,
+          ),
+        )
+      }
+
+      verify(exactly = 1) {
+        cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
+          shortened = true,
         )
       }
     }
@@ -1579,7 +1604,8 @@ class Cas1SpaceBookingServiceTest {
       every { cas1PremisesService.findPremiseById(any()) } returns premises
       every { spaceBookingRepository.findByIdOrNull(any()) } returns existingSpaceBooking
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
-      every { cas1BookingEmailService.spaceBookingShortened(any(), any()) } returns Unit
+      every { cas1BookingDomainEventService.spaceBookingChanged(any()) } returns Unit
+      every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
       val result = service.shortenSpaceBooking(shortenSpaceBookingDetails)
 
@@ -1592,9 +1618,23 @@ class Cas1SpaceBookingServiceTest {
       assertThat(updatedSpaceBooking.canonicalDepartureDate).isEqualTo(shortenSpaceBookingDetails.departureDate)
 
       verify(exactly = 1) {
-        cas1BookingEmailService.spaceBookingShortened(
+        cas1BookingDomainEventService.spaceBookingChanged(
+          Cas1BookingChangedEvent(
+            booking = updatedSpaceBookingCaptor.captured,
+            changedBy = user,
+            bookingChangedAt = OffsetDateTime.now(clock),
+            previousArrivalDateIfChanged = null,
+            previousDepartureDateIfChanged = originalDepartureDate,
+            previousCharacteristicsIfChanged = null,
+          ),
+        )
+      }
+
+      verify(exactly = 1) {
+        cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
+          shortened = true,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -324,7 +324,7 @@ class Cas1SpaceBookingServiceTest {
       every { cas1BookingEmailService.spaceBookingMade(any(), any()) } returns Unit
 
       val persistedBookingCaptor = slot<Cas1SpaceBookingEntity>()
-      every { spaceBookingRepository.saveAndFlush(capture(persistedBookingCaptor)) } returnsArgument 0
+      every { spaceBookingRepository.save(capture(persistedBookingCaptor)) } returnsArgument 0
 
       val result = service.createNewBooking(
         premisesId = premises.id,
@@ -338,8 +338,7 @@ class Cas1SpaceBookingServiceTest {
         ),
       )
 
-      assertThat(result).isInstanceOf(CasResult.Success::class.java)
-      result as CasResult.Success
+      assertThatCasResult(result).isSuccess()
 
       val persistedBooking = persistedBookingCaptor.captured
       assertThat(persistedBooking.premises).isEqualTo(premises)
@@ -419,7 +418,7 @@ class Cas1SpaceBookingServiceTest {
       every { cas1BookingEmailService.spaceBookingMade(any(), any()) } returns Unit
 
       val persistedBookingCaptor = slot<Cas1SpaceBookingEntity>()
-      every { spaceBookingRepository.saveAndFlush(capture(persistedBookingCaptor)) } returnsArgument 0
+      every { spaceBookingRepository.save(capture(persistedBookingCaptor)) } returnsArgument 0
 
       val result = service.createNewBooking(
         premisesId = premises.id,
@@ -433,8 +432,7 @@ class Cas1SpaceBookingServiceTest {
         ),
       )
 
-      assertThat(result).isInstanceOf(CasResult.Success::class.java)
-      result as CasResult.Success
+      assertThatCasResult(result).isSuccess()
 
       val persistedBooking = persistedBookingCaptor.captured
       verify { cas1ApplicationStatusService.spaceBookingMade(persistedBooking) }
@@ -1850,13 +1848,15 @@ class Cas1SpaceBookingServiceTest {
 
       every { placementRequestService.getPlacementRequestOrNull(any()) } returns existingSpaceBooking.placementRequest
 
-      every { spaceBookingRepository.saveAndFlush(capture(capturedBookings)) } answers { firstArg() }
+      every { spaceBookingRepository.save(capture(capturedBookings)) } answers { firstArg() }
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
       every { cas1SpaceBookingManagementDomainEventService.emergencyTransferCreated(any(), any(), any()) } returns Unit
 
       every { cas1ApplicationStatusService.spaceBookingMade(any()) } returns Unit
       every { cas1BookingDomainEventService.spaceBookingMade(any()) } returns Unit
       every { cas1BookingEmailService.spaceBookingMade(any(), any()) } returns Unit
+      every { cas1BookingDomainEventService.spaceBookingChanged(any()) } returns Unit
+      every { cas1BookingEmailService.spaceBookingAmended(any(), any(), any()) } returns Unit
 
       assertThat(existingSpaceBooking.transferredTo).isNull()
 
@@ -1876,7 +1876,7 @@ class Cas1SpaceBookingServiceTest {
 
       assertThatCasResult(result).isSuccess()
 
-      verify(exactly = 2) { spaceBookingRepository.saveAndFlush(any()) }
+      verify(exactly = 2) { spaceBookingRepository.save(any()) }
 
       assertEquals(2, capturedBookings.size)
 
@@ -2176,6 +2176,7 @@ class Cas1SpaceBookingServiceTest {
 
       val capturedBookings = mutableListOf<Cas1SpaceBookingEntity>()
 
+      every { spaceBookingRepository.save(capture(capturedBookings)) } answers { firstArg() }
       every { spaceBookingRepository.saveAndFlush(capture(capturedBookings)) } answers { firstArg() }
 
       every { cas1ChangeRequestService.approvedPlannedTransfer(any(), any()) } returns Unit
@@ -2196,7 +2197,8 @@ class Cas1SpaceBookingServiceTest {
 
       assertThat(result).isInstanceOf(CasResult.Success::class.java)
 
-      verify(exactly = 2) { spaceBookingRepository.saveAndFlush(any()) }
+      verify(exactly = 1) { spaceBookingRepository.save(any()) }
+      verify(exactly = 1) { spaceBookingRepository.saveAndFlush(any()) }
 
       assertEquals(2, capturedBookings.size)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -60,6 +60,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.ShortenBookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateBookingDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService.UpdateType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SpaceBookingAction
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
@@ -836,7 +837,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -861,7 +862,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -886,7 +887,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -911,7 +912,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -936,7 +937,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -956,7 +957,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = newDepartureDate,
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -979,7 +980,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = LocalDate.of(2025, 6, 16),
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -1004,7 +1005,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = LocalDate.of(2025, 6, 4),
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -1029,7 +1030,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = null,
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -1055,7 +1056,7 @@ class Cas1SpaceBookingServiceTest {
           departureDate = LocalDate.of(2025, 6, 18),
           updatedBy = user,
           characteristics = null,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         ),
       )
 
@@ -1075,7 +1076,7 @@ class Cas1SpaceBookingServiceTest {
         departureDate = LocalDate.of(2025, 4, 26),
         updatedBy = user,
         characteristics = null,
-        shortened = false,
+        updateType = UpdateType.AMENDMENT,
       )
 
       val updatedSpaceBookingCaptor = slot<Cas1SpaceBookingEntity>()
@@ -1113,7 +1114,7 @@ class Cas1SpaceBookingServiceTest {
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         )
       }
     }
@@ -1137,7 +1138,7 @@ class Cas1SpaceBookingServiceTest {
             .withModelScope("room")
             .produce(),
         ),
-        shortened = false,
+        updateType = UpdateType.AMENDMENT,
       )
 
       existingSpaceBooking.actualArrivalDate = null
@@ -1177,7 +1178,7 @@ class Cas1SpaceBookingServiceTest {
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         )
       }
     }
@@ -1196,7 +1197,7 @@ class Cas1SpaceBookingServiceTest {
         departureDate = newDepartureDate,
         updatedBy = user,
         characteristics = emptyList(),
-        shortened = false,
+        updateType = UpdateType.AMENDMENT,
       )
 
       assertThat(existingSpaceBooking.criteria).isNotEmpty()
@@ -1233,7 +1234,7 @@ class Cas1SpaceBookingServiceTest {
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
-          shortened = false,
+          updateType = UpdateType.AMENDMENT,
         )
       }
     }
@@ -1252,7 +1253,7 @@ class Cas1SpaceBookingServiceTest {
         departureDate = null,
         updatedBy = user,
         characteristics = emptyList(),
-        shortened = false,
+        updateType = UpdateType.AMENDMENT,
       )
 
       assertThat(existingSpaceBooking.criteria).isNotEmpty()
@@ -1304,7 +1305,7 @@ class Cas1SpaceBookingServiceTest {
         departureDate = null,
         updatedBy = user,
         characteristics = emptyList(),
-        shortened = false,
+        updateType = UpdateType.AMENDMENT,
       )
 
       assertThat(existingSpaceBooking.criteria).isNotEmpty()
@@ -1581,7 +1582,7 @@ class Cas1SpaceBookingServiceTest {
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
-          shortened = true,
+          updateType = UpdateType.SHORTENING,
         )
       }
     }
@@ -1633,7 +1634,7 @@ class Cas1SpaceBookingServiceTest {
         cas1BookingEmailService.spaceBookingAmended(
           spaceBooking = updatedSpaceBookingCaptor.captured,
           application = updatedSpaceBookingCaptor.captured.application!!,
-          shortened = true,
+          updateType = UpdateType.SHORTENING,
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
@@ -16,21 +16,21 @@ class CasResultAssertions<T>(actual: CasResult<T>) :
 
   fun isSuccess(): CasSuccessResultAssertions<T> {
     if (actual !is CasResult.Success) {
-      failWithMessage("Expected CasResult.Success but was <%s>", actual.javaClass.simpleName, actual)
+      failWithMessage("Expected CasResult.Success but was <%s>", actual)
     }
     return CasSuccessResultAssertions(actual as CasResult.Success)
   }
 
   fun isConflictError(): CasResultConflictErrorAssertions<T> {
     if (actual !is CasResult.ConflictError) {
-      failWithMessage("Expected CasResult.ConflictError but was <%s>", actual.javaClass.simpleName, actual)
+      failWithMessage("Expected CasResult.ConflictError but was <%s>", actual)
     }
     return CasResultConflictErrorAssertions(actual as CasResult.ConflictError)
   }
 
   fun isFieldValidationError(): CasResultFieldValidationErrorAssertions<T> {
     if (actual !is CasResult.FieldValidationError) {
-      failWithMessage("Expected CasResult.FieldValidationError but was <%s>", actual.javaClass.simpleName, actual)
+      failWithMessage("Expected CasResult.FieldValidationError but was <%s>", actual)
     }
     return CasResultFieldValidationErrorAssertions(actual as CasResult.FieldValidationError)
   }
@@ -38,7 +38,7 @@ class CasResultAssertions<T>(actual: CasResult<T>) :
   @Deprecated("Use the chained version isFieldValidationError()")
   fun isFieldValidationError(field: String, expectedMessage: String): CasResultAssertions<T> {
     if (actual !is CasResult.FieldValidationError) {
-      failWithMessage("Expected CasResult.FieldValidationError but was <%s>", actual.javaClass.simpleName, actual)
+      failWithMessage("Expected CasResult.FieldValidationError but was <%s>", actual)
     }
     val validationMessages = (actual as CasResult.FieldValidationError<T>).validationMessages
 
@@ -57,7 +57,7 @@ class CasResultAssertions<T>(actual: CasResult<T>) :
 
   fun isUnauthorised(expectedMessage: String? = null): CasResultAssertions<T> {
     if (actual !is CasResult.Unauthorised) {
-      failWithMessage("Expected CasResult.Unauthorised but was <%s>", actual.javaClass.simpleName, actual)
+      failWithMessage("Expected CasResult.Unauthorised but was <%s>", actual)
     }
     val message = (actual as CasResult.Unauthorised<T>).message
     assertThat(message).isEqualTo(expectedMessage)
@@ -66,7 +66,7 @@ class CasResultAssertions<T>(actual: CasResult<T>) :
 
   fun isGeneralValidationError(expectedMessage: String): CasResultAssertions<T> {
     if (actual !is CasResult.GeneralValidationError) {
-      failWithMessage("Expected CasResult.GeneralValidationError but was <%s>", actual.javaClass.simpleName, actual)
+      failWithMessage("Expected CasResult.GeneralValidationError but was <%s>", actual)
     }
     val message = (actual as CasResult.GeneralValidationError<T>).message
     if (message != expectedMessage) {
@@ -81,7 +81,7 @@ class CasResultAssertions<T>(actual: CasResult<T>) :
 
   fun isNotFound(expectedEntityType: String, expectedId: Any) {
     if (actual !is CasResult.NotFound) {
-      failWithMessage("Expected CasResult.NotFound but was <%s>", actual.javaClass.simpleName, actual)
+      failWithMessage("Expected CasResult.NotFound but was <%s>", actual)
     }
     val notFound = actual as CasResult.NotFound
 


### PR DESCRIPTION
This PR refactors the code to reuse common logic for validation and application of updating and creating space bookings, ensuring that common domain events are raised for shortened bookings, emergency transfers and planned transfers. 