### PR TITLE
APS-2264 Add CAS1 OASys optional needs endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.OAsysCas1Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysNeedsQuestion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1CreateApplicationLaoStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+
+@Service
+class Cas1OasysController(
+  private val offenderService: OffenderService,
+  private val userService: UserService,
+  private val cas1OASysNeedsQuestionTransformer: Cas1OASysNeedsQuestionTransformer,
+  private val oaSysService: OASysService,
+) : OAsysCas1Delegate {
+
+  override fun optionalNeeds(crn: String): ResponseEntity<List<OASysNeedsQuestion>> {
+    when (
+      offenderService.canAccessOffender(
+        crn = crn,
+        laoStrategy = userService.getUserForRequest().cas1CreateApplicationLaoStrategy(),
+      )
+    ) {
+      null -> throw NotFoundProblem(crn, "Offender")
+      false -> throw throw ForbiddenProblem()
+      else -> Unit
+    }
+
+    return ResponseEntity.ok(
+      cas1OASysNeedsQuestionTransformer.transformToApi(
+        extractEntityFromCasResult(oaSysService.getOASysNeeds(crn)),
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PlacementApplicationsController.kt
@@ -61,7 +61,7 @@ class Cas1PlacementApplicationsController(
     val result = placementApplicationService.getApplication(id)
     val placementApplication = extractEntityFromCasResult(result)
 
-    if (!offenderService.canAccessOffender(placementApplication.application.crn, user.cas1LaoStrategy())) {
+    if (offenderService.canAccessOffender(placementApplication.application.crn, user.cas1LaoStrategy()) != true) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -182,7 +182,7 @@ class ApplicationService(
         UserRole.CAS1_ASSESSOR,
         UserRole.CAS1_FUTURE_MANAGER,
       ) &&
-      offenderService.canAccessOffender(deliusUsername, applicationEntity.crn)
+      offenderService.canAccessOffender(deliusUsername, applicationEntity.crn) == true
     ) {
       return CasResult.Success(applicationEntity)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/LaoStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/LaoStrategy.kt
@@ -77,12 +77,15 @@ sealed interface LaoStrategy {
 }
 
 /**
- * This strategy is _not_ applied when creating an application. In that case, we always apply [LaoStrategy.CheckUserAccess]
+ * This strategy is _not_ applied when creating an application. In that case, use cas1CreateApplicationLaoStrategy, which
+ * always applies [LaoStrategy.CheckUserAccess]
  */
 fun UserEntity.cas1LaoStrategy() = if (this.hasQualification(UserQualification.LAO)) {
   LaoStrategy.NeverRestricted
 } else {
   LaoStrategy.CheckUserAccess(this.deliusUsername)
 }
+
+fun UserEntity.cas1CreateApplicationLaoStrategy() = LaoStrategy.CheckUserAccess(this.deliusUsername)
 
 fun UserEntity.cas3LaoStrategy() = LaoStrategy.CheckUserAccess(this.deliusUsername)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -329,9 +329,9 @@ class OffenderService(
     )
   }
 
-  fun canAccessOffender(username: String, crn: String) = canAccessOffenders(username, listOf(crn))[crn] == true
+  fun canAccessOffender(username: String, crn: String) = canAccessOffenders(username, listOf(crn))[crn]
 
-  fun canAccessOffenders(username: String, crns: List<String>): Map<String, Boolean> {
+  fun canAccessOffenders(username: String, crns: List<String>): Map<String, Boolean?> {
     if (crns.isEmpty()) return emptyMap()
 
     if (crns.size > MAX_OFFENDER_REQUEST_COUNT) {
@@ -350,7 +350,7 @@ class OffenderService(
           valueTransform = { crn ->
             val access = crnToAccessResult[crn]
 
-            access?.hasNotLimitedAccess() ?: false
+            access?.hasNotLimitedAccess()
           },
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -109,7 +109,7 @@ class UserAccessService(
     }
 
     return when (application) {
-      is ApprovedPremisesApplicationEntity -> userCanViewApprovedPremisesApplicationCreatedBySomeoneElse(user, application)
+      is ApprovedPremisesApplicationEntity -> userCanViewApprovedPremisesApplicationCreatedBySomeoneElse(user, application) == true
       is TemporaryAccommodationApplicationEntity -> userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse(user, application)
       else -> false
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestService.kt
@@ -134,7 +134,7 @@ class PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return CasResult.NotFound("PlacementRequest", id.toString())
 
-    if (!offenderService.canAccessOffender(placementRequest.application.crn, user.cas1LaoStrategy())) {
+    if (offenderService.canAccessOffender(placementRequest.application.crn, user.cas1LaoStrategy()) != true) {
       return CasResult.Unauthorised()
     }
 
@@ -149,7 +149,7 @@ class PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return CasResult.NotFound("PlacementRequest", id.toString())
 
-    if (!offenderService.canAccessOffender(placementRequest.application.crn, user.cas1LaoStrategy())) {
+    if (offenderService.canAccessOffender(placementRequest.application.crn, user.cas1LaoStrategy()) != true) {
       return CasResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysNeedsQuestionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysNeedsQuestionTransformer.kt
@@ -1,80 +1,64 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
-import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSection
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysNeedsQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NeedsDetailsTransformer.Companion.sectionToName
 
-@Component
-class NeedsDetailsTransformer {
-
-  companion object {
-    val sectionToName = mapOf(
-      3 to "Accommodation",
-      4 to "Education, Training and Employment",
-      5 to "Finance",
-      6 to "Relationships",
-      7 to "Lifestyle",
-      10 to "Emotional",
-      11 to "Thinking and Behavioural",
-      12 to "Attitude",
-      13 to "Health",
-    )
-  }
+@Service
+class Cas1OASysNeedsQuestionTransformer {
 
   fun transformToApi(needsDetails: NeedsDetails) = listOf(
-    OASysSection(
+    OASysNeedsQuestion(
       section = 3,
       name = sectionToName[3]!!,
+      optional = isOptional(needsDetails.linksToHarm?.accommodationLinkedToHarm),
       linkedToHarm = needsDetails.linksToHarm?.accommodationLinkedToHarm,
       linkedToReOffending = needsDetails.linksToReOffending?.accommodationLinkedToReOffending,
     ),
-    OASysSection(
-      section = 4,
-      name = sectionToName[4]!!,
-      linkedToHarm = needsDetails.linksToHarm?.educationTrainingEmploymentLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.educationTrainingEmploymentLinkedToReOffending,
-    ),
-    OASysSection(
-      section = 5,
-      name = sectionToName[5]!!,
-      linkedToHarm = needsDetails.linksToHarm?.financeLinkedToHarm,
-      linkedToReOffending = needsDetails.linksToReOffending?.financeLinkedToReOffending,
-    ),
-    OASysSection(
+    OASysNeedsQuestion(
       section = 6,
       name = sectionToName[6]!!,
+      optional = isOptional(needsDetails.linksToHarm?.relationshipLinkedToHarm),
       linkedToHarm = needsDetails.linksToHarm?.relationshipLinkedToHarm,
       linkedToReOffending = needsDetails.linksToReOffending?.relationshipLinkedToReOffending,
     ),
-    OASysSection(
+    OASysNeedsQuestion(
       section = 7,
       name = sectionToName[7]!!,
+      optional = isOptional(needsDetails.linksToHarm?.lifestyleLinkedToHarm),
       linkedToHarm = needsDetails.linksToHarm?.lifestyleLinkedToHarm,
       linkedToReOffending = needsDetails.linksToReOffending?.lifestyleLinkedToReOffending,
     ),
-    OASysSection(
+    OASysNeedsQuestion(
       section = 10,
       name = sectionToName[10]!!,
+      optional = isOptional(needsDetails.linksToHarm?.emotionalLinkedToHarm),
       linkedToHarm = needsDetails.linksToHarm?.emotionalLinkedToHarm,
       linkedToReOffending = needsDetails.linksToReOffending?.emotionalLinkedToReOffending,
     ),
-    OASysSection(
+    OASysNeedsQuestion(
       section = 11,
       name = sectionToName[11]!!,
+      optional = isOptional(needsDetails.linksToHarm?.thinkingBehaviouralLinkedToHarm),
       linkedToHarm = needsDetails.linksToHarm?.thinkingBehaviouralLinkedToHarm,
       linkedToReOffending = needsDetails.linksToReOffending?.thinkingBehaviouralLinkedToReOffending,
     ),
-    OASysSection(
+    OASysNeedsQuestion(
       section = 12,
       name = sectionToName[12]!!,
+      optional = isOptional(needsDetails.linksToHarm?.attitudeLinkedToHarm),
       linkedToHarm = needsDetails.linksToHarm?.attitudeLinkedToHarm,
       linkedToReOffending = needsDetails.linksToReOffending?.attitudeLinkedToReOffending,
     ),
-    OASysSection(
+    OASysNeedsQuestion(
       section = 13,
       name = sectionToName[13]!!,
+      optional = true,
       linkedToHarm = null,
       linkedToReOffending = null,
     ),
   )
+
+  private fun isOptional(linkedToHarm: Boolean?) = linkedToHarm != true
 }

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -2046,6 +2046,34 @@ paths:
                 items:
                   $ref: 'cas1-schemas.yml#/components/schemas/Cas1ApplicationSummary'
 
+  /people/{crn}/oasys/optional-needs-questions:
+    get:
+      tags:
+        - OAsys
+      summary: Returns information about which needs questions & answers can be optionally included in an application (and which are mandatory), for a given CRN
+      operationId: optionalNeeds
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys selection
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: 'cas1-schemas.yml#/components/schemas/OASysNeedsQuestion'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
   /people/{crn}/timeline:
     get:
       tags:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1850,6 +1850,29 @@ components:
           $ref: '_shared.yml#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
+    OASysNeedsQuestion:
+      type: object
+      properties:
+        section:
+          type: integer
+          example: 10
+          description: The OAsys section that this needs question relates to
+        name:
+          type: string
+          example: Emotional wellbeing
+        optional:
+          type: boolean
+          description: If the user can optionally elect to include this question in an application. If not optional, it will always be included in the application
+        linkedToHarm:
+          type: boolean
+          description: If the response to this question is linked to harm
+        linkedToReOffending:
+          type: boolean
+          description: If the response to this question is linked to re-offending
+      required:
+        - section
+        - name
+        - optional
 
 
 

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2048,6 +2048,34 @@ paths:
                 items:
                   $ref: '#/components/schemas/Cas1ApplicationSummary'
 
+  /people/{crn}/oasys/optional-needs-questions:
+    get:
+      tags:
+        - OAsys
+      summary: Returns information about which needs questions & answers can be optionally included in an application (and which are mandatory), for a given CRN
+      operationId: optionalNeeds
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys selection
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OASysNeedsQuestion'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
   /people/{crn}/timeline:
     get:
       tags:
@@ -8590,6 +8618,29 @@ components:
           $ref: '#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
+    OASysNeedsQuestion:
+      type: object
+      properties:
+        section:
+          type: integer
+          example: 10
+          description: The OAsys section that this needs question relates to
+        name:
+          type: string
+          example: Emotional wellbeing
+        optional:
+          type: boolean
+          description: If the user can optionally elect to include this question in an application. If not optional, it will always be included in the application
+        linkedToHarm:
+          type: boolean
+          description: If the response to this question is linked to harm
+        linkedToReOffending:
+          type: boolean
+          description: If the response to this question is linked to re-offending
+      required:
+        - section
+        - name
+        - optional
 
 
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NeedsDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NeedsDetailsFactory.kt
@@ -40,65 +40,61 @@ class NeedsDetailsFactory : AssessmentInfoFactory<NeedsDetails>() {
   private var thinkingBehaviouralIssuesLinkedToHarm: Yielded<Boolean?> = { false }
   private var thinkingBehaviouralIssuesLinkedToReOffending: Yielded<Boolean?> = { false }
 
-  fun withOffenceAnalysisDetails(offenceAnalysisDetails: String?) = apply {
-    this.offenceAnalysisDetails = { offenceAnalysisDetails }
-  }
-
-  fun withEmotionalIssuesDetails(emotionalIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withEmotionalIssuesDetails(emotionalIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.emotionalIssuesDetails = { emotionalIssuesDetails }
     this.emotionalIssuesLinkedToHarm = { linkedToHarm }
     this.emotionalIssuesLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withDrugIssuesDetails(drugIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withDrugIssuesDetails(drugIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.drugIssuesDetails = { drugIssuesDetails }
     this.drugIssuesLinkedToHarm = { linkedToHarm }
     this.drugIssuesLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withAlcoholIssuesDetails(alcoholIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withAlcoholIssuesDetails(alcoholIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.alcoholIssuesDetails = { alcoholIssuesDetails }
     this.alcoholIssuesLinkedToHarm = { linkedToHarm }
     this.alcoholIssuesLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withLifestyleIssuesDetails(lifestyleIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withLifestyleIssuesDetails(lifestyleIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.lifestyleIssuesDetails = { lifestyleIssuesDetails }
     this.lifestyleLinkedToHarm = { linkedToHarm }
     this.lifestyleLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withRelationshipIssuesDetails(relationshipIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withRelationshipIssuesDetails(relationshipIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.relationshipIssuesDetails = { relationshipIssuesDetails }
     this.relationshipIssuesLinkedToHarm = { linkedToHarm }
     this.relationshipIssuesLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withFinanceIssuesDetails(financeIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withFinanceIssuesDetails(financeIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.financeIssuesDetails = { financeIssuesDetails }
     this.financeLinkedToHarm = { linkedToHarm }
     this.financeLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withEducationTrainingEmploymentIssuesDetails(educationTrainingEmploymentIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withEducationTrainingEmploymentIssuesDetails(educationTrainingEmploymentIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.educationTrainingEmploymentIssuesDetails = { educationTrainingEmploymentIssuesDetails }
     this.educationTrainingEmploymentIssuesLinkedToHarm = { linkedToHarm }
     this.educationTrainingEmploymentIssuesLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withAccommodationIssuesDetails(accommodationIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withAccommodationIssuesDetails(accommodationIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.accommodationIssuesDetails = { accommodationIssuesDetails }
     this.accommodationLinkedToHarm = { linkedToHarm }
     this.accommodationLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withAttitudeIssuesDetails(attitudeIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withAttitudeIssuesDetails(attitudeIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.attitudeIssuesDetails = { attitudeIssuesDetails }
     this.attitudeIssuesLinkedToHarm = { linkedToHarm }
     this.attitudeIssuesLinkedToReOffending = { linkedToReoffending }
   }
 
-  fun withThinkingBehaviouralIssuesDetails(thinkingBehaviouralIssuesDetails: String?, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
+  fun withThinkingBehaviouralIssuesDetails(thinkingBehaviouralIssuesDetails: String? = null, linkedToHarm: Boolean?, linkedToReoffending: Boolean?) = apply {
     this.thinkingBehaviouralIssuesDetails = { thinkingBehaviouralIssuesDetails }
     this.thinkingBehaviouralIssuesLinkedToHarm = { linkedToHarm }
     this.thinkingBehaviouralIssuesLinkedToReOffending = { linkedToReoffending }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
+
+class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
+  @Autowired
+  lateinit var cas1OASysNeedsQuestionTransformer: Cas1OASysNeedsQuestionTransformer
+
+  @Nested
+  inner class OptionalNeeds {
+
+    @Test
+    fun `No JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas1/people/CRN/oasys/optional-needs-questions")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Return 404 if access record can't be found for the CRN`() {
+      val (_, jwt) = givenAUser()
+      val crn = "CRN123"
+
+      apDeliusContextUserAccessEmptyResponse()
+
+      webTestClient.get()
+        .uri("/cas1/people/$crn/oasys/optional-needs-questions")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `Return forbidden if user can't access the CRN`() {
+      val (_, jwt) = givenAUser()
+      val crn = "CRN123"
+
+      apDeliusContextMockUserAccess(
+        CaseAccessFactory()
+          .withCrn(crn)
+          .withUserExcluded(true)
+          .produce(),
+      )
+
+      webTestClient.get()
+        .uri("/cas1/people/$crn/oasys/optional-needs-questions")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun success() {
+      val (_, jwt) = givenAUser()
+      val (offenderDetails) = givenAnOffender()
+
+      val needsDetails = NeedsDetailsFactory().apply {
+        withAssessmentId(34853487)
+        withAccommodationIssuesDetails("Accommodation", true, false)
+        withAttitudeIssuesDetails("Attitude", false, true)
+        withFinanceIssuesDetails(null, null, null)
+      }.produce()
+
+      apOASysContextMockSuccessfulNeedsDetailsCall(offenderDetails.otherIds.crn, needsDetails)
+
+      webTestClient.get()
+        .uri("/cas1/people/${offenderDetails.otherIds.crn}/oasys/optional-needs-questions")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            cas1OASysNeedsQuestionTransformer.transformToApi(needsDetails),
+          ),
+        )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -70,6 +70,10 @@ fun IntegrationTestBase.apDeliusContextMockUserAccess(caseAccess: CaseAccess, us
   apDeliusContextAddSingleResponseToUserAccessCall(caseAccess, username)
 }
 
+fun IntegrationTestBase.apDeliusContextUserAccessEmptyResponse() {
+  apDeliusContextAddResponseToUserAccessCall(emptyList())
+}
+
 fun IntegrationTestBase.apDeliusContextAddResponseToUserAccessCall(casesAccess: List<CaseAccess>, username: String = ".*") {
   val url = "/users/access"
   val existingMock = wiremockServer.listAllStubMappings().mappings.find { it.request.url == url && it.metadata != null && it.metadata.containsKey("bulk") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -300,7 +300,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `return false when no access result returned for crn, ReturnRestrictedIfLimitedAccess strategy`() {
+    fun `return null when no access result returned for crn, ReturnRestrictedIfLimitedAccess strategy`() {
       val crn = randomNumberChars(8)
 
       every {
@@ -311,7 +311,7 @@ class OffenderServiceTest {
       } returns ClientResult.Success(HttpStatus.OK, UserAccess(emptyList()))
 
       val result = offenderService.canAccessOffender(crn, CheckUserAccess("distinguished.name"))
-      assertThat(result).isFalse()
+      assertThat(result).isNull()
     }
 
     @Test
@@ -401,7 +401,7 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `return false when no access result returned for crn`() {
+    fun `return null when no access result returned for crn`() {
       val crn = randomNumberChars(8)
 
       every {
@@ -412,7 +412,7 @@ class OffenderServiceTest {
       } returns ClientResult.Success(HttpStatus.OK, UserAccess(emptyList()))
 
       val result = offenderService.canAccessOffenders("distinguished.name", listOf(crn))
-      assertThat(result[crn]).isFalse()
+      assertThat(result[crn]).isNull()
     }
 
     @Test
@@ -479,7 +479,7 @@ class OffenderServiceTest {
       assertThat(result[crns[1]]).isFalse()
       assertThat(result[crns[2]]).isFalse()
       assertThat(result[crns[3]]).isFalse()
-      assertThat(result[crns[4]]).isFalse()
+      assertThat(result[crns[4]]).isNull()
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysNeedsQuestionTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysNeedsQuestionTransformerTest.kt
@@ -1,0 +1,113 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysNeedsQuestion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
+
+class Cas1OASysNeedsQuestionTransformerTest {
+
+  private val transformer = Cas1OASysNeedsQuestionTransformer()
+
+  @Test
+  fun `exclude irrelevant questions`() {
+    val needsDetails = NeedsDetailsFactory()
+      .withEmotionalIssuesDetails(linkedToHarm = true, linkedToReoffending = false)
+      .withLifestyleIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withRelationshipIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withAccommodationIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withAttitudeIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withThinkingBehaviouralIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      // the following are excluded
+      .withDrugIssuesDetails(linkedToHarm = true, linkedToReoffending = false)
+      .withAlcoholIssuesDetails(linkedToHarm = false, linkedToReoffending = true)
+      .withEducationTrainingEmploymentIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withFinanceIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .produce()
+
+    val result = transformer.transformToApi(needsDetails)
+
+    assertThat(result.map { it.name }).containsExactlyInAnyOrder(
+      "Emotional",
+      "Accommodation",
+      "Relationships",
+      "Lifestyle",
+      "Thinking and Behavioural",
+      "Attitude",
+      "Health",
+    )
+  }
+
+  @Test
+  fun `If linked to harm is true, question is not optional`() {
+    val needsDetails = NeedsDetailsFactory()
+      .withEmotionalIssuesDetails(linkedToHarm = true, linkedToReoffending = false)
+      .withLifestyleIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withRelationshipIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withAccommodationIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withAttitudeIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .withThinkingBehaviouralIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
+      .produce()
+
+    val result = transformer.transformToApi(needsDetails)
+
+    assertThat(result).containsExactlyInAnyOrder(
+      OASysNeedsQuestion(section = 10, name = "Emotional", optional = false, linkedToHarm = true, linkedToReOffending = false),
+      OASysNeedsQuestion(section = 3, name = "Accommodation", optional = false, linkedToHarm = true, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 6, name = "Relationships", optional = false, linkedToHarm = true, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 7, name = "Lifestyle", optional = false, linkedToHarm = true, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 11, name = "Thinking and Behavioural", optional = false, linkedToHarm = true, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 12, name = "Attitude", optional = false, linkedToHarm = true, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 13, name = "Health", optional = true, linkedToHarm = null, linkedToReOffending = null),
+    )
+  }
+
+  @Test
+  fun `If linked to harm is false, question is optional`() {
+    val needsDetails = NeedsDetailsFactory()
+      .withEmotionalIssuesDetails(linkedToHarm = false, linkedToReoffending = false)
+      .withLifestyleIssuesDetails(linkedToHarm = false, linkedToReoffending = null)
+      .withRelationshipIssuesDetails(linkedToHarm = false, linkedToReoffending = null)
+      .withAccommodationIssuesDetails(linkedToHarm = false, linkedToReoffending = null)
+      .withAttitudeIssuesDetails(linkedToHarm = false, linkedToReoffending = null)
+      .withThinkingBehaviouralIssuesDetails(linkedToHarm = false, linkedToReoffending = null)
+      .produce()
+
+    val result = transformer.transformToApi(needsDetails)
+
+    assertThat(result).containsExactlyInAnyOrder(
+      OASysNeedsQuestion(section = 10, name = "Emotional", optional = true, linkedToHarm = false, linkedToReOffending = false),
+      OASysNeedsQuestion(section = 3, name = "Accommodation", optional = true, linkedToHarm = false, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 6, name = "Relationships", optional = true, linkedToHarm = false, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 7, name = "Lifestyle", optional = true, linkedToHarm = false, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 11, name = "Thinking and Behavioural", optional = true, linkedToHarm = false, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 12, name = "Attitude", optional = true, linkedToHarm = false, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 13, name = "Health", optional = true, linkedToHarm = null, linkedToReOffending = null),
+    )
+  }
+
+  @Test
+  fun `If linked to harm is null, question is optional`() {
+    val needsDetails = NeedsDetailsFactory()
+      .withEmotionalIssuesDetails(linkedToHarm = null, linkedToReoffending = false)
+      .withLifestyleIssuesDetails(linkedToHarm = null, linkedToReoffending = null)
+      .withRelationshipIssuesDetails(linkedToHarm = null, linkedToReoffending = null)
+      .withAccommodationIssuesDetails(linkedToHarm = null, linkedToReoffending = null)
+      .withAttitudeIssuesDetails(linkedToHarm = null, linkedToReoffending = null)
+      .withThinkingBehaviouralIssuesDetails(linkedToHarm = null, linkedToReoffending = null)
+      .produce()
+
+    val result = transformer.transformToApi(needsDetails)
+
+    assertThat(result).containsExactlyInAnyOrder(
+      OASysNeedsQuestion(section = 10, name = "Emotional", optional = true, linkedToHarm = null, linkedToReOffending = false),
+      OASysNeedsQuestion(section = 3, name = "Accommodation", optional = true, linkedToHarm = null, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 6, name = "Relationships", optional = true, linkedToHarm = null, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 7, name = "Lifestyle", optional = true, linkedToHarm = null, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 11, name = "Thinking and Behavioural", optional = true, linkedToHarm = null, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 12, name = "Attitude", optional = true, linkedToHarm = null, linkedToReOffending = null),
+      OASysNeedsQuestion(section = 13, name = "Health", optional = true, linkedToHarm = null, linkedToReOffending = null),
+    )
+  }
+}


### PR DESCRIPTION
This is similar to the existing shared `GET /people/X320741/oasys/sections` endpoint, but:

1. It has a clear name, better expressing its purpose and result
2. It filters out questions from sections 4&5 (currently filtered out in the UI)
3. It indicates if a question is optional, allowing us to move the optionality logic out of the UI and into the API. This will allow us to make changes to optionality going forward without having sync UI and API changes

This PR also makes some internal changes to CRN permission checks to allow calling code to determine if a record didn't exist for the given CRN (previously the code would instead return a 'forbidden' outcome, which isn't strictly correct)