### PR TITLE
APS-2092 enable prometheus alerts for prod

### DIFF
--- a/helm_deploy/hmpps-approved-premises-api/Chart.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 2.9.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.4.0
+    version: 1.11.7
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -145,6 +145,10 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises
+  rdsAlertsDatabases:
+    cloud-platform-914625011536d5f1: "community accommodation"
+  rdsAlertsConnectionThreshold: 1
+
 
 env_details:
   production_env: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -105,5 +105,8 @@ generic-service:
       NOTIFY_APIKEY: "NOTIFY_APIKEY"
       NOTIFY_EMAILADDRESSES_CAS2ASSESSORS: "NOTIFY_EMAILADDRESSES_CAS2ASSESSORS"
 
+generic-prometheus-alerts:
+  alertSeverity: hmpps-approved-premises
+
 env_details:
   production_env: true


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2092

This PR enables Prometheus alerting in `prod` and enables database alerts to be triggered in the `dev` environment when we have at least one connection.  This is to check that database alerting works as expected.

Once this is confirmed we can set the alerting threshold values to those appropriate for each environment.

