### PR TITLE
APS-1570 - Remove schema validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,8 +53,6 @@ dependencies {
 
   implementation(kotlin("reflect"))
 
-  implementation("com.networknt:json-schema-validator:1.1.0")
-
   implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.10.0")
 
   implementation("org.jetbrains.kotlinx:dataframe:0.15.0") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonSchemaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JsonSchemaService.kt
@@ -1,44 +1,19 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.networknt.schema.JsonSchema
-import com.networknt.schema.JsonSchemaFactory
-import com.networknt.schema.SpecVersionDetector
 import org.hibernate.Hibernate
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRepository
-import java.util.Collections.synchronizedMap
-import java.util.UUID
 
+@Deprecated("APS-1570 Schema validation will be removed in the future")
 @Service
 class JsonSchemaService(
-  private val objectMapper: ObjectMapper,
   private val jsonSchemaRepository: JsonSchemaRepository,
 ) {
-  private val log = LoggerFactory.getLogger(this::class.java)
-
-  private val schemas = synchronizedMap<UUID, JsonSchema>(mutableMapOf())
-
-  fun validate(schema: JsonSchemaEntity, json: String): Boolean {
-    val schemaJsonNode = objectMapper.readTree(schema.schema)
-    val jsonNode = objectMapper.readTree(json)
-
-    if (!schemas.containsKey(schema.id)) {
-      schemas[schema.id] = JsonSchemaFactory.getInstance(SpecVersionDetector.detect(schemaJsonNode))
-        .getSchema(schemaJsonNode)
-    }
-
-    val validationErrors = schemas[schema.id]!!.validate(jsonNode)
-
-    if (validationErrors.isNotEmpty()) {
-      log.warn("Validation errors whilst validating schema: \n\t${validationErrors.joinToString("\n\t,") { "Schema Path: ${it.schemaPath} -> Path: ${it.path}: ${it.message}" }}")
-    }
-
-    return validationErrors.isEmpty()
-  }
+  @SuppressWarnings("FunctionOnlyReturningConstant", "UnusedParameter")
+  @Deprecated("APS-1570 As a intermediary step to remove schema logic, this always returns true")
+  fun validate(schema: JsonSchemaEntity, json: String) = true
 
   fun checkSchemaOutdated(application: ApplicationEntity): ApplicationEntity {
     val newestSchema = getNewestSchema(Hibernate.getClass(application.schemaVersion))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2JsonSchemaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/Cas2JsonSchemaService.kt
@@ -1,44 +1,18 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.networknt.schema.JsonSchema
-import com.networknt.schema.JsonSchemaFactory
-import com.networknt.schema.SpecVersionDetector
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2.Cas2ApplicationEntity
-import java.util.Collections.synchronizedMap
-import java.util.UUID
 
-@SuppressWarnings("UnusedPrivateProperty")
+@Deprecated("APS-1570 Schema validation will be removed in the future")
 @Service
 class Cas2JsonSchemaService(
-  private val objectMapper: ObjectMapper,
   private val jsonSchemaRepository: JsonSchemaRepository,
 ) {
-  private val log = LoggerFactory.getLogger(this::class.java)
-
-  private val schemas = synchronizedMap<UUID, JsonSchema>(mutableMapOf())
-
-  fun validate(schema: JsonSchemaEntity, json: String): Boolean {
-    val schemaJsonNode = objectMapper.readTree(schema.schema)
-    val jsonNode = objectMapper.readTree(json)
-
-    if (!schemas.containsKey(schema.id)) {
-      schemas[schema.id] = JsonSchemaFactory.getInstance(SpecVersionDetector.detect(schemaJsonNode))
-        .getSchema(schemaJsonNode)
-    }
-
-    val validationErrors = schemas[schema.id]!!.validate(jsonNode)
-
-    if (validationErrors.isNotEmpty()) {
-      log.warn("Validation errors whilst validating schema: \n\t${validationErrors.joinToString("\n\t,") { "Schema Path: ${it.schemaPath} -> Path: ${it.path}: ${it.message}" }}")
-    }
-
-    return validationErrors.isEmpty()
-  }
+  @SuppressWarnings("FunctionOnlyReturningConstant", "UnusedParameter")
+  @Deprecated("APS-1570 As a intermediary step to remove schema logic, this always returns true")
+  fun validate(schema: JsonSchemaEntity, json: String) = true
 
   fun checkSchemaOutdated(application: Cas2ApplicationEntity): Cas2ApplicationEntity {
     val newestSchema = getNewestSchema(application.schemaVersion.javaClass)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2JsonSchemaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2v2/Cas2v2JsonSchemaService.kt
@@ -1,43 +1,18 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2v2
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.networknt.schema.JsonSchema
-import com.networknt.schema.JsonSchemaFactory
-import com.networknt.schema.SpecVersionDetector
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas2v2.Cas2v2ApplicationEntity
-import java.util.Collections.synchronizedMap
-import java.util.UUID
 
+@Deprecated("APS-1570 Schema validation will be removed in the future")
 @Service
 class Cas2v2JsonSchemaService(
-  private val objectMapper: ObjectMapper,
   private val jsonSchemaRepository: JsonSchemaRepository,
 ) {
-  private val log = LoggerFactory.getLogger(this::class.java)
-
-  private val schemas = synchronizedMap<UUID, JsonSchema>(mutableMapOf())
-
-  fun validate(schema: JsonSchemaEntity, json: String): Boolean {
-    val schemaJsonNode = objectMapper.readTree(schema.schema)
-    val jsonNode = objectMapper.readTree(json)
-
-    if (!schemas.containsKey(schema.id)) {
-      schemas[schema.id] = JsonSchemaFactory.getInstance(SpecVersionDetector.detect(schemaJsonNode))
-        .getSchema(schemaJsonNode)
-    }
-
-    val validationErrors = schemas[schema.id]!!.validate(jsonNode)
-
-    if (validationErrors.isNotEmpty()) {
-      log.warn("Validation errors whilst validating schema: \n\t${validationErrors.joinToString("\n\t,") { "Schema Path: ${it.schemaPath} -> Path: ${it.path}: ${it.message}" }}")
-    }
-
-    return validationErrors.isEmpty()
-  }
+  @SuppressWarnings("FunctionOnlyReturningConstant", "UnusedParameter")
+  @Deprecated("APS-1570 As a intermediary step to remove schema logic, this always returns true")
+  fun validate(schema: JsonSchemaEntity, json: String) = true
 
   fun checkCas2v2SchemaOutdated(application: Cas2v2ApplicationEntity): Cas2v2ApplicationEntity {
     val newestSchema = getNewestSchema(application.schemaVersion.javaClass)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/JsonSchemaServiceTest.kt
@@ -15,14 +15,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import java.util.UUID
 
 class JsonSchemaServiceTest {
   private val mockJsonSchemaRepository = mockk<JsonSchemaRepository>()
 
   private val jsonSchemaService = JsonSchemaService(
-    objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper(),
     jsonSchemaRepository = mockJsonSchemaRepository,
   )
 
@@ -195,62 +193,15 @@ class JsonSchemaServiceTest {
   }
 
   @Test
-  fun `validate returns false for JSON that does not satisfy schema`() {
+  fun `validate always returns true`() {
     val schema = ApprovedPremisesApplicationJsonSchemaEntityFactory()
-      .withSchema(
-        """
-        {
-          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-          "${"\$id"}": "https://example.com/product.schema.json",
-          "title": "Thing",
-          "description": "A thing",
-          "type": "object",
-          "properties": {
-            "thingId": {
-              "description": "The unique identifier for a thing",
-              "type": "integer"
-            }
-          },
-          "required": [ "thingId" ]
-        }
-        """,
-      )
-      .produce()
-
-    assertThat(jsonSchemaService.validate(schema, "{}")).isFalse
-  }
-
-  @Test
-  fun `validate returns true for JSON that does satisfy schema`() {
-    val schema = ApprovedPremisesApplicationJsonSchemaEntityFactory()
-      .withSchema(
-        """
-        {
-          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-          "${"\$id"}": "https://example.com/product.schema.json",
-          "title": "Thing",
-          "description": "A thing",
-          "type": "object",
-          "properties": {
-            "thingId": {
-              "description": "The unique identifier for a thing",
-              "type": "integer"
-            }
-          },
-          "required": [ "thingId" ]
-        }
-        """,
-      )
+      .withSchema("doesntmatter")
       .produce()
 
     assertThat(
       jsonSchemaService.validate(
         schema,
-        """
-        {
-           "thingId": 123
-        }
-      """,
+        """irrelevant""",
       ),
     ).isTrue
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/Cas2JsonSchemaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas2/Cas2JsonSchemaServiceTest.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas2.Cas2Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JsonSchemaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.Cas2JsonSchemaService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.ObjectMapperFactory
 import java.util.UUID
 
 @SuppressWarnings("UnusedPrivateProperty")
@@ -18,7 +17,6 @@ class Cas2JsonSchemaServiceTest {
   private val mockJsonSchemaRepository = mockk<JsonSchemaRepository>()
 
   private val jsonSchemaService = Cas2JsonSchemaService(
-    objectMapper = ObjectMapperFactory.createRuntimeLikeObjectMapper(),
     jsonSchemaRepository = mockJsonSchemaRepository,
   )
 
@@ -101,62 +99,15 @@ class Cas2JsonSchemaServiceTest {
   }
 
   @Test
-  fun `validate returns false for JSON that does not satisfy schema`() {
+  fun `validate always returns true`() {
     val schema = Cas2ApplicationJsonSchemaEntityFactory()
-      .withSchema(
-        """
-        {
-          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-          "${"\$id"}": "https://example.com/product.schema.json",
-          "title": "Thing",
-          "description": "A thing",
-          "type": "object",
-          "properties": {
-            "thingId": {
-              "description": "The unique identifier for a thing",
-              "type": "integer"
-            }
-          },
-          "required": [ "thingId" ]
-        }
-        """,
-      )
-      .produce()
-
-    assertThat(jsonSchemaService.validate(schema, "{}")).isFalse
-  }
-
-  @Test
-  fun `validate returns true for JSON that does satisfy schema`() {
-    val schema = Cas2ApplicationJsonSchemaEntityFactory()
-      .withSchema(
-        """
-        {
-          "${"\$schema"}": "https://json-schema.org/draft/2020-12/schema",
-          "${"\$id"}": "https://example.com/product.schema.json",
-          "title": "Thing",
-          "description": "A thing",
-          "type": "object",
-          "properties": {
-            "thingId": {
-              "description": "The unique identifier for a thing",
-              "type": "integer"
-            }
-          },
-          "required": [ "thingId" ]
-        }
-        """,
-      )
+      .withSchema("doesntmatter")
       .produce()
 
     assertThat(
       jsonSchemaService.validate(
         schema,
-        """
-        {
-           "thingId": 123
-        }
-      """,
+        "irrelevant",
       ),
     ).isTrue
   }


### PR DESCRIPTION
This PR removes the schema validation logic, instead always returning that the schema is valid. This is the first step in removing the schema validation code, which has been unused for almost two years.

This intermediary steps allows us to remove the `com.networknt:json-schema-validator` dependency, which was out of date.