### PR TITLE
APS-2348 - Upgrade to Spring 3.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.apache.commons.io.FileUtils
 import java.io.File
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.2.0"
   kotlin("plugin.spring") version "2.1.20"
   kotlin("plugin.jpa") version "2.1.20"
   id("org.openapi.generator") version "7.11.0"


### PR DESCRIPTION
Now that we have resolved JPA repository nullability issues via e3b0f9cd314620c7ae0f8229e95965a9831e2651, we can upgrade to spring 3.5.0