### PR TITLE
APS-2318 Automatically remove corrupted cache metadata

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/PreemptiveCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/PreemptiveCacheTest.kt
@@ -269,6 +269,15 @@ class PreemptiveCacheTest : IntegrationTestBase() {
     assertThat(thirdResult is ClientResult.Failure.CachedValueUnavailable).isTrue
     assertThat((thirdResult as ClientResult.Failure.CachedValueUnavailable).cacheKey).isEqualTo(keys.dataKey)
     assertCallCount("/api/offenders/$nomsNumber", 1)
+
+    // Ensure the metadata is removed as it refers to data that doesn't exist
+    assertThat(getMetadata(keys.metadataKey)).isNull()
+
+    mockSentryService.assertErrorMessageRaised(
+      "Could not find data entry in cache for key '$preemptiveCacheKeyPrefix-inmateDetails-ABCD1234-data', " +
+        "despite the metadata saying the body was available. " +
+        "Will remove the corrupt metadata entry '$preemptiveCacheKeyPrefix-inmateDetails-ABCD1234-metadata'",
+    )
   }
 
   private fun assertMetadataAttemptCount(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/PreemptiveCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/client/PreemptiveCacheTest.kt
@@ -128,10 +128,6 @@ class PreemptiveCacheTest : IntegrationTestBase() {
 
     every { Instant.now() } returns firstCallInstant
 
-    // Call 2 - 404 read from cache
-    //
-    // Subsequent calls up to the first amount of seconds in failureSoftTtlBackoffSeconds
-    // should return the cached value without making an upstream request
     assertStatusCodeFailure(
       preemptivelyCachedClient.getInmateDetailsWithCall(nomsNumber),
       HttpStatus.NOT_FOUND,
@@ -139,7 +135,7 @@ class PreemptiveCacheTest : IntegrationTestBase() {
     assertMetadataAttemptCount("$preemptiveCacheKeyPrefix-inmateDetails-$nomsNumber-metadata", MarshallableHttpMethod.GET, 1)
     assertCallCount("/api/offenders/$nomsNumber", 1)
 
-    // Call 3 - 404 read from cache
+    // Call 2 - 404 read from cache
     //
     // Subsequent calls up to the first amount of seconds in failureSoftTtlBackoffSeconds
     // should return the cached value without making an upstream request
@@ -156,9 +152,9 @@ class PreemptiveCacheTest : IntegrationTestBase() {
       responseStatus = 400,
     )
 
-    // Call 4 - 400 refresh cache
+    // Call 3 - 400 refresh cache
     //
-    // The next call after successSoftTtlSeconds should make an upstream request and
+    // The next call after failureSoftTtlBackoffSeconds should make an upstream request and
     // replace the original cached value, attempt number in metadata should increase to 2
     every { Instant.now() } returns sixSecondsLaterInstant
 
@@ -169,7 +165,7 @@ class PreemptiveCacheTest : IntegrationTestBase() {
     assertMetadataAttemptCount("$preemptiveCacheKeyPrefix-inmateDetails-$nomsNumber-metadata", MarshallableHttpMethod.GET, 2)
     assertCallCount("/api/offenders/$nomsNumber", 2)
 
-    // Call 5 - 400 read from cache
+    // Call 4 - 400 read from cache
     //
     // The next call should not make an upstream request and return the cached value
     assertStatusCodeFailure(


### PR DESCRIPTION
If cache metadata states that a responseBody is available but that responseBody entry doesn’t exist in the cache, automatically remove the metadata from the cache as inconsistent state will not automatically resolve and we’ll always receive a `CachedValueUnavailable` error when attempting to retrieve from the cache until it’s hard TTL is reached.

We now also raise a sentry alert when this happens, as this really _shouldn’t_ happen