### PR TITLE
Cleanup temporary accommodations characteristics data

### DIFF
--- a/src/main/resources/db/migration/all/20250612095600__temporary_accommodation_characteristics.sql
+++ b/src/main/resources/db/migration/all/20250612095600__temporary_accommodation_characteristics.sql
@@ -1,0 +1,8 @@
+delete from premises_characteristics
+where characteristic_id in (
+    select id
+    from characteristics
+    where service_scope = 'temporary-accommodation'
+    and model_scope = 'room'
+    and name = 'Wheelchair accessible'
+)


### PR DESCRIPTION
**Background**
* The latest migration job work done in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3594 uncovered a data issue
* the migration job failed in preprod as some `room` characteristics are mapped to cas3 premises. We would expect only `premises` characteristics to be mapped to premises. 
* This query proved this theory:
<img width="1728" alt="Screenshot 2025-06-11 at 16 08 05" src="https://github.com/user-attachments/assets/214afcf8-2fa8-42fe-8378-cce7564bd08f" />

* I think this is hanging around from this: https://dsdmoj.atlassian.net/browse/CAS-1203

**PR includes**
* Flyway script to delete the mappings for room characteristics mapped to cas3 premises