### PR TITLE
APS-2300 Remove deprecated space search fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
@@ -38,13 +38,8 @@ class Cas1SpaceSearchService(
 
   private fun getRequiredCharacteristics(parameters: Cas1SpaceSearchParameters): RequiredCharacteristics {
     val requirements = parameters.requirements
-    val apType = requirements.apType
     return RequiredCharacteristics(
-      apType = if (apType != null) {
-        apType.asApprovedPremisesType()
-      } else {
-        requirements.apTypes?.map { it.asApprovedPremisesType() }?.firstOrNull()
-      },
+      apType = requirements.apTypes?.map { it.asApprovedPremisesType() }?.firstOrNull(),
       groupedCharacteristics = getSpaceCharacteristics(parameters),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceSearchService.kt
@@ -8,8 +8,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import java.util.UUID
@@ -29,7 +27,6 @@ class Cas1SpaceSearchService(
 
     return spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
       targetPostcodeDistrict = searchParameters.targetPostcodeDistrict,
-      approvedPremisesType = requiredCharacteristics.apType,
       isWomensPremises = application.isWomensApplication!!,
       premisesCharacteristics = requiredCharacteristics.groupedCharacteristics.premisesCharacteristics,
       roomCharacteristics = requiredCharacteristics.groupedCharacteristics.roomCharacteristics,
@@ -39,7 +36,6 @@ class Cas1SpaceSearchService(
   private fun getRequiredCharacteristics(parameters: Cas1SpaceSearchParameters): RequiredCharacteristics {
     val requirements = parameters.requirements
     return RequiredCharacteristics(
-      apType = requirements.apTypes?.map { it.asApprovedPremisesType() }?.firstOrNull(),
       groupedCharacteristics = getSpaceCharacteristics(parameters),
     )
   }
@@ -65,7 +61,6 @@ class Cas1SpaceSearchService(
 }
 
 data class RequiredCharacteristics(
-  val apType: ApprovedPremisesType?,
   val groupedCharacteristics: GroupedCharacteristics,
 )
 

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -214,18 +214,6 @@ components:
           example: 2022-09-30
       required:
         - departureDate
-    Cas1SpaceSearchRequirements:
-      deprecated: true
-      type: object
-      properties:
-        spaceCharacteristics:
-          deprecated: true
-          description: use Cas1SpaceSearchParameters.spaceCharacteristics
-          type: array
-          items:
-            $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
-      required:
-        - gender
     Cas1SpaceSearchParameters:
       type: object
       properties:
@@ -245,9 +233,6 @@ components:
           type: string
           description: The 'target' location, in the form of a postcode district
           example: SE5
-        requirements:
-          deprecated: true
-          $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
         spaceCharacteristics:
           type: array
           items:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -224,10 +224,6 @@ components:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/ApType'
-        apType:
-          deprecated: true
-          description: "Use 'spaceCharacteristics' to filter on premise types"
-          $ref: '_shared.yml#/components/schemas/ApType'
         spaceCharacteristics:
           deprecated: true
           description: use Cas1SpaceSearchParameters.spaceCharacteristics

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -234,12 +234,6 @@ components:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Cas1SpaceCharacteristic'
-        genders:
-          description: gender is obtained from application's associated gender
-          deprecated: true
-          type: array
-          items:
-            $ref: '_shared.yml#/components/schemas/Gender'
       required:
         - gender
     Cas1SpaceSearchParameters:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -218,12 +218,6 @@ components:
       deprecated: true
       type: object
       properties:
-        apTypes:
-          deprecated: true
-          description: "Use 'spaceCharacteristics' to filter on premise types"
-          type: array
-          items:
-            $ref: '_shared.yml#/components/schemas/ApType'
         spaceCharacteristics:
           deprecated: true
           description: use Cas1SpaceSearchParameters.spaceCharacteristics

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6926,12 +6926,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cas1SpaceCharacteristic'
-        genders:
-          description: gender is obtained from application's associated gender
-          deprecated: true
-          type: array
-          items:
-            $ref: '#/components/schemas/Gender'
       required:
         - gender
     Cas1SpaceSearchParameters:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6910,12 +6910,6 @@ components:
       deprecated: true
       type: object
       properties:
-        apTypes:
-          deprecated: true
-          description: "Use 'spaceCharacteristics' to filter on premise types"
-          type: array
-          items:
-            $ref: '#/components/schemas/ApType'
         spaceCharacteristics:
           deprecated: true
           description: use Cas1SpaceSearchParameters.spaceCharacteristics

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6916,10 +6916,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ApType'
-        apType:
-          deprecated: true
-          description: "Use 'spaceCharacteristics' to filter on premise types"
-          $ref: '#/components/schemas/ApType'
         spaceCharacteristics:
           deprecated: true
           description: use Cas1SpaceSearchParameters.spaceCharacteristics

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6906,18 +6906,6 @@ components:
           example: 2022-09-30
       required:
         - departureDate
-    Cas1SpaceSearchRequirements:
-      deprecated: true
-      type: object
-      properties:
-        spaceCharacteristics:
-          deprecated: true
-          description: use Cas1SpaceSearchParameters.spaceCharacteristics
-          type: array
-          items:
-            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
-      required:
-        - gender
     Cas1SpaceSearchParameters:
       type: object
       properties:
@@ -6937,9 +6925,6 @@ components:
           type: string
           description: The 'target' location, in the form of a postcode district
           example: SE5
-        requirements:
-          deprecated: true
-          $ref: '#/components/schemas/Cas1SpaceSearchRequirements'
         spaceCharacteristics:
           type: array
           items:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchResults
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -59,9 +58,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = null,
-        requirements = Cas1SpaceSearchRequirements(
-          spaceCharacteristics = null,
-        ),
       )
 
       webTestClient.post()
@@ -137,9 +133,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = null,
-        requirements = Cas1SpaceSearchRequirements(
-          spaceCharacteristics = null,
-        ),
       )
 
       val response = webTestClient.post()
@@ -213,9 +206,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = null,
-        requirements = Cas1SpaceSearchRequirements(
-          spaceCharacteristics = null,
-        ),
       )
 
       val response = webTestClient.post()
@@ -277,9 +267,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = listOf(Cas1SpaceCharacteristic.isPIPE),
-        requirements = Cas1SpaceSearchRequirements(
-          spaceCharacteristics = null,
-        ),
       )
 
       val response = webTestClient.post()
@@ -382,9 +369,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = listOf(characteristic),
-        requirements = Cas1SpaceSearchRequirements(
-          spaceCharacteristics = null,
-        ),
       )
 
       val response = webTestClient.post()
@@ -466,10 +450,7 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         startDate = LocalDate.now(),
         durationInDays = 14,
         targetPostcodeDistrict = "SE1",
-        spaceCharacteristics = Cas1SpaceCharacteristic.entries.slice(1..2),
-        requirements = Cas1SpaceSearchRequirements(
-          spaceCharacteristics = listOf(Cas1SpaceCharacteristic.entries[3]),
-        ),
+        spaceCharacteristics = Cas1SpaceCharacteristic.entries.slice(1..3),
       )
 
       val response = webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -244,133 +244,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
 
   @ParameterizedTest
   @EnumSource(mode = EnumSource.Mode.EXCLUDE, names = ["normal"])
-  fun `Filtering APs by AP type returns only APs of that type - using single ap type option`(apType: ApType) {
-    postCodeDistrictFactory.produceAndPersist {
-      withOutcode("SE1")
-      withLatitude(-0.07)
-      withLongitude(51.48)
-    }
-
-    givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA)) { user, jwt ->
-      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
-
-      val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion { givenAProbationRegion() }
-        withYieldedLocalAuthorityArea {
-          localAuthorityEntityFactory.produceAndPersist()
-        }
-        withLatitude((it * -0.01) - 0.08)
-        withLongitude((it * 0.01) + 51.49)
-        withCharacteristicsList(listOfNotNull(apType.asCharacteristicEntity()))
-        withSupportsSpaceBookings(true)
-      }
-
-      val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(4) {
-        withYieldedProbationRegion { givenAProbationRegion() }
-        withYieldedLocalAuthorityArea {
-          localAuthorityEntityFactory.produceAndPersist()
-        }
-        withLatitude((it * -0.01) - 0.08)
-        withLongitude((it * 0.01) + 51.49)
-        withCharacteristicsList(listOfNotNull(ApType.entries.first { it != apType }.asCharacteristicEntity()))
-        withSupportsSpaceBookings(true)
-      }
-
-      val searchParameters = Cas1SpaceSearchParameters(
-        applicationId = application.id,
-        startDate = LocalDate.now(),
-        durationInDays = 14,
-        targetPostcodeDistrict = "SE1",
-        spaceCharacteristics = null,
-        requirements = Cas1SpaceSearchRequirements(
-          apTypes = emptyList(),
-          apType = apType,
-          spaceCharacteristics = null,
-        ),
-      )
-
-      val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(searchParameters)
-        .exchange()
-        .expectStatus()
-        .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
-
-      val results = response.responseBody.blockFirst()!!
-
-      assertThat(results.resultsCount).isEqualTo(5)
-
-      val expectedApType = if (apType == ApType.mhapElliottHouse) {
-        ApType.mhapStJosephs
-      } else {
-        apType
-      }
-
-      assertThatResultMatches(results.results[0], expectedPremises[0], expectedApType)
-      assertThatResultMatches(results.results[1], expectedPremises[1], expectedApType)
-      assertThatResultMatches(results.results[2], expectedPremises[2], expectedApType)
-      assertThatResultMatches(results.results[3], expectedPremises[3], expectedApType)
-      assertThatResultMatches(results.results[4], expectedPremises[4], expectedApType)
-    }
-  }
-
-  @Test
-  fun `Filtering AP type 'normal' returns all APs regardless of type`() {
-    postCodeDistrictFactory.produceAndPersist {
-      withOutcode("SE1")
-      withLatitude(-0.07)
-      withLongitude(51.48)
-    }
-
-    givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA)) { user, jwt ->
-      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
-
-      val onePremiseOfEachType = ApType.entries.map { apType ->
-        approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedProbationRegion { givenAProbationRegion() }
-          withYieldedLocalAuthorityArea {
-            localAuthorityEntityFactory.produceAndPersist()
-          }
-          withCharacteristicsList(listOfNotNull(apType.asCharacteristicEntity()))
-          withSupportsSpaceBookings(true)
-        }
-      }
-
-      val searchParameters = Cas1SpaceSearchParameters(
-        applicationId = application.id,
-        startDate = LocalDate.now(),
-        durationInDays = 14,
-        targetPostcodeDistrict = "SE1",
-        spaceCharacteristics = null,
-        requirements = Cas1SpaceSearchRequirements(
-          apTypes = emptyList(),
-          apType = ApType.normal,
-          spaceCharacteristics = null,
-        ),
-      )
-
-      val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(searchParameters)
-        .exchange()
-        .expectStatus()
-        .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
-
-      val results = response.responseBody.blockFirst()!!
-
-      assertThat(results.resultsCount).isEqualTo(onePremiseOfEachType.size)
-
-      assertThat(results.results.map { it.premises.id })
-        .containsExactlyInAnyOrder(*onePremiseOfEachType.map { it.id }.toTypedArray())
-    }
-  }
-
-  @ParameterizedTest
-  @EnumSource(mode = EnumSource.Mode.EXCLUDE, names = ["normal"])
   fun `Filtering APs by AP type returns only APs of that type - using multiple ap types option`(apType: ApType) {
     postCodeDistrictFactory.produceAndPersist {
       withOutcode("SE1")
@@ -411,7 +284,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
           apTypes = listOf(apType),
-          apType = null,
           spaceCharacteristics = null,
         ),
       )
@@ -483,7 +355,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         spaceCharacteristics = listOf(Cas1SpaceCharacteristic.isPIPE),
         requirements = Cas1SpaceSearchRequirements(
           apTypes = null,
-          apType = null,
           spaceCharacteristics = null,
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceSearchTest.kt
@@ -60,7 +60,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
-          apTypes = null,
           spaceCharacteristics = null,
         ),
       )
@@ -139,7 +138,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
-          apTypes = null,
           spaceCharacteristics = null,
         ),
       )
@@ -216,7 +214,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = null,
         requirements = Cas1SpaceSearchRequirements(
-          apTypes = null,
           spaceCharacteristics = null,
         ),
       )
@@ -239,79 +236,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
       assertThatResultMatches(results.results[2], expectedPremises[2])
       assertThatResultMatches(results.results[3], expectedPremises[3])
       assertThatResultMatches(results.results[4], expectedPremises[4])
-    }
-  }
-
-  @ParameterizedTest
-  @EnumSource(mode = EnumSource.Mode.EXCLUDE, names = ["normal"])
-  fun `Filtering APs by AP type returns only APs of that type - using multiple ap types option`(apType: ApType) {
-    postCodeDistrictFactory.produceAndPersist {
-      withOutcode("SE1")
-      withLatitude(-0.07)
-      withLongitude(51.48)
-    }
-
-    givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA)) { user, jwt ->
-      val application = givenAnApplication(createdByUser = user, isWomensApplication = false)
-
-      val expectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(5) {
-        withYieldedProbationRegion { givenAProbationRegion() }
-        withYieldedLocalAuthorityArea {
-          localAuthorityEntityFactory.produceAndPersist()
-        }
-        withLatitude((it * -0.01) - 0.08)
-        withLongitude((it * 0.01) + 51.49)
-        withCharacteristicsList(listOfNotNull(apType.asCharacteristicEntity()))
-        withSupportsSpaceBookings(true)
-      }
-
-      val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersistMultipleIndexed(4) {
-        withYieldedProbationRegion { givenAProbationRegion() }
-        withYieldedLocalAuthorityArea {
-          localAuthorityEntityFactory.produceAndPersist()
-        }
-        withLatitude((it * -0.01) - 0.08)
-        withLongitude((it * 0.01) + 51.49)
-        withCharacteristicsList(listOfNotNull(ApType.entries.first { it != apType }.asCharacteristicEntity()))
-        withSupportsSpaceBookings(true)
-      }
-
-      val searchParameters = Cas1SpaceSearchParameters(
-        applicationId = application.id,
-        startDate = LocalDate.now(),
-        durationInDays = 14,
-        targetPostcodeDistrict = "SE1",
-        spaceCharacteristics = null,
-        requirements = Cas1SpaceSearchRequirements(
-          apTypes = listOf(apType),
-          spaceCharacteristics = null,
-        ),
-      )
-
-      val response = webTestClient.post()
-        .uri("/cas1/spaces/search")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(searchParameters)
-        .exchange()
-        .expectStatus()
-        .isOk
-        .returnResult(Cas1SpaceSearchResults::class.java)
-
-      val results = response.responseBody.blockFirst()!!
-
-      assertThat(results.resultsCount).isEqualTo(5)
-
-      val expectedApType = if (apType == ApType.mhapElliottHouse) {
-        ApType.mhapStJosephs
-      } else {
-        apType
-      }
-
-      assertThatResultMatches(results.results[0], expectedPremises[0], expectedApType)
-      assertThatResultMatches(results.results[1], expectedPremises[1], expectedApType)
-      assertThatResultMatches(results.results[2], expectedPremises[2], expectedApType)
-      assertThatResultMatches(results.results[3], expectedPremises[3], expectedApType)
-      assertThatResultMatches(results.results[4], expectedPremises[4], expectedApType)
     }
   }
 
@@ -354,7 +278,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = listOf(Cas1SpaceCharacteristic.isPIPE),
         requirements = Cas1SpaceSearchRequirements(
-          apTypes = null,
           spaceCharacteristics = null,
         ),
       )
@@ -460,7 +383,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = listOf(characteristic),
         requirements = Cas1SpaceSearchRequirements(
-          apTypes = null,
           spaceCharacteristics = null,
         ),
       )
@@ -546,7 +468,6 @@ class Cas1SpaceSearchTest : InitialiseDatabasePerClassTestBase() {
         targetPostcodeDistrict = "SE1",
         spaceCharacteristics = Cas1SpaceCharacteristic.entries.slice(1..2),
         requirements = Cas1SpaceSearchRequirements(
-          apTypes = null,
           spaceCharacteristics = listOf(Cas1SpaceCharacteristic.entries[3]),
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
@@ -28,7 +28,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.CandidatePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1SpaceSearchRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceSearchService
 import java.time.LocalDate
@@ -64,9 +63,7 @@ class Cas1SpaceSearchServiceTest {
           durationInDays = 14,
           targetPostcodeDistrict = "TB1",
           spaceCharacteristics = Cas1SpaceCharacteristic.entries,
-          requirements = Cas1SpaceSearchRequirements(
-            apTypes = ApType.entries,
-          ),
+          requirements = Cas1SpaceSearchRequirements(),
         ),
       )
     }.hasMessage(
@@ -140,7 +137,6 @@ class Cas1SpaceSearchServiceTest {
         any(),
         any(),
         any(),
-        any(),
       )
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
@@ -153,7 +149,6 @@ class Cas1SpaceSearchServiceTest {
         durationInDays = 14,
         targetPostcodeDistrict = "TB1",
         requirements = Cas1SpaceSearchRequirements(
-          apTypes = ApType.entries,
           spaceCharacteristics = Cas1SpaceCharacteristic.entries,
         ),
       ),
@@ -176,116 +171,10 @@ class Cas1SpaceSearchServiceTest {
 
       spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
         "TB1",
-        ApType.entries.map { it.asApprovedPremisesType() }.firstOrNull(),
         isWomensPremises = false,
         spaceCharacteristics.filter { it.modelMatches("premises") }.map { it.id },
         spaceCharacteristics.filter { it.modelMatches("room") }.map { it.id },
       )
-    }
-
-    confirmVerified()
-  }
-
-  @ParameterizedTest
-  @MethodSource("apTypeArgs")
-  fun `findSpaces uses the correct list of AP types`(apTypes: List<ApType>) {
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withDefaults()
-      .withIsWomensApplication(false)
-      .produce()
-
-    val candidatePremises1 = CandidatePremises(
-      UUID.randomUUID(),
-      1.0f,
-      ApprovedPremisesType.NORMAL,
-      "Some AP",
-      fullAddress = "the full address",
-      "1 The Street",
-      null,
-      "Townsbury",
-      "TB1 2AB",
-      UUID.randomUUID(),
-      "Some AP Area",
-      characteristics = emptyList(),
-    )
-
-    val candidatePremises2 = CandidatePremises(
-      UUID.randomUUID(),
-      2.0f,
-      ApprovedPremisesType.ESAP,
-      "Some Other AP",
-      fullAddress = "the full address",
-      "2 The Street",
-      null,
-      "Townsbury",
-      "TB1 2AB",
-      UUID.randomUUID(),
-      "Some AP Area",
-      characteristics = emptyList(),
-    )
-
-    val candidatePremises3 = CandidatePremises(
-      UUID.randomUUID(),
-      3.0f,
-      ApprovedPremisesType.PIPE,
-      "Some AP",
-      fullAddress = "the full address",
-      "3 The Street",
-      null,
-      "Townsbury",
-      "TB1 2AB",
-      UUID.randomUUID(),
-      "Some AP Area",
-      characteristics = emptyList(),
-    )
-
-    val spaceCharacteristics = Cas1SpaceCharacteristic.entries.map { characteristicWithRandomModelScopeCalled(it.value) }
-
-    every { applicationRepository.findByIdOrNull(application.id) } returns application
-
-    every {
-      characteristicService.getCharacteristicsByPropertyNames(any(), ServiceName.approvedPremises)
-    } returnsMany listOf(
-      spaceCharacteristics,
-    )
-
-    every {
-      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
-        any(),
-        any(),
-        any(),
-        any(),
-        any(),
-      )
-    } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
-
-    service.findSpaces(
-      Cas1SpaceSearchParameters(
-        applicationId = application.id,
-        startDate = LocalDate.parse("2024-08-01"),
-        durationInDays = 14,
-        targetPostcodeDistrict = "TB1",
-        requirements = Cas1SpaceSearchRequirements(
-          apTypes = apTypes,
-          spaceCharacteristics = Cas1SpaceCharacteristic.entries,
-        ),
-      ),
-    )
-
-    verify(exactly = 1) {
-      applicationRepository.findByIdOrNull(application.id)
-
-      spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
-        "TB1",
-        apTypes.map { it.asApprovedPremisesType() }.firstOrNull(),
-        any(),
-        any(),
-        any(),
-      )
-    }
-
-    verify {
-      characteristicService.getCharacteristicsByPropertyNames(any(), ServiceName.approvedPremises)
     }
 
     confirmVerified()
@@ -360,7 +249,6 @@ class Cas1SpaceSearchServiceTest {
         any(),
         any(),
         any(),
-        any(),
       )
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
@@ -371,7 +259,6 @@ class Cas1SpaceSearchServiceTest {
         durationInDays = 14,
         targetPostcodeDistrict = "TB1",
         requirements = Cas1SpaceSearchRequirements(
-          apTypes = ApType.entries,
           spaceCharacteristics = Cas1SpaceCharacteristic.entries,
         ),
       ),
@@ -381,7 +268,6 @@ class Cas1SpaceSearchServiceTest {
       applicationRepository.findByIdOrNull(application.id)
 
       spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
-        any(),
         any(),
         isWomensPremises = isWomensApplication,
         any(),
@@ -464,7 +350,6 @@ class Cas1SpaceSearchServiceTest {
         any(),
         any(),
         any(),
-        any(),
       )
     } returns listOf(candidatePremises1, candidatePremises2, candidatePremises3)
 
@@ -475,9 +360,7 @@ class Cas1SpaceSearchServiceTest {
         durationInDays = 14,
         targetPostcodeDistrict = "TB1",
         spaceCharacteristics = spaceCharacteristics,
-        requirements = Cas1SpaceSearchRequirements(
-          apTypes = ApType.entries,
-        ),
+        requirements = Cas1SpaceSearchRequirements(),
       ),
     )
 
@@ -490,7 +373,6 @@ class Cas1SpaceSearchServiceTest {
       )
 
       spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
-        any(),
         any(),
         any(),
         spaceCharacteristicEntities.filter { it.modelMatches("premises") }.map { it.id },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceSearchServiceTest.kt
@@ -20,7 +20,6 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchParameters
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceSearchRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
@@ -63,7 +62,6 @@ class Cas1SpaceSearchServiceTest {
           durationInDays = 14,
           targetPostcodeDistrict = "TB1",
           spaceCharacteristics = Cas1SpaceCharacteristic.entries,
-          requirements = Cas1SpaceSearchRequirements(),
         ),
       )
     }.hasMessage(
@@ -148,9 +146,7 @@ class Cas1SpaceSearchServiceTest {
         startDate = LocalDate.parse("2024-08-01"),
         durationInDays = 14,
         targetPostcodeDistrict = "TB1",
-        requirements = Cas1SpaceSearchRequirements(
-          spaceCharacteristics = Cas1SpaceCharacteristic.entries,
-        ),
+        spaceCharacteristics = Cas1SpaceCharacteristic.entries,
       ),
     )
 
@@ -163,12 +159,16 @@ class Cas1SpaceSearchServiceTest {
 
     verify(exactly = 1) {
       applicationRepository.findByIdOrNull(application.id)
+    }
 
+    verify(exactly = 1) {
       characteristicService.getCharacteristicsByPropertyNames(
         Cas1SpaceCharacteristic.entries.map { it.value },
         ServiceName.approvedPremises,
       )
+    }
 
+    verify(exactly = 1) {
       spaceSearchRepository.findAllPremisesWithCharacteristicsByDistance(
         "TB1",
         isWomensPremises = false,
@@ -257,10 +257,8 @@ class Cas1SpaceSearchServiceTest {
         applicationId = application.id,
         startDate = LocalDate.parse("2024-08-01"),
         durationInDays = 14,
+        spaceCharacteristics = Cas1SpaceCharacteristic.entries,
         targetPostcodeDistrict = "TB1",
-        requirements = Cas1SpaceSearchRequirements(
-          spaceCharacteristics = Cas1SpaceCharacteristic.entries,
-        ),
       ),
     )
 
@@ -360,7 +358,6 @@ class Cas1SpaceSearchServiceTest {
         durationInDays = 14,
         targetPostcodeDistrict = "TB1",
         spaceCharacteristics = spaceCharacteristics,
-        requirements = Cas1SpaceSearchRequirements(),
       ),
     )
 


### PR DESCRIPTION
The UI no longer populates the `requirements` value, instead using `spaceCharacteristics` to provide filter criteria. This PR removes the `requirements` property and corresponding type