### PR TITLE
APS-2348 - Ensure JPA result nullability is correct

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AppealEntity.kt
@@ -15,7 +15,6 @@ import java.util.UUID
 @Repository
 interface AppealRepository : JpaRepository<AppealEntity, UUID> {
   fun findByApplication(application: ApplicationEntity): List<AppealEntity>
-  fun findAllByAssessmentId(assessmentId: UUID): List<AppealEntity>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -124,27 +124,6 @@ AND (
   fun <T : ApplicationEntity> findAllByCreatedByUserId(id: UUID, type: Class<T>): List<ApplicationEntity>
 
   @Query(
-    "SELECT * FROM approved_premises_applications apa " +
-      "LEFT JOIN applications a ON a.id = apa.id " +
-      "WHERE apa.status IS NULL",
-    nativeQuery = true,
-  )
-  fun findAllWithNullStatus(pageable: Pageable?): Slice<ApprovedPremisesApplicationEntity>
-
-  @Query(
-    "SELECT application.created_at as createdAt, CAST(application.created_by_user_id as TEXT) as createdByUserId FROM approved_premises_applications apa " +
-      "LEFT JOIN applications application ON application.id = apa.id " +
-      "where date_part('month', application.created_at) = :month " +
-      "AND date_part('year', application.created_at) = :year " +
-      "AND application.service = 'approved-premises'",
-    nativeQuery = true,
-  )
-  fun findAllApprovedPremisesApplicationsCreatedInMonth(
-    month: Int,
-    year: Int,
-  ): List<ApprovedPremisesApplicationMetricsSummary>
-
-  @Query(
     value = """
     SELECT 
      CAST(id AS text) as id,
@@ -606,9 +585,4 @@ interface TemporaryAccommodationApplicationSummary : ApplicationSummary {
   fun getLatestAssessmentDecision(): AssessmentDecision?
   fun getLatestAssessmentHasClarificationNotesWithoutResponse(): Boolean
   fun getHasBooking(): Boolean
-}
-
-interface ApprovedPremisesApplicationMetricsSummary {
-  fun getCreatedAt(): Instant
-  fun getCreatedByUserId(): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -27,7 +27,6 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
-import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -504,16 +503,4 @@ enum class ReferralHistorySystemNoteType {
   READY_TO_PLACE,
   REJECTED,
   COMPLETED,
-}
-
-interface ReferralsDataResult {
-  fun getTier(): String?
-  fun getIsEsapApplication(): Boolean?
-  fun getIsPipeApplication(): Boolean?
-  fun getDecision(): String?
-  fun getApplicationSubmittedAt(): Timestamp?
-  fun getAssessmentSubmittedAt(): Timestamp?
-  fun getRejectionRationale(): String?
-  fun getReleaseType(): String?
-  fun getClarificationNoteCount(): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -185,7 +185,7 @@ interface Cas3BookingRepository : JpaRepository<BookingEntity, UUID> {
     premisesIds: List<UUID>,
     startDate: LocalDate,
     endDate: LocalDate,
-  ): List<OverlapBookingsSearchResult>
+  ): List<Cas3OverlapBookingsSearchResult>
 
   /*
   This query is to find the closest booking to the start date for the current bedspace search
@@ -279,7 +279,7 @@ interface Cas3BookingRepository : JpaRepository<BookingEntity, UUID> {
     probationRegionId: UUID?,
     crnOrName: String?,
     pageable: Pageable?,
-  ): Page<BookingSearchResult>
+  ): Page<Cas3BookingSearchResult>
 }
 
 @Entity
@@ -396,7 +396,7 @@ data class BookingEntity(
 }
 
 @Suppress("TooManyFunctions")
-interface BookingSearchResult {
+interface Cas3BookingSearchResult {
   fun getPersonName(): String?
   fun getPersonCrn(): String
   fun getBookingStatus(): String
@@ -416,7 +416,7 @@ interface BookingSearchResult {
   fun getBedName(): String
 }
 
-interface OverlapBookingsSearchResult {
+interface Cas3OverlapBookingsSearchResult {
   val bookingId: UUID
   val crn: String
   val arrivalDate: LocalDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -285,7 +285,7 @@ interface Cas1SpaceBookingDaySummarySearchResult {
   val canonicalDepartureDate: LocalDate
   val tier: String?
   val releaseType: String
-  val characteristicsPropertyNames: String
+  val characteristicsPropertyNames: String?
 }
 
 interface Cas1SpaceBookingSearchResult {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2SubmittedApplicationReport.kt
@@ -54,9 +54,9 @@ interface Cas2SubmittedApplicationReportRow {
   fun getPersonNoms(): String
   fun getPersonCrn(): String
   fun getReferringPrisonCode(): String
-  fun getPreferredAreas(): String
-  fun getHdcEligibilityDate(): String
-  fun getConditionalReleaseDate(): String
+  fun getPreferredAreas(): String?
+  fun getHdcEligibilityDate(): String?
+  fun getConditionalReleaseDate(): String?
   fun getStartedAt(): String
   fun getNumberOfTransfers(): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -142,6 +142,9 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 data class DomainEventEntity(
   @Id
   val id: UUID,
+  /**
+   * This is always provided for CAS1 and CAS2 events (e.g service='CAS1|CAS2')
+   */
   val applicationId: UUID?,
   val assessmentId: UUID?,
   val bookingId: UUID?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2ApplicationStatusUpdatesReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2ApplicationStatusUpdatesReportRepository.kt
@@ -47,6 +47,10 @@ interface Cas2v2ApplicationStatusUpdatedReportRow {
   fun getApplicationOrigin(): ApplicationOrigin
   fun getUpdatedBy(): String
   fun getUpdatedAt(): String
+
+  /*
+  Note that this may be the string value "null", but will never be truly 'null'
+   */
   fun getPersonNoms(): String
   fun getPersonCrn(): String
   fun getNewStatus(): String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2SubmittedApplicationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2SubmittedApplicationReportRepository.kt
@@ -48,8 +48,8 @@ interface Cas2v2SubmittedApplicationReportRow {
   fun getPersonNoms(): String
   fun getPersonCrn(): String
   fun getReferringPrisonCode(): String
-  fun getPreferredAreas(): String
-  fun getHdcEligibilityDate(): String
-  fun getConditionalReleaseDate(): String
+  fun getPreferredAreas(): String?
+  fun getHdcEligibilityDate(): String?
+  fun getConditionalReleaseDate(): String?
   fun getStartedAt(): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2UnsubmittedApplicationsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2UnsubmittedApplicationsReportRepository.kt
@@ -32,7 +32,7 @@ interface Cas2v2UnsubmittedApplicationsReportRepository : JpaRepository<Cas2v2Ap
 interface Cas2v2UnsubmittedApplicationReportRow {
   fun getApplicationId(): String
   fun getApplicationOrigin(): ApplicationOrigin
-  fun getPersonNoms(): String
+  fun getPersonNoms(): String?
   fun getPersonCrn(): String
   fun getStartedBy(): String
   fun getStartedAt(): String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BedspaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BedspaceSearchService.kt
@@ -4,9 +4,9 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3BedspaceSearchParameters
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3OverlapBookingsSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS3_PROPERTY_NAME_MEN_ONLY
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS3_PROPERTY_NAME_WOMEN_ONLY
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OverlapBookingsSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
@@ -167,7 +167,7 @@ class Cas3BedspaceSearchService(
   }
 
   fun transformBookingToOverlap(
-    overlappedBooking: OverlapBookingsSearchResult,
+    overlappedBooking: Cas3OverlapBookingsSearchResult,
     startDate: LocalDate,
     endDate: LocalDate,
     personSummaryInfo: PersonSummaryInfoResult,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingSearchService.kt
@@ -8,8 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortOrder
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
@@ -79,7 +79,7 @@ class Cas3BookingSearchService(
       }
   }
 
-  private fun mapToBookingSearchResults(findBookings: Page<BookingSearchResult>) = findBookings.content
+  private fun mapToBookingSearchResults(findBookings: Page<Cas3BookingSearchResult>) = findBookings.content
     .mapNotNull { rs ->
       BookingSearchResultDto(
         rs.getPersonName(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestBookingSearchResult.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestBookingSearchResult.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -12,7 +12,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class TestBookingSearchResult : BookingSearchResult {
+class TestBookingSearchResult : Cas3BookingSearchResult {
   private var personName: String? = null
   private var personCrn: String = randomStringMultiCaseWithNumbers(6)
   private var bookingId: UUID = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OverlapBookingsSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3OverlapBookingsSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.BedSearchRepository
@@ -437,5 +437,5 @@ class Cas3BedSearchServiceTest {
     override val roomId: UUID,
     override val assessmentId: UUID,
     override val sexualRisk: Boolean,
-  ) : OverlapBookingsSearchResult
+  ) : Cas3OverlapBookingsSearchResult
 }


### PR DESCRIPTION
This commit updates various JPA ‘result row’ interface definitions to correctly indicate if a value is nullable.

It also renames some result rows that only apply to CAS3 to make this clear (nullability on certain shared tables differes for CAS1/CAS3).

It also removes some unused repository code
