### PR TITLE
Fix preemptive cache test flakiness

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/WebClientCache.kt
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.minusRandomSeconds
+import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
@@ -23,6 +24,7 @@ class WebClientCache(
   private val redisTemplate: RedisTemplate<String, String>,
   @Value("\${preemptive-cache-key-prefix}") private val preemptiveCacheKeyPrefix: String,
   private val sentryService: SentryService,
+  private val clock: Clock,
 ) {
 
   fun checkPreemptiveCacheStatus(cacheConfig: PreemptiveCacheConfig, key: String): PreemptiveCacheEntryStatus {
@@ -123,7 +125,7 @@ class WebClientCache(
     writeToRedis(cacheKeySet, cacheEntry, result.body, cacheConfig.hardTtlSeconds.toLong())
   }
 
-  private fun now() = Instant.now()
+  private fun now() = Instant.now(clock)
 
   private fun <ResponseType : Any> pollCacheWithBlockingWait(
     cacheKeyResolver: CacheKeyResolver,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/ClockConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/mocks/ClockConfiguration.kt
@@ -35,6 +35,10 @@ class ClockConfiguration {
       fixedTime = now.toInstant(ZoneOffset.UTC)
     }
 
+    fun setNow(now: Instant) {
+      fixedTime = now
+    }
+
     fun setToNowWithoutMillis() {
       setNow(LocalDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
     }


### PR DESCRIPTION
Static mocks are tricky because you need to remember to unset them once done. We’ve also found that mocking a commonly used function (`Instant.now()`) lead to errors when some other code used the the function before we’d had a chance to set a response e.g.

```
2025-06-03 14:26:34.375 ERROR 452 --- [Container#0-0-1] c.s.l.a.BatchingAcknowledgementProcessor : Error executing scheduled acknowledgement in io.awspring.cloud.sqs.sqsListenerEndpointContainer#0-0. Resuming. |

io.mockk.MockKException: no answer provided for class java.time.Instant.now())
```

This commit removes use of static mocks in PreemptiveCacheTest and replaces it with the pre-existing mutable clock