### PR TITLE
CAS-1746 Add log when the user probation region is updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserService.kt
@@ -328,6 +328,7 @@ class UserService(
     staffDetail.probationArea.let { probationArea ->
       findProbationRegionFromArea(probationArea.code)?.let { probationRegion ->
         user.probationRegion = probationRegion
+        log.info("Updating user probation region with probation area code ${probationArea.code} to ${probationRegion.name} for the user $username.")
       }
     }
 


### PR DESCRIPTION
This [PR CAS-1746](https://dsdmoj.atlassian.net/browse/CAS-1746) is to add log when the user probation region is updated during the logging process in CAS3