### PR TITLE
Upgrade to latest springdoc-starter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
   implementation("org.postgresql:postgresql:42.7.4")
   implementation("org.javers:javers-core:7.7.0")
 
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 
   implementation("org.zalando:problem-spring-web-starter:0.29.1")
 


### PR DESCRIPTION
CVE-2025-26791 relates to DOMPurify, which is used by swagger ui. Upgrading to a later version of the starter to see if this resolves the issue