### PR TITLE
Cas2UserEntity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2ApplicationEntity.kt
@@ -22,6 +22,7 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2.Cas2UserEntity
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -88,9 +89,14 @@ data class Cas2ApplicationEntity(
 
   val crn: String,
 
+  // BAIL-WIP - When start to create application for delius users, this will need to be nullable, but that creates cas2cade effects whenever we us code like `staffIdentifier = application.createdByUser.nomisStaffId`,`
   @ManyToOne
   @JoinColumn(name = "created_by_user_id")
   val createdByUser: NomisUserEntity,
+
+  @ManyToOne
+  @JoinColumn(name = "created_by_cas2_user_id")
+  val createdByCas2User: Cas2UserEntity? = null,
 
   @Type(JsonType::class)
   var data: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2/Cas2UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2/Cas2UserEntity.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2
+
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.converter.StringListConverter
+import java.time.OffsetDateTime
+import java.util.UUID
+
+enum class Cas2UserType(val authSource: String) {
+  DELIUS("delius"),
+  NOMIS("nomis"),
+  EXTERNAL("auth"),
+  ;
+
+  companion object {
+    fun fromString(authSource: String): Cas2UserType = entries.first { it.authSource == authSource }
+  }
+}
+
+@Repository
+interface Cas2UserRepository : JpaRepository<Cas2UserEntity, UUID> {
+  fun findByUsername(username: String): Cas2UserEntity?
+  fun findByUsernameAndUserType(username: String, type: Cas2UserType): Cas2UserEntity?
+}
+
+@Entity
+@Table(name = "cas_2_users")
+data class Cas2UserEntity(
+  @Id
+  val id: UUID,
+  val username: String,
+
+  // Cas2v2User interface implementation
+  var email: String?,
+  var name: String,
+
+  @Enumerated(EnumType.STRING)
+  var userType: Cas2UserType,
+
+  // Nomis specific fields that are only expected to have values if the
+  // accountType is Cas2v2UserType.NOMIS
+  var nomisStaffId: Long? = null,
+  var activeNomisCaseloadId: String? = null,
+
+  // Delius specific fields that are only expected to have values if the
+  // accountType is Cas2v2UserType.DELIUS
+  @Convert(converter = StringListConverter::class)
+  var deliusTeamCodes: List<String>?,
+  var deliusStaffCode: String?,
+
+  var isEnabled: Boolean,
+  var isActive: Boolean,
+
+  @CreationTimestamp
+  private val createdAt: OffsetDateTime? = null,
+
+  @OneToMany(mappedBy = "createdByCas2User")
+  val applications: MutableList<Cas2ApplicationEntity> = mutableListOf(),
+) {
+  override fun toString() = "CAS2 user $id"
+
+  fun staffIdentifier() = when (userType) {
+    Cas2UserType.NOMIS -> nomisStaffId?.toString() ?: error("Couldn't resolve nomis ID for user $id")
+    Cas2UserType.DELIUS -> deliusStaffCode ?: error("Couldn't resolve delius ID for user $id")
+    Cas2UserType.EXTERNAL -> ""
+  }
+
+  fun isExternal() = userType == Cas2UserType.EXTERNAL
+}

--- a/src/main/resources/db/migration/all/20250523095335__add_cas2_user_to_the_cas2_application.sql
+++ b/src/main/resources/db/migration/all/20250523095335__add_cas2_user_to_the_cas2_application.sql
@@ -1,0 +1,28 @@
+-- Create the new cas2 user table
+CREATE TABLE cas_2_users
+(
+    id                       UUID    NOT NULL,
+    name                     TEXT    NOT NULL,
+    username                 TEXT    NOT NULL,
+    email                    TEXT,
+    user_type                TEXT    NOT NULL,
+    nomis_staff_id           BIGINT,
+    active_nomis_caseload_id TEXT,
+    delius_staff_code        TEXT,
+    delius_team_codes        TEXT,
+    is_enabled               BOOLEAN NOT NULL,
+    is_active                BOOLEAN NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL,
+    CONSTRAINT pk_cas_2_users PRIMARY KEY (id)
+);
+
+
+
+-- Add the new cas2 user to the existing cas2 applications table
+ALTER TABLE cas_2_applications ADD created_by_cas2_user_id UUID;
+
+
+
+-- Add the FK constraints to the applications table
+ALTER TABLE cas_2_applications
+    ADD CONSTRAINT FK_CAS_2_APPLICATIONS_ON_CREATED_BY_USER FOREIGN KEY (created_by_cas2_user_id) REFERENCES cas_2_users (id);

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1545,6 +1545,36 @@ components:
         - username
         - authSource
         - isActive
+    Cas2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
     Cas2v2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/cas2-schemas.yml
+++ b/src/main/resources/static/cas2-schemas.yml
@@ -38,6 +38,8 @@ components:
           properties:
             createdBy:
               $ref: '_shared.yml#/components/schemas/NomisUser'
+            cas2CreatedBy:
+              $ref: '_shared.yml#/components/schemas/Cas2User'
             schemaVersion:
               type: string
               format: uuid

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4829,6 +4829,36 @@ components:
         - username
         - authSource
         - isActive
+    Cas2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
     Cas2v2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3845,6 +3845,36 @@ components:
         - username
         - authSource
         - isActive
+    Cas2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
     Cas2v2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2069,6 +2069,36 @@ components:
         - username
         - authSource
         - isActive
+    Cas2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
     Cas2v2StatusUpdate:
       type: object
       properties:
@@ -4957,6 +4987,8 @@ components:
           properties:
             createdBy:
               $ref: '#/components/schemas/NomisUser'
+            cas2CreatedBy:
+              $ref: '#/components/schemas/Cas2User'
             schemaVersion:
               type: string
               format: uuid

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -2080,6 +2080,36 @@ components:
         - username
         - authSource
         - isActive
+    Cas2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
     Cas2v2StatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -1916,6 +1916,36 @@ components:
         - username
         - authSource
         - isActive
+    Cas2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
     Cas2v2StatusUpdate:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/Cas2ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas2/Cas2ApplicationsTransformerTest.kt
@@ -119,6 +119,7 @@ class Cas2ApplicationsTransformerTest {
         "omuEmailAddress",
         "applicationOrigin",
         "bailHearingDate",
+        "cas2CreatedBy",
       )
 
       assertThat(result.id).isEqualTo(application.id)
@@ -285,6 +286,7 @@ class Cas2ApplicationsTransformerTest {
         "omuEmailAddress",
         "applicationOrigin",
         "bailHearingDate",
+        "cas2CreatedBy",
       )
 
       assertThat(result.id).isEqualTo(application.id)


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CBA-646

The current cas2 application entity has a field that records created by user, currently this is a nomis user, we need it to support delius users. In the cas2v2 system it leverages a new user entity (cas2 user) which is able to accept either auth source as a user type.

To compound this nomis users are identified by a primary identifier of a number (long) and delius users are identified by an alphanumeric (string).

Changing the user type of created by users in the cas2 application would involve a high degree of risk as all existing, nomis based, applications would need to be migrated to the new user type.

To mitigate this we propose to add a field to the cas2 application of type cas2user that supports both nomis and delius user.

All new applications will use the new cas2 user to store the created by field, identified by a UUID, leaving the nomis user field blank. When referrer information is attached to applications the API would use the cas2 user to find the referrer details, supporting both nomis and delius auth sources. If that search fails it will then use the existing nomis user id, in the nomis user field to located referrer details.

This will support existing applications by using the existing fields and ids, and support new applications that may have a referer source of delius.

In the initial phase of this transition we will need to keep the nomis field on applications and add the new cas2 user to it. The current services are unaware of the change and will continue to only support nomis originated referrers for now. The next step is to update the services and dependent entities to support the cas2 user, while failing over to the nomis user if the cas2 user is not populated. Again this will allow the current cas2 system to function without needing to be changed for nomis based referees.

 - [x] cas2 e2e tests passed
 - [x] cas2v2 e2e tests passed