### PR TITLE
CAS-536: Remove PDU from temporary_accommodation_applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -512,7 +512,6 @@ class ApplicationsController(
     eligibilityReason = submitApplication.eligibilityReason,
     dutyToReferLocalAuthorityAreaName = submitApplication.dutyToReferLocalAuthorityAreaName,
     personReleaseDate = submitApplication.personReleaseDate,
-    pdu = submitApplication.pdu,
     probationDeliveryUnitId = submitApplication.probationDeliveryUnitId,
     isHistoryOfSexualOffence = submitApplication.isHistoryOfSexualOffence,
     isConcerningSexualBehaviour = submitApplication.isConcerningSexualBehaviour,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -522,7 +522,6 @@ class TemporaryAccommodationApplicationEntity(
   var dutyToReferLocalAuthorityAreaName: String?,
   var prisonNameOnCreation: String?,
   var personReleaseDate: LocalDate?,
-  var pdu: String?,
   var name: String?,
   var prisonReleaseTypes: String?,
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CAS3SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CAS3SubjectAccessRequestRepository.kt
@@ -38,7 +38,7 @@ class CAS3SubjectAccessRequestRepository(
              taa.prison_name_on_creation,
              taa.prison_release_types,
              taa.person_release_date,
-             taa.pdu,
+             pdu.name as pdu,
              taa.needs_accessible_property,
              taa.has_history_of_arson,
              taa.is_registered_sex_offender,
@@ -47,11 +47,10 @@ class CAS3SubjectAccessRequestRepository(
              taa.is_concerning_arson_behaviour
         from
              temporary_accommodation_applications taa
-        inner join applications a on
-        	a.id = taa.id
-        inner join users u on
-        	u.id = a.created_by_user_id
+        inner join applications a on a.id = taa.id
+        inner join users u on u.id = a.created_by_user_id
         inner join probation_regions pr on pr.id = taa.probation_region_id
+        left join probation_delivery_units pdu on pdu.id = taa.probation_delivery_unit_id
         where
         	(a.crn = :crn
         		or a.noms_number = :noms_number )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -415,7 +415,6 @@ class ApplicationService(
     dutyToReferOutcome = null,
     prisonNameOnCreation = prisonName,
     personReleaseDate = null,
-    pdu = null,
     name = "${offenderDetails.firstName} ${offenderDetails.surname}",
     isHistoryOfSexualOffence = null,
     isConcerningSexualBehaviour = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3ApplicationService.kt
@@ -97,7 +97,6 @@ class Cas3ApplicationService(
       eligibilityReason = submitApplication.eligibilityReason
       dutyToReferLocalAuthorityAreaName = submitApplication.dutyToReferLocalAuthorityAreaName
       personReleaseDate = submitApplication.personReleaseDate
-      pdu = submitApplication.pdu
       prisonReleaseTypes = submitApplication.prisonReleaseTypes?.joinToString(",")
       probationDeliveryUnit = submitApplication.probationDeliveryUnitId?.let {
         probationDeliveryUnitRepository.findByIdOrNull(it)

--- a/src/main/resources/db/migration/all/2025052713485000__drop_pdu_from_temporary_accommodation_applications.sql
+++ b/src/main/resources/db/migration/all/2025052713485000__drop_pdu_from_temporary_accommodation_applications.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE temporary_accommodation_applications
+DROP COLUMN IF EXISTS pdu;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2078,8 +2078,6 @@ components:
               type: string
               format: date
               example: '2024-02-21'
-            pdu:
-              type: string
             probationDeliveryUnitId:
               type: string
               format: uuid
@@ -2097,6 +2095,7 @@ components:
             summaryData:
               $ref: '#/components/schemas/Unit'
           required:
+            - probationDeliveryUnitId
             - arrivalDate
             - summaryData
     ReleaseTypeOption:

--- a/src/main/resources/static/cas3-schemas.yml
+++ b/src/main/resources/static/cas3-schemas.yml
@@ -131,8 +131,6 @@ components:
           type: string
           format: date
           example: '2024-02-21'
-        pdu:
-          type: string
         probationDeliveryUnitId:
           type: string
           format: uuid
@@ -152,6 +150,7 @@ components:
         translatedDocument:
           $ref: '_shared.yml#/components/schemas/Unit'
       required:
+        - probationDeliveryUnitId
         - arrivalDate
         - summaryData
     FutureBooking:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -5362,8 +5362,6 @@ components:
               type: string
               format: date
               example: '2024-02-21'
-            pdu:
-              type: string
             probationDeliveryUnitId:
               type: string
               format: uuid
@@ -5381,6 +5379,7 @@ components:
             summaryData:
               $ref: '#/components/schemas/Unit'
           required:
+            - probationDeliveryUnitId
             - arrivalDate
             - summaryData
     ReleaseTypeOption:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4392,8 +4392,6 @@ components:
               type: string
               format: date
               example: '2024-02-21'
-            pdu:
-              type: string
             probationDeliveryUnitId:
               type: string
               format: uuid
@@ -4411,6 +4409,7 @@ components:
             summaryData:
               $ref: '#/components/schemas/Unit'
           required:
+            - probationDeliveryUnitId
             - arrivalDate
             - summaryData
     ReleaseTypeOption:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2602,8 +2602,6 @@ components:
               type: string
               format: date
               example: '2024-02-21'
-            pdu:
-              type: string
             probationDeliveryUnitId:
               type: string
               format: uuid
@@ -2621,6 +2619,7 @@ components:
             summaryData:
               $ref: '#/components/schemas/Unit'
           required:
+            - probationDeliveryUnitId
             - arrivalDate
             - summaryData
     ReleaseTypeOption:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -2613,8 +2613,6 @@ components:
               type: string
               format: date
               example: '2024-02-21'
-            pdu:
-              type: string
             probationDeliveryUnitId:
               type: string
               format: uuid
@@ -2632,6 +2630,7 @@ components:
             summaryData:
               $ref: '#/components/schemas/Unit'
           required:
+            - probationDeliveryUnitId
             - arrivalDate
             - summaryData
     ReleaseTypeOption:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2503,8 +2503,6 @@ components:
               type: string
               format: date
               example: '2024-02-21'
-            pdu:
-              type: string
             probationDeliveryUnitId:
               type: string
               format: uuid
@@ -2522,6 +2520,7 @@ components:
             summaryData:
               $ref: '#/components/schemas/Unit'
           required:
+            - probationDeliveryUnitId
             - arrivalDate
             - summaryData
     ReleaseTypeOption:
@@ -4982,8 +4981,6 @@ components:
           type: string
           format: date
           example: '2024-02-21'
-        pdu:
-          type: string
         probationDeliveryUnitId:
           type: string
           format: uuid
@@ -5003,6 +5000,7 @@ components:
         translatedDocument:
           $ref: '#/components/schemas/Unit'
       required:
+        - probationDeliveryUnitId
         - arrivalDate
         - summaryData
     FutureBooking:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -49,7 +49,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var dutyToReferLocalAuthorityAreaName: Yielded<String?> = { null }
   private var prisonNameAtReferral: Yielded<String?> = { null }
   private var personReleaseDate: Yielded<LocalDate?> = { null }
-  private var pdu: Yielded<String?> = { null }
   private var name: Yielded<String?> = { null }
   private var hasHistoryOfSexualOffence: Yielded<Boolean?> = { null }
   private var isConcerningSexualBehaviour: Yielded<Boolean?> = { null }
@@ -185,10 +184,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     this.personReleaseDate = { personReleaseDate }
   }
 
-  fun withPdu(pdu: String?) = apply {
-    this.pdu = { pdu }
-  }
-
   fun withName(name: String?) = apply {
     this.name = { name }
   }
@@ -250,7 +245,6 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     dutyToReferLocalAuthorityAreaName = this.dutyToReferLocalAuthorityAreaName(),
     prisonNameOnCreation = this.prisonNameAtReferral(),
     personReleaseDate = this.personReleaseDate(),
-    pdu = this.pdu(),
     name = this.name(),
     prisonReleaseTypes = this.prisonReleaseTypes(),
     probationDeliveryUnit = this.probationDeliveryUnit(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS3SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CAS3SubjectAccessRequestServiceTest.kt
@@ -351,7 +351,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
         "prison_name_on_creation": "${temporaryAccommodationApplication.prisonNameOnCreation}",
         "prison_release_types": "${temporaryAccommodationApplication.prisonReleaseTypes}",
         "person_release_date": "$arrivedAtDateOnly",
-        "pdu": "${temporaryAccommodationApplication.pdu}",
+        "pdu": "${temporaryAccommodationApplication.probationDeliveryUnit?.name}",
         "needs_accessible_property": ${temporaryAccommodationApplication.needsAccessibleProperty},
         "has_history_of_arson": ${temporaryAccommodationApplication.hasHistoryOfArson},
         "is_registered_sex_offender": ${temporaryAccommodationApplication.isRegisteredSexOffender},
@@ -432,10 +432,10 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
       withIsConcerningArsonBehaviour(false)
       withIsEligible(false)
       withNeedsAccessibleProperty(false)
-      withPdu(randomStringMultiCaseWithNumbers(5))
       withProbationRegion(probationRegionEntity())
       withPrisonReleaseTypes("ANY")
       withPrisonNameAtReferral("HMP Birmingham")
+      withProbationDeliveryUnit(probationDeliveryUnitEntity(user))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
@@ -370,6 +371,10 @@ open class SubjectAccessRequestServiceTestBase : Cas2v2IntegrationTestBase() {
 
   protected fun userEntity(): UserEntity = userEntityFactory.produceAndPersist {
     withProbationRegion(givenAProbationRegion())
+  }
+
+  protected fun probationDeliveryUnitEntity(user: UserEntity): ProbationDeliveryUnitEntity = probationDeliveryUnitFactory.produceAndPersist {
+    withProbationRegion(user.probationRegion)
   }
 
   protected fun personRisks() = PersonRisksFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ApplicationTest.kt
@@ -634,6 +634,10 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
             withSchema(schemaText())
           }
 
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(submittingUser.probationRegion)
+          }
+
           temporaryAccommodationApplicationEntityFactory.produceAndPersist {
             withCrn(offenderDetails.otherIds.crn)
             withId(applicationId)
@@ -657,6 +661,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
                   val num = 50
                   val text = "Hello world!"
                 },
+                probationDeliveryUnitId = probationDeliveryUnit.id,
               ),
             )
             .exchange()
@@ -1117,6 +1122,10 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               withSchema(schemaText())
             }
 
+            val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+              withProbationRegion(submittingUser.probationRegion)
+            }
+
             temporaryAccommodationApplicationEntityFactory.produceAndPersist {
               withCrn(offenderDetails.otherIds.crn)
               withId(applicationId)
@@ -1140,6 +1149,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
                   val num = 50
                   val text = "Hello world!"
                 },
+                probationDeliveryUnitId = probationDeliveryUnit.id,
               )
 
               callCasApiAndAssertApiResponse(jwt, applicationId, submitApplication)
@@ -1153,6 +1163,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
                   val num = 50
                   val text = "Hello world!"
                 },
+                probationDeliveryUnitId = probationDeliveryUnit.id,
               )
 
               callCas3ApiAndAssertApiResponse(jwt, applicationId, cas3SubmitApplication)
@@ -1174,7 +1185,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
     @CsvSource("CAS", "CAS3")
     fun `Submit Temporary Accommodation application returns 200 with optional elements in the request`(apiEndpoint: String) {
       givenAUser { submittingUser, jwt ->
-        givenAUser { _, _ ->
+        givenAUser { user, _ ->
           givenAnOffender { offenderDetails, _ ->
             val applicationId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
 
@@ -1184,13 +1195,17 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               withSchema(schemaText())
             }
 
+            val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+              withProbationRegion(user.probationRegion)
+            }
+
             temporaryAccommodationApplicationEntityFactory.produceAndPersist {
               withCrn(offenderDetails.otherIds.crn)
               withId(applicationId)
               withApplicationSchema(applicationSchema)
               withCreatedByUser(submittingUser)
               withProbationRegion(submittingUser.probationRegion)
-              withPdu("Probation Delivery Unit Test")
+              withProbationDeliveryUnit(probationDeliveryUnit)
               withHasHistoryOfSexualOffence(true)
               withIsConcerningSexualBehaviour(true)
               withIsConcerningArsonBehaviour(true)
@@ -1219,7 +1234,6 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
                   val text = "Hello world!"
                 },
                 personReleaseDate = LocalDate.now(),
-                pdu = "Probation Delivery Unit Test",
                 isHistoryOfSexualOffence = true,
                 isConcerningSexualBehaviour = true,
                 isConcerningArsonBehaviour = true,
@@ -1243,7 +1257,6 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
                   val text = "Hello world!"
                 },
                 personReleaseDate = LocalDate.now(),
-                pdu = "Probation Delivery Unit Test",
                 isHistoryOfSexualOffence = true,
                 isConcerningSexualBehaviour = true,
                 isConcerningArsonBehaviour = true,
@@ -1289,6 +1302,10 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               withSchema(schemaText())
             }
 
+            val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+              withProbationRegion(submittingUser.probationRegion)
+            }
+
             temporaryAccommodationApplicationEntityFactory.produceAndPersist {
               withCrn(offenderDetails.otherIds.crn)
               withId(applicationId)
@@ -1312,6 +1329,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
                 val num = 50
                 val text = "Hello world!"
               },
+              probationDeliveryUnitId = probationDeliveryUnit.id,
             )
 
             callCasApiAndAssertApiResponse(jwt, applicationId, submitApplication)
@@ -1328,6 +1346,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
                 val num = 50
                 val text = "Hello world!"
               },
+              probationDeliveryUnitId = probationDeliveryUnit.id,
             )
 
             callCas3ApiAndAssertApiResponse(jwt, applicationId, cas3SubmitApplication)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -947,6 +947,10 @@ class Cas3ReportsTest : IntegrationTestBase() {
               withAddedAt(OffsetDateTime.now())
             }
 
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(user.probationRegion)
+          }
+
           val prisonReleaseTypes = "Standard recall,CRD licence,ECSL"
           val application =
             temporaryAccommodationApplicationEntityFactory.produceAndPersist {
@@ -984,7 +988,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
               }
               withPrisonNameAtReferral("HM Hounslow")
               withPersonReleaseDate(LocalDate.now())
-              withPdu("Probation Delivery Unit Test")
+              withProbationDeliveryUnit(probationDeliveryUnit)
             }
 
           val assessment =
@@ -4249,7 +4253,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
     assertThat(actualReferralReportRow.prisonAtReferral).isEqualTo(application.prisonNameOnCreation)
     assertThat(actualReferralReportRow.releaseDate).isEqualTo(application.personReleaseDate)
     assertThat(actualReferralReportRow.updatedReleaseDate).isNull()
-    assertThat(actualReferralReportRow.pdu).isEqualTo(application.pdu)
+    assertThat(actualReferralReportRow.pdu).isEqualTo(application.probationDeliveryUnit?.name)
   }
 
   private fun createTemporaryAccommodationAssessmentForStatus(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3ApplicationServiceTest.kt
@@ -97,6 +97,7 @@ class Cas3ApplicationServiceTest {
         val num = 50
         val text = "Hello world!"
       },
+      probationDeliveryUnitId = UUID.randomUUID(),
     )
 
     private val submitTemporaryAccommodationApplicationWithMiReportingData = Cas3SubmitApplication(
@@ -116,8 +117,8 @@ class Cas3ApplicationServiceTest {
       eligibilityReason = "homelessFromApprovedPremises",
       dutyToReferLocalAuthorityAreaName = "Aberdeen City",
       personReleaseDate = LocalDate.now().plusDays(1),
-      pdu = "Probation Delivery Unit Test",
       isHistoryOfSexualOffence = true,
+      probationDeliveryUnitId = UUID.randomUUID(),
       isConcerningSexualBehaviour = true,
       isConcerningArsonBehaviour = true,
       prisonReleaseTypes = listOf(
@@ -393,7 +394,7 @@ class Cas3ApplicationServiceTest {
       assertThat(persistedApplication.eligibilityReason).isEqualTo("homelessFromApprovedPremises")
       assertThat(persistedApplication.dutyToReferLocalAuthorityAreaName).isEqualTo("Aberdeen City")
       assertThat(persistedApplication.personReleaseDate).isEqualTo(submitTemporaryAccommodationApplicationWithMiReportingData.personReleaseDate)
-      assertThat(persistedApplication.pdu).isEqualTo("Probation Delivery Unit Test")
+      assertThat(persistedApplication.probationDeliveryUnit?.id).isNull()
       assertThat(persistedApplication.name).isEqualTo(user.name)
       assertThat(persistedApplication.isHistoryOfSexualOffence).isEqualTo(true)
       assertThat(persistedApplication.isConcerningSexualBehaviour).isEqualTo(true)


### PR DESCRIPTION
The `pdu` column in `temporary_accommodation_applications` table is no longer required; pdus have been moved into a separate table. Therefore this field is now redundant and can be removed. This PR will remove it from the code and from the DB.