### PR TITLE
APS-2355 - CAS1 OASys Endpoint Naming Improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.OAsysCas1Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysNeedsQuestion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationMetaData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
@@ -25,11 +25,11 @@ class Cas1OasysController(
   private val oaSysSectionsTransformer: OASysSectionsTransformer,
 ) : OAsysCas1Delegate {
 
-  override fun optionalNeeds(crn: String): ResponseEntity<List<Cas1OASysNeedsQuestion>> {
+  override fun supportingInformationMetadata(crn: String): ResponseEntity<List<Cas1OASysSupportingInformationMetaData>> {
     ensureOffenderAccess(crn)
 
     return ResponseEntity.ok(
-      cas1OASysNeedsQuestionTransformer.transformToNeedsQuestion(
+      cas1OASysNeedsQuestionTransformer.transformToSupportingInformationMetadata(
         extractEntityFromCasResult(oaSysService.getOASysNeeds(crn)),
       ),
     )
@@ -52,7 +52,7 @@ class Cas1OasysController(
       Cas1OASysGroupName.ROSH_SUMMARY -> oaSysSectionsTransformer.roshSummaryAnswers(
         extractEntityFromCasResult(oaSysService.getOASysRoshSummary(crn)),
       )
-      Cas1OASysGroupName.NEEDS -> cas1OASysNeedsQuestionTransformer.transformToOASysQuestion(
+      Cas1OASysGroupName.SUPPORTING_INFORMATION -> cas1OASysNeedsQuestionTransformer.transformToOASysQuestion(
         needsDetails = extractEntityFromCasResult(oaSysService.getOASysNeeds(crn)),
         includeOptionalSections = includeOptionalSections ?: emptyList(),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysNeedsQuestionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysNeedsQuestionTransformer.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysNeedsQuestion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationMetaData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.NeedsDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysLabels
@@ -9,13 +9,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysLabels
 @Service
 class Cas1OASysNeedsQuestionTransformer {
 
-  fun transformToNeedsQuestion(needsDetails: NeedsDetails) = toQuestionState(needsDetails).map {
-    Cas1OASysNeedsQuestion(
+  fun transformToSupportingInformationMetadata(needsDetails: NeedsDetails) = toQuestionState(needsDetails).map {
+    Cas1OASysSupportingInformationMetaData(
       section = it.sectionNumber,
       sectionLabel = it.sectionLabel,
-      optional = it.optional,
-      linkedToHarm = it.linkedToHarm,
-      linkedToReOffending = it.linkedToReOffending,
+      inclusionOptional = it.optional,
+      oasysAnswerLinkedToHarm = it.linkedToHarm,
+      oasysAnswerLinkedToReOffending = it.linkedToReOffending,
     )
   }
 

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -2087,12 +2087,12 @@ paths:
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
 
-  /people/{crn}/oasys/optional-needs-questions:
+  /people/{crn}/oasys/supporting-information-metadata:
     get:
       tags:
         - OAsys
-      summary: Returns information about which 'needs' questions & answers can be optionally included in an application (and which are mandatory), for a given CRN
-      operationId: optionalNeeds
+      summary: Returns metadata about supporting information questions for a given CRN
+      operationId: supportingInformationMetadata
       parameters:
         - name: crn
           in: path
@@ -2107,7 +2107,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: 'cas1-schemas.yml#/components/schemas/Cas1OASysNeedsQuestion'
+                  $ref: 'cas1-schemas.yml#/components/schemas/Cas1OASysSupportingInformationMetaData'
         404:
           description: invalid CRN
           content:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1850,41 +1850,41 @@ components:
           $ref: '_shared.yml#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
-    Cas1OASysNeedsQuestion:
+    Cas1OASysSupportingInformationMetaData:
       type: object
       properties:
         section:
           type: integer
           example: 10
-          description: The OAsys section that this 'needs' question relates to
+          description: The OAsys section that this question relates to
         sectionLabel:
           type: string
-        optional:
+        inclusionOptional:
           type: boolean
-          description: If the user can optionally elect to include this question in an application. If not optional, it will always be included in the application
-        linkedToHarm:
+          description: If the user can optionally elect to include this question in an application. If not optional, it will always be returned by calls to '/cas1/people/{crn}/oasys/answers'
+        oasysAnswerLinkedToHarm:
           type: boolean
-          description: If the response to this question for the person is linked to harm
-        linkedToReOffending:
+          description: If the response to this question in OASys for the person has been identified as 'linked to harm'
+        oasysAnswerLinkedToReOffending:
           type: boolean
-          description: If the response to this question for the person is linked to re-offending
+          description: If the response to this question in OAsys for the person hsa been identified as 'linked to re-offending'
       required:
         - section
-        - name
-        - optional
+        - sectionLabel
+        - inclusionOptional
     Cas1OASysGroupName:
       type: string
       enum:
         - riskManagementPlan
         - offenceDetails
         - roshSummary
-        - needs
+        - supportingInformation
         - riskToSelf
       x-enum-varnames:
         - RISK_MANAGEMENT_PLAN
         - OFFENCE_DETAILS
         - ROSH_SUMMARY
-        - NEEDS
+        - SUPPORTING_INFORMATION
         - RISK_TO_SELF
     Cas1OASysGroup:
       type: object

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2089,12 +2089,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Problem'
 
-  /people/{crn}/oasys/optional-needs-questions:
+  /people/{crn}/oasys/supporting-information-metadata:
     get:
       tags:
         - OAsys
-      summary: Returns information about which 'needs' questions & answers can be optionally included in an application (and which are mandatory), for a given CRN
-      operationId: optionalNeeds
+      summary: Returns metadata about supporting information questions for a given CRN
+      operationId: supportingInformationMetadata
       parameters:
         - name: crn
           in: path
@@ -2109,7 +2109,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Cas1OASysNeedsQuestion'
+                  $ref: '#/components/schemas/Cas1OASysSupportingInformationMetaData'
         404:
           description: invalid CRN
           content:
@@ -8658,41 +8658,41 @@ components:
           $ref: '#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
-    Cas1OASysNeedsQuestion:
+    Cas1OASysSupportingInformationMetaData:
       type: object
       properties:
         section:
           type: integer
           example: 10
-          description: The OAsys section that this 'needs' question relates to
+          description: The OAsys section that this question relates to
         sectionLabel:
           type: string
-        optional:
+        inclusionOptional:
           type: boolean
-          description: If the user can optionally elect to include this question in an application. If not optional, it will always be included in the application
-        linkedToHarm:
+          description: If the user can optionally elect to include this question in an application. If not optional, it will always be returned by calls to '/cas1/people/{crn}/oasys/answers'
+        oasysAnswerLinkedToHarm:
           type: boolean
-          description: If the response to this question for the person is linked to harm
-        linkedToReOffending:
+          description: If the response to this question in OASys for the person has been identified as 'linked to harm'
+        oasysAnswerLinkedToReOffending:
           type: boolean
-          description: If the response to this question for the person is linked to re-offending
+          description: If the response to this question in OAsys for the person hsa been identified as 'linked to re-offending'. Nul
       required:
         - section
-        - name
-        - optional
+        - sectionLabel
+        - inclusionOptional
     Cas1OASysGroupName:
       type: string
       enum:
         - riskManagementPlan
         - offenceDetails
         - roshSummary
-        - needs
+        - supportingInformation
         - riskToSelf
       x-enum-varnames:
         - RISK_MANAGEMENT_PLAN
         - OFFENCE_DETAILS
         - ROSH_SUMMARY
-        - NEEDS
+        - SUPPORTING_INFORMATION
         - RISK_TO_SELF
     Cas1OASysGroup:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -34,12 +34,12 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
   }
 
   @Nested
-  inner class OptionalNeedsQuestions {
+  inner class SupportingInformationMetadata {
 
     @Test
     fun `No JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas1/people/CRN/oasys/optional-needs-questions")
+        .uri("/cas1/people/CRN/oasys/supporting-information-metadata")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -52,7 +52,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       apDeliusContextUserAccessEmptyResponse()
 
       webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/optional-needs-questions")
+        .uri("/cas1/people/$CRN/oasys/supporting-information-metadata")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -71,7 +71,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/optional-needs-questions")
+        .uri("/cas1/people/$CRN/oasys/supporting-information-metadata")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -94,7 +94,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       apOASysContextMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
 
       webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/optional-needs-questions")
+        .uri("/cas1/people/$CRN/oasys/supporting-information-metadata")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -102,7 +102,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
         .expectBody()
         .json(
           objectMapper.writeValueAsString(
-            cas1OASysNeedsQuestionTransformer.transformToNeedsQuestion(needsDetails),
+            cas1OASysNeedsQuestionTransformer.transformToSupportingInformationMetadata(needsDetails),
           ),
         )
     }
@@ -270,7 +270,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Needs`() {
+    fun `Supporting Information`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
@@ -284,14 +284,14 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       apOASysContextMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
 
       val result = webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/answers?group=needs&includeOptionalSections=10")
+        .uri("/cas1/people/$CRN/oasys/answers?group=supportingInformation&includeOptionalSections=10")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
         .isOk
         .bodyAsObject<Cas1OASysGroup>()
 
-      assertThat(result.group).isEqualTo(Cas1OASysGroupName.NEEDS)
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.SUPPORTING_INFORMATION)
       assertThat(result.answers).contains(
         OASysQuestion(
           label = "Relationship issues contributing to risks of offending and harm",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysNeedsQuestionTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysNeedsQuestionTransformerTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysNeedsQuestion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationMetaData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
@@ -33,7 +33,7 @@ class Cas1OASysNeedsQuestionTransformerTest {
         .withFinanceIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
         .produce()
 
-      val result = transformer.transformToNeedsQuestion(needsDetails)
+      val result = transformer.transformToSupportingInformationMetadata(needsDetails)
 
       assertThat(result.map { it.sectionLabel }).containsExactlyInAnyOrder(
         "Emotional",
@@ -60,64 +60,64 @@ class Cas1OASysNeedsQuestionTransformerTest {
         .withThinkingBehaviouralIssuesDetails(linkedToHarm = true, linkedToReoffending = null)
         .produce()
 
-      val result = transformer.transformToNeedsQuestion(needsDetails)
+      val result = transformer.transformToSupportingInformationMetadata(needsDetails)
 
       assertThat(result).containsExactlyInAnyOrder(
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 10,
           sectionLabel = "Emotional",
-          optional = false,
-          linkedToHarm = true,
-          linkedToReOffending = false,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = true,
+          oasysAnswerLinkedToReOffending = false,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 3,
           sectionLabel = "Accommodation",
-          optional = false,
-          linkedToHarm = true,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = true,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 6,
           sectionLabel = "Relationships",
-          optional = false,
-          linkedToHarm = true,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = true,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 7,
           sectionLabel = "Lifestyle",
-          optional = false,
-          linkedToHarm = true,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = true,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 8,
           sectionLabel = "Drugs",
-          optional = false,
-          linkedToHarm = true,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = true,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 9,
           sectionLabel = "Alcohol",
-          optional = false,
-          linkedToHarm = true,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = true,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 11,
           sectionLabel = "Thinking and Behavioural",
-          optional = false,
-          linkedToHarm = true,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = true,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 12,
           sectionLabel = "Attitude",
-          optional = false,
-          linkedToHarm = true,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = true,
+          oasysAnswerLinkedToReOffending = null,
         ),
       )
     }
@@ -136,64 +136,64 @@ class Cas1OASysNeedsQuestionTransformerTest {
         .withThinkingBehaviouralIssuesDetails(linkedToHarm = linkedToHarm, linkedToReoffending = null)
         .produce()
 
-      val result = transformer.transformToNeedsQuestion(needsDetails)
+      val result = transformer.transformToSupportingInformationMetadata(needsDetails)
 
       assertThat(result).containsExactlyInAnyOrder(
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 10,
           sectionLabel = "Emotional",
-          optional = true,
-          linkedToHarm = linkedToHarm,
-          linkedToReOffending = false,
+          inclusionOptional = true,
+          oasysAnswerLinkedToHarm = linkedToHarm,
+          oasysAnswerLinkedToReOffending = false,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 3,
           sectionLabel = "Accommodation",
-          optional = true,
-          linkedToHarm = linkedToHarm,
-          linkedToReOffending = null,
+          inclusionOptional = true,
+          oasysAnswerLinkedToHarm = linkedToHarm,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 6,
           sectionLabel = "Relationships",
-          optional = true,
-          linkedToHarm = linkedToHarm,
-          linkedToReOffending = null,
+          inclusionOptional = true,
+          oasysAnswerLinkedToHarm = linkedToHarm,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 7,
           sectionLabel = "Lifestyle",
-          optional = true,
-          linkedToHarm = linkedToHarm,
-          linkedToReOffending = null,
+          inclusionOptional = true,
+          oasysAnswerLinkedToHarm = linkedToHarm,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 8,
           sectionLabel = "Drugs",
-          optional = false,
-          linkedToHarm = linkedToHarm,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = linkedToHarm,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 9,
           sectionLabel = "Alcohol",
-          optional = false,
-          linkedToHarm = linkedToHarm,
-          linkedToReOffending = null,
+          inclusionOptional = false,
+          oasysAnswerLinkedToHarm = linkedToHarm,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 11,
           sectionLabel = "Thinking and Behavioural",
-          optional = true,
-          linkedToHarm = linkedToHarm,
-          linkedToReOffending = null,
+          inclusionOptional = true,
+          oasysAnswerLinkedToHarm = linkedToHarm,
+          oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysNeedsQuestion(
+        Cas1OASysSupportingInformationMetaData(
           section = 12,
           sectionLabel = "Attitude",
-          optional = true,
-          linkedToHarm = linkedToHarm,
-          linkedToReOffending = null,
+          inclusionOptional = true,
+          oasysAnswerLinkedToHarm = linkedToHarm,
+          oasysAnswerLinkedToReOffending = null,
         ),
       )
     }


### PR DESCRIPTION
* Rename endpoint ‘optional-needs-questions’ to ‘supporting-information-metadata`. This is in preparation for answers from health to this response in a subsequent commit, which aren’t directly related to naneeds
* Aligned with the previous change, rename CAS1 OASys group ‘needs’ to ‘supportingInformation’
* Rename the response type to better reflect what it contains
* Rename properties of `Cas1OASysSupportingInformationMetaData` to better reflect their purpose