### PR TITLE
APS-2247 limit booking length to two years

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingCreateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingCreateService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent
 import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 /**
@@ -27,6 +28,10 @@ class Cas1SpaceBookingCreateService(
   private val cas1BookingEmailService: Cas1BookingEmailService,
   private val clock: Clock,
 ) {
+
+  companion object {
+    const val MAX_LENGTH_YEARS: Int = 2
+  }
 
   fun create(validatedDetails: ValidatedCreateBooking): Cas1SpaceBookingEntity {
     val bookingToCreate = validatedDetails.bookingToCreate
@@ -71,6 +76,10 @@ class Cas1SpaceBookingCreateService(
 
     if (details.expectedArrivalDate >= details.expectedDepartureDate) {
       "$.departureDate" hasValidationError "shouldBeAfterArrivalDate"
+    }
+
+    if (ChronoUnit.YEARS.between(details.expectedArrivalDate, details.expectedDepartureDate) >= MAX_LENGTH_YEARS) {
+      "$.departureDate" hasValidationError "mustBeLessThan2Years"
     }
 
     if (hasErrors()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingUpdateService.kt
@@ -9,11 +9,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.successOrErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingCreateService.Companion.MAX_LENGTH_YEARS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.Cas1BookingChangedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.TransferInfo
 import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 /**
@@ -114,6 +116,10 @@ class Cas1SpaceBookingUpdateService(
 
     if (effectiveDepartureDate.isBefore(effectiveArrivalDate)) {
       "$.departureDate" hasValidationError "The departure date is before the arrival date."
+    }
+
+    if (ChronoUnit.YEARS.between(effectiveArrivalDate, effectiveDepartureDate) >= MAX_LENGTH_YEARS) {
+      "$.departureDate" hasValidationError "mustBeLessThan2Years"
     }
 
     return successOrErrors()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingCreateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingCreateServiceTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.ClockC
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockablePlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TransferType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationStatusService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
@@ -73,7 +72,7 @@ class Cas1SpaceBookingCreateServiceTest {
       LockablePlacementRequestEntity(placementRequest.id)
 
       val result = service.validate(
-        Cas1SpaceBookingCreateService.CreateBookingDetails(
+        CreateBookingDetails(
           premisesId = UUID.randomUUID(),
           placementRequestId = placementRequest.id,
           expectedArrivalDate = LocalDate.now(),
@@ -84,12 +83,7 @@ class Cas1SpaceBookingCreateServiceTest {
         ),
       )
 
-      assertThat(result).isInstanceOf(CasResult.FieldValidationError::class.java)
-      result as CasResult.FieldValidationError
-
-      assertThat(result.validationMessages).anySatisfy { key, value ->
-        key == "$.premisesId" && value == "doesNotExist"
-      }
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.premisesId", "doesNotExist")
     }
 
     @Test
@@ -104,7 +98,7 @@ class Cas1SpaceBookingCreateServiceTest {
       LockablePlacementRequestEntity(placementRequest.id)
 
       val result = service.validate(
-        Cas1SpaceBookingCreateService.CreateBookingDetails(
+        CreateBookingDetails(
           premisesId = premisesDoesntSupportSpaceBookings.id,
           placementRequestId = placementRequest.id,
           expectedArrivalDate = LocalDate.now(),
@@ -115,12 +109,7 @@ class Cas1SpaceBookingCreateServiceTest {
         ),
       )
 
-      assertThat(result).isInstanceOf(CasResult.FieldValidationError::class.java)
-      result as CasResult.FieldValidationError
-
-      assertThat(result.validationMessages).anySatisfy { key, value ->
-        key == "$.premisesId" && value == "doesNotSupportSpaceBookings"
-      }
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.premisesId", "doesNotSupportSpaceBookings")
     }
 
     @Test
@@ -130,7 +119,7 @@ class Cas1SpaceBookingCreateServiceTest {
       LockablePlacementRequestEntity(placementRequest.id)
 
       val result = service.validate(
-        Cas1SpaceBookingCreateService.CreateBookingDetails(
+        CreateBookingDetails(
           premisesId = premises.id,
           placementRequestId = UUID.randomUUID(),
           expectedArrivalDate = LocalDate.now(),
@@ -141,12 +130,7 @@ class Cas1SpaceBookingCreateServiceTest {
         ),
       )
 
-      assertThat(result).isInstanceOf(CasResult.FieldValidationError::class.java)
-      result as CasResult.FieldValidationError
-
-      assertThat(result.validationMessages).anySatisfy { key, value ->
-        key == "$.placementRequestId" && value == "doesNotExist"
-      }
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.placementRequestId", "doesNotExist")
     }
 
     @Test
@@ -156,7 +140,7 @@ class Cas1SpaceBookingCreateServiceTest {
       LockablePlacementRequestEntity(placementRequest.id)
 
       val result = service.validate(
-        Cas1SpaceBookingCreateService.CreateBookingDetails(
+        CreateBookingDetails(
           premisesId = premises.id,
           placementRequestId = placementRequest.id,
           expectedArrivalDate = LocalDate.now().plusDays(1),
@@ -167,12 +151,7 @@ class Cas1SpaceBookingCreateServiceTest {
         ),
       )
 
-      assertThat(result).isInstanceOf(CasResult.FieldValidationError::class.java)
-      result as CasResult.FieldValidationError
-
-      assertThat(result.validationMessages).anySatisfy { key, value ->
-        key == "$.departureDate" && value == "shouldBeAfterArrivalDate"
-      }
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.departureDate", "shouldBeAfterArrivalDate")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingUpdateServiceTest.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.ClockConfiguration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
@@ -84,12 +83,7 @@ class Cas1SpaceBookingUpdateServiceTest {
         ),
       )
 
-      assertThat(result).isInstanceOf(CasResult.FieldValidationError::class.java)
-      result as CasResult.FieldValidationError
-
-      assertThat(result.validationMessages).anySatisfy { key, value ->
-        key == "$.premisesId" && value == "doesNotExist"
-      }
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.premisesId", "doesNotExist")
     }
 
     @Test


### PR DESCRIPTION
Modify the booking create and update validation logic to ensure a booking is never more than 2 years old.

This upper limit is being set as we’ve discovered memory issues when amending bookings with a very long duration (e.g. 100 years). This is due to the capacity calculation logic trying to calculate the capacity in the premise for the length of the entire bookings. Furthermore, bookings will never be longer than 2 years, so this is a sensible limitation to put in place.