### PR TITLE
Upgrade sentry library & fix MDC leak

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
-  implementation("io.sentry:sentry-spring-boot-starter-jakarta:7.11.0")
+  implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.11.1")
 
   runtimeOnly("org.ehcache:ehcache")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
 import io.sentry.IScope
+import io.sentry.ScopeType
 import io.sentry.Sentry
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -37,7 +38,7 @@ class MDCHandlerInterceptor(
     }
     MDC.put("request.serviceName", request.getHeader("X-Service-Name") ?: "Not specified")
 
-    Sentry.configureScope { scope: IScope -> scope.setTag("request.serviceName", request.getHeader("X-Service-Name") ?: "Not specified") }
+    Sentry.configureScope(ScopeType.ISOLATION) { scope: IScope -> scope.setTag("request.serviceName", request.getHeader("X-Service-Name") ?: "Not specified") }
 
     MDC.put("request.user", userService.getDeliusUserNameForRequestOrNull() ?: "Anonymous")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/MDCHandlerInterceptor.kt
@@ -12,6 +12,7 @@ import org.springframework.web.servlet.HandlerMapping
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.lang.Exception
 import java.util.UUID
 
 @Component
@@ -22,6 +23,17 @@ class MDCHandlerInterceptor(
     appendRequestDiagnosticsToMDC(request)
 
     return super.preHandle(request, response, handler)
+  }
+
+  override fun afterCompletion(
+    request: HttpServletRequest,
+    response: HttpServletResponse,
+    handler: Any,
+    ex: Exception?,
+  ) {
+    MDC.clear()
+
+    super.afterCompletion(request, response, handler, ex)
   }
 
   private fun appendRequestDiagnosticsToMDC(request: HttpServletRequest) {


### PR DESCRIPTION
Upgrade to the latest version of the Sentry Library

Clear the MDC after request is complete. We have observed unexpected MDC/Sentry Tags appearing on requests before this interceptor has ran. We believe this is because we’re not correctly tidying up the MDC on request completion.
