### PR TITLE
CAS-1685: Pt2 Change logging and sorting for migration job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3UpdateBookingOffenderNameJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3UpdateBookingOffenderNameJob.kt
@@ -60,7 +60,7 @@ class Cas3UpdateBookingOffenderNameJob(
     try {
       val offenderName = when (personInfo) {
         is PersonSummaryInfoResult.Success.Full -> "${personInfo.summary.name.forename} ${personInfo.summary.name.surname}"
-        is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> throw Exception("Offender not found")
+        is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> throw Exception("Offender not found for crn ${it.crn}")
         is PersonSummaryInfoResult.Success.Restricted -> throw Exception("You are not authorized")
       }
 


### PR DESCRIPTION
There are some `offender_name` for the `bookings` table that are still null this PR attempts to run through null values first and enhance the logging too.