### PR TITLE
Exclude `hibernate-spatial` from renovate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.retry:spring-retry")
   implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.10.0")
+  // this should match the version of hibernate provided by spring
   implementation("org.hibernate:hibernate-spatial:6.6.4.Final")
   implementation("org.hibernate.orm:hibernate-jcache")
   implementation("org.flywaydb:flyway-core")

--- a/renovate.json
+++ b/renovate.json
@@ -29,5 +29,6 @@
       ]
     }
   ],
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "ignoreDeps": ["org.hibernate:hibernate-spatial"]
 }


### PR DESCRIPTION
This should be manually updated, matching the version of hibernate provided by spring