### PR TITLE
APS-1633 - Backfill space booking event no. from delius info

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingManagementInfoService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingManagementInfoService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonRepository
@@ -29,6 +30,7 @@ class Cas1BookingManagementInfoService(
 
   fun fromBooking(booking: BookingEntity) = ManagementInfo(
     source = ManagementInfoSource.LEGACY_CAS_1,
+    eventNumber = (booking.application as ApprovedPremisesApplicationEntity?)?.eventNumber ?: (booking.offlineApplication?.eventNumber),
     deliusId = null,
     arrivedAtDate = booking.arrival?.arrivalDateTime?.toLocalDate(),
     arrivedAtTime = booking.arrival?.arrivalDateTime?.toLocalDateTime()?.toLocalTime(),
@@ -46,6 +48,7 @@ class Cas1BookingManagementInfoService(
 
   fun fromDeliusBookingImport(import: Cas1DeliusBookingImportEntity) = ManagementInfo(
     source = ManagementInfoSource.DELIUS,
+    eventNumber = import.eventNumber,
     deliusId = import.approvedPremisesReferralId,
     arrivedAtDate = import.arrivalDate,
     arrivedAtTime = null,
@@ -87,6 +90,7 @@ class Cas1BookingManagementInfoService(
 
 data class ManagementInfo(
   val source: ManagementInfoSource,
+  val eventNumber: String?,
   val deliusId: String?,
   val arrivedAtDate: LocalDate?,
   val arrivedAtTime: LocalTime?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -129,7 +129,7 @@ class Cas1BookingToSpaceBookingSeedJob(
         nonArrivalReason = managementInfo.nonArrivalReason,
         nonArrivalConfirmedAt = managementInfo.nonArrivalConfirmedAt?.toInstant(),
         nonArrivalNotes = managementInfo.nonArrivalNotes,
-        deliusEventNumber = bookingMadeDomainEvent?.data?.eventDetails?.deliusEventNumber,
+        deliusEventNumber = bookingMadeDomainEvent?.data?.eventDetails?.deliusEventNumber ?: managementInfo.eventNumber,
         migratedManagementInfoFrom = managementInfo.source,
         deliusId = managementInfo.deliusId,
         transferredTo = null,


### PR DESCRIPTION
When migrating a booking to space booking, if the original booking doesn’t have a corresponding booking made domain event (i.e. for offline applications), populate its delius event number using the delius export