### PR TITLE
Remove overloaded assertThat(CasResult)

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/reference/Cas2PersistedApplicationStatusFinderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/reference/Cas2PersistedApplicationStatusFinderTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.model.reference
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -22,7 +22,7 @@ class Cas2PersistedApplicationStatusFinderTest {
     fun `returns all statuses`() {
       val finder = Cas2PersistedApplicationStatusFinder(statusList())
 
-      Assertions.assertThat(finder.all().map { it.name }).isEqualTo(
+      assertThat(finder.all().map { it.name }).isEqualTo(
         listOf(
           "moreInfoRequested",
           "awaitingDecision",
@@ -38,7 +38,7 @@ class Cas2PersistedApplicationStatusFinderTest {
     fun `returns only the ACTIVE statuses`() {
       val finder = Cas2PersistedApplicationStatusFinder(statusList())
 
-      Assertions.assertThat(finder.active().map { it.name }).isEqualTo(
+      assertThat(finder.active().map { it.name }).isEqualTo(
         listOf(
           "moreInfoRequested",
           "placeOffered",
@@ -53,13 +53,13 @@ class Cas2PersistedApplicationStatusFinderTest {
     fun `returns the matching status regardless of _isActive_ flag`() {
       val finder = Cas2PersistedApplicationStatusFinder(statusList())
 
-      Assertions.assertThat(
+      assertThat(
         finder.getById(UUID.fromString("f5cd423b-08eb-4efb-96ff-5cc6bb073905")).name,
       ).isEqualTo(
         "moreInfoRequested",
       )
 
-      Assertions.assertThat(
+      assertThat(
         finder.getById(UUID.fromString("ba4d8432-250b-4ab9-81ec-7eb4b16e5dd1")).name,
       ).isEqualTo(
         "awaitingDecision",
@@ -74,7 +74,7 @@ class Cas2PersistedApplicationStatusFinderTest {
         finder.getById(UUID.fromString("9887f81e-1a81-49b8-b0a6-5a17b3c9d7d1"))
       }
 
-      Assertions.assertThat(exception.message).isEqualTo(
+      assertThat(exception.message).isEqualTo(
         "Status with id 9887f81e-1a81-49b8-b0a6-5a17b3c9d7d1 not found",
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/BookingServiceTest.kt
@@ -87,7 +87,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntityType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawalTriggeredByUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThat
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -1999,7 +1999,7 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-14"),
       )
 
-      assertThat(result)
+      assertThatCasResult(result)
         .isConflictError()
         .hasMessageContaining("A Booking already exists")
     }
@@ -2038,7 +2038,7 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-14"),
       )
 
-      assertThat(result)
+      assertThatCasResult(result)
         .isConflictError()
         .hasMessageContaining("A Lost Bed already exists")
     }
@@ -2062,7 +2062,7 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-14"),
       )
 
-      assertThat(result)
+      assertThatCasResult(result)
         .isFieldValidationError()
         .hasMessage("$.newDepartureDate", "beforeBookingArrivalDate")
     }
@@ -2091,7 +2091,7 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-16"),
       )
 
-      assertThat(result)
+      assertThatCasResult(result)
         .isFieldValidationError()
         .hasMessage("$.newArrivalDate", "arrivalDateCannotBeChangedOnArrivedBooking")
     }
@@ -2123,7 +2123,7 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-16"),
       )
 
-      assertThat(result).isGeneralValidationError("This Booking is cancelled and as such cannot be modified")
+      assertThatCasResult(result).isGeneralValidationError("This Booking is cancelled and as such cannot be modified")
     }
 
     @Test
@@ -2152,7 +2152,7 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-15"),
       )
 
-      assertThat(result).isSuccess()
+      assertThatCasResult(result).isSuccess()
       result as CasResult.Success
 
       verify {
@@ -2200,7 +2200,7 @@ class BookingServiceTest {
         newDepartureDate = LocalDate.parse("2023-07-22"),
       )
 
-      assertThat(result).isSuccess()
+      assertThatCasResult(result).isSuccess()
       result as CasResult.Success
 
       verify {
@@ -2260,7 +2260,7 @@ class BookingServiceTest {
         newDepartureDate = newDepartureDate,
       )
 
-      assertThat(result).isSuccess()
+      assertThatCasResult(result).isSuccess()
       result as CasResult.Success
 
       verify {
@@ -2337,7 +2337,7 @@ class BookingServiceTest {
         newDepartureDate = newDepartureDate,
       )
 
-      assertThat(result).isSuccess()
+      assertThatCasResult(result).isSuccess()
       result as CasResult.Success
 
       verify(exactly = 1) {
@@ -2383,7 +2383,7 @@ class BookingServiceTest {
         newDepartureDate = newDepartureDate,
       )
 
-      assertThat(result).isSuccess()
+      assertThatCasResult(result).isSuccess()
       result as CasResult.Success
 
       verify {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/PlacementApplicationServiceTest.kt
@@ -6,8 +6,8 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -884,7 +884,7 @@ class PlacementApplicationServiceTest {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
 
-      Assertions.assertThatThrownBy {
+      assertThatThrownBy {
         placementApplicationService.withdrawPlacementApplication(
           placementApplication.id,
           PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TaskServiceTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -148,7 +148,7 @@ class TaskServiceTest {
     val result = taskService.reallocateTask(requestUserWithPermission, TaskType.assessment, assigneeUser.id, assessment.id)
 
     assertThatCasResult(result).isSuccess().with {
-      Assertions.assertThat(it).isEqualTo(reallocation)
+      assertThat(it).isEqualTo(reallocation)
     }
   }
 
@@ -191,7 +191,7 @@ class TaskServiceTest {
     val result = taskService.reallocateTask(requestUserWithPermission, TaskType.placementApplication, assigneeUser.id, placementApplication.id)
 
     assertThatCasResult(result).isSuccess().with {
-      Assertions.assertThat(it).isEqualTo(reallocation)
+      assertThat(it).isEqualTo(reallocation)
     }
   }
 
@@ -320,8 +320,8 @@ class TaskServiceTest {
       placementApplications.map { TypedTask.PlacementApplication(it) },
     ).flatten()
 
-    Assertions.assertThat(result.first).isEqualTo(expectedTasks)
-    Assertions.assertThat(result.second).isEqualTo(metadata)
+    assertThat(result.first).isEqualTo(expectedTasks)
+    assertThat(result.second).isEqualTo(metadata)
   }
 
   private fun generateAndStubAssigneeUser(): UserEntity {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
@@ -45,6 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.ArrivalRecorded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -236,7 +237,7 @@ class Cas1BookingManagementServiceTest {
       assertThat(result).isInstanceOf(CasResult.ConflictError::class.java)
       result as CasResult.ConflictError
 
-      uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThat(result)
+      assertThatCasResult(result)
         .isConflictError()
         .hasMessageContaining("The booking has already been cancelled")
     }
@@ -465,7 +466,7 @@ class Cas1BookingManagementServiceTest {
       assertThat(result).isInstanceOf(CasResult.ConflictError::class.java)
       result as CasResult.ConflictError
 
-      uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThat(result)
+      assertThatCasResult(result)
         .isConflictError()
         .hasMessageContaining("The booking has already been cancelled")
     }
@@ -865,7 +866,7 @@ class Cas1BookingManagementServiceTest {
       assertThat(result).isInstanceOf(CasResult.ConflictError::class.java)
       result as CasResult.ConflictError
 
-      uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThat(result)
+      assertThatCasResult(result)
         .isConflictError()
         .hasMessageContaining("The booking has already been cancelled")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Request
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThat
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -60,7 +60,7 @@ class Cas1RequestForPlacementServiceTest {
       val id = UUID.randomUUID()
       val result = cas1RequestForPlacementService.getRequestsForPlacementByApplication(id, user)
 
-      assertThat(result).isNotFound("Application", id)
+      assertThatCasResult(result).isNotFound("Application", id)
     }
 
     @Test
@@ -92,7 +92,7 @@ class Cas1RequestForPlacementServiceTest {
 
       val result = cas1RequestForPlacementService.getRequestsForPlacementByApplication(application.id, user)
 
-      assertThat(result).isSuccess().with {
+      assertThatCasResult(result).isSuccess().with {
         assertThat(it).hasSize(placementApplications.size)
       }
 
@@ -141,7 +141,7 @@ class Cas1RequestForPlacementServiceTest {
 
       val result = cas1RequestForPlacementService.getRequestsForPlacementByApplication(application.id, user)
 
-      assertThat(result).isSuccess().with {
+      assertThatCasResult(result).isSuccess().with {
         assertThat(it).hasSize(placementRequests.size)
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BedSearchServiceTest.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicSe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3BedspaceSearchService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThat
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
 import java.util.UUID
@@ -72,7 +72,7 @@ class Cas3BedSearchServiceTest {
       ),
     )
 
-    assertThat(result).isFieldValidationError("$.durationDays", "mustBeAtLeast1")
+    assertThatCasResult(result).isFieldValidationError("$.durationDays", "mustBeAtLeast1")
   }
 
   @Test
@@ -97,7 +97,7 @@ class Cas3BedSearchServiceTest {
         probationDeliveryUnits = probationDeliveryUnitIds,
       ),
     )
-    assertThat(result).isFieldValidationError("$.probationDeliveryUnits", "maxNumberProbationDeliveryUnits")
+    assertThatCasResult(result).isFieldValidationError("$.probationDeliveryUnits", "maxNumberProbationDeliveryUnits")
   }
 
   @Test
@@ -133,7 +133,7 @@ class Cas3BedSearchServiceTest {
         probationDeliveryUnits = probationDeliveryUnitIds,
       ),
     )
-    assertThat(result).isFieldValidationError("$.probationDeliveryUnits[3]", "doesNotExist")
+    assertThatCasResult(result).isFieldValidationError("$.probationDeliveryUnits[3]", "doesNotExist")
   }
 
   @Test
@@ -234,7 +234,7 @@ class Cas3BedSearchServiceTest {
       ),
     )
 
-    assertThat(result).isSuccess().hasValueEqualTo(candidateBedspaces)
+    assertThatCasResult(result).isSuccess().hasValueEqualTo(candidateBedspaces)
   }
 
   @Test
@@ -424,7 +424,7 @@ class Cas3BedSearchServiceTest {
         probationDeliveryUnits = listOf(probationDeliveryUnit.id),
       ),
     )
-    assertThat(result).isSuccess().hasValueEqualTo(expectedResults)
+    assertThatCasResult(result).isSuccess().hasValueEqualTo(expectedResults)
   }
 
   @Suppress("LongParameterList")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/Cas2v2ApplicationUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/Cas2v2ApplicationUtilsTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Constants.CAS2_COURT_BAIL_APPLICATION_TYPE
@@ -21,8 +21,8 @@ class Cas2v2ApplicationUtilsTest {
     val applicationOrigin3 = ApplicationOrigin.homeDetentionCurfew
     val applicationType3 = Cas2v2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin3)
 
-    Assertions.assertThat(applicationType1.equals(CAS2_COURT_BAIL_APPLICATION_TYPE)).isTrue
-    Assertions.assertThat(applicationType2.equals(CAS2_PRISON_BAIL_APPLICATION_TYPE)).isTrue
-    Assertions.assertThat(applicationType3.equals(HDC_APPLICATION_TYPE)).isTrue
+    assertThat(applicationType1).isEqualTo(CAS2_COURT_BAIL_APPLICATION_TYPE)
+    assertThat(applicationType2).isEqualTo(CAS2_PRISON_BAIL_APPLICATION_TYPE)
+    assertThat(applicationType3).isEqualTo(HDC_APPLICATION_TYPE)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
@@ -4,8 +4,6 @@ import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions.assertThat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 
-fun <T> assertThat(actual: CasResult<T>): CasResultAssertions<T> = CasResultAssertions(actual)
-
 fun <T> assertThatCasResult(actual: CasResult<T>): CasResultAssertions<T> = CasResultAssertions(actual)
 
 class CasResultAssertions<T>(actual: CasResult<T>) :

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/ReferralHistoryNoteHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/ReferralHistoryNoteHelper.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 
 fun assertAssessmentHasSystemNote(assessment: AssessmentEntity, createdByUser: UserEntity, type: ReferralHistorySystemNoteType) {
-  Assertions.assertThat(assessment.referralHistoryNotes)
+  assertThat(assessment.referralHistoryNotes)
     .hasSize(1)
     .allMatch {
       it is AssessmentReferralHistorySystemNoteEntity &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/SeedUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/SeedUtilsTest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util
 
 import io.mockk.every
 import io.mockk.mockkStatic
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -32,7 +32,7 @@ class SeedUtilsTest {
       val dataJson = JSONObject(output)
       val hdcDates = dataJson.getJSONObject("hdc-licence-dates").getJSONObject("hdc-licence-dates")
 
-      Assertions.assertThat(hdcDates.toString()).isEqualTo(
+      assertThat(hdcDates.toString()).isEqualTo(
         JSONObject(
           mapOf(
             "hdcEligibilityDate" to "2023-11-23",


### PR DESCRIPTION
Whilst technically this is fine, it often leads to the IDE importing it by mistake when we really want the default assertj `assertThat` function. To assert on CasResult the `assertThatCasResult` function should be used instead.