### PR TITLE
test(no-ticket): fixed file name for transformer test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2v2/Cas2v2ApplicationTransformerTest.kt
@@ -32,7 +32,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class Cas2v2ApplicationsTransformerTest {
+class Cas2v2ApplicationTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
   private val mockCas2v2UserTransformer = mockk<Cas2v2UserTransformer>()
   private val mockCas2v2StatusUpdateTransformer = mockk<Cas2v2StatusUpdateTransformer>()


### PR DESCRIPTION
This one's a beauty. The linter was failing because the file named Cas2V2ApplicationsTransformerTest.kt contains the class Cas2v2ApplicationsTransformerTest.

Fair enough, so the file was renamed to Cas2v2ApplicationsTransformerTest.kt in line with the other files in the test suite. The linter was re-run and it failed again. The file of that name is not present on the file system:

```
find . -name Cas2V2ApplicationsTransformerTest.kt
```

The linter insists the file is named wrong.

APFS is case in-sensitive, I couldn't find a way to rename the file in place so I've renamed the file to a*new* filename.