### PR TITLE
APS-2278 Add shorten request action.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -231,6 +231,11 @@ class Cas1SpaceBookingService(
     validateShortenedSpaceBooking(shortenedBookingDetails, existingBooking)
     if (hasErrors()) return errors()
 
+    cas1SpaceBookingActionsService.determineActions(existingBooking!!)
+      .unavailableReason(SpaceBookingAction.SHORTEN)?.let {
+        return GeneralValidationError(it)
+      }
+
     val updateBookingDetails = UpdateBookingDetails(
       bookingId = shortenedBookingDetails.bookingId,
       premisesId = shortenedBookingDetails.premisesId,

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -450,10 +450,12 @@ components:
         - appealCreate
         - plannedTransferRequest
         - emergencyTransferCreate
+        - shorten
       x-enum-varnames:
         - APPEAL_CREATE
         - PLANNED_TRANSFER_REQUEST
         - EMERGENCY_TRANSFER_CREATE
+        - SHORTEN
     Cas1SpaceBookingSummarySortField:
       type: string
       enum:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -7211,10 +7211,12 @@ components:
         - appealCreate
         - plannedTransferRequest
         - emergencyTransferCreate
+        - shorten
       x-enum-varnames:
         - APPEAL_CREATE
         - PLANNED_TRANSFER_REQUEST
         - EMERGENCY_TRANSFER_CREATE
+        - SHORTEN
     Cas1SpaceBookingSummarySortField:
       type: string
       enum:


### PR DESCRIPTION
Ref: [APS-2278](https://dsdmoj.atlassian.net/browse/APS-2278)

Add shorten request action.

**Acceptance Criteria:**

- Given I don’t have the permission CAS1_SPACE_BOOKING_SHORTEN, when I access the endpoint then I am shown the message "User must have permission 'CAS1_SPACE_BOOKING_SHORTEN'"
- Given the space booking does not have an arrival marked against it, when I determine the list of Actions, then SHORTEN is an available action
- Given the space booking has a non arrival marked against it, when I determine the list of Actions, then SHORTEN is not an available action
- Given the space booking has an associated departure date, when I determine the list of Actions, then SHORTEN is not an available action
- Given the space booking has an associated cancellation, when I determine the list of Actions, then SHORTEN is not an available action
- Given the space booking has an associated un-cancelled transfer, when I determine the list of Actions, then SHORTEN is not an available action
- Given the action is not available for this booking, when I attempt to shorten a booking, then I see a general validation error


[APS-2278]: https://dsdmoj.atlassian.net/browse/APS-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ