### PR TITLE
CAS-1684: Add offender_name to bookings table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -247,7 +247,8 @@ interface Cas3BookingRepository : JpaRepository<BookingEntity, UUID> {
         Cast(r.id as varchar) roomId,
         r.name AS roomName,
         Cast(b2.id as varchar) bedId,
-        b2.name AS bedName
+        b2.name AS bedName,
+        b.offender_name AS offenderName
       FROM bookings b
       LEFT JOIN beds b2 ON b.bed_id = b2.id
       LEFT JOIN rooms r ON b2.room_id = r.id
@@ -332,6 +333,7 @@ data class BookingEntity(
   val adhoc: Boolean? = null,
   @Version
   var version: Long = 1,
+  var offenderName: String?,
 ) {
   val departure: DepartureEntity?
     get() = departures.maxByOrNull { it.createdAt }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
@@ -351,6 +351,7 @@ class Cas1ApplicationSeedService(
         placementRequest = null,
         status = BookingStatus.confirmed,
         adhoc = true,
+        offenderName = null,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/BookingService.kt
@@ -202,6 +202,7 @@ class BookingService(
           placementRequest = null,
           status = BookingStatus.confirmed,
           adhoc = false,
+          offenderName = null,
         ),
       )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingService.kt
@@ -162,6 +162,7 @@ class Cas3BookingService(
           turnarounds = mutableListOf(),
           placementRequest = null,
           status = BookingStatus.provisional,
+          offenderName = null,
         ),
       )
 

--- a/src/main/resources/db/migration/all/2025060209075000__add_offender_name_to_bookings.sql
+++ b/src/main/resources/db/migration/all/2025060209075000__add_offender_name_to_bookings.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE bookings
+ADD COLUMN IF NOT EXISTS offender_name text;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/BookingEntityFactory.kt
@@ -53,6 +53,7 @@ class BookingEntityFactory : Factory<BookingEntity> {
   private var placementRequest: Yielded<PlacementRequestEntity?> = { null }
   private var status: Yielded<BookingStatus?> = { null }
   private var adhoc: Yielded<Boolean?> = { null }
+  private var offenderName: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -201,6 +202,10 @@ class BookingEntityFactory : Factory<BookingEntity> {
     this.adhoc = { adhoc }
   }
 
+  fun withOffenderName(offenderName: String?) = apply {
+    this.offenderName = { offenderName }
+  }
+
   override fun produce(): BookingEntity = BookingEntity(
     id = this.id(),
     crn = this.crn(),
@@ -227,5 +232,6 @@ class BookingEntityFactory : Factory<BookingEntity> {
     placementRequest = this.placementRequest(),
     status = this.status.invoke(),
     adhoc = this.adhoc(),
+    offenderName = this.offenderName(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/BookingTransformerTest.kt
@@ -153,6 +153,7 @@ class BookingTransformerTest {
     nomsNumber = "NOMS123",
     placementRequest = null,
     status = null,
+    offenderName = null,
   )
 
   private val offenderDetails = OffenderDetailsSummaryFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestBookingSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestBookingSummaryTransformerTest.kt
@@ -53,6 +53,7 @@ class PlacementRequestBookingSummaryTransformerTest {
         nomsNumber = "NOMS123",
         placementRequest = null,
         status = null,
+        offenderName = null,
       )
 
       val result = transformer.transformJpaToApi(booking)


### PR DESCRIPTION
This adds a migration script only to add the offender_name to the bookings table in the DB and updated code to handle new column, setting to null for the time being.