### PR TITLE
feature: cas2v2 entities, services, & transformers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/Cas2ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/Cas2ApplicationsController.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.net.URI
@@ -26,7 +26,7 @@ import java.util.UUID
 @Service
 class Cas2ApplicationsController(
   private val applicationService: Cas2ApplicationService,
-  private val applicationsTransformer: ApplicationsTransformer,
+  private val cas2ApplicationsTransformer: Cas2ApplicationsTransformer,
   private val objectMapper: ObjectMapper,
   private val offenderService: Cas2OffenderService,
   private val userService: NomisUserService,
@@ -79,7 +79,7 @@ class Cas2ApplicationsController(
 
     return ResponseEntity
       .created(URI.create("/cas2/applications/${application.id}"))
-      .body(applicationsTransformer.transformJpaToApi(application, personInfo))
+      .body(cas2ApplicationsTransformer.transformJpaToApi(application, personInfo))
   }
 
   @Transactional
@@ -114,7 +114,7 @@ class Cas2ApplicationsController(
     val personNamesMap = offenderService.getMapOfPersonNamesAndCrns(crns)
 
     return applicationSummaries.map { application ->
-      applicationsTransformer.transformJpaSummaryToSummary(application, personNamesMap[application.crn]!!)
+      cas2ApplicationsTransformer.transformJpaSummaryToSummary(application, personNamesMap[application.crn]!!)
     }
   }
 
@@ -123,6 +123,6 @@ class Cas2ApplicationsController(
   ): Cas2Application {
     val personInfo = offenderService.getFullInfoForPersonOrThrow(application.crn)
 
-    return applicationsTransformer.transformJpaToApi(application, personInfo)
+    return cas2ApplicationsTransformer.transformJpaToApi(application, personInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CAS2SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CAS2SubjectAccessRequestRepository.kt
@@ -34,7 +34,9 @@ class CAS2SubjectAccessRequestRepository(
         	ca.telephone_number,
         	ca.hdc_eligibility_date,
         	ca.conditional_release_date,
-        	ca.abandoned_at 
+        	ca.abandoned_at,
+          ca.application_origin,
+          CAST( ca.bail_hearing_date as DATE) 
         from
         	cas_2_applications ca
         inner join nomis_users nu on

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import io.hypersistence.utils.hibernate.type.json.JsonType
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -19,6 +21,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -127,6 +130,9 @@ data class Cas2ApplicationEntity(
   var hdcEligibilityDate: LocalDate? = null,
   var conditionalReleaseDate: LocalDate? = null,
   var telephoneNumber: String? = null,
+  var bailHearingDate: LocalDate? = null,
+  @Enumerated(EnumType.STRING)
+  var applicationOrigin: ApplicationOrigin = ApplicationOrigin.homeDetentionCurfew,
 ) {
   override fun toString() = "Cas2ApplicationEntity: $id"
   val currentPrisonCode: String?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationSummaryEntity.kt
@@ -87,5 +87,9 @@ data class Cas2ApplicationSummaryEntity(
   val currentPrisonCode: String?,
   @Column(name = "assignment_date")
   val assignmentDate: OffsetDateTime?,
+  @Column(name = "bail_hearing_date")
+  var bailHearingDate: LocalDate? = null,
+  @Column(name = "application_origin")
+  var applicationOrigin: String? = null,
 
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2UnsubmittedApplicationsReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2UnsubmittedApplicationsReport.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import java.util.UUID
 
 @Repository
@@ -14,7 +15,8 @@ interface Cas2UnsubmittedApplicationsReportRepository : JpaRepository<Cas2Applic
         applications.crn AS personCrn,
         applications.noms_number AS personNoms,
         to_char(applications.created_at, 'YYYY-MM-DD"T"HH24:MI:SS') AS startedAt,
-        users.nomis_username AS startedBy
+        users.nomis_username AS startedBy,
+        applications.application_origin AS applicationOrigin
 
       FROM cas_2_applications applications
       JOIN nomis_users users ON users.id = applications.created_by_user_id
@@ -29,6 +31,7 @@ interface Cas2UnsubmittedApplicationsReportRepository : JpaRepository<Cas2Applic
 
 interface Cas2UnsubmittedApplicationReportRow {
   fun getApplicationId(): String
+  fun getApplicationOrigin(): ApplicationOrigin
   fun getPersonNoms(): String
   fun getPersonCrn(): String
   fun getStartedBy(): String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/SubmittedApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/SubmittedApplicationReportRow.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+
 data class SubmittedApplicationReportRow(
   val eventId: String,
   val applicationId: String,
@@ -13,4 +15,6 @@ data class SubmittedApplicationReportRow(
   val submittedBy: String,
   val startedAt: String,
   val numberOfTransfers: String,
+  val applicationOrigin: ApplicationOrigin,
+  val bailHearingDate: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2ReportsService.kt
@@ -34,6 +34,8 @@ class Cas2ReportsService(
         submittedAt = row.getSubmittedAt(),
         startedAt = row.getStartedAt(),
         numberOfTransfers = row.getNumberOfTransfers(),
+        applicationOrigin = row.getApplicationOrigin(),
+        bailHearingDate = row.getBailHearingDate(),
       )
     }
 
@@ -74,6 +76,7 @@ class Cas2ReportsService(
         personNoms = row.getPersonNoms(),
         startedBy = row.getStartedBy(),
         startedAt = row.getStartedAt(),
+        applicationOrigin = row.getApplicationOrigin(),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/Cas2ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/Cas2ApplicationsTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary
@@ -14,8 +15,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTra
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import java.util.UUID
 
-@Component("Cas2ApplicationsTransformer")
-class ApplicationsTransformer(
+@Component()
+class Cas2ApplicationsTransformer(
   private val objectMapper: ObjectMapper,
   private val personTransformer: PersonTransformer,
   private val nomisUserTransformer: NomisUserTransformer,
@@ -50,6 +51,8 @@ class ApplicationsTransformer(
       isTransferredApplication = jpa.isTransferredApplication(),
       assignmentDate = jpa.currentAssignmentDate,
       omuEmailAddress = omu?.email,
+      applicationOrigin = jpa.applicationOrigin,
+      bailHearingDate = jpa.bailHearingDate,
     )
   }
 
@@ -74,6 +77,13 @@ class ApplicationsTransformer(
     crn = jpaSummary.crn,
     nomsNumber = jpaSummary.nomsNumber,
     personName = personName,
+    applicationOrigin = when (jpaSummary.applicationOrigin) {
+      "courtBail" -> ApplicationOrigin.courtBail
+      "prisonBail" -> ApplicationOrigin.prisonBail
+      "homeDetentionCurfew" -> ApplicationOrigin.homeDetentionCurfew
+      else -> error("Unexpected original value ${jpaSummary.applicationOrigin}")
+    },
+    bailHearingDate = jpaSummary.bailHearingDate,
   )
 
   private fun getStatus(entity: Cas2ApplicationEntity): ApplicationStatus {

--- a/src/main/resources/db/migration/all/20250430103605__merge_cas2_application_entity_with_cas2v2_application_entity.sql
+++ b/src/main/resources/db/migration/all/20250430103605__merge_cas2_application_entity_with_cas2v2_application_entity.sql
@@ -1,0 +1,77 @@
+-- First, drop the dependent views
+DROP VIEW IF EXISTS cas_2_application_live_summary;
+DROP VIEW IF EXISTS cas_2_application_summary;
+
+-- Then alter the table
+ALTER TABLE cas_2_applications
+    ADD application_origin TEXT DEFAULT 'homeDetentionCurfew' NOT NULL,
+    ADD bail_hearing_date TIMESTAMP WITH TIME ZONE;
+
+-- Adding the most recent assignment data from the cas_2_application_assignments view
+CREATE OR REPLACE VIEW cas_2_application_summary AS
+SELECT a.id,
+       a.crn,
+       a.noms_number,
+       a.created_by_user_id::text AS created_by_user_id,
+       nu.name,
+       a.created_at,
+       a.submitted_at,
+       a.hdc_eligibility_date,
+       asu.label,
+       asu.status_id::text        AS status_id,
+       a.referring_prison_code,
+       a.conditional_release_date,
+       a.bail_hearing_date,
+       a.application_origin,
+       asu.created_at             AS status_created_at,
+       a.abandoned_at,
+       aa.allocated_pom_user_id,
+       nu2.name as allocated_pom_name,
+       aa.created_at  as assignment_date,
+       aa.prison_code as current_prison_code
+FROM cas_2_applications a
+         LEFT JOIN (SELECT DISTINCT ON (aa.application_id) *
+                    FROM cas_2_application_assignments aa
+                    ORDER BY aa.application_id, created_at DESC) aa ON a.id = aa.application_id
+
+         LEFT JOIN (SELECT DISTINCT ON (su.application_id) su.application_id,
+                                                           su.label,
+                                                           su.status_id,
+                                                           su.created_at
+                    FROM cas_2_status_updates su
+                    ORDER BY su.application_id, su.created_at DESC) asu ON a.id = asu.application_id
+         JOIN nomis_users nu ON nu.id = a.created_by_user_id
+         LEFT JOIN nomis_users nu2 ON nu2.id = aa.allocated_pom_user_id;
+
+
+-- Adding the most recent assignment data from the cas_2_application_live_assignments view
+CREATE OR REPLACE VIEW cas_2_application_live_summary AS
+SELECT a.id,
+       a.crn,
+       a.noms_number,
+       a.created_by_user_id,
+       a.name,
+       a.created_at,
+       a.submitted_at,
+       a.hdc_eligibility_date,
+       a.label,
+       a.status_id,
+       a.referring_prison_code,
+       a.abandoned_at,
+       a.allocated_pom_user_id,
+       a.allocated_pom_name,
+       a.assignment_date,
+       a.current_prison_code,
+       a.bail_hearing_date,
+       a.application_origin
+FROM cas_2_application_summary a
+WHERE (a.conditional_release_date IS NULL OR a.conditional_release_date >= CURRENT_DATE) AND a.abandoned_at IS NULL AND
+      a.status_id IS NULL
+   OR a.status_id = '004e2419-9614-4c1e-a207-a8418009f23d'::text AND
+      a.status_created_at > (CURRENT_DATE - '32 days'::interval)
+   OR a.status_id = 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9'::text AND
+      a.status_created_at > (CURRENT_DATE - '32 days'::interval)
+   OR a.status_id = '89458555-3219-44a2-9584-c4f715d6b565'::text AND
+      a.status_created_at > (CURRENT_DATE - '32 days'::interval)
+   OR (a.status_id <> ALL
+       (ARRAY ['004e2419-9614-4c1e-a207-a8418009f23d'::text, 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9'::text, '89458555-3219-44a2-9584-c4f715d6b565'::text]))

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1863,6 +1863,9 @@ components:
         offenceId:
           type: string
           example: "M1502750438"
+        #BAIL-WIP - this should be a mandatory field once migration is complete in API & UI
+        applicationOrigin:
+          $ref: "_shared.yml#/components/schemas/ApplicationOrigin"
       required:
         - crn
     UpdateApplicationType:

--- a/src/main/resources/static/cas2-schemas.yml
+++ b/src/main/resources/static/cas2-schemas.yml
@@ -73,6 +73,11 @@ components:
             assignmentDate:
               type: string
               format: date
+            applicationOrigin:
+              $ref: "_shared.yml#/components/schemas/ApplicationOrigin"
+            bailHearingDate:
+              type: string
+              format: date
           required:
             - createdBy
             - schemaVersion
@@ -176,6 +181,11 @@ components:
         currentPrisonName:
           type: string
         assignmentDate:
+          type: string
+          format: date
+        applicationOrigin:
+          $ref: "_shared.yml#/components/schemas/ApplicationOrigin"
+        bailHearingDate:
           type: string
           format: date
       required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5147,6 +5147,9 @@ components:
         offenceId:
           type: string
           example: "M1502750438"
+        #BAIL-WIP - this should be a mandatory field once migration is complete in API & UI
+        applicationOrigin:
+          $ref: "#/components/schemas/ApplicationOrigin"
       required:
         - crn
     UpdateApplicationType:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4163,6 +4163,9 @@ components:
         offenceId:
           type: string
           example: "M1502750438"
+        #BAIL-WIP - this should be a mandatory field once migration is complete in API & UI
+        applicationOrigin:
+          $ref: "#/components/schemas/ApplicationOrigin"
       required:
         - crn
     UpdateApplicationType:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2387,6 +2387,9 @@ components:
         offenceId:
           type: string
           example: "M1502750438"
+        #BAIL-WIP - this should be a mandatory field once migration is complete in API & UI
+        applicationOrigin:
+          $ref: "#/components/schemas/ApplicationOrigin"
       required:
         - crn
     UpdateApplicationType:
@@ -4989,6 +4992,11 @@ components:
             assignmentDate:
               type: string
               format: date
+            applicationOrigin:
+              $ref: "#/components/schemas/ApplicationOrigin"
+            bailHearingDate:
+              type: string
+              format: date
           required:
             - createdBy
             - schemaVersion
@@ -5092,6 +5100,11 @@ components:
         currentPrisonName:
           type: string
         assignmentDate:
+          type: string
+          format: date
+        applicationOrigin:
+          $ref: "#/components/schemas/ApplicationOrigin"
+        bailHearingDate:
           type: string
           format: date
       required:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -2398,6 +2398,9 @@ components:
         offenceId:
           type: string
           example: "M1502750438"
+        #BAIL-WIP - this should be a mandatory field once migration is complete in API & UI
+        applicationOrigin:
+          $ref: "#/components/schemas/ApplicationOrigin"
       required:
         - crn
     UpdateApplicationType:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2234,6 +2234,9 @@ components:
         offenceId:
           type: string
           example: "M1502750438"
+        #BAIL-WIP - this should be a mandatory field once migration is complete in API & UI
+        applicationOrigin:
+          $ref: "#/components/schemas/ApplicationOrigin"
       required:
         - crn
     UpdateApplicationType:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2/Cas2ApplicationEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import io.mockk.mockk
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationAssignmentEntity
@@ -44,6 +45,9 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var preferredAreas: Yielded<String?> = { null }
   private var hdcEligibilityDate: Yielded<LocalDate?> = { null }
   private var conditionalReleaseDate: Yielded<LocalDate?> = { null }
+
+  private var applicationOrigin: Yielded<ApplicationOrigin> = { ApplicationOrigin.homeDetentionCurfew }
+  private var bailHearingDate: Yielded<LocalDate?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -150,6 +154,14 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.conditionalReleaseDate = { conditionalReleaseDate }
   }
 
+  fun withApplicationOrigin(applicationOrigin: ApplicationOrigin) = apply {
+    this.applicationOrigin = { applicationOrigin }
+  }
+
+  fun withBailHearingDate(bailHearingDate: LocalDate) = apply {
+    this.bailHearingDate = { bailHearingDate }
+  }
+
   override fun produce(): Cas2ApplicationEntity {
     val application = Cas2ApplicationEntity(
       id = this.id(),
@@ -172,6 +184,8 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
       hdcEligibilityDate = this.hdcEligibilityDate(),
       conditionalReleaseDate = this.conditionalReleaseDate(),
       preferredAreas = this.preferredAreas(),
+      applicationOrigin = this.applicationOrigin(),
+      bailHearingDate = this.bailHearingDate(),
     )
     return application
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2/Cas2ApplicationSummaryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas2/Cas2ApplicationSummaryEntityFactory.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
@@ -26,6 +27,7 @@ object Cas2ApplicationSummaryEntityFactory {
     referringPrisonCode: String = "LON",
     currentPrisonCode: String = referringPrisonCode,
     assignmentDate: OffsetDateTime = OffsetDateTime.now(),
+    applicationOrigin: ApplicationOrigin = ApplicationOrigin.homeDetentionCurfew,
   ) = Cas2ApplicationSummaryEntity(
     id = id,
     crn = crn,
@@ -43,5 +45,6 @@ object Cas2ApplicationSummaryEntityFactory {
     prisonCode = referringPrisonCode,
     currentPrisonCode = currentPrisonCode,
     assignmentDate = assignmentDate,
+    applicationOrigin = applicationOrigin.toString(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS2SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS2SubjectAccessRequestServiceTest.kt
@@ -288,7 +288,9 @@ class CAS2SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
       "telephone_number": "${application.telephoneNumber}",
       "hdc_eligibility_date": "$arrivedAtDateOnly",
       "conditional_release_date": "$arrivedAtDateOnly",
-      "abandoned_at": null
+      "abandoned_at": null,
+      "application_origin": "${application.applicationOrigin}",
+      "bail_hearing_date": null,
     }
   """.trimIndent()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationEntityTest.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
@@ -99,6 +101,83 @@ class Cas2ApplicationEntityTest : IntegrationTestBase() {
         assertThat(assignments.size).isEqualTo(2)
         assertThat(assignment2.id).isEqualTo(assignments[0].id)
         assertThat(assignment1.id).isEqualTo(assignments[1].id)
+      }
+    }
+  }
+
+  @Nested
+  inner class BailFields {
+
+    @Test
+    fun `test application origin persists`() {
+      val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+        withAddedAt(OffsetDateTime.now())
+        withId(UUID.randomUUID())
+      }
+
+      givenACas2PomUser { userEntity, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val applicationHDC = cas2ApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(userEntity)
+            withApplicationSchema(applicationSchema)
+          }
+          val applicationCourt = cas2ApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(userEntity)
+            withApplicationOrigin(ApplicationOrigin.courtBail)
+            withApplicationSchema(applicationSchema)
+          }
+          val applicationPrison = cas2ApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(userEntity)
+            withApplicationOrigin(ApplicationOrigin.prisonBail)
+            withApplicationSchema(applicationSchema)
+          }
+
+          cas2ApplicationRepository.save(applicationHDC)
+          cas2ApplicationRepository.save(applicationCourt)
+          cas2ApplicationRepository.save(applicationPrison)
+
+          val retrievedApplicationHDC = cas2ApplicationRepository.findById(applicationHDC.id).get()
+          val retrievedApplicationCourt = cas2ApplicationRepository.findById(applicationCourt.id).get()
+          val retrievedApplicationPrison = cas2ApplicationRepository.findById(applicationPrison.id).get()
+
+          assertThat(retrievedApplicationHDC.applicationOrigin).isEqualTo(ApplicationOrigin.homeDetentionCurfew)
+          assertThat(retrievedApplicationCourt.applicationOrigin).isEqualTo(ApplicationOrigin.courtBail)
+          assertThat(retrievedApplicationPrison.applicationOrigin).isEqualTo(ApplicationOrigin.prisonBail)
+        }
+      }
+    }
+
+    @Test
+    fun `test bail hearing is persisted if present`() {
+      val applicationSchema = cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+        withAddedAt(OffsetDateTime.now())
+        withId(UUID.randomUUID())
+      }
+
+      val now = OffsetDateTime.now().toLocalDate()
+
+      givenACas2PomUser { userEntity, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val applicationNoBailHearingDate = cas2ApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(userEntity)
+            withApplicationSchema(applicationSchema)
+          }
+
+          val applicationBailHearingDate = cas2ApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(userEntity)
+            withApplicationSchema(applicationSchema)
+            withBailHearingDate(now)
+          }
+
+          cas2ApplicationRepository.save(applicationNoBailHearingDate)
+          cas2ApplicationRepository.save(applicationBailHearingDate)
+
+          val retrievedApplicationNoBailHearingDate = cas2ApplicationRepository.findById(applicationNoBailHearingDate.id).get()
+          val retrievedApplicationBailHearingDate = cas2ApplicationRepository.findById(applicationBailHearingDate.id).get()
+
+          assertThat(retrievedApplicationNoBailHearingDate.bailHearingDate).isNull()
+          assertThat(retrievedApplicationBailHearingDate.bailHearingDate).isEqualTo(now)
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ApplicationTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssignmentType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ApplicationSummary
@@ -1805,6 +1806,50 @@ class Cas2ApplicationTest : IntegrationTestBase() {
   inner class PostToCreate {
 
     @Nested
+    inner class Cas2BailFields {
+      @Test
+      fun `Create new application for CAS-2 returns 201 with correct body - check that although we pass in prisonBail we will get out homeDetentionCurfew as this not written yet`() {
+        givenACas2PomUser { userEntity, jwt ->
+          givenAnOffender { offenderDetails, _ ->
+            val applicationSchema =
+              cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withAddedAt(OffsetDateTime.now())
+                withId(UUID.randomUUID())
+              }
+
+            // BAIL-WIP we are passing in ApplicationOrigin.prisonBail BUT WE KNOW that we have not implemented
+            // in the cas2 application service this to be set so it will default to homeDetentionCurfew/
+            val result = webTestClient.post()
+              .uri("/cas2/applications")
+              .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.cas2.value)
+              .bodyValue(
+                NewApplication(
+                  crn = offenderDetails.otherIds.crn,
+                  applicationOrigin = ApplicationOrigin.prisonBail,
+                ),
+              )
+              .exchange()
+              .expectStatus()
+              .isCreated
+              .returnResult(Cas2Application::class.java)
+
+            Assertions.assertThat(result.responseHeaders["Location"]).anyMatch {
+              it.matches(Regex("/cas2/applications/.+"))
+            }
+
+            assertThat(result.responseBody.blockFirst()).matches {
+              it.person.crn == offenderDetails.otherIds.crn &&
+                it.schemaVersion == applicationSchema.id &&
+                it.applicationOrigin == ApplicationOrigin.homeDetentionCurfew &&
+                it.bailHearingDate == null
+            }
+          }
+        }
+      }
+    }
+
+    @Nested
     inner class PomUsers {
       @Test
       fun `Create new application for CAS-2 returns 201 with correct body and Location header`() {
@@ -1975,6 +2020,56 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
   @Nested
   inner class PutToUpdate {
+
+    @Nested
+    inner class BailFields {
+      @Test
+      fun `Update existing CAS2 application returns 200 with correct body and bail fields`() {
+        givenACas2PomUser { submittingUser, jwt ->
+          givenAnOffender { offenderDetails, _ ->
+            val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+
+            val applicationSchema =
+              cas2ApplicationJsonSchemaEntityFactory.produceAndPersist {
+                withAddedAt(OffsetDateTime.now())
+                withId(UUID.randomUUID())
+                withSchema(
+                  schema,
+                )
+              }
+
+            cas2ApplicationEntityFactory.produceAndPersist {
+              withCrn(offenderDetails.otherIds.crn)
+              withId(applicationId)
+              withApplicationSchema(applicationSchema)
+              withCreatedByUser(submittingUser)
+            }
+
+            val resultBody = webTestClient.put()
+              .uri("/cas2/applications/$applicationId")
+              .header("Authorization", "Bearer $jwt")
+              .bodyValue(
+                UpdateCas2Application(
+                  data = mapOf("thingId" to 123),
+                  type = UpdateApplicationType.CAS2,
+                ),
+              )
+              .exchange()
+              .expectStatus()
+              .isOk
+              .returnResult(String::class.java)
+              .responseBody
+              .blockFirst()
+
+            val result = objectMapper.readValue(resultBody, Cas2Application::class.java)
+
+            assertThat(result.person.crn).isEqualTo(offenderDetails.otherIds.crn)
+            assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.homeDetentionCurfew)
+            assertThat(result.bailHearingDate).isNull()
+          }
+        }
+      }
+    }
 
     @Nested
     inner class PomUsers {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2ReportsTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas2.Cas2ApplicationStatusUpdatedEventDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.cas2.Cas2ApplicationSubmittedEventDetailsFactory
@@ -144,6 +145,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withData("{}")
         withSubmittedAt(oldSubmitted)
         withReferringPrisonCode("NEW")
+        withApplicationOrigin(ApplicationOrigin.prisonBail)
       }
 
       val application2 = cas2ApplicationEntityFactory.produceAndPersist {
@@ -155,6 +157,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withCreatedAt(newerCreated)
         withData("{}")
         withSubmittedAt(newerSubmitted)
+        withApplicationOrigin(ApplicationOrigin.courtBail)
       }
 
       val application1Assignment1 = Cas2ApplicationAssignmentEntity(
@@ -272,6 +275,8 @@ class Cas2ReportsTest : IntegrationTestBase() {
           submittedBy = event2Details.submittedBy.staffMember.username.toString(),
           startedAt = application2.createdAt.toString().split(".").first(),
           numberOfTransfers = "0",
+          applicationOrigin = application2.applicationOrigin,
+          bailHearingDate = null,
         ),
         SubmittedApplicationReportRow(
           eventId = event1Id.toString(),
@@ -286,6 +291,8 @@ class Cas2ReportsTest : IntegrationTestBase() {
           submittedBy = event1Details.submittedBy.staffMember.username.toString(),
           startedAt = application1.createdAt.toString().split(".").first(),
           numberOfTransfers = "1",
+          applicationOrigin = application1.applicationOrigin,
+          bailHearingDate = null,
         ),
       )
         .toDataFrame()
@@ -533,6 +540,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withCreatedAt(old.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
         withData("{}")
         withSubmittedAt(null)
+        withApplicationOrigin(ApplicationOrigin.homeDetentionCurfew)
       }
 
       val application2 = cas2ApplicationEntityFactory.produceAndPersist {
@@ -543,6 +551,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
         withCreatedAt(newer.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
         withData("{}")
         withSubmittedAt(null)
+        withApplicationOrigin(ApplicationOrigin.prisonBail)
       }
 
       // outside time limit -- should not feature in report
@@ -570,6 +579,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           personNoms = application2.nomsNumber.toString(),
           startedAt = application2.createdAt.toString().split(".").first(),
           startedBy = application2.createdByUser.nomisUsername,
+          applicationOrigin = application2.applicationOrigin,
         ),
         UnsubmittedApplicationsReportRow(
           applicationId = application1.id.toString(),
@@ -577,6 +587,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
           personNoms = application1.nomsNumber.toString(),
           startedAt = application1.createdAt.toString().split(".").first(),
           startedBy = application1.createdByUser.nomisUsername,
+          applicationOrigin = application1.applicationOrigin,
         ),
       )
         .toDataFrame()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2v2/Cas2v2ReportsTest.kt
@@ -559,7 +559,7 @@ class Cas2v2ReportsTest : Cas2v2IntegrationTestBase() {
         UnsubmittedApplicationsReportRow(
           applicationId = application2.id.toString(),
           personCrn = application2.crn,
-          applicationOrigin = ApplicationOrigin.prisonBail,
+          applicationOrigin = application2.applicationOrigin,
           personNoms = application2.nomsNumber.toString(),
           startedAt = application2.createdAt.toString().split(".").first() + 'Z',
           startedBy = application2.createdByUser.username,
@@ -570,6 +570,7 @@ class Cas2v2ReportsTest : Cas2v2IntegrationTestBase() {
           personNoms = application1.nomsNumber.toString(),
           startedAt = application1.createdAt.toString().split(".").first() + 'Z',
           startedBy = application1.createdByUser.username,
+          applicationOrigin = application1.applicationOrigin,
         ),
       )
         .toDataFrame()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/Cas2ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/Cas2ApplicationsTransformerTest.kt
@@ -56,7 +56,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary as DomainApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationSummary as DomainTemporaryAccommodationApplicationSummary
 
-class ApplicationsTransformerTest {
+class Cas2ApplicationsTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val mockRisksTransformer = mockk<RisksTransformer>()
   private val mockApAreaTransformer = mockk<ApAreaTransformer>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/Cas2ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/Cas2ApplicationsTransformerTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2StatusUpdate
@@ -28,8 +29,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OffenderManag
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NomisUserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.AssessmentsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.StatusUpdateTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.TimelineEventsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
@@ -37,7 +38,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class ApplicationsTransformerTest {
+class Cas2ApplicationsTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val mockNomisTransformer = mockk<NomisUserTransformer>()
   private val mockStatusUpdateTransformer = mockk<StatusUpdateTransformer>()
@@ -52,7 +53,7 @@ class ApplicationsTransformerTest {
     registerKotlinModule()
   }
 
-  private val applicationsTransformer = ApplicationsTransformer(
+  private val cas2ApplicationsTransformer = Cas2ApplicationsTransformer(
     objectMapper,
     mockPersonTransformer,
     mockNomisTransformer,
@@ -93,7 +94,7 @@ class ApplicationsTransformerTest {
         .withSubmittedAt(null)
         .produce()
 
-      val result = applicationsTransformer.transformJpaToApi(application, mockk())
+      val result = cas2ApplicationsTransformer.transformJpaToApi(application, mockk())
 
       assertThat(result).hasOnlyFields(
         "id",
@@ -116,6 +117,8 @@ class ApplicationsTransformerTest {
         "currentPrisonName",
         "isTransferredApplication",
         "omuEmailAddress",
+        "applicationOrigin",
+        "bailHearingDate",
       )
 
       assertThat(result.id).isEqualTo(application.id)
@@ -131,6 +134,8 @@ class ApplicationsTransformerTest {
       assertThat(result.currentPrisonName).isNull()
       assertThat(result.isTransferredApplication).isFalse()
       assertThat(result.omuEmailAddress).isNull()
+      assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.homeDetentionCurfew)
+      assertThat(result.bailHearingDate).isNull()
     }
 
     @Test
@@ -146,7 +151,7 @@ class ApplicationsTransformerTest {
         .withReferringPrisonCode("PRI")
         .withApplicationAssignments().produce()
 
-      val result = applicationsTransformer.transformJpaToApi(application, mockk())
+      val result = cas2ApplicationsTransformer.transformJpaToApi(application, mockk())
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
@@ -161,6 +166,8 @@ class ApplicationsTransformerTest {
       assertThat(result.currentPrisonName).isEqualTo(prison.prisonName)
       assertThat(result.isTransferredApplication).isFalse()
       assertThat(result.omuEmailAddress).isEqualTo(prison.email)
+      assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.homeDetentionCurfew)
+      assertThat(result.bailHearingDate).isNull()
     }
 
     @Test
@@ -186,7 +193,7 @@ class ApplicationsTransformerTest {
         .withApplicationAssignments()
         .produce()
 
-      val result = applicationsTransformer.transformJpaToApi(application, mockk())
+      val result = cas2ApplicationsTransformer.transformJpaToApi(application, mockk())
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.assessment!!.statusUpdates).hasSize(1).containsExactly(mockStatusUpdate)
@@ -207,7 +214,8 @@ class ApplicationsTransformerTest {
       every { mockAssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns assessment
       every { nomisUserService.getNomisUserById(any()) } returns user
       val prison = OffenderManagementUnitEntityFactory().produce()
-      val newPrison = OffenderManagementUnitEntityFactory().withPrisonCode("NEW").withPrisonName("New Prison").withEmail("test@test.co.uk").produce()
+      val newPrison = OffenderManagementUnitEntityFactory().withPrisonCode("NEW").withPrisonName("New Prison")
+        .withEmail("test@test.co.uk").produce()
       every { offenderManagementUnitRepository.findByPrisonCode(eq(prison.prisonCode)) } returns prison
       every { offenderManagementUnitRepository.findByPrisonCode(eq(newPrison.prisonCode)) } returns newPrison
 
@@ -216,9 +224,17 @@ class ApplicationsTransformerTest {
         .withReferringPrisonCode(prison.prisonCode)
         .withApplicationAssignments().produce()
 
-      application.applicationAssignments.add(Cas2ApplicationAssignmentEntity(UUID.randomUUID(), application, newPrison.prisonCode, null, OffsetDateTime.now()))
+      application.applicationAssignments.add(
+        Cas2ApplicationAssignmentEntity(
+          UUID.randomUUID(),
+          application,
+          newPrison.prisonCode,
+          null,
+          OffsetDateTime.now(),
+        ),
+      )
 
-      val result = applicationsTransformer.transformJpaToApi(application, mockk())
+      val result = cas2ApplicationsTransformer.transformJpaToApi(application, mockk())
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
@@ -233,6 +249,59 @@ class ApplicationsTransformerTest {
       assertThat(result.currentPrisonName).isEqualTo(newPrison.prisonName)
       assertThat(result.isTransferredApplication).isTrue()
       assertThat(result.omuEmailAddress).isEqualTo(newPrison.email)
+    }
+
+    @Test
+    fun `check bail fields transformed correctly`() {
+      val now = OffsetDateTime.now().toLocalDate()
+      val application = cas2ApplicationFactory
+        .withSubmittedAt(null)
+        .withApplicationOrigin(ApplicationOrigin.courtBail)
+        .withBailHearingDate(now)
+        .produce()
+
+      val result = cas2ApplicationsTransformer.transformJpaToApi(application, mockk())
+
+      assertThat(result).hasOnlyFields(
+        "id",
+        "person",
+        "createdBy",
+        "schemaVersion",
+        "outdatedSchema",
+        "createdAt",
+        "submittedAt",
+        "data",
+        "document",
+        "status",
+        "type",
+        "telephoneNumber",
+        "assessment",
+        "timelineEvents",
+        "allocatedPomEmailAddress",
+        "allocatedPomName",
+        "assignmentDate",
+        "currentPrisonName",
+        "isTransferredApplication",
+        "omuEmailAddress",
+        "applicationOrigin",
+        "bailHearingDate",
+      )
+
+      assertThat(result.id).isEqualTo(application.id)
+      assertThat(result.createdBy.id).isEqualTo(user.id)
+      assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
+      assertThat(result.timelineEvents).isEqualTo(listOf<Cas2TimelineEvent>())
+
+      // these are assigned after an application is submitted
+      assertThat(result.submittedAt).isNull()
+      assertThat(result.allocatedPomEmailAddress).isNull()
+      assertThat(result.allocatedPomName).isNull()
+      assertThat(result.assignmentDate).isNull()
+      assertThat(result.currentPrisonName).isNull()
+      assertThat(result.isTransferredApplication).isFalse()
+      assertThat(result.omuEmailAddress).isNull()
+      assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.courtBail)
+      assertThat(result.bailHearingDate).isEqualTo(now)
     }
   }
 
@@ -255,6 +324,8 @@ class ApplicationsTransformerTest {
       allocatedPomName = "${randomStringUpperCase(8)} ${randomStringUpperCase(6)}",
       currentPrisonCode = prisonCode,
       assignmentDate = OffsetDateTime.now(),
+      // BAIL-WIP - come back and check application summary view
+      applicationOrigin = ApplicationOrigin.prisonBail.toString(),
     )
 
     @Test
@@ -266,7 +337,7 @@ class ApplicationsTransformerTest {
       val prison = OffenderManagementUnitEntityFactory().produce()
       every { offenderManagementUnitRepository.findByPrisonCode(any()) } returns prison
 
-      val result = applicationsTransformer.transformJpaSummaryToSummary(
+      val result = cas2ApplicationsTransformer.transformJpaSummaryToSummary(
         application,
         "firstName surname",
       )
@@ -280,6 +351,8 @@ class ApplicationsTransformerTest {
       assertThat(result.hdcEligibilityDate).isNull()
       assertThat(result.latestStatusUpdate).isNull()
       assertThat(result.createdByUserName).isEqualTo(application.userName)
+      assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.homeDetentionCurfew)
+      assertThat(result.bailHearingDate).isNull()
     }
 
     @Test
@@ -293,7 +366,7 @@ class ApplicationsTransformerTest {
         label = application.latestStatusUpdateLabel!!,
       )
 
-      val result = applicationsTransformer.transformJpaSummaryToSummary(
+      val result = cas2ApplicationsTransformer.transformJpaSummaryToSummary(
         application,
         "firstName surname",
       )
@@ -328,12 +401,47 @@ class ApplicationsTransformerTest {
         label = application.latestStatusUpdateLabel!!,
       )
 
-      val result = applicationsTransformer.transformJpaSummaryToSummary(
+      val result = cas2ApplicationsTransformer.transformJpaSummaryToSummary(
         application,
         "firstName surname",
       )
 
       assertThat(result.currentPrisonName).isEqualTo(application.currentPrisonCode)
+    }
+
+    @Test
+    fun `check bail fields transformed correctly`() {
+      every { offenderManagementUnitRepository.findByPrisonCode(any()) } returns null
+
+      val now = OffsetDateTime.now().toLocalDate()
+      val applicationSummary = Cas2ApplicationSummaryEntity(
+        id = UUID.fromString("2f838a8c-dffc-48a3-9536-f0e95985e809"),
+        crn = "CRNNUM",
+        nomsNumber = "NOMNUM",
+        userId = "836a9460-b177-433a-a0d9-262509092c9f",
+        userName = "first last",
+        createdAt = OffsetDateTime.parse("2023-04-19T13:25:00+01:00"),
+        submittedAt = OffsetDateTime.parse("2023-04-19T13:25:30+01:00"),
+        hdcEligibilityDate = LocalDate.parse("2023-04-29"),
+        latestStatusUpdateStatusId = "ae544aee-7170-4794-99fb-703090cbc7db",
+        latestStatusUpdateLabel = "my latest status update",
+        prisonCode = "BRI",
+        allocatedPomUserId = UUID.randomUUID(),
+        allocatedPomName = "${randomStringUpperCase(8)} ${randomStringUpperCase(6)}",
+        currentPrisonCode = "BRI",
+        assignmentDate = OffsetDateTime.now(),
+        applicationOrigin = ApplicationOrigin.prisonBail.toString(),
+        bailHearingDate = now,
+      )
+
+      val result = cas2ApplicationsTransformer.transformJpaSummaryToSummary(
+        applicationSummary,
+        "firstName surname",
+      )
+
+      assertThat(result.id).isEqualTo(applicationSummary.id)
+      assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.prisonBail)
+      assertThat(result.bailHearingDate).isEqualTo(now)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2V2ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2V2ApplicationsTransformerTest.kt
@@ -32,7 +32,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class Cas2v2ApplicationsTransformerTest {
+class Cas2V2ApplicationsTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val mockCas2v2UserTransformer = mockk<Cas2v2UserTransformer>()
   private val mockCas2v2StatusUpdateTransformer = mockk<Cas2v2StatusUpdateTransformer>()


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CBA-590

https://dsdmoj.atlassian.net/browse/CBA-626

https://dsdmoj.atlassian.net/browse/CBA-629

https://dsdmoj.atlassian.net/browse/CBA-639

This adds persistence for the new bail fields across cas2 application entities and summaries. It updates the application entity, transformer, service and controller.

There is a new value called applicationOrigin. This is populated in the 2 services with one of three values identifying the type of CAS2 application. This is already being prepopulated in CAS2 HDC - More info https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/5338431579/ADR+CAS2+Data+Change+-+Application+Origin

There is a new value called bailHearingDate. This is solely for CAS2 Bail so should be nullable. This is a primary value on the entities as it is surfaced more often and used in prioritisation - More info https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/5380473639/ADR+CAS2+Bail+data+change+-+Bail+hearing+data