### PR TITLE
APS-2348 - Revert spring upgrade to 3.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.apache.commons.io.FileUtils
 import java.io.File
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.2.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.1.0"
   kotlin("plugin.spring") version "2.1.20"
   kotlin("plugin.jpa") version "2.1.20"
   id("org.openapi.generator") version "7.11.0"


### PR DESCRIPTION
E2E tests have uncovered some additional cases where a nullable value is being returned in a JPA query that has been returned null (some of these were resolved in the upgrade commit - 5ec7b69b9ab58e7b6752bb23e9fa149370309d9c)

Temporarily reverting the upgrade so we can review all the code to find any over occurances of this issue.
