### PR TITLE
APS-2092 enable database and cache alerting

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -150,6 +150,8 @@ generic-prometheus-alerts:
   # API pool users = 20 per pod
   # Max expected connections for 2 x pods = 40 + additional 10 (buffer for direct connections)
   rdsAlertsConnectionThreshold: 50
+  elastiCacheAlertsClusterIds:
+    cp-ede0649d3201fded: "community accommodation"
 
 
 env_details:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -114,6 +114,8 @@ generic-prometheus-alerts:
   # API pool users = 20 per pod
   # Max expected connections for 4 x pods = 80 + additional 10 (buffer for direct connections)
   rdsAlertsConnectionThreshold: 90
+  elastiCacheAlertsClusterIds:
+    cp-1faf5cb78c4ab173: "community accommodation"
 
 env_details:
   production_env: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -112,6 +112,8 @@ generic-prometheus-alerts:
   # API pool users = 20 per pod
   # Max expected connections for 4 x pods = 80 + additional 10 (buffer for direct connections)
   rdsAlertsConnectionThreshold: 90
+  elastiCacheAlertsClusterIds:
+   cp-76ca3c1a20d6d72a: "community accommodation"
 
 env_details:
   production_env: true

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -147,6 +147,8 @@ generic-prometheus-alerts:
   # API pool users = 20 per pod
   # Max expected connections for 2 x pods = 40 + additional 10 (buffer for direct connections)
   rdsAlertsConnectionThreshold: 50
+  elastiCacheAlertsClusterIds:
+    cp-377025d1a50411fe: "community accommodation"
 
 env_details:
   production_env: false


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2092

Now that database alerting has been enabled for dev (see https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3611) and tested (see Slack alert [here](https://mojdt.slack.com/archives/C07APDZN8TG/p1749633518160369)), this PR:
- enables database alerting for test, pre-prod and prod environments
- sets a sensible value for `rdsAlertsConnectionThreshold`
- enables cache alerting for all environments

All other alert thresholds are as per default Prometheus values: https://github.com/ministryofjustice/hmpps-helm-charts/blob/31ea40f8db83eb8a01a489471485706028111ac3/charts/generic-prometheus-alerts/values.yaml

Also see related Slack conversation [here](https://mojdt.slack.com/archives/C03K0HB0LBE/p1749569739116499).