### PR TITLE
Ensure local workflows inherit secrets

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   docker_build:
     name: Build docker image from hmpps-github-actions
@@ -38,6 +39,7 @@ jobs:
     needs:
       - deploy_dev
     uses: ./.github/workflows/e2e.yml
+    secrets: inherit
 
   deploy_preprod:
     name: Deploy to pre-production environment


### PR DESCRIPTION
This will ensure the E2E pipeline workflow is able to relay the repo secrets over to the UI workflows. This is necessary for local workflows too: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-of-jobsjob_idsecretsinherit