### PR TITLE
APS-2388 add /cas1/applications/me endpoint to return all users applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -52,6 +52,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy.CheckUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1RequestForPlacementService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableEntitiesWithNotes
@@ -75,6 +76,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesAp
 class ApplicationsController(
   private val httpAuthService: HttpAuthService,
   private val applicationService: ApplicationService,
+  private val cas1ApplicationService: Cas1ApplicationService,
   private val cas3ApplicationService: Cas3ApplicationService,
   private val applicationsTransformer: ApplicationsTransformer,
   private val assessmentTransformer: AssessmentTransformer,
@@ -125,7 +127,7 @@ class ApplicationsController(
     val statusTransformed = status?.map { DomainApprovedPremisesApplicationStatus.valueOf(it) } ?: emptyList()
 
     val (applications, metadata) =
-      applicationService.getAllApprovedPremisesApplications(
+      cas1ApplicationService.getAllApprovedPremisesApplications(
         page,
         crnOrName,
         sortDirection,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ApplicationsController.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy.CheckUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import java.util.UUID
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesAp
 class Cas1ApplicationsController(
   private val cas1TimelineService: Cas1TimelineService,
   private val applicationService: ApplicationService,
+  private val cas1ApplicationService: Cas1ApplicationService,
   private val userService: UserService,
   private val offenderService: OffenderService,
   private val applicationsTransformer: ApplicationsTransformer,
@@ -50,7 +52,7 @@ class Cas1ApplicationsController(
     val statusTransformed = status?.map { DomainApprovedPremisesApplicationStatus.valueOf(it) } ?: emptyList()
 
     val (applications, metadata) =
-      applicationService.getAllApprovedPremisesApplications(
+      cas1ApplicationService.getAllApprovedPremisesApplications(
         page,
         crnOrName,
         sortDirection,
@@ -74,7 +76,7 @@ class Cas1ApplicationsController(
     val user = userService.getUserForRequest()
 
     val (applications, metadata) =
-      applicationService.getAllApprovedPremisesApplications(
+      cas1ApplicationService.getAllApprovedPremisesApplications(
         page = null,
         crnOrName = null,
         sortDirection = SortDirection.asc,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ApplicationsController.kt
@@ -70,6 +70,31 @@ class Cas1ApplicationsController(
     )
   }
 
+  override fun getApplicationsMe(): ResponseEntity<List<Cas1ApplicationSummary>> {
+    val user = userService.getUserForRequest()
+
+    val (applications, metadata) =
+      applicationService.getAllApprovedPremisesApplications(
+        page = null,
+        crnOrName = null,
+        sortDirection = SortDirection.asc,
+        status = emptyList(),
+        sortBy = ApplicationSortField.createdAt,
+        apAreaId = null,
+        releaseType = null,
+        createdByUserId = user.id,
+      )
+
+    return ResponseEntity.ok().headers(
+      metadata?.toHeaders(),
+    ).body(
+      getPersonDetailAndTransformToSummary(
+        applications = applications,
+        laoStrategy = user.cas1LaoStrategy(),
+      ),
+    )
+  }
+
   override fun getApplicationsForUser(): ResponseEntity<List<Cas1ApplicationSummary>> {
     val user = userService.getUserForRequest()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -87,6 +87,9 @@ AND (
 AND (
     (:releaseType IS NULL) OR (apa.release_type = :releaseType)
 )
+AND (
+    (:createdByUserId IS NULL) OR (a.created_by_user_id = :createdByUserId)
+)
 """,
     countQuery = """
     SELECT COUNT(*)
@@ -118,6 +121,7 @@ AND (
     status: List<String>,
     apAreaId: UUID?,
     releaseType: String?,
+    createdByUserId: UUID?,
   ): Page<ApprovedPremisesApplicationSummary>
 
   @Query("SELECT a FROM ApplicationEntity a WHERE TYPE(a) = :type AND a.createdByUser.id = :id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -5,11 +5,9 @@ import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
@@ -22,7 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
@@ -40,7 +37,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Offe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.ApplicationListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
@@ -56,8 +52,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableState
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalTime
@@ -104,41 +98,6 @@ class ApplicationService(
     ServiceName.cas2 -> throw RuntimeException("CAS2 applications now require NomisUser")
     ServiceName.cas2v2 -> throw RuntimeException("CAS2v2 applications now require Cas2v2User")
     ServiceName.temporaryAccommodation -> getAllTemporaryAccommodationApplicationsForUser(userEntity)
-  }
-
-  fun getAllApprovedPremisesApplications(
-    page: Int?,
-    crnOrName: String?,
-    sortDirection: SortDirection?,
-    status: List<ApprovedPremisesApplicationStatus>,
-    sortBy: ApplicationSortField?,
-    apAreaId: UUID?,
-    releaseType: String?,
-    pageSize: Int? = 10,
-    createdByUserId: UUID? = null,
-  ): Pair<List<ApprovedPremisesApplicationSummary>, PaginationMetadata?> {
-    val sortField = when (sortBy) {
-      ApplicationSortField.arrivalDate -> "arrivalDate"
-      ApplicationSortField.createdAt -> "a.created_at"
-      ApplicationSortField.tier -> "tier"
-      ApplicationSortField.releaseType -> "releaseType"
-      else -> "a.created_at"
-    }
-    val pageable = getPageableOrAllPages(sortField, sortDirection, page, pageSize)
-
-    val statusNames = status.map { it.name }
-
-    val response = applicationRepository.findAllApprovedPremisesSummaries(
-      pageable = pageable,
-      crnOrName = crnOrName,
-      statusProvided = statusNames.isNotEmpty(),
-      status = statusNames,
-      apAreaId = apAreaId,
-      releaseType,
-      createdByUserId,
-    )
-
-    return Pair(response.content, getMetadata(response, page, pageSize))
   }
 
   fun getAllApprovedPremisesApplicationsForUser(user: UserEntity) = applicationRepository.findNonWithdrawnApprovedPremisesSummariesForUser(user.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -57,7 +57,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Offende
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableState
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageable
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalTime
@@ -115,6 +115,7 @@ class ApplicationService(
     apAreaId: UUID?,
     releaseType: String?,
     pageSize: Int? = 10,
+    createdByUserId: UUID? = null,
   ): Pair<List<ApprovedPremisesApplicationSummary>, PaginationMetadata?> {
     val sortField = when (sortBy) {
       ApplicationSortField.arrivalDate -> "arrivalDate"
@@ -123,7 +124,7 @@ class ApplicationService(
       ApplicationSortField.releaseType -> "releaseType"
       else -> "a.created_at"
     }
-    val pageable = getPageable(sortField, sortDirection, page, pageSize)
+    val pageable = getPageableOrAllPages(sortField, sortDirection, page, pageSize)
 
     val statusNames = status.map { it.name }
 
@@ -134,6 +135,7 @@ class ApplicationService(
       status = statusNames,
       apAreaId = apAreaId,
       releaseType,
+      createdByUserId,
     )
 
     return Pair(response.content, getMetadata(response, page, pageSize))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
@@ -2,15 +2,60 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.data.domain.Limit
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
+import java.util.UUID
 
 @Service
 class Cas1ApplicationService(
-  private val applicationRepository: ApprovedPremisesApplicationRepository,
+  private val approvedPremisesApplicationRepository: ApprovedPremisesApplicationRepository,
+  private val applicationRepository: ApplicationRepository,
   private val offlineApplicationRepository: OfflineApplicationRepository,
 ) {
-  fun getApplicationsForCrn(crn: String, limit: Int) = applicationRepository.findByCrn(crn, Limit.of(limit))
+  fun getApplicationsForCrn(crn: String, limit: Int) = approvedPremisesApplicationRepository.findByCrn(crn, Limit.of(limit))
 
   fun getOfflineApplicationsForCrn(crn: String, limit: Int) = offlineApplicationRepository.findAllByCrn(crn, Limit.of(limit))
+
+  fun getAllApprovedPremisesApplications(
+    page: Int?,
+    crnOrName: String?,
+    sortDirection: SortDirection?,
+    status: List<ApprovedPremisesApplicationStatus>,
+    sortBy: ApplicationSortField?,
+    apAreaId: UUID?,
+    releaseType: String?,
+    pageSize: Int? = 10,
+    createdByUserId: UUID? = null,
+  ): Pair<List<ApprovedPremisesApplicationSummary>, PaginationMetadata?> {
+    val sortField = when (sortBy) {
+      ApplicationSortField.arrivalDate -> "arrivalDate"
+      ApplicationSortField.createdAt -> "a.created_at"
+      ApplicationSortField.tier -> "tier"
+      ApplicationSortField.releaseType -> "releaseType"
+      else -> "a.created_at"
+    }
+    val pageable = getPageableOrAllPages(sortField, sortDirection, page, pageSize)
+
+    val statusNames = status.map { it.name }
+
+    val response = applicationRepository.findAllApprovedPremisesSummaries(
+      pageable = pageable,
+      crnOrName = crnOrName,
+      statusProvided = statusNames.isNotEmpty(),
+      status = statusNames,
+      apAreaId = apAreaId,
+      releaseType,
+      createdByUserId,
+    )
+
+    return Pair(response.content, getMetadata(response, page, pageSize))
+  }
 }

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -2051,6 +2051,8 @@ paths:
         - Applications
       summary: Lists all applications that the user has created
       operationId: getApplicationsForUser
+      deprecated: true
+      description: Deprecated, use GET /cas1/applications/me instead.
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -2029,6 +2029,21 @@ paths:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '_shared.yml#/components/headers/X-Pagination-TotalResults'
+  /applications/me:
+    get:
+      tags:
+        - Applications
+      summary: Lists all applications that the user has created
+      operationId: getApplicationsMe
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: 'cas1-schemas.yml#/components/schemas/Cas1ApplicationSummary'
 
   /applications:
     get:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2031,6 +2031,21 @@ paths:
               $ref: '#/components/headers/X-Pagination-TotalResults'
             X-Pagination-PageSize:
               $ref: '#/components/headers/X-Pagination-TotalResults'
+  /applications/me:
+    get:
+      tags:
+        - Applications
+      summary: Lists all applications that any user has created
+      operationId: getApplicationsMe
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas1ApplicationSummary'
 
   /applications:
     get:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -2035,7 +2035,7 @@ paths:
     get:
       tags:
         - Applications
-      summary: Lists all applications that any user has created
+      summary: Lists all applications that the user has created
       operationId: getApplicationsMe
       responses:
         200:
@@ -2053,6 +2053,8 @@ paths:
         - Applications
       summary: Lists all applications that the user has created
       operationId: getApplicationsForUser
+      deprecated: true
+      description: Deprecated, use GET /cas1/applications/me instead.
       responses:
         200:
           description: successful operation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -30,7 +30,7 @@ import kotlin.random.Random
 
 class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
-  private lateinit var applicationService: ApplicationService
+  private lateinit var cas1ApplicationService: Cas1ApplicationService
 
   private lateinit var crn1: String
   private lateinit var crn2: String
@@ -209,7 +209,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
     val chunkedApplications = allApplications.chunked(10)
 
     chunkedApplications.forEachIndexed { page, chunk ->
-      val (result, metadata) = applicationService.getAllApprovedPremisesApplications(
+      val (result, metadata) = cas1ApplicationService.getAllApprovedPremisesApplications(
         page + 1,
         null,
         null,
@@ -234,7 +234,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   @Test
   fun `findAllApprovedPremisesSummaries filters by CRN`() {
     val expectedApplications = allApplications.filter { it.crn == crn1 }
-    val result = applicationService.getAllApprovedPremisesApplications(
+    val result = cas1ApplicationService.getAllApprovedPremisesApplications(
       1,
       crn1,
       null,
@@ -252,7 +252,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   @Test
   fun `findAllApprovedPremisesSummaries filters by name`() {
     val expectedApplications = allApplications.filter { it.name == name }
-    val result = applicationService.getAllApprovedPremisesApplications(
+    val result = cas1ApplicationService.getAllApprovedPremisesApplications(
       1,
       name,
       null,
@@ -272,7 +272,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   fun `findAllApprovedPremisesSummaries filters by status`(status: ApprovedPremisesApplicationStatus) {
     val expectedApplications = allApplications.filter { it.status == status }
 
-    val result = applicationService.getAllApprovedPremisesApplications(
+    val result = cas1ApplicationService.getAllApprovedPremisesApplications(
       1,
       null,
       null,
@@ -298,7 +298,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
     val expectedApplications = allApplications.filter { statuses.contains(it.status) }
     assertThat(expectedApplications).hasSizeGreaterThan(2)
 
-    val result = applicationService.getAllApprovedPremisesApplications(
+    val result = cas1ApplicationService.getAllApprovedPremisesApplications(
       1,
       null,
       null,
@@ -317,7 +317,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   fun `findAllApprovedPremisesSummaries filters by AP Area`() {
     val expectedApplications = allApplications.filter { it.apArea?.id == apArea.id }
 
-    val result = applicationService.getAllApprovedPremisesApplications(
+    val result = cas1ApplicationService.getAllApprovedPremisesApplications(
       1,
       null,
       null,
@@ -337,7 +337,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   fun `findAllApprovedPremisesSummaries filters by release type`(releaseType: ReleaseTypeOption) {
     val expectedApplications = allApplications.filter { it.releaseType == releaseType.name }
 
-    val result = applicationService.getAllApprovedPremisesApplications(
+    val result = cas1ApplicationService.getAllApprovedPremisesApplications(
       1,
       null,
       null,
@@ -355,7 +355,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   @Test
   fun `findAllApprovedPremisesSummaries handles pagination`() {
     allApplications.forEachIndexed { index, application ->
-      val (result, metadata) = applicationService.getAllApprovedPremisesApplications(
+      val (result, metadata) = cas1ApplicationService.getAllApprovedPremisesApplications(
         index + 1,
         null,
         null,
@@ -384,7 +384,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
     val chunkedApplications = allApplications.chunked(10)
 
     chunkedApplications.forEachIndexed { page, chunk ->
-      val (result, metadata) = applicationService.getAllApprovedPremisesApplications(
+      val (result, metadata) = cas1ApplicationService.getAllApprovedPremisesApplications(
         page + 1,
         null,
         SortDirection.asc,
@@ -413,7 +413,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
     val chunkedApplications = allApplications.chunked(10)
 
     chunkedApplications.forEachIndexed { page, chunk ->
-      val (result, metadata) = applicationService.getAllApprovedPremisesApplications(
+      val (result, metadata) = cas1ApplicationService.getAllApprovedPremisesApplications(
         page + 1,
         null,
         SortDirection.desc,


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2388

This is being added as a replacement for `/cas1/applications`. It is being added for a few reasons:

- The new path makes it clearer that it’s returning applications created by the calling user
- It will also include withdrawn/cancelled applications. The current API used by the UI (/cas1/applications) doesn’t do this, and these are required for APS-2189

Internally this can use the same query as `/cas1/applications/all`, but:
- It doesn’t need paging (set page to maximum size)
- It’ll only return applications created by the calling user. To support this a new nullable `createdByUserId` argument will need adding to `findAllApprovedPremisesSummaries`
- It should always sort on `created_at` ascending

Deprecate `/cas1/applications` and any service/repository methods it is using exclusively