### PR TITLE
Update Arrival Job should also update domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -100,6 +100,8 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 
   fun findByApplicationIdOrderByCreatedAtAsc(applicationId: UUID): List<DomainEventEntity>
 
+  fun findByCas1SpaceBookingId(bookingId: UUID): List<DomainEventEntity>
+
   fun findByType(type: DomainEventType): List<DomainEventEntity>
 
   @Query(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentRejection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBookingCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBooking
@@ -28,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 
 @Component
@@ -335,6 +337,29 @@ class Cas1SimpleApiClient {
           occurredAt = LocalDate.now(),
           reasonId = reason.id,
           reasonNotes = "",
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  fun recordArrival(
+    integrationTestBase: IntegrationTestBase,
+    premisesId: UUID,
+    bookingId: UUID,
+    arrivalDate: LocalDate,
+    arrivalTime: LocalTime,
+  ) {
+    val managerJwt = integrationTestBase.givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)).second
+
+    integrationTestBase.webTestClient.post()
+      .uri("/cas1/premises/$premisesId/space-bookings/$bookingId/arrival")
+      .header("Authorization", "Bearer $managerJwt")
+      .bodyValue(
+        Cas1NewArrival(
+          arrivalDate = arrivalDate,
+          arrivalTime = arrivalTime.toString(),
         ),
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1UpdateActualArrivalDateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1UpdateActualArrivalDateTest.kt
@@ -2,24 +2,45 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.seed
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.PersonArrivedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1SimpleApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateActualArrivalDateSeedJobCsvRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
+import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 
 class SeedCas1UpdateActualArrivalDateTest : SeedTestBase() {
 
+  @Autowired
+  lateinit var simpleApiClient: Cas1SimpleApiClient
+
+  @Autowired
+  lateinit var domainEventService: Cas1DomainEventService
+
   @Test
   fun success() {
+    val offender = givenAnOffender().first
+
     val spaceBooking = givenACas1SpaceBooking(
-      crn = "CRN1",
+      crn = offender.otherIds.crn,
       deliusEventNumber = "101",
-      actualArrivalDate = LocalDate.of(2025, 5, 1),
-      canonicalArrivalDate = LocalDate.of(2025, 5, 1),
       premises = givenAnApprovedPremises(name = "My Test Premise"),
+    )
+
+    simpleApiClient.recordArrival(
+      this,
+      spaceBooking.premises.id,
+      spaceBooking.id,
+      arrivalDate = LocalDate.of(2025, 5, 1),
+      arrivalTime = LocalTime.of(12, 0, 0),
     )
 
     seed(
@@ -46,6 +67,11 @@ class SeedCas1UpdateActualArrivalDateTest : SeedTestBase() {
       .contains(
         "Actual arrival date for booking at 'My Test Premise' has been updated from 2025-05-01 to 2025-07-01 by application support",
       )
+
+    val domainEventAfterUpdate = domainEventRepository.findByApplicationId(spaceBooking.application!!.id)[0]
+
+    val unmarshalledData = objectMapper.readValue(domainEventAfterUpdate.data, PersonArrivedEnvelope::class.java)
+    assertThat(unmarshalledData.eventDetails.arrivedAt).isEqualTo(Instant.parse("2025-07-01T12:00:00.00Z"))
   }
 
   private fun rowsToCsv(rows: List<Cas1UpdateActualArrivalDateSeedJobCsvRow>): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1UpdateActualArrivalDateSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1UpdateActualArrivalDateSeedJobTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.seed.cas1
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateActualArrivalDateSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.cas1.Cas1UpdateActualArrivalDateSeedJobCsvRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationTimelineNoteService
@@ -29,6 +31,12 @@ class Cas1UpdateActualArrivalDateSeedJobTest {
 
   @MockK
   private lateinit var applicationTimelineNoteService: ApplicationTimelineNoteService
+
+  @MockK
+  private lateinit var domainEventService: DomainEventRepository
+
+  @MockK
+  private lateinit var objectMapper: ObjectMapper
 
   @InjectMockKs
   private lateinit var seedJob: Cas1UpdateActualArrivalDateSeedJob


### PR DESCRIPTION
This allows us to replay the domain event with the correct arrival date, if required.
