### PR TITLE
Upgrade open csv

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
 
   implementation("io.arrow-kt:arrow-core:1.2.4")
 
-  implementation("com.opencsv:opencsv:5.9")
+  implementation("com.opencsv:opencsv:5.11")
 
   implementation("net.javacrumbs.shedlock:shedlock-spring:5.16.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0")


### PR DESCRIPTION
This is a pre-req to get us to the latest version of open-csv before manually upgrading dependency commons-beanutils to a newer version not currently used by open-csv, resolving CVE-2025-48734
