### PR TITLE
Changes to the verification queries for the cas3 characteristics migration work

### DIFF
--- a/script/migration/cas3/03__verify_data_migration_to_cas3_premises_characterists_tables.sql
+++ b/script/migration/cas3/03__verify_data_migration_to_cas3_premises_characterists_tables.sql
@@ -9,9 +9,8 @@ join characteristics c on c.id = pc.characteristic_id;
 select count(c3pc.*)
 from cas3_premises c3p
 join cas3_premises_characteristic_assignments c3pcm on c3pcm.premises_id = c3p.id
-join cas3_premises_characteristics c3pc on c3pc.id = c3pcm.premises_id
-join premises_characteristics pc on pc.premises_id = c3p.id
-join characteristics c on c.id = pc.characteristic_id
-where c3pc.name = c.name
-and (c3pc.property_name = c.property_name OR (c3pc.property_name IS NULL AND c.property_name IS NULL))
-and c3pc.is_active = c.is_active
+join cas3_premises_characteristics c3pc on c3pc.id = c3pcm.premises_characteristics_id
+join characteristics c on c.id = c3pc.id
+where c3pc.description = c.name
+and (c3pc.name = c.property_name OR (c3pc.name IS NULL AND c.property_name IS NULL))
+and c3pc.is_active = c.is_active;

--- a/script/migration/cas3/04__verify_data_migration_to_cas3_bedspaces_characterists_tables.sql
+++ b/script/migration/cas3/04__verify_data_migration_to_cas3_bedspaces_characterists_tables.sql
@@ -10,11 +10,8 @@ join characteristics c on c.id = rc.characteristic_id;
 select count(c3bc.*)
 from cas3_bedspaces c3b
 join cas3_bedspace_characteristic_assignments c3bcm on c3bcm.bedspace_id = c3b.id
-join cas3_bedspace_characteristics c3bc on c3bc.id = c3bcm.bedspace_id
-join beds b on b.id = c3b.id
-join rooms r on r.id = b.room_id
-join room_characteristics rc on rc.room_id = r.id
-join characteristics c on c.id = rc.characteristic_id
-where c3bc.name = c.name
-and (c3bc.property_name = c.property_name OR (c3bc.property_name IS NULL AND c.property_name IS NULL))
+join cas3_bedspace_characteristics c3bc on c3bc.id = c3bcm.bedspace_characteristics_id
+join characteristics c on c.id = c3bc.id
+where c3bc.description = c.name
+and (c3bc.name = c.property_name OR (c3bc.name IS NULL AND c.property_name IS NULL))
 and c3bc.is_active = c.is_active


### PR DESCRIPTION
**Background**
* I was unable to run the verification queries locally for the characteristics migration work. This is because we do not have any default characteristics mappings for cas3 data (in the local infrastructure)
* After running the migration job I could see that the data had been migration but the counts on the queries were coming back as 0

**PR includes**
* Amendments to the queries so that they check the counts "line up" for old data and migrated data