### PR TITLE
Refactor reports date range

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ReportsController.kt
@@ -145,14 +145,14 @@ class Cas1ReportsController(
     endDate: LocalDate? = null,
   ): ReportDateRange = when {
     year != null && month != null -> {
-      val start = LocalDate.of(year, month, 1)
-      val end = YearMonth.of(year, month).atEndOfMonth()
+      val start = LocalDate.of(year, month, 1).atStartOfDay()
+      val end = YearMonth.of(year, month).atEndOfMonth().atTime(23, 59, 59)
       ReportDateRange(start, end)
     }
 
     startDate != null && endDate != null -> {
-      val start = startDate
-      val end = endDate
+      val start = startDate.atStartOfDay()
+      val end = endDate.atTime(23, 59, 59)
       ReportDateRange(start, end)
     }
     else -> throw IllegalArgumentException("Either year/month or startDate/endDate must be provided")
@@ -166,8 +166,8 @@ class Cas1ReportsController(
 
   private fun createCas1ReportName(
     name: String,
-    startDate: LocalDate,
-    endDate: LocalDate,
+    startDate: LocalDateTime,
+    endDate: LocalDateTime,
     contentType: ContentType,
   ): String {
     val timestamp = LocalDateTime.now().format(TIMESTAMP_FORMAT)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DailyMetricsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1DailyMetricsReportRepository.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.JdbcResultSetConsumer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.ReportJdbcTemplate
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Repository
 class Cas1DailyMetricsReportRepository(
@@ -13,66 +13,85 @@ class Cas1DailyMetricsReportRepository(
   companion object {
 
     const val QUERY = """
-       WITH all_dates AS (
-           SELECT generate_series(
-               :start_date::DATE,
-               :end_date::DATE,
-               '1 day'::INTERVAL
-           )::DATE AS report_date
-         ),
-       applications_by_day AS (
-           SELECT
-               DATE(application.created_at) AS report_date,
-               COUNT(*) AS applications_started,
-               COUNT(DISTINCT CAST(application.created_by_user_id AS TEXT)) AS unique_users_starting_applications
-           FROM approved_premises_applications apa
-               INNER JOIN applications application ON application.id = apa.id
-           WHERE DATE(application.created_at) BETWEEN :start_date AND :end_date
-           GROUP BY DATE(application.created_at)
-         ),
-       domain_events_by_day AS (
-           SELECT
-               DATE(domain_event.occurred_at) AS report_date,
-               COUNT(*) FILTER (WHERE domain_event.type = 'APPROVED_PREMISES_APPLICATION_SUBMITTED') AS applications_submitted,
-               COUNT(DISTINCT CAST(domain_event.data->'eventDetails'->'submittedBy'->'staffMember'->>'staffCode' AS TEXT))
-               FILTER (WHERE domain_event.type = 'APPROVED_PREMISES_APPLICATION_SUBMITTED') AS unique_users_submitting_applications,
-               COUNT(*) FILTER (WHERE domain_event.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED') AS assessments_completed,
-               COUNT(DISTINCT CAST(domain_event.data->'eventDetails'->'assessedBy'->'staffMember'->>'staffCode' AS TEXT))
-               FILTER (WHERE domain_event.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED') AS unique_users_completing_assessments,
-               COUNT(*) FILTER (WHERE domain_event.type = 'APPROVED_PREMISES_BOOKING_MADE') AS bookings_made,
-               COUNT(DISTINCT CAST(domain_event.data->'eventDetails'->>'bookedBy' AS TEXT))
-               FILTER (WHERE domain_event.type = 'APPROVED_PREMISES_BOOKING_MADE') AS unique_users_making_bookings
-           FROM domain_events domain_event
-           WHERE DATE(domain_event.occurred_at) BETWEEN :start_date AND :end_date
-           AND domain_event.service='CAS1'
-           GROUP BY DATE(domain_event.occurred_at)
-        )
-       SELECT
-           TO_CHAR(dates.report_date, 'YYYY-MM-DD') AS report_date,
-           COALESCE(applications_started, 0) AS applications_started,
-           COALESCE(unique_users_starting_applications, 0) AS unique_users_starting_applications,
-           COALESCE(applications_submitted, 0) AS applications_submitted,
-           COALESCE(unique_users_submitting_applications, 0) AS unique_users_submitting_applications,
-           COALESCE(assessments_completed, 0) AS assessments_completed,
-           COALESCE(unique_users_completing_assessments, 0) AS unique_users_completing_assessments,
-           COALESCE(bookings_made, 0) AS bookings_made,
-           COALESCE(unique_users_making_bookings, 0) AS unique_users_making_bookings
-       FROM all_dates dates
-           LEFT JOIN applications_by_day ON dates.report_date = applications_by_day.report_date
-           LEFT JOIN domain_events_by_day ON dates.report_date = domain_events_by_day.report_date
-       ORDER BY dates.report_date
+        WITH all_dates AS (
+        SELECT generate_series(
+            :startDateTimeInclusive, 
+            :endDateTimeInclusive,
+            '1 day'::INTERVAL
+        )::DATE AS report_date
+    ),
+    applications_by_day AS (
+        SELECT
+            DATE_TRUNC('day', application.created_at)::DATE AS report_date,
+            COUNT(*) AS applications_started,
+            COUNT(DISTINCT CAST(application.created_by_user_id AS TEXT)) AS unique_users_starting_applications
+        FROM approved_premises_applications apa
+        INNER JOIN applications application ON application.id = apa.id
+        WHERE application.created_at >= :startDateTimeInclusive
+          AND application.created_at <= :endDateTimeInclusive
+        GROUP BY DATE_TRUNC('day', application.created_at)::DATE
+    ),
+    domain_events_by_day AS (
+        SELECT
+            DATE_TRUNC('day', domain_event.occurred_at)::DATE AS report_date,
+            COUNT(*) FILTER (
+                WHERE domain_event.type = 'APPROVED_PREMISES_APPLICATION_SUBMITTED'
+            ) AS applications_submitted,
+            COUNT(
+                DISTINCT CAST(domain_event.data->'eventDetails'->'submittedBy'->'staffMember'->>'staffCode' AS TEXT)
+            ) FILTER (
+                WHERE domain_event.type = 'APPROVED_PREMISES_APPLICATION_SUBMITTED'
+            ) AS unique_users_submitting_applications,
+            COUNT(*) FILTER (
+                WHERE domain_event.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED'
+            ) AS assessments_completed,
+            COUNT(
+                DISTINCT CAST(domain_event.data->'eventDetails'->'assessedBy'->'staffMember'->>'staffCode' AS TEXT)
+            ) FILTER (
+                WHERE domain_event.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED'
+            ) AS unique_users_completing_assessments,
+            COUNT(*) FILTER (
+                WHERE domain_event.type = 'APPROVED_PREMISES_BOOKING_MADE'
+            ) AS bookings_made,
+            COUNT(
+                DISTINCT CAST(domain_event.data->'eventDetails'->>'bookedBy' AS TEXT)
+            ) FILTER (
+                WHERE domain_event.type = 'APPROVED_PREMISES_BOOKING_MADE'
+            ) AS unique_users_making_bookings
+        FROM domain_events domain_event
+        WHERE domain_event.occurred_at >= :startDateTimeInclusive
+          AND domain_event.occurred_at <= :endDateTimeInclusive
+          AND domain_event.service = 'CAS1'
+        GROUP BY DATE_TRUNC('day', domain_event.occurred_at)::DATE
+    )
+    SELECT
+        TO_CHAR(dates.report_date, 'YYYY-MM-DD') AS report_date,
+        COALESCE(applications_started, 0) AS applications_started,
+        COALESCE(unique_users_starting_applications, 0) AS unique_users_starting_applications,
+        COALESCE(applications_submitted, 0) AS applications_submitted,
+        COALESCE(unique_users_submitting_applications, 0) AS unique_users_submitting_applications,
+        COALESCE(assessments_completed, 0) AS assessments_completed,
+        COALESCE(unique_users_completing_assessments, 0) AS unique_users_completing_assessments,
+        COALESCE(bookings_made, 0) AS bookings_made,
+        COALESCE(unique_users_making_bookings, 0) AS unique_users_making_bookings
+    FROM all_dates dates
+    LEFT JOIN applications_by_day 
+        ON dates.report_date = applications_by_day.report_date
+    LEFT JOIN domain_events_by_day 
+        ON dates.report_date = domain_events_by_day.report_date
+    ORDER BY dates.report_date
   """
   }
 
   fun generateCas1DailyMetricsReport(
-    startDate: LocalDate,
-    endDate: LocalDate,
+    startDateTimeInclusive: LocalDateTime,
+    endDateTimeInclusive: LocalDateTime,
     jdbcResultSetConsumer: JdbcResultSetConsumer,
   ) = reportJdbcTemplate.query(
     QUERY,
     mapOf<String, Any>(
-      "start_date" to startDate,
-      "end_date" to endDate,
+      "startDateTimeInclusive" to startDateTimeInclusive,
+      "endDateTimeInclusive" to endDateTimeInclusive,
     ),
     jdbcResultSetConsumer,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ReportService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.generator.Cas1
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.util.CsvJdbcResultSetConsumer
 import java.io.OutputStream
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 
 @Service
@@ -70,8 +71,8 @@ class Cas1ReportService(
       columnsToExclude = emptyList(),
     ).use { consumer ->
       cas1DailyMetricsReportRepository.generateCas1DailyMetricsReport(
-        startDate = reportDateRange.start,
-        endDate = reportDateRange.end,
+        startDateTimeInclusive = reportDateRange.start,
+        endDateTimeInclusive = reportDateRange.end,
         jdbcResultSetConsumer = consumer,
 
       )
@@ -166,8 +167,8 @@ class Cas1ReportService(
   }
 
   data class ReportDateRange(
-    val start: LocalDate,
-    val end: LocalDate,
+    val start: LocalDateTime,
+    val end: LocalDateTime,
   )
 
   @Deprecated("Will be removed soon", replaceWith = ReplaceWith("ReportDateRange(startDate, endDate)"))


### PR DESCRIPTION
Updated reports to use date-time range instead of just date, as it will have an impact on other report generation.