### PR TITLE
CHORE: Add missing service account name to test helm chart

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -2,6 +2,7 @@
 # Per environment values which override defaults in approved-premises-api/values.yaml
 
 generic-service:
+  serviceAccountName: hmpps-community-accommodation-api-service-account
   replicaCount: 2
 
   resources:
@@ -97,6 +98,7 @@ generic-service:
 
     NOTIFY_MODE: TEST_AND_GUEST_LIST
     NOTIFY_LOG_EMAILS: true
+    HMPPS_SQS_USE_WEB_TOKEN: true
     CAS3-REPORT_END-DATE-OVERRIDE: 3
 
     FEATURE-FLAGS_CAS2-SQS-LISTENER-ENABLED: true


### PR DESCRIPTION
This will ensure account name is set for resolving all necessary credentials.