### PR TITLE
APS-2375 - Use `givenAnApprovedPremises()` in all tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedDetailQueryTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 
 class BedDetailQueryTest : IntegrationTestBase() {
@@ -12,14 +12,7 @@ class BedDetailQueryTest : IntegrationTestBase() {
 
   @Test
   fun `summary works as expected`() {
-    val probationRegion = givenAProbationRegion()
-
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(probationRegion)
-      withLocalAuthorityArea(localAuthorityArea)
-    }
+    val premises = givenAnApprovedPremises()
 
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryQueryTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainBedSummary
@@ -20,14 +20,7 @@ class BedSummaryQueryTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
-    val probationRegion = givenAProbationRegion()
-
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-
-    this.premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(probationRegion)
-      withLocalAuthorityArea(localAuthorityArea)
-    }
+    this.premises = givenAnApprovedPremises()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BedSummaryTest.kt
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BedSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import java.time.LocalDate
 import java.util.UUID
@@ -15,14 +15,7 @@ class BedSummaryTest : InitialiseDatabasePerClassTestBase() {
 
   @BeforeEach
   fun setup() {
-    val probationRegion = givenAProbationRegion()
-
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-
-    this.premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(probationRegion)
-      withLocalAuthorityArea(localAuthorityArea)
-    }
+    this.premises = givenAnApprovedPremises()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASubmittedApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulGetReferralDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulStaffMembersCall
@@ -90,10 +91,7 @@ class BookingTest : IntegrationTestBase() {
     fun `Get a booking returns OK with the correct body`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
         givenAnOffender { offenderDetails, inmateDetails ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegion }
-          }
+          val premises = givenAnApprovedPremises()
 
           val booking = bookingEntityFactory.produceAndPersist {
             withPremises(premises)
@@ -141,10 +139,7 @@ class BookingTest : IntegrationTestBase() {
             withNomsNumber(null)
           },
         ) { offenderDetails, _ ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegion }
-          }
+          val premises = givenAnApprovedPremises()
 
           val keyWorker = ContextStaffMemberFactory().produce()
           apDeliusContextMockSuccessfulStaffMembersCall(keyWorker, premises.qCode)
@@ -171,10 +166,7 @@ class BookingTest : IntegrationTestBase() {
     fun `Get a booking for an Approved Premises returns OK with the correct body`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
         givenAnOffender { offenderDetails, inmateDetails ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegion }
-          }
+          val premises = givenAnApprovedPremises()
 
           val booking = bookingEntityFactory.produceAndPersist {
             withPremises(premises)
@@ -204,10 +196,7 @@ class BookingTest : IntegrationTestBase() {
     @Test
     fun `Get a booking returns OK with the correct body when person details for a booking could not be found`() {
       givenAUser { _, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { probationRegion }
-        }
+        val premises = givenAnApprovedPremises()
 
         val booking = bookingEntityFactory.produceAndPersist {
           withPremises(premises)
@@ -241,10 +230,7 @@ class BookingTest : IntegrationTestBase() {
             withNomsNumber(null)
           },
         ) { offenderDetails, _ ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { probationRegion }
-          }
+          val premises = givenAnApprovedPremises()
 
           val booking = bookingEntityFactory.produceAndPersist {
             withPremises(premises)
@@ -382,10 +368,7 @@ class BookingTest : IntegrationTestBase() {
     role: UserRole,
   ) {
     givenAUser(roles = listOf(role)) { _, jwt ->
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion { probationRegion }
-      }
+      val premises = givenAnApprovedPremises()
 
       webTestClient.get()
         .uri("/premises/${premises.id}/bookings")
@@ -403,12 +386,7 @@ class BookingTest : IntegrationTestBase() {
   fun `Get all Bookings returns OK with correct body when user has one of roles FUTURE_MANAGER, CAS1_WORKFLOW_MANAGER`(role: UserRole) {
     givenAUser(roles = listOf(role)) { _, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegion
-          }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bookings = bookingEntityFactory.produceAndPersistMultiple(5) {
           withPremises(premises)
@@ -465,12 +443,7 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Get all Bookings for premises returns OK with correct body when person details for a booking could not be found`() {
     givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion {
-          probationRegion
-        }
-      }
+      val premises = givenAnApprovedPremises()
 
       val booking = bookingEntityFactory.produceAndPersist {
         withPremises(premises)
@@ -503,12 +476,7 @@ class BookingTest : IntegrationTestBase() {
     givenAUser(roles = listOf(UserRole.CAS1_WORKFLOW_MANAGER)) { _, jwt ->
       givenAnOffender(mockServerErrorForPrisonApi = true) { offenderDetails, _ ->
 
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegion
-          }
-        }
+        val premises = givenAnApprovedPremises()
 
         val booking = bookingEntityFactory.produceAndPersist {
           withPremises(premises)
@@ -594,12 +562,7 @@ class BookingTest : IntegrationTestBase() {
 
   @Test
   fun `Create Booking without JWT returns 401`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion {
-        probationRegion
-      }
-    }
+    val premises = givenAnApprovedPremises()
 
     webTestClient.post()
       .uri("/premises/${premises.id}/bookings")
@@ -2518,12 +2481,7 @@ class BookingTest : IntegrationTestBase() {
 
             val booking = bookingEntityFactory.produceAndPersist {
               withYieldedPremises {
-                approvedPremisesEntityFactory.produceAndPersist {
-                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion {
-                    probationRegion
-                  }
-                }
+                givenAnApprovedPremises()
               }
               withCrn(offenderDetails.otherIds.crn)
               withApplication(application)
@@ -2600,12 +2558,7 @@ class BookingTest : IntegrationTestBase() {
 
               val booking = bookingEntityFactory.produceAndPersist {
                 withYieldedPremises {
-                  approvedPremisesEntityFactory.produceAndPersist {
-                    withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                    withYieldedProbationRegion {
-                      probationRegion
-                    }
-                  }
+                  givenAnApprovedPremises()
                 }
                 withCrn(offenderDetails.otherIds.crn)
                 withApplication(application)
@@ -2693,12 +2646,7 @@ class BookingTest : IntegrationTestBase() {
 
             val booking = bookingEntityFactory.produceAndPersist {
               withYieldedPremises {
-                approvedPremisesEntityFactory.produceAndPersist {
-                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion {
-                    probationRegion
-                  }
-                }
+                givenAnApprovedPremises()
               }
               withCrn(offenderDetails.otherIds.crn)
               withApplication(application)
@@ -3417,12 +3365,7 @@ class BookingTest : IntegrationTestBase() {
     @Test
     fun `CAS1 Date Change for a booking on a premises that does not exist returns 404 Not Found`() {
       givenAUser(roles = emptyList()) { _, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegion
-          }
-        }
+        val premises = givenAnApprovedPremises()
 
         val booking = bookingEntityFactory.produceAndPersist {
           withArrivalDate(LocalDate.parse("2022-08-18"))
@@ -3455,12 +3398,7 @@ class BookingTest : IntegrationTestBase() {
       govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
 
       givenAUser(roles = listOf(role)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegion
-          }
-        }
+        val premises = givenAnApprovedPremises()
 
         val application = givenASubmittedApplication(
           createdByUser = user,
@@ -3532,12 +3470,7 @@ class BookingTest : IntegrationTestBase() {
     givenAUser(roles = listOf(role)) { userEntity, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
         withYieldedPremises {
-          approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegion
-            }
-          }
+          givenAnApprovedPremises()
         }
         withServiceName(ServiceName.approvedPremises)
       }
@@ -3566,12 +3499,7 @@ class BookingTest : IntegrationTestBase() {
     givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
       val booking = bookingEntityFactory.produceAndPersist {
         withYieldedPremises {
-          approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion {
-              probationRegion
-            }
-          }
+          givenAnApprovedPremises()
         }
         withServiceName(ServiceName.approvedPremises)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CancellationQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CancellationQueryTest.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationRepository
 
 class CancellationQueryTest : IntegrationTestBase() {
@@ -16,10 +16,7 @@ class CancellationQueryTest : IntegrationTestBase() {
   fun `Get cancellations for application returns all the relevant cancellations`() {
     givenAUser { user, _ ->
       givenAnApplication(createdByUser = user) { application ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withProbationRegion(givenAProbationRegion())
-          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
-        }
+        val premises = givenAnApprovedPremises()
 
         val cancellationsForApplication = listOf(
           cancellationEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CharacteristicQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CharacteristicQueryTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
 
 class CharacteristicQueryTest : IntegrationTestBase() {
@@ -12,16 +12,9 @@ class CharacteristicQueryTest : IntegrationTestBase() {
 
   @Test
   fun `findAllForRoomId returns all the characteristics for a roomId`() {
-    val probationRegion = givenAProbationRegion()
+    val premises = givenAnApprovedPremises()
 
-    var localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-
-    var premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(probationRegion)
-      withLocalAuthorityArea(localAuthorityArea)
-    }
-
-    var roomCharacteristics = mutableListOf(
+    val roomCharacteristics = mutableListOf(
       characteristicEntityFactory.produceAndPersist(),
       characteristicEntityFactory.produceAndPersist(),
       characteristicEntityFactory.produceAndPersist(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestRepositoryTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementReque
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import java.time.LocalDate
@@ -78,12 +79,7 @@ class PlacementRequestRepositoryTest : IntegrationTestBase() {
 
     @BeforeEach
     fun setup() {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withProbationRegion(givenAProbationRegion())
-        withLocalAuthorityArea(
-          localAuthorityEntityFactory.produceAndPersist(),
-        )
-      }
+      val premises = givenAnApprovedPremises()
 
       val room = roomEntityFactory.produceAndPersist {
         withPremises(premises)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementRequestsTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
@@ -44,10 +45,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestDetailTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PlacementRequestSummaryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsListOfObjects
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -57,12 +56,6 @@ class PlacementRequestsTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var placementRequestTransformer: PlacementRequestTransformer
-
-  @Autowired
-  lateinit var cas1PlacementRequestSummaryTransformer: Cas1PlacementRequestSummaryTransformer
-
-  @Autowired
-  lateinit var personTransformer: PersonTransformer
 
   @Autowired
   lateinit var realPlacementRequestRepository: PlacementRequestRepository
@@ -84,12 +77,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
   inner class Dashboard {
 
     private fun createBooking(placementRequest: PlacementRequestEntity) {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withProbationRegion(probationRegion)
-        withLocalAuthorityArea(
-          localAuthorityEntityFactory.produceAndPersist(),
-        )
-      }
+      val premises = givenAnApprovedPremises()
 
       placementRequest.booking = bookingEntityFactory.produceAndPersist {
         withPremises(premises)
@@ -1288,12 +1276,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
             ) { placementRequest, _ ->
-              val premises = approvedPremisesEntityFactory.produceAndPersist {
-                withProbationRegion(probationRegion)
-                withLocalAuthorityArea(
-                  localAuthorityEntityFactory.produceAndPersist(),
-                )
-              }
+              val premises = givenAnApprovedPremises()
 
               val room = roomEntityFactory.produceAndPersist {
                 withPremises(premises)
@@ -1369,10 +1352,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                 createdByUser = applicant,
                 crn = offenderDetails.otherIds.crn,
               ) { placementRequest, _ ->
-                val premises = approvedPremisesEntityFactory.produceAndPersist {
-                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion { probationRegion }
-                }
+                val premises = givenAnApprovedPremises()
 
                 val room = roomEntityFactory.produceAndPersist {
                   withPremises(premises)
@@ -1432,10 +1412,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                     crn = offenderDetails.otherIds.crn,
                     placementApplication = placementApplication,
                   ) { placementRequest, _ ->
-                    val premises = approvedPremisesEntityFactory.produceAndPersist {
-                      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                      withYieldedProbationRegion { probationRegion }
-                    }
+                    val premises = givenAnApprovedPremises()
 
                     val room = roomEntityFactory.produceAndPersist {
                       withPremises(premises)
@@ -1534,10 +1511,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                 createdByUser = applicant,
                 crn = offenderDetails.otherIds.crn,
               ) { placementRequest, _ ->
-                val premises = approvedPremisesEntityFactory.produceAndPersist {
-                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion { probationRegion }
-                }
+                val premises = givenAnApprovedPremises()
 
                 val room = roomEntityFactory.produceAndPersist {
                   withPremises(premises)
@@ -1579,10 +1553,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                 createdByUser = otherUser,
                 crn = offenderDetails.otherIds.crn,
               ) { placementRequest, _ ->
-                val premises = approvedPremisesEntityFactory.produceAndPersist {
-                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion { probationRegion }
-                }
+                val premises = givenAnApprovedPremises()
 
                 webTestClient.post()
                   .uri("/placement-requests/${placementRequest.id}/booking")
@@ -1622,10 +1593,7 @@ class PlacementRequestsTest : IntegrationTestBase() {
                 createdByUser = otherUser,
                 crn = offenderDetails.otherIds.crn,
               ) { placementRequest, _ ->
-                val premises = approvedPremisesEntityFactory.produceAndPersist {
-                  withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                  withYieldedProbationRegion { probationRegion }
-                }
+                val premises = givenAnApprovedPremises()
 
                 webTestClient.post()
                   .uri("/placement-requests/${placementRequest.id}/booking")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -31,9 +31,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1CruManagementArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForTemporaryAccommodation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
@@ -1423,12 +1423,7 @@ class TasksTest {
                 createdByUser = user,
                 crn = offenderDetails.otherIds.crn,
                 booking = bookingEntityFactory.produceAndPersist {
-                  withPremises(
-                    approvedPremisesEntityFactory.produceAndPersist {
-                      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                      withYieldedProbationRegion { givenAProbationRegion() }
-                    },
-                  )
+                  withPremises(givenAnApprovedPremises())
                 },
               )
 
@@ -1439,12 +1434,7 @@ class TasksTest {
                 crn = offenderDetails.otherIds.crn,
                 dueAt = OffsetDateTime.now().randomDateTimeBefore(14).truncatedTo(ChronoUnit.MICROS),
                 booking = bookingEntityFactory.produceAndPersist {
-                  withPremises(
-                    approvedPremisesEntityFactory.produceAndPersist {
-                      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                      withYieldedProbationRegion { givenAProbationRegion() }
-                    },
-                  )
+                  withPremises(givenAnApprovedPremises())
                 },
               )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -17,9 +17,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas1NotifyTemplates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1CruManagementArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1SpaceBooking
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulGetReferralDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -1835,10 +1835,7 @@ class WithdrawalTest : IntegrationTestBase() {
     hasArrivalInDelius: Boolean = false,
     adhoc: Boolean? = false,
   ): BookingEntity {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { givenAProbationRegion() }
-    }
+    val premises = givenAnApprovedPremises()
 
     val booking = bookingEntityFactory.produceAndPersist {
       withApplication(application)
@@ -1877,10 +1874,7 @@ class WithdrawalTest : IntegrationTestBase() {
     arrivalDate: LocalDateTime? = null,
     placementRequest: PlacementRequestEntity,
   ): Cas1SpaceBookingEntity {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { givenAProbationRegion() }
-    }
+    val premises = givenAnApprovedPremises()
 
     val spaceBooking = cas1SpaceBookingEntityFactory.produceAndPersist {
       withApplication(application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
@@ -35,8 +35,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenABooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1SpaceBooking
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
@@ -378,10 +378,7 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
     val application = realApplicationRepository.findByIdOrNull(applicationId) as ApprovedPremisesApplicationEntity
     val placementRequest = application.getLatestPlacementRequest()!!
 
-    premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { givenAProbationRegion() }
-    }
+    premises = givenAnApprovedPremises()
 
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -415,11 +412,7 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
     val application = realApplicationRepository.findByIdOrNull(applicationId) as ApprovedPremisesApplicationEntity
     val placementRequest = application.getLatestPlacementRequest()!!
 
-    premises = approvedPremisesEntityFactory.produceAndPersist {
-      withSupportsSpaceBookings(true)
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { givenAProbationRegion() }
-    }
+    premises = givenAnApprovedPremises(supportsSpaceBookings = true)
 
     webTestClient.post()
       .uri("/cas1/placement-requests/${placementRequest.id}/space-bookings")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1BedDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1BedDetailTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
@@ -26,10 +27,7 @@ class Cas1BedDetailTest : InitialiseDatabasePerClassTestBase() {
     probationRegion = givenAProbationRegion()
     localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
 
-    this.premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(probationRegion)
-      withLocalAuthorityArea(localAuthorityArea)
-    }
+    this.premises = givenAnApprovedPremises()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1BedSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1BedSummaryTest.kt
@@ -4,32 +4,22 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1BedSummaryTransformer
 import java.util.UUID
 
 class Cas1BedSummaryTest : InitialiseDatabasePerClassTestBase() {
   lateinit var premises: PremisesEntity
-  lateinit var probationRegion: ProbationRegionEntity
-  lateinit var localAuthorityArea: LocalAuthorityAreaEntity
 
   @Autowired
   lateinit var cas1BedSummaryTransformer: Cas1BedSummaryTransformer
 
   @BeforeEach
   fun setup() {
-    probationRegion = givenAProbationRegion()
-    localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-
-    this.premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(probationRegion)
-      withLocalAuthorityArea(localAuthorityArea)
-    }
+    this.premises = givenAnApprovedPremises()
   }
 
   @Test
@@ -66,10 +56,7 @@ class Cas1BedSummaryTest : InitialiseDatabasePerClassTestBase() {
         }
       }
 
-      val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
-        withProbationRegion(probationRegion)
-        withLocalAuthorityArea(localAuthorityArea)
-      }
+      val otherPremises = givenAnApprovedPremises()
 
       bedEntityFactory.produceAndPersist {
         withYieldedRoom {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OutOfServiceBedTest.kt
@@ -22,8 +22,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Temporality
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas1OutOfServiceBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
@@ -129,10 +129,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     )
     fun `Get All Out-Of-Service Beds returns OK with correct body when user has the correct role`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -176,10 +173,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Get All Out-Of-Service Beds ignores cancelled out-of-service-bed records`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -244,10 +238,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Get All Out-Of-Service Beds filters by premises ID correctly`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -257,10 +248,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
           }
         }
 
-        val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val otherPremises = givenAnApprovedPremises()
 
         val otherBed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -319,10 +307,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Get All Out-Of-Service Beds filters by AP area ID correctly`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -332,10 +317,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
           }
         }
 
-        val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val otherPremises = givenAnApprovedPremises()
 
         val otherBed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -399,10 +381,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
       private val futureOosBedEndDate: LocalDate = LocalDate.now().plusDays(10)
 
       private fun initialiseOosBedsForAllTemporalities(user: UserEntity) {
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         bedEntityFactory.produceAndPersistMultiple(2) {
           withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
@@ -571,10 +550,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Suppress("detekt:CyclomaticComplexMethod")
     fun `Get All Out-Of-Service Beds sorts correctly`(sortField: Cas1OutOfServiceBedSortField, sortDirection: SortDirection) {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -584,10 +560,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
           }
         }
 
-        val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val otherPremises = givenAnApprovedPremises()
 
         val otherBed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -656,10 +629,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Get All Out-Of-Service Beds paginates correctly`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -715,10 +685,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
   inner class GetAllPremisesOutOfServiceBeds {
     @Test
     fun `Get All Out-Of-Service Beds On Premises without JWT returns 401`() {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion { givenAProbationRegion() }
-      }
+      val premises = givenAnApprovedPremises()
 
       webTestClient.get()
         .uri("/cas1/premises/${premises.id}/out-of-service-beds")
@@ -764,10 +731,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     )
     fun `Get All Out-Of-Service Beds On Premises returns OK with correct body when user has correct role`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -827,10 +791,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Get Out-Of-Service Bed without JWT returns 401`() {
       givenAUser { user, _ ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withBed(
@@ -877,10 +838,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER" ])
     fun `Get Out-Of-Service Bed for non-existent out-of-service bed returns 404`(role: UserRole) {
       givenAUser(roles = listOf(role)) { _, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         webTestClient.get()
           .uri("/cas1/premises/${premises.id}/out-of-service-beds/9054b6a8-65ad-4d55-91ee-26ba65e05488")
@@ -898,10 +856,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     )
     fun `Get Out-Of-Service Bed returns OK with correct body when user has the correct role`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
@@ -961,10 +916,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
   inner class CreateOutOfServiceBed {
     @Test
     fun `Create Out-Of-Service Beds without JWT returns 401`() {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion { givenAProbationRegion() }
-      }
+      val premises = givenAnApprovedPremises()
 
       val bed = bedEntityFactory.produceAndPersist {
         withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
@@ -990,10 +942,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Create Out-Of-Service Beds returns 400 Bad Request if the bed ID does not reference a bed on the premises`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
 
@@ -1053,10 +1002,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     )
     fun `Create Out-Of-Service Beds returns OK with correct body when user has correct roles`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         bedEntityFactory.produceAndPersistMultiple(3) {
           withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
@@ -1130,10 +1076,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Create Out-Of-Service Bed succeeds even if overlapping with Booking`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         bedEntityFactory.produceAndPersistMultiple(2) {
           withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
@@ -1215,10 +1158,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Create Out-Of-Service Bed returns 409 Conflict when An out-of-service bed for the same bed overlaps`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { _, _ ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { givenAProbationRegion() }
-          }
+          val premises = givenAnApprovedPremises()
 
           val bed = bedEntityFactory.produceAndPersist {
             withYieldedRoom {
@@ -1272,10 +1212,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Create Out-Of-Service Bed returns OK with correct body when only cancelled out-of-service beds for the same bed overlap`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { _, _ ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { givenAProbationRegion() }
-          }
+          val premises = givenAnApprovedPremises()
 
           val bed = bedEntityFactory.produceAndPersist {
             withYieldedRoom {
@@ -1394,10 +1331,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Update Out-Of-Service Bed without JWT returns 401`() {
       givenAUser { user, _ ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withBed(
@@ -1468,10 +1402,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Update Out-Of-Service Bed for non-existent out-of-service bed returns 404`() {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion { givenAProbationRegion() }
-      }
+      val premises = givenAnApprovedPremises()
 
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
         webTestClient.put()
@@ -1526,10 +1457,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     )
     fun `Update Out-Of-Service Beds returns OK with correct body when user the correct role`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         bedEntityFactory.produceAndPersistMultiple(2) {
           withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }
@@ -1638,10 +1566,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Update Out-Of-Service Beds succeeds even if overlapping with Booking`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -1699,10 +1624,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Update Out-Of-Service Beds returns OK with correct body when only cancelled bookings for the same bed overlap`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { offenderDetails, _ ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { givenAProbationRegion() }
-          }
+          val premises = givenAnApprovedPremises()
 
           val bed = bedEntityFactory.produceAndPersist {
             withYieldedRoom {
@@ -1824,10 +1746,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Update Out-Of-Service Beds returns 409 Conflict when An out-of-service bed for the same bed overlaps`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { _, _ ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { givenAProbationRegion() }
-          }
+          val premises = givenAnApprovedPremises()
 
           val bed = bedEntityFactory.produceAndPersist {
             withYieldedRoom {
@@ -1893,10 +1812,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     fun `Update Out-Of-Service Beds returns OK with correct body when only cancelled out-of-service beds for the same bed overlap`() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { user, jwt ->
         givenAnOffender { _, _ ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withYieldedProbationRegion { givenAProbationRegion() }
-          }
+          val premises = givenAnApprovedPremises()
 
           val bed = bedEntityFactory.produceAndPersist {
             withYieldedRoom {
@@ -2050,10 +1966,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Cancel Out-Of-Service Bed without JWT returns 401`() {
       givenAUser { user, _ ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
           withBed(
@@ -2108,10 +2021,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
 
     @Test
     fun `Cancel Out-Of-Service Bed for non-existent out-of-service bed returns 404`() {
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withYieldedProbationRegion { givenAProbationRegion() }
-      }
+      val premises = givenAnApprovedPremises()
 
       givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA)) { _, jwt ->
         webTestClient.post()
@@ -2158,10 +2068,7 @@ class Cas1OutOfServiceBedTest : InitialiseDatabasePerClassTestBase() {
     )
     fun `Cancel Out-Of-Service Bed returns OK with correct body when user has the correct roles`(role: UserRole) {
       givenAUser(roles = listOf(role)) { user, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { givenAProbationRegion() }
-        }
+        val premises = givenAnApprovedPremises()
 
         bedEntityFactory.produceAndPersistMultiple(2) {
           withYieldedRoom { roomEntityFactory.produceAndPersist { withPremises(premises) } }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
@@ -80,12 +80,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
 
     private fun createBooking(
       placementRequest: PlacementRequestEntity,
-      premises: ApprovedPremisesEntity? = approvedPremisesEntityFactory.produceAndPersist {
-        withProbationRegion(probationRegion)
-        withLocalAuthorityArea(
-          localAuthorityEntityFactory.produceAndPersist(),
-        )
-      },
+      premises: ApprovedPremisesEntity? = givenAnApprovedPremises(),
       arrivalDate: LocalDate? = LocalDate.now(),
     ): BookingEntity {
       placementRequest.booking = bookingEntityFactory.produceAndPersist {
@@ -1500,12 +1495,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
             ) { placementRequest, _ ->
-              val premises = approvedPremisesEntityFactory.produceAndPersist {
-                withProbationRegion(probationRegion)
-                withLocalAuthorityArea(
-                  localAuthorityEntityFactory.produceAndPersist(),
-                )
-              }
+              val premises = givenAnApprovedPremises()
 
               val room = roomEntityFactory.produceAndPersist {
                 withPremises(premises)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -85,19 +85,17 @@ class Cas1PremisesTest : IntegrationTestBase() {
     @BeforeAll
     fun setupTestData() {
       user = givenAUser().first
-      val region = givenAProbationRegion(
-        apArea = givenAnApArea(name = "The ap area name"),
-      )
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withName("the premises name")
-        withApCode("the ap code")
-        withPostcode("the postcode")
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withManagerDetails("manager details")
-        withSupportsSpaceBookings(true)
-      }
+      premises = givenAnApprovedPremises(
+        name = "the premises name",
+        supportsSpaceBookings = true,
+        apCode = "the ap code",
+        postCode = "the postcode",
+        region = givenAProbationRegion(
+          apArea = givenAnApArea(name = "The ap area name"),
+        ),
+        managerDetails = "manager details",
+      )
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -113,14 +113,9 @@ class Cas1SpaceBookingTest {
 
     @Test
     fun `Returns 403 Forbidden if user does not have correct role`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
+      givenAUser(roles = listOf(CAS1_FUTURE_MANAGER)) { _, jwt ->
         val placementRequestId = UUID.randomUUID()
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedProbationRegion { givenAProbationRegion() }
-          withYieldedLocalAuthorityArea {
-            localAuthorityEntityFactory.produceAndPersist()
-          }
-        }
+        val premises = givenAnApprovedPremises()
 
         webTestClient.post()
           .uri("/cas1/placement-requests/$placementRequestId/space-bookings")
@@ -142,13 +137,7 @@ class Cas1SpaceBookingTest {
     @Test
     fun `Booking a space for an unknown placement request returns 400 Bad Request`() {
       givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA)) { _, jwt ->
-        val premises = approvedPremisesEntityFactory.produceAndPersist {
-          withSupportsSpaceBookings(true)
-          withYieldedProbationRegion { givenAProbationRegion() }
-          withYieldedLocalAuthorityArea {
-            localAuthorityEntityFactory.produceAndPersist()
-          }
-        }
+        val premises = givenAnApprovedPremises(supportsSpaceBookings = true)
 
         val placementRequestId = UUID.randomUUID()
 
@@ -209,13 +198,7 @@ class Cas1SpaceBookingTest {
           assessmentAllocatedTo = user,
           createdByUser = user,
         ) { placementRequest, _ ->
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withSupportsSpaceBookings(true)
-            withYieldedProbationRegion { givenAProbationRegion() }
-            withYieldedLocalAuthorityArea {
-              localAuthorityEntityFactory.produceAndPersist()
-            }
-          }
+          val premises = givenAnApprovedPremises(supportsSpaceBookings = true)
 
           webTestClient.post()
             .uri("/cas1/placement-requests/${placementRequest.id}/space-bookings")
@@ -266,13 +249,7 @@ class Cas1SpaceBookingTest {
 
           placementRequestRepository.saveAndFlush(placementRequest)
 
-          val premises = approvedPremisesEntityFactory.produceAndPersist {
-            withSupportsSpaceBookings(true)
-            withYieldedProbationRegion { givenAProbationRegion() }
-            withYieldedLocalAuthorityArea {
-              localAuthorityEntityFactory.produceAndPersist()
-            }
-          }
+          val premises = givenAnApprovedPremises(supportsSpaceBookings = true)
 
           val response = webTestClient.post()
             .uri("/cas1/placement-requests/${placementRequest.id}/space-bookings")
@@ -975,17 +952,15 @@ class Cas1SpaceBookingTest {
     fun setupTestData() {
       val region = givenAProbationRegion()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+      )
 
-      val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      val otherPremises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+      )
 
       val (user) = givenAUser()
       val (offender) = givenAnOffender()
@@ -1138,16 +1113,15 @@ class Cas1SpaceBookingTest {
     fun setupTestData() {
       val region = givenAProbationRegion()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+      )
 
-      val otherPremises = approvedPremisesEntityFactory.produceAndPersist {
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      val otherPremises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = false,
+      )
 
       val (user) = givenAUser()
       val (offender) = givenAnOffender()
@@ -1279,11 +1253,10 @@ class Cas1SpaceBookingTest {
     fun setupTestData() {
       region = givenAProbationRegion()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+      )
 
       val (user) = givenAUser()
       val (offender) = givenAnOffender()
@@ -1623,11 +1596,10 @@ class Cas1SpaceBookingTest {
     fun setupTestData() {
       region = givenAProbationRegion()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+      )
 
       nonArrivalReason = nonArrivalReasonEntityFactory.produceAndPersist {
         withName("nonArrivalName")
@@ -1781,12 +1753,11 @@ class Cas1SpaceBookingTest {
     fun setupTestData() {
       region = givenAProbationRegion()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withQCode("QCODE")
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+        qCode = "QCODE",
+      )
 
       keyWorker = givenAUser().first
       val (user) = givenAUser()
@@ -1871,11 +1842,10 @@ class Cas1SpaceBookingTest {
     fun setupTestData() {
       region = givenAProbationRegion()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+      )
 
       val (user) = givenAUser()
       val (offender) = givenAnOffender()
@@ -2387,12 +2357,11 @@ class Cas1SpaceBookingTest {
       val (user) = givenAUser()
       val (offender) = givenAnOffender()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withEmailAddress("premises@test.com")
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+        emailAddress = "premises@test.com",
+      )
 
       applicant = givenAUser(
         staffDetail =
@@ -2487,13 +2456,9 @@ class Cas1SpaceBookingTest {
         createdByUser = user,
       )
 
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      val premises = givenAnApprovedPremises(supportsSpaceBookings = true)
 
-      var characteristics = mutableListOf(
+      val characteristics = mutableListOf(
         characteristicEntityFactory.produceAndPersist {
           withName("Arson Room")
           withPropertyName("isArsonSuitable")
@@ -2579,13 +2544,12 @@ class Cas1SpaceBookingTest {
         createdByUser = user,
       )
 
-      val premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      }
+      val premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+      )
 
-      var characteristics = mutableListOf(
+      val characteristics = mutableListOf(
         characteristicEntityFactory.produceAndPersist {
           withName("Step Free Designated")
           withPropertyName("isStepFreeDesignated")
@@ -2742,19 +2706,17 @@ class Cas1SpaceBookingTest {
       val (user) = givenAUser()
       val (offender) = givenAnOffender()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withEmailAddress("premises@test.com")
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+        emailAddress = "premises@test.com",
+      )
 
-      destinationPremises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withEmailAddress("destPremises@test.com")
-      }
+      destinationPremises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+        emailAddress = "destPremises@test.com",
+      )
 
       applicant = givenAUser(
         staffDetail =
@@ -2871,19 +2833,17 @@ class Cas1SpaceBookingTest {
       val (user) = givenAUser()
       val (offender) = givenAnOffender()
 
-      premises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withEmailAddress("premises@test.com")
-      }
+      premises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+        emailAddress = "premises@test.com",
+      )
 
-      destinationPremises = approvedPremisesEntityFactory.produceAndPersist {
-        withSupportsSpaceBookings(true)
-        withYieldedProbationRegion { region }
-        withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-        withEmailAddress("destPremises@test.com")
-      }
+      destinationPremises = givenAnApprovedPremises(
+        region = region,
+        supportsSpaceBookings = true,
+        emailAddress = "destPremises@test.com",
+      )
 
       applicant = givenAUser(
         staffDetail =
@@ -3024,17 +2984,15 @@ abstract class SpaceBookingIntegrationTestBase : InitialiseDatabasePerClassTestB
       withLegacyDeliusReasonCode("legacyDeliusCode")
     }
 
-    premisesWithNoBooking = approvedPremisesEntityFactory.produceAndPersist {
-      withSupportsSpaceBookings(true)
-      withYieldedProbationRegion { region }
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-    }
+    premisesWithNoBooking = givenAnApprovedPremises(
+      region = region,
+      supportsSpaceBookings = true,
+    )
 
-    premisesWithBookings = approvedPremisesEntityFactory.produceAndPersist {
-      withSupportsSpaceBookings(true)
-      withYieldedProbationRegion { region }
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-    }
+    premisesWithBookings = givenAnApprovedPremises(
+      region = region,
+      supportsSpaceBookings = true,
+    )
   }
 
   @SuppressWarnings("LongParameterList")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/planning/SpacePlanningServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/planning/SpacePlanningServiceTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE
@@ -42,13 +43,11 @@ class SpacePlanningServiceTest : InitialiseDatabasePerClassTestBase() {
 
   @BeforeAll
   fun setupTestData() {
-    val premises = approvedPremisesEntityFactory
-      .produceAndPersist {
-        withId(UUID.fromString("0f9384e2-2f94-41d9-a79c-4e35e67111ec"))
-        withName("Premises 1")
-        withProbationRegion(probationRegionEntityFactory.produceAndPersist())
-        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
-      }
+    val premises = givenAnApprovedPremises(
+      id = UUID.fromString("0f9384e2-2f94-41d9-a79c-4e35e67111ec"),
+      name = "Premises 1",
+    )
+
     premiseId = premises.id
 
     val room1 = roomEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -46,6 +46,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.reporti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
@@ -586,12 +587,10 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       probationRegion = givenAProbationRegion(apArea = givenAnApArea(name = matcherApAreaName)),
     ).second
 
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-      withYieldedProbationRegion { givenAProbationRegion() }
-      withName(premisesName)
-      withSupportsSpaceBookings(true)
-    }
+    val premises = givenAnApprovedPremises(
+      name = premisesName,
+      supportsSpaceBookings = true,
+    )
 
     return cas1SimpleApiClient.spaceBookingForPlacementRequest(
       integrationTestBase = this,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementReportTest.kt
@@ -42,6 +42,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.reporti
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
@@ -128,13 +129,11 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
       },
     )
 
-    premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-
-      withYieldedProbationRegion { givenAProbationRegion(name = "southWest", apArea = givenAnApArea(name = "matcherApAreaName")) }
-      withName("premisesName")
-      withSupportsSpaceBookings(true)
-    }
+    premises = givenAnApprovedPremises(
+      region = givenAProbationRegion(name = "southWest", apArea = givenAnApArea(name = "matcherApAreaName")),
+      name = "premisesName",
+      supportsSpaceBookings = true,
+    )
 
     applicationSchema = approvedPremisesApplicationJsonSchemaEntityFactory.produceAndPersist { withDefaults() }
     assessmentSchema = approvedPremisesAssessmentJsonSchemaEntityFactory.produceAndPersist { withDefaults() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1LinkBookingToPlacementRequestTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -91,12 +91,7 @@ class SeedCas1LinkBookingToPlacementRequestTest : SeedTestBase() {
 
   private fun createBooking(application: ApprovedPremisesApplicationEntity): BookingEntity {
     val booking = bookingEntityFactory.produceAndPersist {
-      withPremises(
-        approvedPremisesEntityFactory.produceAndPersist {
-          withProbationRegion(givenAProbationRegion())
-          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
-        },
-      )
+      withPremises(givenAnApprovedPremises())
       withAdhoc(true)
       withApplication(application)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1OutOfServiceBedTest.kt
@@ -5,7 +5,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremisesBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
@@ -78,12 +78,7 @@ class SeedCas1OutOfServiceBedTest : SeedTestBase() {
 
   @Test
   fun `Logs an error if no bed exists with the given ID`() {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withYieldedProbationRegion { givenAProbationRegion() }
-      withYieldedLocalAuthorityArea {
-        localAuthorityEntityFactory.produceAndPersist()
-      }
-    }
+    val premises = givenAnApprovedPremises()
 
     val reason = cas1OutOfServiceBedReasonEntityFactory.produceAndPersist()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFromExcelFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DataFrameUtils.createNameValueDataFrame
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DataFrameUtils.dataFrameForHeadersAndRows
@@ -57,14 +58,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating a new room and a new bed with a characteristic succeeds, ensuring no redundant decimal points`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    givenAnApprovedPremises(qCode = qCode)
 
     val values = mutableListOf<List<Any>>(
       listOf("Unique Reference Number for Bed", "SWABI01NEW"),
@@ -102,14 +97,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating a new room and a new bed with a characteristic succeeds, retaining non-redundant decimal points`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    givenAnApprovedPremises(qCode = qCode)
 
     val values = mutableListOf<List<Any>>(
       listOf("Unique Reference Number for Bed", "SWABI01NEW"),
@@ -147,14 +136,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating three new rooms and three new beds with a characteristic succeeds`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    givenAnApprovedPremises(qCode = qCode)
 
     val values = mutableListOf<List<Any>>(
       listOf("Unique Reference Number for Bed", "SWABI01NEW", "SWABI02NEW", "SWABI03NEW"),
@@ -223,14 +206,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating one new room with two beds but different characteristics fails`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    givenAnApprovedPremises(qCode = qCode)
 
     val values = mutableListOf<List<Any>>(
       listOf("Unique Reference Number for Bed", "SWABI01NEW", "SWABI02NEW"),
@@ -270,14 +247,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating two new rooms and three new beds with a characteristic succeeds`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    givenAnApprovedPremises(qCode = qCode)
 
     val values = mutableListOf<List<Any>>(
       listOf("Unique Reference Number for Bed", "SWABI01NEW", "SWABI02NEW", "SWABI03NEW"),
@@ -343,14 +314,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating a new room and a new bed without a characteristic succeeds`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    givenAnApprovedPremises(qCode = qCode)
 
     val values = mutableListOf<List<Any>>(
       listOf("Unique Reference Number for Bed", "SWABI01NEW"),
@@ -392,14 +357,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Updating an existing room with a new bed and a characteristic succeeds`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    val premises = givenAnApprovedPremises(qCode = qCode)
     val roomCode = "$qCode-1"
     roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -449,14 +408,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Updating an existing room with an existing bed and a characteristic succeeds`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    val premises = givenAnApprovedPremises(qCode = qCode)
     val roomCode = "$qCode-1"
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -511,14 +464,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating a new room with two beds with the same name fails`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    val premises = givenAnApprovedPremises(qCode = qCode)
     val roomCode = "$qCode-2"
     roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -563,14 +510,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating a new room and a new bed using an existing bed code fails`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    val premises = givenAnApprovedPremises(qCode = qCode)
     val roomCode = "$qCode-1"
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -618,14 +559,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Creating a new room and new beds using existing bed codes fails`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode(qCode)
-    }
+    val premises = givenAnApprovedPremises(qCode = qCode)
     val roomCode = "$qCode-1"
     val room1 = roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -681,14 +616,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Invalid questions throws exception, fails to process xlsx, rolls back transaction and logs an error`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode("Q999")
-    }
+    givenAnApprovedPremises(qCode = qCode)
 
     val values = mutableListOf<List<Any>>(
       listOf("Unique Reference Number for Bed", "SWABI01NEW"),
@@ -735,14 +664,8 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
 
   @Test
   fun `Invalid answer throws exception, fails to process xlsx, rolls back transaction and logs an error`() {
-    val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
-    val probationRegion = probationRegionEntityFactory.produceAndPersist()
     val qCode = "Q999"
-    approvedPremisesEntityFactory.produceAndPersist {
-      withLocalAuthorityArea(localAuthorityArea)
-      withProbationRegion(probationRegion)
-      withQCode("Q999")
-    }
+    givenAnApprovedPremises(qCode = qCode)
 
     val values = mutableListOf<List<Any>>(
       listOf("Unique Reference Number for Bed", "SWABI01NEW"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3ReportsTest.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
@@ -1856,10 +1857,7 @@ class Cas3ReportsTest : IntegrationTestBase() {
             }
           }
 
-          val unexpectedPremises = approvedPremisesEntityFactory.produceAndPersist {
-            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-            withProbationRegion(userEntity.probationRegion)
-          }
+          val unexpectedPremises = givenAnApprovedPremises()
 
           // Unexpected bookings
           bookingEntityFactory.produceAndPersistMultiple(5) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApprovedPremises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApprovedPremises.kt
@@ -3,10 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesGender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDouble
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
 
 fun IntegrationTestBase.givenAnApprovedPremises(
   name: String = randomStringMultiCaseWithNumbers(8),
@@ -15,13 +20,29 @@ fun IntegrationTestBase.givenAnApprovedPremises(
   region: ProbationRegionEntity? = null,
   emailAddress: String? = randomStringUpperCase(10),
   status: PropertyStatus = randomOf(PropertyStatus.entries),
+  apCode: String = randomStringUpperCase(10),
+  postCode: String = randomPostCode(),
+  managerDetails: String = randomStringUpperCase(10),
+  latitude: Double = randomDouble(53.50, 54.99),
+  longitude: Double = randomDouble(-1.56, 1.10),
+  characteristics: List<CharacteristicEntity> = emptyList(),
+  gender: ApprovedPremisesGender = ApprovedPremisesGender.MAN,
+  id: UUID = UUID.randomUUID(),
 ): ApprovedPremisesEntity = approvedPremisesEntityFactory
   .produceAndPersist {
+    withId(id)
     withName(name)
     withQCode(qCode)
     withEmailAddress(emailAddress)
-    withProbationRegion(region ?: probationRegionEntityFactory.produceAndPersist())
+    withProbationRegion(region ?: givenAProbationRegion())
     withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
     withSupportsSpaceBookings(supportsSpaceBookings)
     withStatus(status)
+    withApCode(apCode)
+    withPostcode(postCode)
+    withManagerDetails(managerDetails)
+    withLatitude(latitude)
+    withLongitude(longitude)
+    withCharacteristics(characteristics.toMutableList())
+    withGender(gender)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/MigrateBookingStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/MigrateBookingStatusTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
@@ -21,7 +22,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
     givenAUser { userEntity, _ ->
       givenAnOffender { _, _ ->
         val approvedPremises = ServiceName.approvedPremises
-        val booking = createCAS1CancelledBooking(userEntity)
+        val booking = createCAS1CancelledBooking()
 
         assertBookingStatusIsNull(booking, approvedPremises)
 
@@ -262,8 +263,8 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
     return booking
   }
 
-  private fun createCAS1CancelledBooking(userEntity: UserEntity): BookingEntity {
-    val booking = createApprovedAccommodationBooking(userEntity)
+  private fun createCAS1CancelledBooking(): BookingEntity {
+    val booking = createApprovedAccommodationBooking()
     booking.cancellations = cancellationEntityFactory.produceAndPersistMultiple(1) {
       withBooking(booking)
       withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
@@ -296,13 +297,8 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
     return booking
   }
 
-  private fun createApprovedAccommodationBooking(userEntity: UserEntity): BookingEntity {
-    val premises = approvedPremisesEntityFactory.produceAndPersist {
-      withProbationRegion(userEntity.probationRegion)
-      withYieldedLocalAuthorityArea {
-        localAuthorityEntityFactory.produceAndPersist()
-      }
-    }
+  private fun createApprovedAccommodationBooking(): BookingEntity {
+    val premises = givenAnApprovedPremises()
 
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/SeedUpdateNomsNumberSeedJobTest.kt
@@ -8,6 +8,7 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.UpdateNomsNumberSeedRow
@@ -71,27 +72,13 @@ class SeedUpdateNomsNumberSeedJobTest : SeedTestBase() {
     }
 
     val booking = bookingEntityFactory.produceAndPersist {
-      withPremises(
-        approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { givenAnApArea() } }
-          }
-        },
-      )
+      withPremises(givenAnApprovedPremises())
       withCrn(CRN)
       withNomsNumber(OLD_NOMS)
     }
 
     val otherCrnBooking = bookingEntityFactory.produceAndPersist {
-      withPremises(
-        approvedPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion {
-            probationRegionEntityFactory.produceAndPersist { withYieldedApArea { givenAnApArea() } }
-          }
-        },
-      )
+      withPremises(givenAnApprovedPremises())
       withCrn(OTHER_CRN)
       withNomsNumber(OTHER_NOMS)
     }


### PR DESCRIPTION
Where practical, replace usage of the `ApprovedPremisesEntityFactory` with `givenAnApprovedPremises()`. This is in preparation for adding a new column to the `ApprovedPremisesEntity`, which would require alot of test updates if they all used the factory directly