### PR TITLE
APS-2392 Add CAS3 OASys Endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -91,7 +91,7 @@ class Cas1OasysController(
       )
     ) {
       null -> throw NotFoundProblem(crn, "Offender")
-      false -> throw throw ForbiddenProblem()
+      false -> throw ForbiddenProblem()
       else -> Unit
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3PeopleController.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas3
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas3.PeopleCas3Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3OASysGroup
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3OASysOffenceDetailsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+
+@Service
+class Cas3PeopleController(
+  private val offenderService: OffenderService,
+  private val userService: UserService,
+  private val oaSysService: OASysService,
+  private val oaSysSectionsTransformer: OASysSectionsTransformer,
+  private val oaSysOffenceDetailsTransformer: Cas3OASysOffenceDetailsTransformer,
+) : PeopleCas3Delegate {
+
+  override fun riskManagement(crn: String): ResponseEntity<Cas3OASysGroup> {
+    ensureOffenderAccess(crn)
+
+    val offenceDetails = extractEntityFromCasResult(oaSysService.getOASysOffenceDetails(crn))
+
+    val assessmentMetadata = oaSysOffenceDetailsTransformer.toAssessmentMetadata(offenceDetails)
+
+    val answers = oaSysSectionsTransformer.riskManagementPlanAnswers(
+      extractEntityFromCasResult(oaSysService.getOASysRiskManagementPlan(crn)).riskManagementPlan,
+    )
+
+    return ResponseEntity.ok(
+      Cas3OASysGroup(
+        assessmentMetadata = assessmentMetadata,
+        answers = answers,
+      ),
+    )
+  }
+
+  @SuppressWarnings("ThrowsCount")
+  private fun ensureOffenderAccess(crn: String) {
+    when (
+      offenderService.canAccessOffender(
+        crn = crn,
+        laoStrategy = userService.getUserForRequest().cas3LaoStrategy(),
+      )
+    ) {
+      null -> throw NotFoundProblem(crn, "Offender")
+      false -> throw ForbiddenProblem()
+      else -> Unit
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3OASysOffenceDetailsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3OASysOffenceDetailsTransformer.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3OASysAssessmentMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.OffenceDetails
+
+@Service
+class Cas3OASysOffenceDetailsTransformer {
+  fun toAssessmentMetadata(offenceDetails: OffenceDetails?) = offenceDetails?.let {
+    Cas3OASysAssessmentMetadata(
+      hasApplicableAssessment = true,
+      dateStarted = offenceDetails.initiationDate.toInstant(),
+      dateCompleted = offenceDetails.dateCompleted?.toInstant(),
+    )
+  } ?: Cas3OASysAssessmentMetadata(hasApplicableAssessment = false)
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -839,7 +839,7 @@ paths:
       deprecated: true
       tags:
         - OASys
-      summary: Returns the importable sections of OASys including details of links to harm and reoffending. This is only used by CAS1, which should use /cas1/people/X320741/oasys/supporting-information-metadata instead.
+      summary: Returns the importable sections of OASys including details of links to harm and reoffending. This is only used by CAS1, which should use /cas1/people/CRN/oasys/supporting-information-metadata instead.
       operationId: peopleCrnOasysSelectionGet
       parameters:
         - name: crn
@@ -867,7 +867,8 @@ paths:
     get:
       tags:
         - OASys
-      summary: Returns OASys sections to support an Application.  The Supporting Information sections are returned if linked to harm and optionally if their section number appears in the selected-sections query parameter.
+      summary: Returns OASys sections to support an Application.  The Supporting Information sections are returned if linked to harm and optionally if their section number appears in the selected-sections query parameter. CAS1 should use /cas1/people/CRN/oasys/answers. CAS3 shoudl use /cas3/people/CRN/oasys/riskManagement
+      deprecated: true
       operationId: peopleCrnOasysSectionsGet
       parameters:
         - name: crn
@@ -878,7 +879,7 @@ paths:
             type: string
         - name: selected-sections
           in: query
-          description: Section numbers for optional (not Linked to Harm) suppprting information
+          description: Section numbers for optional (not Linked to Harm) supporting information
           required: false
           schema:
             type: array

--- a/src/main/resources/static/cas3-api.yml
+++ b/src/main/resources/static/cas3-api.yml
@@ -460,4 +460,28 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
-
+  /people/{crn}/oasys/riskManagement:
+    get:
+      tags:
+        - OAsys
+      operationId: riskManagement
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys selection
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: 'cas3-schemas.yml#/components/schemas/Cas3OASysGroup'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'

--- a/src/main/resources/static/cas3-schemas.yml
+++ b/src/main/resources/static/cas3-schemas.yml
@@ -464,3 +464,29 @@ components:
         - futureBookings
         - futureBookingsCsv
         - bookingGap
+    Cas3OASysGroup:
+      type: object
+      description: Groups questions and answers from OAsys
+      properties:
+        assessmentMetadata:
+          $ref: '#/components/schemas/Cas3OASysAssessmentMetadata'
+        answers:
+          type: array
+          items:
+            $ref: '_shared.yml#/components/schemas/OASysQuestion'
+      required:
+        - assessmentMetadata
+        - answers
+    Cas3OASysAssessmentMetadata:
+      type: object
+      properties:
+        hasApplicableAssessment:
+          type: boolean
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+      required:
+        - hasApplicableAssessment

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -841,7 +841,7 @@ paths:
       deprecated: true
       tags:
         - OASys
-      summary: Returns the importable sections of OASys including details of links to harm and reoffending. This is only used by CAS1, which should use /cas1/people/X320741/oasys/supporting-information-metadata instead.
+      summary: Returns the importable sections of OASys including details of links to harm and reoffending. This is only used by CAS1, which should use /cas1/people/CRN/oasys/supporting-information-metadata instead.
       operationId: peopleCrnOasysSelectionGet
       parameters:
         - name: crn
@@ -869,7 +869,8 @@ paths:
     get:
       tags:
         - OASys
-      summary: Returns OASys sections to support an Application.  The Supporting Information sections are returned if linked to harm and optionally if their section number appears in the selected-sections query parameter.
+      summary: Returns OASys sections to support an Application.  The Supporting Information sections are returned if linked to harm and optionally if their section number appears in the selected-sections query parameter. CAS1 should use /cas1/people/CRN/oasys/answers. CAS3 shoudl use /cas3/people/CRN/oasys/riskManagement
+      deprecated: true
       operationId: peopleCrnOasysSectionsGet
       parameters:
         - name: crn
@@ -880,7 +881,7 @@ paths:
             type: string
         - name: selected-sections
           in: query
-          description: Section numbers for optional (not Linked to Harm) suppprting information
+          description: Section numbers for optional (not Linked to Harm) supporting information
           required: false
           schema:
             type: array

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -462,7 +462,31 @@ paths:
             'application/problem+json':
               schema:
                 $ref: '#/components/schemas/ValidationError'
-
+  /people/{crn}/oasys/riskManagement:
+    get:
+      tags:
+        - OAsys
+      operationId: riskManagement
+      parameters:
+        - name: crn
+          in: path
+          description: CRN of the Person to fetch latest OASys selection
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas3OASysGroup'
+        404:
+          description: invalid CRN
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
 components:
   headers:
     X-Pagination-CurrentPage:
@@ -5359,3 +5383,29 @@ components:
         - futureBookings
         - futureBookingsCsv
         - bookingGap
+    Cas3OASysGroup:
+      type: object
+      description: Groups questions and answers from OAsys
+      properties:
+        assessmentMetadata:
+          $ref: '#/components/schemas/Cas3OASysAssessmentMetadata'
+        answers:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysQuestion'
+      required:
+        - assessmentMetadata
+        - answers
+    Cas3OASysAssessmentMetadata:
+      type: object
+      properties:
+        hasApplicableAssessment:
+          type: boolean
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+      required:
+        - hasApplicableAssessment

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3PeopleTest.kt
@@ -1,0 +1,112 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3OASysGroup
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1OAsysTest.Companion.CRN
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockNeedsDetails404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockOffenceDetails404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulOffenceDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRiskManagementPlanCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+
+class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
+
+  @Nested
+  inner class OASysRiskManagement {
+
+    @Test
+    fun `No JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas3/people/CRN/oasys/riskManagement")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Return 404 if access record can't be found for the CRN  (legacy behaviour)`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextUserAccessEmptyResponse()
+
+      webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `Return 404 if offence details record can't be found for the CRN`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+      apOASysContextMockOffenceDetails404Call(CRN)
+
+      webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `Return 404 if needs record can't be found for the CRN`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+      apOASysContextMockNeedsDetails404Call(CRN)
+
+      webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun success() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .produce()
+      apOASysContextMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas3OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = "The supervision answer",
+        ),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3OASysOffenceDetailsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3OASysOffenceDetailsTransformerTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3OASysOffenceDetailsTransformer
+import java.time.Instant
+import java.time.OffsetDateTime
+
+class Cas3OASysOffenceDetailsTransformerTest {
+
+  private val transformer = Cas3OASysOffenceDetailsTransformer()
+
+  @Nested
+  inner class ToAssessmentMetadata {
+
+    @Test
+    fun `has applicable assessment`() {
+      val initiationDate = OffsetDateTime.parse("2020-05-02T12:01:00+00:00")
+      val completionDate = OffsetDateTime.parse("2021-05-02T12:02:00+00:00")
+
+      val result = transformer.toAssessmentMetadata(
+        OffenceDetailsFactory()
+          .withInitiationDate(initiationDate)
+          .withDateCompleted(completionDate)
+          .produce(),
+      )
+
+      assertThat(result.hasApplicableAssessment).isTrue()
+      assertThat(result.dateStarted).isEqualTo(Instant.parse("2020-05-02T12:01:00+00:00"))
+      assertThat(result.dateCompleted).isEqualTo(Instant.parse("2021-05-02T12:02:00+00:00"))
+    }
+
+    @Test
+    fun `no applicable assessment`() {
+      val result = transformer.toAssessmentMetadata(null)
+
+      assertThat(result.hasApplicableAssessment).isFalse()
+      assertThat(result.dateStarted).isNull()
+      assertThat(result.dateCompleted).isNull()
+    }
+  }
+}


### PR DESCRIPTION
CAS3 currently uses the /people/$CRN/oasys/sections endpoint. This endpoint calls five different OASys APIs, despite CAS3 only requiring answers from two of them (offence details for metadata, and risk management for questions and answers).

This commit adds a new /cas3/person/CRN/oasys/riskManagement endpoint that only provides just the information required by the UI. This makes 2 calls to OASys API instead of 5.