### PR TITLE
APS-2348 - Fix Cas2 Bail Submitted App Report Optionality

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2SubmittedApplicationReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas2v2/Cas2v2SubmittedApplicationReportRepository.kt
@@ -45,9 +45,9 @@ interface Cas2v2SubmittedApplicationReportRow {
   fun getBailHearingDate(): String?
   fun getSubmittedBy(): String
   fun getSubmittedAt(): String
-  fun getPersonNoms(): String
+  fun getPersonNoms(): String?
   fun getPersonCrn(): String
-  fun getReferringPrisonCode(): String
+  fun getReferringPrisonCode(): String?
   fun getPreferredAreas(): String?
   fun getHdcEligibilityDate(): String?
   fun getConditionalReleaseDate(): String?


### PR DESCRIPTION
Ensure CAS2 Bail Submitted Application Report Row class reflects which fields can be nullable. This has only become an issue since upgrading to Spring Boot 3.5