### PR TITLE
APS-2295 - Space Booking migration duplicate import fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DeliusBookingImportEntity.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 
 @Repository
 interface Cas1DeliusBookingImportRepository : JpaRepository<Cas1DeliusBookingImportEntity, UUID> {
-  fun findByBookingId(id: UUID): Cas1DeliusBookingImportEntity?
+  fun findByBookingIdOrderByCreatedAtDesc(id: UUID): List<Cas1DeliusBookingImportEntity>
 
   /**
    * Returns all active bookings created in delius that were not created in CAS1, using the data in

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1BookingToSpaceBookingTest.kt
@@ -201,6 +201,35 @@ class SeedCas1BookingToSpaceBookingTest : SeedTestBase() {
       ),
     )
 
+    // add a second older entry which will be ignored
+    deliusBookingImportRepository.save(
+      Cas1DeliusBookingImportEntity(
+        id = UUID.randomUUID(),
+        bookingId = booking1ManagementInfoFromDelius.id,
+        approvedPremisesReferralId = "Delius Ref Id 1-older",
+        crn = "irrelevant",
+        eventNumber = "irrelevant",
+        keyWorkerStaffCode = "kw002",
+        keyWorkerForename = "kay 2",
+        keyWorkerMiddleName = "m 2",
+        keyWorkerSurname = "werker 2",
+        departureReasonCode = "dr2 ",
+        moveOnCategoryCode = "moc2",
+        moveOnCategoryDescription = null,
+        expectedArrivalDate = LocalDate.of(4000, 1, 1),
+        arrivalDate = LocalDate.of(3024, 5, 2),
+        expectedDepartureDate = LocalDate.of(4001, 2, 2),
+        departureDate = LocalDate.of(3024, 5, 4),
+        nonArrivalDate = LocalDate.of(4000, 1, 1),
+        nonArrivalContactDatetime = OffsetDateTime.of(LocalDateTime.of(3024, 2, 1, 9, 58, 23), ZoneOffset.UTC),
+        nonArrivalReasonCode = "narc2",
+        nonArrivalReasonDescription = null,
+        nonArrivalNotes = "the non arrival notes 2",
+        premisesQcode = "hostel code 2",
+        createdAt = OffsetDateTime.now().minusDays(1),
+      ),
+    )
+
     val booking2MinimalManagementInfoFromDelius = givenABooking(
       crn = "CRN1",
       premises = premises,


### PR DESCRIPTION
Testing the `Cas1BookingToSpaceBookingSeedJob` against production data has highlighted a small number of bookings in the NE region where there are multiple Delius Bookings for a given CAS1 booking id.

These are all from around 2023/06-2023/07, when CAS1 first went live exclusively to the NE region. The duplicate entries are likely caused by a bug between CAS1 and Domain Event Handling which has long been fixed.

As these are old bookings that have been completed, it’s safe to pick one of the two duplicates to use for data backfill during migration. This commit changes the `Cas1BookingToSpaceBookingSeedJob` to handle multiple corresponding entries in the delius export, and pick the newer one to support the migration.
