### PR TITLE
APS-2295 - Remove extensions when migrating to space booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -308,7 +308,7 @@ data class BookingEntity(
   @OneToOne
   @JoinColumn(name = "offline_application_id")
   var offlineApplication: OfflineApplicationEntity?,
-  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
   var extensions: MutableList<ExtensionEntity>,
   @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
   var dateChanges: MutableList<DateChangeEntity>,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.St
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedMoveEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExtensionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenABooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenABookingForAnOfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
@@ -164,6 +165,11 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       BedMoveEntityFactory()
         .withBooking(booking1ManagementInfoFromDelius)
         .withNewBed(givenAnApprovedPremisesBed())
+        .produce(),
+    )
+    extensionRepository.save(
+      ExtensionEntityFactory()
+        .withBooking(booking1ManagementInfoFromDelius)
         .produce(),
     )
 


### PR DESCRIPTION
This follows the pattern already established for other tables linked to bookings (E.g. arrivals, cancellations, departures). The information in the extensions table does not need migrating as the changes are already captured via domain events, and they haven’t been used in CAS1 for some time.
