### PR TITLE
APS-2295 - Remove bed_move entries on space booking migration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedMoveEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedMoveEntity.kt
@@ -10,9 +10,19 @@ import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 import java.util.UUID
 
+@Deprecated(
+  "Bed moves were exclusively used by CAS1. There usage ended mid 2024." +
+    "Once all CAS1 bookings have been migrated to space bookings this repo can be removed",
+)
 @Repository
-interface BedMoveRepository : JpaRepository<BedMoveEntity, UUID>
+interface BedMoveRepository : JpaRepository<BedMoveEntity, UUID> {
+  fun deleteByBooking(booking: BookingEntity)
+}
 
+@Deprecated(
+  "Bed moves were exclusively used by CAS1. There usage ended mid 2024." +
+    "Once all CAS1 bookings have been migrated to space bookings this table can be removed",
+)
 @Entity
 @Table(name = "bed_moves")
 data class BedMoveEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BookingToSpaceBookingSeedJob.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
@@ -31,6 +32,7 @@ class Cas1BookingToSpaceBookingSeedJob(
   private val approvedPremisesRepository: ApprovedPremisesRepository,
   private val spaceBookingRepository: Cas1SpaceBookingRepository,
   private val bookingRepository: BookingRepository,
+  private val bedMoveRepository: BedMoveRepository,
   private val domainEventRepository: DomainEventRepository,
   private val domainEventService: Cas1DomainEventService,
   private val userRepository: UserRepository,
@@ -150,6 +152,8 @@ class Cas1BookingToSpaceBookingSeedJob(
       it.booking = null
       placementRequestRepository.save(it)
     }
+
+    bedMoveRepository.deleteByBooking(booking)
     bookingRepository.delete(booking)
 
     log.info("Have migrated booking $bookingId to space booking")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BedMoveEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BedMoveEntityFactory.kt
@@ -14,7 +14,7 @@ class BedMoveEntityFactory : Factory<BedMoveEntity> {
 
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var booking: Yielded<BookingEntity>? = null
-  private var previousBed: Yielded<BedEntity>? = null
+  private var previousBed: Yielded<BedEntity?> = { null }
   private var newBed: Yielded<BedEntity>? = null
   private var notes: Yielded<String> = { "TEST NOTES" }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
@@ -27,7 +27,7 @@ class BedMoveEntityFactory : Factory<BedMoveEntity> {
     this.booking = { booking }
   }
 
-  fun withPreviousBed(previousBed: BedEntity) = apply {
+  fun withPreviousBed(previousBed: BedEntity?) = apply {
     this.previousBed = { previousBed }
   }
 
@@ -47,7 +47,7 @@ class BedMoveEntityFactory : Factory<BedMoveEntity> {
     id = this.id(),
 
     booking = this.booking?.invoke() ?: throw RuntimeException("Must provide a booking"),
-    previousBed = this.previousBed?.invoke() ?: throw RuntimeException("Must provide previous bed"),
+    previousBed = this.previousBed.invoke(),
     newBed = this.newBed?.invoke() ?: throw RuntimeException("Must provide new bed"),
     notes = this.notes(),
     createdAt = this.createdAt(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
@@ -16,12 +16,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Pr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedMoveEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenABooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenABookingForAnOfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremisesBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
@@ -157,6 +159,12 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       booking1ManagementInfoFromDelius,
       booking1CreatedByUser,
       placementRequest1,
+    )
+    bedMoveRepository.save(
+      BedMoveEntityFactory()
+        .withBooking(booking1ManagementInfoFromDelius)
+        .withNewBed(givenAnApprovedPremisesBed())
+        .produce(),
     )
 
     deliusBookingImportRepository.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1BookingToSpaceBookingSeedJobTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
@@ -29,6 +30,7 @@ class Cas1BookingToSpaceBookingSeedJobTest {
     approvedPremisesRepository = approvedPremisesRepository,
     spaceBookingRepository = mockk<Cas1SpaceBookingRepository>(),
     bookingRepository = mockk<BookingRepository>(),
+    bedMoveRepository = mockk<BedMoveRepository>(),
     domainEventRepository = mockk<DomainEventRepository>(),
     domainEventService = mockk<Cas1DomainEventService>(),
     userRepository = mockk<UserRepository>(),


### PR DESCRIPTION
When migrating a booking to a space booking, the existence of a corresponding entry in `bed_moves` blocks deletion of the `booking` entry. Usage of bed_moves was removed in 08/24 as we stopped tracking bed allocation in CAS1. This information doesn’t need migrating to space bookings. Bed moves were only ever captured for the NE region.

This commit updates the booking to space booking migration logic removing any linked entries in bed_moves. This follows the established pattern of removing any information related to the legacy booking entry.

This commit also deprecates the bed move table, in preparation for its removal once all CAS1 bookings have been migrated to space bookings