### PR TITLE
Bedspace model refactor - migrate data to new cas3_premises table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3PremisesEntity.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
+import java.util.UUID
+
+@SuppressWarnings("LongParameterList")
+@Entity
+@Table(name = "cas3_premises")
+@Inheritance(strategy = InheritanceType.JOINED)
+class Cas3PremisesEntity(
+  @Id
+  val id: UUID,
+  var name: String,
+  var postcode: String,
+  var addressLine1: String,
+  var addressLine2: String?,
+  var town: String?,
+
+  @ManyToOne
+  @JoinColumn(name = "probation_delivery_unit_id")
+  var probationDeliveryUnit: ProbationDeliveryUnitEntity,
+
+  @ManyToOne
+  @JoinColumn(name = "local_authority_area_id")
+  var localAuthorityArea: LocalAuthorityAreaEntity?,
+
+  @Enumerated(value = EnumType.STRING)
+  var status: PropertyStatus,
+  var notes: String,
+)
+
+@Repository
+interface Cas3PremisesRepository : JpaRepository<Cas3PremisesEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationInBatchesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationInBatchesJob.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration
+
+import org.springframework.transaction.support.TransactionTemplate
+
+abstract class MigrationInBatchesJob(
+  private val migrationLogger: MigrationLogger,
+  private val transactionTemplate: TransactionTemplate,
+) : MigrationJob() {
+
+  @SuppressWarnings("MagicNumber")
+  protected fun <T> processInBatches(
+    items: List<T>,
+    batchSize: Int,
+    processBatch: (List<T>) -> Unit,
+  ) {
+    items.chunked(batchSize).forEachIndexed { index, batch ->
+      migrationLogger.info("Processing batch ${index + 1} of ${items.size / batchSize}...")
+      transactionTemplate.executeWithoutResult {
+        processBatch(batch)
+      }
+      if (index < items.chunked(batchSize).lastIndex) {
+        Thread.sleep(1000L)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1Updat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas2.Cas2AssessmentMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas2.Cas2NoteMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas2.Cas2StatusUpdateMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3MigrateNewBedspaceModelDataJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateApplicationOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob
 import kotlin.reflect.KClass
@@ -55,6 +56,7 @@ class MigrationJobService(
         MigrationJobType.cas1ApprovedPremisesAssessmentReportProperties -> getBean(Cas1UpdateAssessmentReportPropertiesJob::class)
         MigrationJobType.cas1RoomCodes -> getBean(Cas1UpdateRoomCodesJob::class)
         MigrationJobType.cas1ApplicationsWithOffender -> getBean(Cas1UpdateApprovedPremisesApplicationWithOffenderJob::class)
+        MigrationJobType.cas3BedspaceModelData -> getBean(Cas3MigrateNewBedspaceModelDataJob::class)
       }
 
       if (job.shouldRunInTransaction) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3MigrateNewBedspaceModelDataJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3MigrateNewBedspaceModelDataJob.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationInBatchesJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import java.util.UUID
+
+@Component
+class Cas3MigrateNewBedspaceModelDataJob(
+  private val temporaryAccommodationPremisesRepository: TemporaryAccommodationPremisesRepository,
+  private val cas3PremisesRepository: Cas3PremisesRepository,
+  private val migrationLogger: MigrationLogger,
+  transactionTemplate: TransactionTemplate,
+) : MigrationInBatchesJob(migrationLogger, transactionTemplate) {
+  override val shouldRunInTransaction: Boolean = java.lang.Boolean.FALSE
+
+  override fun process(pageSize: Int) {
+    migrationLogger.info("Starting migration process...")
+    val cas3PremisesIds = temporaryAccommodationPremisesRepository.findTemporaryAccommodationPremisesIds()
+    super.processInBatches(cas3PremisesIds, batchSize = 100) { batchIds ->
+      migrateDataToNewBedspaceModelTables(batchIds)
+    }
+    migrationLogger.info("Completed migration process...")
+  }
+
+  private fun migrateDataToNewBedspaceModelTables(premiseIds: List<UUID>) {
+    migrationLogger.info("Starting bedspace model migration with batch size of ${premiseIds.size}...")
+    migrateDataToCas3Premises(premiseIds)
+    migrationLogger.info("Migrated batch size of ${premiseIds.size} to new cas3_premises table - data migrated from the premises and temporary_accommodation tables.")
+  }
+
+  private fun migrateDataToCas3Premises(premiseIds: List<UUID>) {
+    val temporaryAccommodationPremisesBatch = temporaryAccommodationPremisesRepository.findTemporaryAccommodationPremisesByIds(premiseIds)
+    val cas3Premises = transformCas3PremisesBatch(temporaryAccommodationPremisesBatch)
+    cas3PremisesRepository.saveAllAndFlush(cas3Premises)
+  }
+
+  private fun transformCas3PremisesBatch(temporaryAccommodationPremisesBatch: List<TemporaryAccommodationPremisesEntity>) = temporaryAccommodationPremisesBatch.map { premise ->
+    Cas3PremisesEntity(
+      id = premise.id,
+      name = premise.name,
+      postcode = premise.postcode,
+      addressLine1 = premise.addressLine1,
+      addressLine2 = premise.addressLine2,
+      town = premise.town,
+      localAuthorityArea = premise.localAuthorityArea,
+      status = premise.status,
+      notes = premise.notes,
+      probationDeliveryUnit = premise.probationDeliveryUnit!!,
+    )
+  }
+}
+
+@Repository
+interface TemporaryAccommodationPremisesRepository : JpaRepository<TemporaryAccommodationPremisesEntity, UUID> {
+  @Query("SELECT tap.id FROM TemporaryAccommodationPremisesEntity tap")
+  fun findTemporaryAccommodationPremisesIds(): List<UUID>
+
+  @Query("SELECT tap FROM TemporaryAccommodationPremisesEntity tap WHERE tap.id IN :ids")
+  fun findTemporaryAccommodationPremisesByIds(ids: List<UUID>): List<TemporaryAccommodationPremisesEntity>
+}

--- a/src/main/resources/db/migration/all/20250527172300__cas3_premises_table.sql
+++ b/src/main/resources/db/migration/all/20250527172300__cas3_premises_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE cas3_premises(
+    id                              UUID not null,
+    name                            TEXT not null,
+    postcode                        TEXT not null,
+    probation_delivery_unit_id      UUID not null,
+    local_authority_area_id         UUID,
+    address_line1                   TEXT not null,
+    address_line2                   TEXT,
+    town                            TEXT,
+    status                          TEXT default 'active'::TEXT not null,
+    notes                           TEXT,
+    created_at                      TIMESTAMP WITH TIME ZONE default now(),
+    last_updated_at                 TIMESTAMP WITH TIME ZONE default now(),
+    FOREIGN KEY (probation_delivery_unit_id)    REFERENCES probation_delivery_units(id),
+    FOREIGN KEY (local_authority_area_id)       REFERENCES local_authority_areas(id),
+    PRIMARY KEY(id)
+);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3363,6 +3363,7 @@ components:
         - update_cas1_approved_premises_assessment_report_properties
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
+        - update_cas3_bedspace_model_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6647,6 +6647,7 @@ components:
         - update_cas1_approved_premises_assessment_report_properties
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
+        - update_cas3_bedspace_model_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5677,6 +5677,7 @@ components:
         - update_cas1_approved_premises_assessment_report_properties
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
+        - update_cas3_bedspace_model_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3887,6 +3887,7 @@ components:
         - update_cas1_approved_premises_assessment_report_properties
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
+        - update_cas3_bedspace_model_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3898,6 +3898,7 @@ components:
         - update_cas1_approved_premises_assessment_report_properties
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
+        - update_cas3_bedspace_model_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3734,6 +3734,7 @@ components:
         - update_cas1_approved_premises_assessment_report_properties
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
+        - update_cas3_bedspace_model_data
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -206,6 +206,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Chan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
@@ -574,6 +575,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var mockFeatureFlagService: MockFeatureFlagService
+
+  @Autowired
+  lateinit var cas3PremisesRepository: Cas3PremisesRepository
 
   lateinit var offenderManagementUnitEntityFactory: PersistedFactory<OffenderManagementUnitEntity, UUID, OffenderManagementUnitEntityFactory>
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3MigrateNewBedspaceModelDataJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3MigrateNewBedspaceModelDataJobTest.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJobService
+
+const val NO_OF_PREMISES_TO_MIGRATE = 110
+
+class Cas3MigrateNewBedspaceModelDataJobTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+  lateinit var temporaryAccommodationPremises: List<TemporaryAccommodationPremisesEntity>
+
+  @BeforeEach
+  fun setupDataRequiredForDataMigrationToBedspaceModelTables() {
+    temporaryAccommodationPremises = generateSequence {
+      temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        val probationRegion = givenAProbationRegion()
+        withProbationRegion(probationRegion)
+        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        withProbationDeliveryUnit(
+          probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(probationRegion)
+          },
+        )
+      }
+    }.take(NO_OF_PREMISES_TO_MIGRATE).toList()
+  }
+
+  @Test
+  fun `should migrate all data required to new cas3 bedspace model tables and running the job twice`() {
+    migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceModelData, 1)
+    val migratedPremises = assertExpectedNumberOfPremisesWereMigrated()
+    assertThatAllCas3PremisesDataWasMigratedSuccessfully(migratedPremises)
+  }
+
+  @Test
+  fun `running the migration job twice does not create duplicate rows`() {
+    migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceModelData, 1)
+    var migratedPremises = assertExpectedNumberOfPremisesWereMigrated()
+    assertThatAllCas3PremisesDataWasMigratedSuccessfully(migratedPremises)
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceModelData, 1)
+    migratedPremises = assertExpectedNumberOfPremisesWereMigrated()
+    assertThatAllCas3PremisesDataWasMigratedSuccessfully(migratedPremises)
+  }
+
+  private fun assertExpectedNumberOfPremisesWereMigrated(): List<Cas3PremisesEntity> {
+    val migratedPremises = cas3PremisesRepository.findAll()
+    assertThat(migratedPremises.size).isEqualTo(NO_OF_PREMISES_TO_MIGRATE)
+    return migratedPremises
+  }
+
+  private fun assertThatAllCas3PremisesDataWasMigratedSuccessfully(migratedPremises: List<Cas3PremisesEntity>) {
+    migratedPremises.forEach { migratedPremise ->
+      val tap = temporaryAccommodationPremises.firstOrNull { it.id == migratedPremise.id }!!
+      assertThatPremisesMatch(
+        cas3PremisesEntity = migratedPremise,
+        temporaryAccommodationPremisesEntity = tap,
+      )
+    }
+  }
+
+  private fun assertThatPremisesMatch(cas3PremisesEntity: Cas3PremisesEntity, temporaryAccommodationPremisesEntity: TemporaryAccommodationPremisesEntity) {
+    assertThat(cas3PremisesEntity.name).isEqualTo(temporaryAccommodationPremisesEntity.name)
+    assertThat(cas3PremisesEntity.postcode).isEqualTo(temporaryAccommodationPremisesEntity.postcode)
+    assertThat(cas3PremisesEntity.addressLine1).isEqualTo(temporaryAccommodationPremisesEntity.addressLine1)
+    assertThat(cas3PremisesEntity.addressLine2).isEqualTo(temporaryAccommodationPremisesEntity.addressLine2)
+    assertThat(cas3PremisesEntity.town).isEqualTo(temporaryAccommodationPremisesEntity.town)
+    assertThat(cas3PremisesEntity.probationDeliveryUnit).isEqualTo(temporaryAccommodationPremisesEntity.probationDeliveryUnit)
+    assertThat(cas3PremisesEntity.localAuthorityArea?.id).isEqualTo(temporaryAccommodationPremisesEntity.localAuthorityArea?.id)
+    assertThat(cas3PremisesEntity.status).isEqualTo(temporaryAccommodationPremisesEntity.status)
+    assertThat(cas3PremisesEntity.notes).isEqualTo(temporaryAccommodationPremisesEntity.notes)
+  }
+}


### PR DESCRIPTION
JIRA: https://dsdmoj.atlassian.net/browse/CAS-1569

## Context

We are trying to gradually create the tables required for this new database architecture and migrate the data:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

## PR includes

* Create the new `cas3_premises` table using flyway
* Create an entity and repository for this new table
* Migrate the CAS3 related data from the `premises` and `temporary_accomodation_premises` into our new new `cas3_premises` table