### PR TITLE
APS-2355 - CAS1 OASys Endpoint Improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.OAsysCas1Delegate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationMetaData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
@@ -25,12 +25,14 @@ class Cas1OasysController(
   private val oaSysSectionsTransformer: OASysSectionsTransformer,
 ) : OAsysCas1Delegate {
 
-  override fun supportingInformationMetadata(crn: String): ResponseEntity<List<Cas1OASysSupportingInformationMetaData>> {
+  override fun supportingInformationMetadata(crn: String): ResponseEntity<Cas1OASysMetadata> {
     ensureOffenderAccess(crn)
 
     return ResponseEntity.ok(
-      cas1OASysNeedsQuestionTransformer.transformToSupportingInformationMetadata(
-        extractEntityFromCasResult(oaSysService.getOASysNeeds(crn)),
+      Cas1OASysMetadata(
+        cas1OASysNeedsQuestionTransformer.transformToSupportingInformationMetadata(
+          extractEntityFromCasResult(oaSysService.getOASysNeeds(crn)),
+        ),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysNeedsQuestionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysNeedsQuestionTransformer.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationMetaData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationQuestionMetaData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.NeedsDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysLabels
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysLabels
 class Cas1OASysNeedsQuestionTransformer {
 
   fun transformToSupportingInformationMetadata(needsDetails: NeedsDetails) = toQuestionState(needsDetails).map {
-    Cas1OASysSupportingInformationMetaData(
+    Cas1OASysSupportingInformationQuestionMetaData(
       section = it.sectionNumber,
       sectionLabel = it.sectionLabel,
       inclusionOptional = it.optional,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysOffenceDetailsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysOffenceDetailsTransformer.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysAssessmentMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.OffenceDetails
+
+@Service
+class Cas1OASysOffenceDetailsTransformer {
+  fun toAssessmentMetadata(offenceDetails: OffenceDetails) = Cas1OASysAssessmentMetadata(
+    dateStarted = offenceDetails.initiationDate.toInstant(),
+    dateCompleted = offenceDetails.dateCompleted?.toInstant(),
+  )
+}

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -2087,7 +2087,7 @@ paths:
               schema:
                 $ref: '_shared.yml#/components/schemas/Problem'
 
-  /people/{crn}/oasys/supporting-information-metadata:
+  /people/{crn}/oasys/metadata:
     get:
       tags:
         - OAsys
@@ -2105,9 +2105,7 @@ paths:
           content:
             'application/json':
               schema:
-                type: array
-                items:
-                  $ref: 'cas1-schemas.yml#/components/schemas/Cas1OASysSupportingInformationMetaData'
+                $ref: 'cas1-schemas.yml#/components/schemas/Cas1OASysMetadata'
         404:
           description: invalid CRN
           content:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1850,7 +1850,15 @@ components:
           $ref: '_shared.yml#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
-    Cas1OASysSupportingInformationMetaData:
+    Cas1OASysMetadata:
+      properties:
+        supportingInformation:
+          type: array
+          items:
+            $ref: 'cas1-schemas.yml#/components/schemas/Cas1OASysSupportingInformationQuestionMetaData'
+      required:
+        - supportingInformationQuestions
+    Cas1OASysSupportingInformationQuestionMetaData:
       type: object
       properties:
         section:

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1900,10 +1900,29 @@ components:
       properties:
         group:
           $ref: '#/components/schemas/Cas1OASysGroupName'
+        assessmentMetadata:
+          $ref: '#/components/schemas/Cas1OASysAssessmentMetadata'
         answers:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/OASysQuestion'
+      required:
+        - group
+        - assessmentMetadata
+        - answers
+    Cas1OASysAssessmentMetadata:
+      type: object
+      properties:
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+      required:
+        - dateStarted
+
+
 
 
 

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2089,7 +2089,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Problem'
 
-  /people/{crn}/oasys/supporting-information-metadata:
+  /people/{crn}/oasys/metadata:
     get:
       tags:
         - OAsys
@@ -2107,9 +2107,7 @@ paths:
           content:
             'application/json':
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Cas1OASysSupportingInformationMetaData'
+                $ref: '#/components/schemas/Cas1OASysMetadata'
         404:
           description: invalid CRN
           content:
@@ -8659,7 +8657,15 @@ components:
           $ref: '#/components/schemas/WithdrawPlacementRequestReason'
       required:
         - reason
-    Cas1OASysSupportingInformationMetaData:
+    Cas1OASysMetadata:
+      properties:
+        supportingInformation:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1OASysSupportingInformationQuestionMetaData'
+      required:
+        - supportingInformationQuestions
+    Cas1OASysSupportingInformationQuestionMetaData:
       type: object
       properties:
         section:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -8707,10 +8707,29 @@ components:
       properties:
         group:
           $ref: '#/components/schemas/Cas1OASysGroupName'
+        assessmentMetadata:
+          $ref: '#/components/schemas/Cas1OASysAssessmentMetadata'
         answers:
           type: array
           items:
             $ref: '#/components/schemas/OASysQuestion'
+      required:
+        - group
+        - assessmentMetadata
+        - answers
+    Cas1OASysAssessmentMetadata:
+      type: object
+      properties:
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+      required:
+        - dateStarted
+
+
 
 
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -162,6 +162,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
+      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+
       val riskManagementPlan = RiskManagementPlanFactory()
         .withSupervision("The supervision answer")
         .produce()
@@ -220,6 +222,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
+      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+
       val roshSummary = RoshSummaryFactory()
         .withWhoAtRisk("Who at risk answer")
         .produce()
@@ -249,6 +253,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
+      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+
       val riskToIndividual = RiskToTheIndividualFactory()
         .withCurrentVulnerability("Current vuln answer")
         .produce()
@@ -277,6 +283,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val needsDetails = NeedsDetailsFactory().apply {
         withRelationshipIssuesDetails(linkedToHarm = true, relationshipIssuesDetails = "relationship answer")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
@@ -34,12 +35,12 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
   }
 
   @Nested
-  inner class SupportingInformationMetadata {
+  inner class Metadata {
 
     @Test
     fun `No JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas1/people/CRN/oasys/supporting-information-metadata")
+        .uri("/cas1/people/CRN/oasys/metadata")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -52,7 +53,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       apDeliusContextUserAccessEmptyResponse()
 
       webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/supporting-information-metadata")
+        .uri("/cas1/people/$CRN/oasys/metadata")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -71,7 +72,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/supporting-information-metadata")
+        .uri("/cas1/people/$CRN/oasys/metadata")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -94,7 +95,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       apOASysContextMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
 
       webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/supporting-information-metadata")
+        .uri("/cas1/people/$CRN/oasys/metadata")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -102,7 +103,9 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
         .expectBody()
         .json(
           objectMapper.writeValueAsString(
-            cas1OASysNeedsQuestionTransformer.transformToSupportingInformationMetadata(needsDetails),
+            Cas1OASysMetadata(
+              cas1OASysNeedsQuestionTransformer.transformToSupportingInformationMetadata(needsDetails),
+            ),
           ),
         )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysNeedsQuestionTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysNeedsQuestionTransformerTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationMetaData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationQuestionMetaData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
@@ -63,56 +63,56 @@ class Cas1OASysNeedsQuestionTransformerTest {
       val result = transformer.transformToSupportingInformationMetadata(needsDetails)
 
       assertThat(result).containsExactlyInAnyOrder(
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 10,
           sectionLabel = "Emotional",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = true,
           oasysAnswerLinkedToReOffending = false,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 3,
           sectionLabel = "Accommodation",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = true,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 6,
           sectionLabel = "Relationships",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = true,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 7,
           sectionLabel = "Lifestyle",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = true,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 8,
           sectionLabel = "Drugs",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = true,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 9,
           sectionLabel = "Alcohol",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = true,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 11,
           sectionLabel = "Thinking and Behavioural",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = true,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 12,
           sectionLabel = "Attitude",
           inclusionOptional = false,
@@ -139,56 +139,56 @@ class Cas1OASysNeedsQuestionTransformerTest {
       val result = transformer.transformToSupportingInformationMetadata(needsDetails)
 
       assertThat(result).containsExactlyInAnyOrder(
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 10,
           sectionLabel = "Emotional",
           inclusionOptional = true,
           oasysAnswerLinkedToHarm = linkedToHarm,
           oasysAnswerLinkedToReOffending = false,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 3,
           sectionLabel = "Accommodation",
           inclusionOptional = true,
           oasysAnswerLinkedToHarm = linkedToHarm,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 6,
           sectionLabel = "Relationships",
           inclusionOptional = true,
           oasysAnswerLinkedToHarm = linkedToHarm,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 7,
           sectionLabel = "Lifestyle",
           inclusionOptional = true,
           oasysAnswerLinkedToHarm = linkedToHarm,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 8,
           sectionLabel = "Drugs",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = linkedToHarm,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 9,
           sectionLabel = "Alcohol",
           inclusionOptional = false,
           oasysAnswerLinkedToHarm = linkedToHarm,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 11,
           sectionLabel = "Thinking and Behavioural",
           inclusionOptional = true,
           oasysAnswerLinkedToHarm = linkedToHarm,
           oasysAnswerLinkedToReOffending = null,
         ),
-        Cas1OASysSupportingInformationMetaData(
+        Cas1OASysSupportingInformationQuestionMetaData(
           section = 12,
           sectionLabel = "Attitude",
           inclusionOptional = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysOffenceDetailsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysOffenceDetailsTransformerTest.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysOffenceDetailsTransformer
+import java.time.Instant
+import java.time.OffsetDateTime
+
+class Cas1OASysOffenceDetailsTransformerTest {
+
+  private val transformer = Cas1OASysOffenceDetailsTransformer()
+
+  @Nested
+  inner class ToAssessmentMetadata {
+
+    @Test
+    fun success() {
+      val initiationDate = OffsetDateTime.parse("2020-05-02T12:01:00+00:00")
+      val completionDate = OffsetDateTime.parse("2021-05-02T12:02:00+00:00")
+
+      val result = transformer.toAssessmentMetadata(
+        OffenceDetailsFactory()
+          .withInitiationDate(initiationDate)
+          .withDateCompleted(completionDate)
+          .produce(),
+      )
+
+      assertThat(result.dateStarted).isEqualTo(Instant.parse("2020-05-02T12:01:00+00:00"))
+      assertThat(result.dateCompleted).isEqualTo(Instant.parse("2021-05-02T12:02:00+00:00"))
+    }
+  }
+}


### PR DESCRIPTION
**Make CAS1 OASys Metadata Endpoint future proof**

This commit updates the cas1 metadata endpoint to return a container type, allowing us to add additional metadata to the response in the future (e.g. data record created/updated) without making a breaking change. The path of the endpoint has also been changes to reflect this.

This change is safe because the endpoint is not currently being used

**Add asssessment metadata to CAS1 OAsys answers**

Include date started/date ended to each CAS1 OAsys Answers response, as this is required on the UI
