### PR TITLE
Seed CAS1 Expired and Withdrawn Apps in Dev

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1StartupScript.kt
@@ -18,20 +18,57 @@ class Cas1StartupScript(
     seedLogger.info("Running Startup Script for CAS1")
 
     if (environmentService.isDev()) {
-      scriptDev()
+      createDevApplications()
     }
   }
 
-  fun createApplicationPendingSubmission(
+  fun createDevApplications() {
+    seedLogger.info("Creating Dev Applications")
+
+    createApplication(
+      deliusUserName = "AP_USER_TEST_1",
+      crn = "X320741",
+      state = Cas1ApplicationSeedService.ApplicationState.PENDING_SUBMISSION,
+    )
+
+    createApplication(
+      deliusUserName = "AP_USER_TEST_1",
+      crn = "X698340",
+      state = Cas1ApplicationSeedService.ApplicationState.WITHDRAWN_BEFORE_SUBMISSION,
+    )
+
+    createApplication(
+      deliusUserName = "AP_USER_TEST_1",
+      crn = "X698227",
+      state = Cas1ApplicationSeedService.ApplicationState.WITHDRAWN_AFTER_SUBMISSION,
+    )
+
+    createApplication(
+      deliusUserName = "AP_USER_TEST_1",
+      crn = "X698317",
+      state = Cas1ApplicationSeedService.ApplicationState.EXPIRED_BEFORE_SUBMISSION,
+    )
+
+    createApplication(
+      deliusUserName = "AP_USER_TEST_1",
+      crn = "X698338",
+      state = Cas1ApplicationSeedService.ApplicationState.EXPIRED_AFTER_AUTHORISATION,
+    )
+
+    createOfflineApplicationWithBooking(deliusUserName = "AP_USER_TEST_1", crn = "X320741")
+  }
+
+  fun createApplication(
     deliusUserName: String,
     crn: String,
+    state: Cas1ApplicationSeedService.ApplicationState,
   ) {
-    seedLogger.info("Auto-scripting application for CRN $crn")
+    seedLogger.info("Creating application with state $state for CRN X320741")
     try {
       cas1ApplicationSeedService.createApplication(
         deliusUserName = deliusUserName,
         crn = crn,
-        state = Cas1ApplicationSeedService.ApplicationState.PENDING_SUBMISSION,
+        state = state,
       )
     } catch (e: Exception) {
       seedLogger.error("Creating application with crn $crn failed", e)
@@ -49,15 +86,5 @@ class Cas1StartupScript(
     } catch (e: Exception) {
       seedLogger.error("Creating offline application with crn $crn failed", e)
     }
-  }
-
-  fun scriptDev() {
-    seedLogger.info("Running Startup Script for CAS1 dev")
-
-    createApplicationPendingSubmission(
-      deliusUserName = "AP_USER_TEST_1",
-      crn = "X320741",
-    )
-    createOfflineApplicationWithBooking(deliusUserName = "AP_USER_TEST_1", crn = "X320741")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1StartupScriptConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1StartupScriptConfigTest.kt
@@ -12,6 +12,6 @@ class Cas1StartupScriptConfigTest : IntegrationTestBase() {
 
   @Test
   fun `ensure dev auto script runs`() {
-    cas1StartupScript.scriptDev()
+    cas1StartupScript.createDevApplications()
   }
 }


### PR DESCRIPTION
This commit seeds an additional 4 applications when deploying locally:

* withdrawn before submission
* withdrawn after authorisation
* expired before submission
* expired after authorisation

To achieve this the expiry scheduled jobs have been refactored to allow us to access the application expiry logic from the `Cas1ApplicationSeedService`