### PR TITLE
APS-2168 Remove domain_events.cas1_placement_request_id

### DIFF
--- a/src/main/resources/db/migration/all/20250513171535__remove_domain_events_placement_request_id.sql
+++ b/src/main/resources/db/migration/all/20250513171535__remove_domain_events_placement_request_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domain_events DROP COLUMN cas1_placement_request_id;


### PR DESCRIPTION
This has already been removed in code via a06e316a6da63c762ceb347a54bbd342ab95ac7a. This commit is removing it from the database.
