### PR TITLE
APS-2148 - Remove PlacementRequirements.gender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CAS1SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CAS1SubjectAccessRequestRepository.kt
@@ -333,19 +333,14 @@ from
              pr.application_id,
              pr.assessment_id,
              pr.id as placement_requirements_id,
-             case 
-                 when pr.gender = '0' then 'MALE'
-                 when pr.gender = '1' then 'FEMALE'
-                 else 'OTHER'
-             end gender,
-               case
-                 when pr.ap_type = '0' then 'NORMAL'
-                 when pr.ap_type = '1' then 'PIPE'
-                 when pr.ap_type = '2' then 'ESAP'
-                 when pr.ap_type = '3' then 'RFAP'
-                 when pr.ap_type = '4' then 'MHAP_ST_JOSEPHS'
-                 when pr.ap_type = '5' then 'MHAP_ELLIOTT_HOUSE'
-                 else 'other'
+             case
+               when pr.ap_type = '0' then 'NORMAL'
+               when pr.ap_type = '1' then 'PIPE'
+               when pr.ap_type = '2' then 'ESAP'
+               when pr.ap_type = '3' then 'RFAP'
+               when pr.ap_type = '4' then 'MHAP_ST_JOSEPHS'
+               when pr.ap_type = '5' then 'MHAP_ELLIOTT_HOUSE'
+               else 'other'
              end ap_type,
              pd.outcode,
              pr.radius,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
@@ -11,7 +11,6 @@ import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -25,7 +24,6 @@ interface PlacementRequirementsRepository : JpaRepository<PlacementRequirementsE
 data class PlacementRequirementsEntity(
   @Id
   val id: UUID,
-  val gender: JpaGender,
   val apType: JpaApType,
 
   @ManyToOne
@@ -74,17 +72,5 @@ enum class JpaApType(val apiType: ApType) {
 
   companion object {
     fun fromApiType(apiType: ApType) = entries.first { it.apiType == apiType }
-  }
-}
-
-// Do not re-order these elements as we currently use ordinal enum mapping in hibernate
-// (i.e. they're persisted as index numbers, not enum name strings)
-enum class JpaGender(val apiType: Gender) {
-  MALE(Gender.male),
-  FEMALE(Gender.female),
-  ;
-
-  companion object {
-    fun fromApiType(apiType: Gender) = entries.first { it.apiType == apiType }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
@@ -262,7 +261,6 @@ class Cas1ApplicationSeedService(
         assessmentId = getAssessmentId(application),
         document = ASSESSMENT_DOCUMENT_JSON,
         placementRequirements = PlacementRequirements(
-          gender = Gender.male,
           type = ApType.normal,
           location = application.targetLocation!!,
           radius = 25,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequirementsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequirementsService.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostcodeDistrictRepository
@@ -43,7 +42,6 @@ class Cas1PlacementRequirementsService(
       PlacementRequirementsEntity(
         id = UUID.randomUUID(),
         apType = JpaApType.fromApiType(requirements.type),
-        gender = JpaGender.fromApiType(requirements.gender),
         postcodeDistrict = postcodeDistrict,
         radius = requirements.radius,
         desirableCriteria = desirableCriteria,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestDetailTransformer.kt
@@ -33,7 +33,6 @@ class PlacementRequestDetailTransformer(
 
     return PlacementRequestDetail(
       id = placementRequest.id,
-      gender = placementRequest.gender,
       type = placementRequest.type,
       expectedArrival = placementRequest.expectedArrival,
       duration = placementRequest.duration,
@@ -78,7 +77,6 @@ class PlacementRequestDetailTransformer(
 
     return Cas1PlacementRequestDetail(
       id = placementRequest.id,
-      gender = placementRequest.gender,
       type = placementRequest.type,
       expectedArrival = placementRequest.expectedArrival,
       duration = placementRequest.duration,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -32,7 +32,6 @@ class PlacementRequestTransformer(
 
   fun transformJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult): PlacementRequest = PlacementRequest(
     id = jpa.id,
-    gender = jpa.placementRequirements.gender.apiType,
     type = jpa.placementRequirements.apType.apiType,
     expectedArrival = jpa.expectedArrival,
     duration = jpa.duration,

--- a/src/main/resources/db/migration/all/20250513174936__allow_null_placement_requirements_gender.sql
+++ b/src/main/resources/db/migration/all/20250513174936__allow_null_placement_requirements_gender.sql
@@ -1,0 +1,1 @@
+ALTER TABLE placement_requirements ALTER COLUMN gender DROP NOT NULL;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3344,8 +3344,6 @@ components:
     PlacementRequirements:
       type: object
       properties:
-        gender:
-          $ref: '#/components/schemas/Gender'
         type:
           $ref: '#/components/schemas/ApType'
         location:
@@ -3363,7 +3361,6 @@ components:
           items:
             $ref: '#/components/schemas/PlacementCriteria'
       required:
-        - gender
         - type
         - location
         - radius

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6628,8 +6628,6 @@ components:
     PlacementRequirements:
       type: object
       properties:
-        gender:
-          $ref: '#/components/schemas/Gender'
         type:
           $ref: '#/components/schemas/ApType'
         location:
@@ -6647,7 +6645,6 @@ components:
           items:
             $ref: '#/components/schemas/PlacementCriteria'
       required:
-        - gender
         - type
         - location
         - radius

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5644,8 +5644,6 @@ components:
     PlacementRequirements:
       type: object
       properties:
-        gender:
-          $ref: '#/components/schemas/Gender'
         type:
           $ref: '#/components/schemas/ApType'
         location:
@@ -5663,7 +5661,6 @@ components:
           items:
             $ref: '#/components/schemas/PlacementCriteria'
       required:
-        - gender
         - type
         - location
         - radius

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3868,8 +3868,6 @@ components:
     PlacementRequirements:
       type: object
       properties:
-        gender:
-          $ref: '#/components/schemas/Gender'
         type:
           $ref: '#/components/schemas/ApType'
         location:
@@ -3887,7 +3885,6 @@ components:
           items:
             $ref: '#/components/schemas/PlacementCriteria'
       required:
-        - gender
         - type
         - location
         - radius

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3879,8 +3879,6 @@ components:
     PlacementRequirements:
       type: object
       properties:
-        gender:
-          $ref: '#/components/schemas/Gender'
         type:
           $ref: '#/components/schemas/ApType'
         location:
@@ -3898,7 +3896,6 @@ components:
           items:
             $ref: '#/components/schemas/PlacementCriteria'
       required:
-        - gender
         - type
         - location
         - radius

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3715,8 +3715,6 @@ components:
     PlacementRequirements:
       type: object
       properties:
-        gender:
-          $ref: '#/components/schemas/Gender'
         type:
           $ref: '#/components/schemas/ApType'
         location:
@@ -3734,7 +3732,6 @@ components:
           items:
             $ref: '#/components/schemas/PlacementCriteria'
       required:
-        - gender
         - type
         - location
         - radius

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementRequirementsEntityFactory.kt
@@ -6,7 +6,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistrictEntity
 import java.time.OffsetDateTime
@@ -15,7 +14,6 @@ import java.util.UUID
 class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> {
 
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var gender: Yielded<JpaGender> = { JpaGender.MALE }
   private var apType: Yielded<JpaApType> = { JpaApType.NORMAL }
   private var postcodeDistrict: Yielded<PostCodeDistrictEntity> = { PostCodeDistrictEntityFactory().produce() }
   private var application: Yielded<ApprovedPremisesApplicationEntity>? = null
@@ -66,13 +64,8 @@ class PlacementRequirementsEntityFactory : Factory<PlacementRequirementsEntity> 
     this.createdAt = { createdAt }
   }
 
-  fun withGender(gender: JpaGender) = apply {
-    this.gender = { gender }
-  }
-
   override fun produce(): PlacementRequirementsEntity = PlacementRequirementsEntity(
     id = this.id(),
-    gender = this.gender(),
     apType = this.apType(),
     postcodeDistrict = this.postcodeDistrict(),
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an Application"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus.cas1Reallocated
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus.cas3Rejected
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReferralHistoryUserNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
@@ -65,7 +64,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus.NOT_STARTED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
@@ -2030,7 +2028,6 @@ class AssessmentTest : IntegrationTestBase() {
       )
 
       val placementRequirements = PlacementRequirements(
-        gender = Gender.male,
         type = ApType.normal,
         location = "B74",
         radius = 50,
@@ -2063,7 +2060,7 @@ class AssessmentTest : IntegrationTestBase() {
           ),
         ),
       ) { userEntity, jwt ->
-        givenAnOffender { offenderDetails, inmateDetails ->
+        givenAnOffender { offenderDetails, _ ->
           govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
 
           val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
@@ -2101,7 +2098,6 @@ class AssessmentTest : IntegrationTestBase() {
           )
 
           val placementRequirements = PlacementRequirements(
-            gender = Gender.female,
             type = ApType.normal,
             location = postcodeDistrict.outcode,
             radius = 50,
@@ -2167,7 +2163,6 @@ class AssessmentTest : IntegrationTestBase() {
           val persistedPlacementRequirements = persistedPlacementRequest.placementRequirements
 
           assertThat(persistedPlacementRequirements.apType).isEqualTo(JpaApType.NORMAL)
-          assertThat(persistedPlacementRequirements.gender).isEqualTo(JpaGender.FEMALE)
           assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)
           assertThat(persistedPlacementRequirements.radius).isEqualTo(placementRequirements.radius)
 
@@ -2195,7 +2190,7 @@ class AssessmentTest : IntegrationTestBase() {
           ),
         ),
       ) { userEntity, jwt ->
-        givenAnOffender { offenderDetails, inmateDetails ->
+        givenAnOffender { offenderDetails, _ ->
           val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
           }
@@ -2224,7 +2219,6 @@ class AssessmentTest : IntegrationTestBase() {
             listOf(PlacementCriteria.acceptsNonSexualChildOffenders, PlacementCriteria.acceptsSexOffenders)
 
           val placementRequirements = PlacementRequirements(
-            gender = Gender.male,
             type = ApType.normal,
             location = postcodeDistrict.outcode,
             radius = 50,
@@ -2275,7 +2269,6 @@ class AssessmentTest : IntegrationTestBase() {
             placementRequirementsRepository.findTopByApplicationOrderByCreatedAtDesc(application)!!
 
           assertThat(persistedPlacementRequirements.apType).isEqualTo(JpaApType.NORMAL)
-          assertThat(persistedPlacementRequirements.gender).isEqualTo(JpaGender.MALE)
           assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)
           assertThat(persistedPlacementRequirements.radius).isEqualTo(placementRequirements.radius)
 
@@ -2302,7 +2295,7 @@ class AssessmentTest : IntegrationTestBase() {
           ),
         ),
       ) { userEntity, jwt ->
-        givenAnOffender { offenderDetails, inmateDetails ->
+        givenAnOffender { offenderDetails, _ ->
           val applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist {
             withPermissiveSchema()
           }
@@ -2336,7 +2329,6 @@ class AssessmentTest : IntegrationTestBase() {
           )
 
           val placementRequirements = PlacementRequirements(
-            gender = Gender.male,
             type = ApType.normal,
             location = "SW1",
             radius = 50,
@@ -2433,7 +2425,6 @@ class AssessmentTest : IntegrationTestBase() {
           )
 
           val placementRequirements = PlacementRequirements(
-            gender = Gender.male,
             type = ApType.normal,
             location = postcodeDistrict.outcode,
             radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS1SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS1SubjectAccessRequestServiceTest.kt
@@ -747,7 +747,6 @@ class CAS1SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
         "application_id": "${placementRequirement.application.id}",
         "assessment_id": "${placementRequirement.assessment.id}",
         "placement_requirements_id": "${placementRequirement.id}",
-        "gender": "${placementRequirement.gender.name}",
         "ap_type": "${placementRequirement.apType.name}",
         "outcode": "${placementRequirement.postcodeDistrict.outcode}",
         "radius": ${placementRequirement.radius},

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Applicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBookingCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
@@ -472,7 +471,6 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
     val postcodeDistrict = postCodeDistrictFactory.produceAndPersist()
 
     val placementRequirements = PlacementRequirements(
-      gender = Gender.male,
       type = ApType.normal,
       location = postcodeDistrict.outcode,
       radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AssessmentTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentRejection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
@@ -55,7 +54,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus.NOT_STARTED
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -1156,7 +1154,6 @@ class Cas1AssessmentTest : IntegrationTestBase() {
         )
 
         val placementRequirements = PlacementRequirements(
-          gender = Gender.male,
           type = ApType.normal,
           location = "B74",
           radius = 50,
@@ -1227,7 +1224,6 @@ class Cas1AssessmentTest : IntegrationTestBase() {
             )
 
             val placementRequirements = PlacementRequirements(
-              gender = Gender.female,
               type = ApType.normal,
               location = postcodeDistrict.outcode,
               radius = 50,
@@ -1293,7 +1289,6 @@ class Cas1AssessmentTest : IntegrationTestBase() {
             val persistedPlacementRequirements = persistedPlacementRequest.placementRequirements
 
             assertThat(persistedPlacementRequirements.apType).isEqualTo(JpaApType.NORMAL)
-            assertThat(persistedPlacementRequirements.gender).isEqualTo(JpaGender.FEMALE)
             assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)
             assertThat(persistedPlacementRequirements.radius).isEqualTo(placementRequirements.radius)
 
@@ -1350,7 +1345,6 @@ class Cas1AssessmentTest : IntegrationTestBase() {
               listOf(PlacementCriteria.acceptsNonSexualChildOffenders, PlacementCriteria.acceptsSexOffenders)
 
             val placementRequirements = PlacementRequirements(
-              gender = Gender.male,
               type = ApType.normal,
               location = postcodeDistrict.outcode,
               radius = 50,
@@ -1401,7 +1395,6 @@ class Cas1AssessmentTest : IntegrationTestBase() {
               placementRequirementsRepository.findTopByApplicationOrderByCreatedAtDesc(application)!!
 
             assertThat(persistedPlacementRequirements.apType).isEqualTo(JpaApType.NORMAL)
-            assertThat(persistedPlacementRequirements.gender).isEqualTo(JpaGender.MALE)
             assertThat(persistedPlacementRequirements.postcodeDistrict.outcode).isEqualTo(placementRequirements.location)
             assertThat(persistedPlacementRequirements.radius).isEqualTo(placementRequirements.radius)
 
@@ -1462,7 +1455,6 @@ class Cas1AssessmentTest : IntegrationTestBase() {
             )
 
             val placementRequirements = PlacementRequirements(
-              gender = Gender.male,
               type = ApType.normal,
               location = "SW1",
               radius = 50,
@@ -1559,7 +1551,6 @@ class Cas1AssessmentTest : IntegrationTestBase() {
             )
 
             val placementRequirements = PlacementRequirements(
-              gender = Gender.male,
               type = ApType.normal,
               location = postcodeDistrict.outcode,
               radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1ApplicationV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1ApplicationV2ReportTest.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentReje
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewAppeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal
@@ -1014,7 +1013,6 @@ class Cas1ApplicationV2ReportTest : InitialiseDatabasePerClassTestBase() {
     val desirableCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
 
     val placementRequirements = PlacementRequirements(
-      gender = Gender.male,
       type = ApType.normal,
       location = postCodeDistrictFactory.produceAndPersist().outcode,
       radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Applicatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBookingNotMade
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
@@ -703,7 +702,6 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
     val desirableCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
 
     val placementRequirements = PlacementRequirements(
-      gender = Gender.male,
       type = ApType.normal,
       location = postCodeDistrictFactory.produceAndPersist().outcode,
       radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementReportTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcce
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecision
@@ -717,7 +716,6 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
     val desirableCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
 
     val placementRequirements = PlacementRequirements(
-      gender = Gender.male,
       type = ApType.normal,
       location = postCodeDistrictFactory.produceAndPersist().outcode,
       radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1RequestForPlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1RequestForPlacementReportTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentReje
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecision
@@ -657,7 +656,6 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
     val desirableCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
 
     val placementRequirements = PlacementRequirements(
-      gender = Gender.male,
       type = ApType.normal,
       location = postCodeDistrictFactory.produceAndPersist().outcode,
       radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -25,7 +25,6 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -2994,7 +2993,6 @@ class AssessmentServiceTest {
         .withData("{\"test\": \"data\"}")
 
       placementRequirements = PlacementRequirements(
-        gender = Gender.male,
         type = ApType.normal,
         location = "AB123",
         radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentServiceTest.kt
@@ -16,7 +16,6 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentSortField
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
@@ -833,7 +832,6 @@ class Cas1AssessmentServiceTest {
         .withData("{\"test\": \"data\"}")
 
       placementRequirements = PlacementRequirements(
-        gender = Gender.male,
         type = ApType.normal,
         location = "AB123",
         radius = 50,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequirementsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequirementsServiceTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.capture
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
@@ -88,7 +87,6 @@ class Cas1PlacementRequirementsServiceTest {
       service.createPlacementRequirements(
         assessment = assessment,
         requirements = PlacementRequirements(
-          gender = Gender.male,
           type = ApType.normal,
           location = "location",
           radius = 5,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
@@ -116,7 +116,6 @@ class PlacementRequestDetailTransformerTest {
     val result = placementRequestDetailTransformer.transformJpaToApi(mockPlacementRequestEntity, mockPersonInfoResult, mockCancellationEntities)
 
     assertThat(result.id).isEqualTo(transformedPlacementRequest.id)
-    assertThat(result.gender).isEqualTo(transformedPlacementRequest.gender)
     assertThat(result.type).isEqualTo(transformedPlacementRequest.type)
     assertThat(result.expectedArrival).isEqualTo(transformedPlacementRequest.expectedArrival)
     assertThat(result.duration).isEqualTo(transformedPlacementRequest.duration)
@@ -308,7 +307,6 @@ class PlacementRequestDetailTransformerTest {
     assertThat(result).isInstanceOf(Cas1PlacementRequestDetail::class.java)
 
     assertThat(result.id).isEqualTo(transformedPlacementRequest.id)
-    assertThat(result.gender).isEqualTo(transformedPlacementRequest.gender)
     assertThat(result.type).isEqualTo(transformedPlacementRequest.type)
     assertThat(result.expectedArrival).isEqualTo(transformedPlacementRequest.expectedArrival)
     assertThat(result.duration).isEqualTo(transformedPlacementRequest.duration)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Gender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
@@ -42,7 +41,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequire
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaGender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
@@ -155,7 +153,6 @@ class PlacementRequestTransformerTest {
           ),
         )
         .withApType(JpaApType.ESAP)
-        .withGender(JpaGender.MALE)
         .produce()
 
       val placementRequestEntity = placementRequestFactory
@@ -172,7 +169,6 @@ class PlacementRequestTransformerTest {
         PlacementRequest(
           id = placementRequestEntity.id,
           type = ApType.esap,
-          gender = Gender.male,
           expectedArrival = placementRequestEntity.expectedArrival,
           duration = placementRequestEntity.duration,
           location = placementRequirementsEntity.postcodeDistrict.outcode,


### PR DESCRIPTION
This field has been superseded by `approved_premises_applications.is_womens_application` and regardless, is always populated as male by the UI.

This commit removes the property from the entity model and API, and makes it nullable in the database for subsequent removal in a future commit once this change has been deployed
