### PR TITLE
Upgrade mockk

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:dataframe-excel:0.15.0")
 
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
-  testImplementation("io.mockk:mockk:1.13.17")
+  testImplementation("io.mockk:mockk:1.14.2")
   testImplementation("com.github.tomakehurst:wiremock-standalone:3.0.1")
   testImplementation("io.jsonwebtoken:jjwt-api:0.12.6")
   testRuntimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1OutOfServiceBedSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/seed/cas1/Cas1OutOfServiceBedSeedJobTest.kt
@@ -352,8 +352,6 @@ class Cas1OutOfServiceBedSeedJobTest {
       seedJob.processRow(secondRow)
 
       verify(exactly = 1) {
-        premisesService.getPremises(secondRow.key.premisesId)
-
         cas1OutOfServiceBedService.updateOutOfServiceBed(
           expectedOutOfServiceBed.id,
           secondRow.startDate,


### PR DESCRIPTION
This uncovered a failing verification that had been incorrectly added to a unit test (when updating an out of service bed the premises isn’t retrieved)