### PR TITLE
APS-2375 - Update CRU Management Area in Site Survey Seed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -209,7 +209,7 @@ class ApprovedPremisesEntity(
   var fullAddress: String?,
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "cas1_cru_management_area_id")
-  val cruManagementArea: Cas1CruManagementAreaEntity?,
+  var cruManagementArea: Cas1CruManagementAreaEntity?,
 ) : PremisesEntity(
   id,
   name,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1PremisesFromSiteSurveyXlsxTest.kt
@@ -416,6 +416,7 @@ class SeedCas1PremisesFromSiteSurveyXlsxTest : SeedTestBase() {
     assertThat(createdPremise.gender).isEqualTo(ApprovedPremisesGender.MAN)
     assertThat(createdPremise.supportsSpaceBookings).isEqualTo(true)
     assertThat(createdPremise.managerDetails).isEqualTo("some manager details")
+    assertThat(createdPremise.cruManagementArea?.name).isEqualTo("North East")
 
     assertThat(createdPremise.characteristics).hasSize(2)
 


### PR DESCRIPTION
A previous change updates the Premises Site Survey Seed job to set the CRU Management Area when creating a new Premises. This commit adds the same functionality when updating an existing premises.