### PR TITLE
Fix cas event by fixing race condition when we create new nomis user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/NomisUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/NomisUserService.kt
@@ -55,7 +55,7 @@ class NomisUserService(
     is ClientResult.Failure -> nomsStaffInformationResponse.throwException()
   }
 
-  @Transactional
+  @Transactional(value = Transactional.TxType.REQUIRES_NEW)
   fun getUserForUsername(username: String, jwt: String): NomisUserEntity {
     val nomisUserDetails = when (
       val nomisUserDetailResponse = nomisUserRolesForRequesterApiClient.getUserDetailsForMe(jwt)


### PR DESCRIPTION
We having been seeing this event on the `#cas-events` slack channel a lot recently:
https://ministryofjustice.sentry.io/issues/6656780267/?alert_rule_id=15300595&alert_type=issue&environment=prod&notification_uuid=c20f3bf8-7d5c-478c-8da6-b123b9631c0b&project=4503931792392192&referrer=slack

Suspect this is caused by a race condition to create the user. Hopefully this code change will fix it