### PR TITLE
Make `docker_build` `app_version` available to deploy

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -44,6 +44,7 @@ jobs:
   deploy_preprod:
     name: Deploy to pre-production environment
     needs:
+      - docker_build
       - e2e
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
     secrets: inherit
@@ -54,6 +55,7 @@ jobs:
   deploy_prod:
     name: Deploy to production environment
     needs:
+      - docker_build
       - deploy_preprod
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
     secrets: inherit


### PR DESCRIPTION
The `app_version` passed to the MoJ deploy github action references the output from the `docker_build` job. This means the `docker_build` job must exist as a key of the `need` property for the deploy jobs, as it does for the `deploy_dev` job, which worked earlier.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs