### PR TITLE
CAS-1704/Add migration job for void bedspace cancellations

### DIFF
--- a/script/migration/cas3/05__verify_data_migration_from_cas3_void_bedspaces_cancellations_table.sql
+++ b/script/migration/cas3/05__verify_data_migration_from_cas3_void_bedspaces_cancellations_table.sql
@@ -1,0 +1,16 @@
+select
+-- get count of total bedspace voids
+(select count(vb.*)
+ from cas3_void_bedspaces vb)             as void_bedspaces,
+-- get count of existing/old style cancellations
+(select count(c.*)
+ from cas3_void_bedspace_cancellations c) as void_bedspace_cancellations,
+-- get count of migrated cancellations
+(select count(vb.*)
+ from cas3_void_bedspaces vb
+ where vb.cancellation_date is not null)  as migrated_cancellations,
+
+-- get count of non-migrated bedspaces
+(select count(vb.*)
+ from cas3_void_bedspaces vb
+ where vb.cancellation_date is null)      as migrated_cancellations

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceEntity.kt
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
 
@@ -65,6 +66,13 @@ class Cas3VoidBedspaceEntity(
   @ManyToOne
   @JoinColumn(name = "bed_id")
   var bed: BedEntity,
+
+  @ManyToOne
+  @JoinColumn(name = "bedspace_id")
+  var bedspace: Cas3BedspacesEntity?,
+  var cancellationDate: OffsetDateTime?,
+  var cancellationNotes: String?,
+
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3Updat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateBedSpaceStartDateJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateBookingOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3VoidBedspaceCancellationJob
 import kotlin.reflect.KClass
 
 @Service
@@ -61,6 +62,7 @@ class MigrationJobService(
         MigrationJobType.cas1RoomCodes -> getBean(Cas1UpdateRoomCodesJob::class)
         MigrationJobType.cas1ApplicationsWithOffender -> getBean(Cas1UpdateApprovedPremisesApplicationWithOffenderJob::class)
         MigrationJobType.cas3BedspaceModelData -> getBean(Cas3MigrateNewBedspaceModelDataJob::class)
+        MigrationJobType.cas3VoidBedspaceCancellationData -> getBean(Cas3VoidBedspaceCancellationJob::class)
       }
 
       if (job.shouldRunInTransaction) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3VoidBedspaceCancellationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3VoidBedspaceCancellationJob.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+
+@Component
+class Cas3VoidBedspaceCancellationJob(
+  private val cas3BedspacesRepository: Cas3BedspacesRepository,
+  private val cas3VoidBedspaceRepository: Cas3VoidBedspacesRepository,
+  private val cas3VoidBedspaceCancellationRepository: Cas3VoidBedspaceCancellationRepository,
+  private val migrationLogger: MigrationLogger,
+) : MigrationJob() {
+  override val shouldRunInTransaction = true
+
+  override fun process(pageSize: Int) {
+    var pageNumber = 0
+    var hasNext = true
+
+    while (hasNext) {
+      val page = cas3VoidBedspaceCancellationRepository.findAll(PageRequest.of(pageNumber, pageSize))
+      val cancellations = page.content
+      hasNext = page.hasNext()
+
+      if (cancellations.isEmpty()) break
+
+      val voidBedspaces = cancellations.map { it.voidBedspace }
+      val bedIds = voidBedspaces.map { it.bed.id }
+      val bedspacesMap = cas3BedspacesRepository.findAllById(bedIds).associateBy { it.id }
+
+      migrationLogger.info("Processing page $pageNumber with ${cancellations.size} BedspaceVoidCancellation entities")
+
+      voidBedspaces.forEach {
+        it.bedspace = bedspacesMap[it.bed.id]
+        it.cancellationDate = it.cancellation!!.createdAt
+        it.cancellationNotes = it.cancellation?.notes
+      }
+
+      migrationLogger.info("Adding cancellation data for void bedspaces: ${voidBedspaces.map { it.id }}")
+      cas3VoidBedspaceRepository.saveAllAndFlush(voidBedspaces)
+
+      pageNumber++
+    }
+
+    migrationLogger.info("Finished adding cancellation data")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
@@ -443,6 +443,9 @@ class Cas3PremisesService(
         referenceNumber = referenceNumber,
         notes = notes,
         cancellation = null,
+        cancellationDate = null,
+        cancellationNotes = null,
+        bedspace = null,
       ),
     )
 

--- a/src/main/resources/db/migration/all/20250615232613__migrate_to_cas3_void_bedspace.sql
+++ b/src/main/resources/db/migration/all/20250615232613__migrate_to_cas3_void_bedspace.sql
@@ -1,0 +1,8 @@
+alter table cas3_void_bedspaces
+    add column if not exists cancellation_date  timestamptz null,
+    add column if not exists cancellation_notes text        null,
+    add column if not exists bedspace_id        uuid        null,
+    alter column bed_id drop not null,
+    add constraint cas3_void_bedspaces_bedspace_id_cas3_bedspaces_id_fk foreign key (bedspace_id)
+        references cas3_bedspaces (id)
+;

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3371,6 +3371,7 @@ components:
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
+        - update_cas3_void_bedspace_cancellation_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6523,6 +6523,7 @@ components:
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
+        - update_cas3_void_bedspace_cancellation_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5775,6 +5775,7 @@ components:
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
+        - update_cas3_void_bedspace_cancellation_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3895,6 +3895,7 @@ components:
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
+        - update_cas3_void_bedspace_cancellation_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3906,6 +3906,7 @@ components:
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
+        - update_cas3_void_bedspace_cancellation_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3899,6 +3899,7 @@ components:
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
+        - update_cas3_void_bedspace_cancellation_data
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
@@ -3403,6 +3403,7 @@ components:
         - update_cas1_room_codes
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
+        - update_cas3_void_bedspace_cancellation_data
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceEntityFactory.kt
@@ -83,5 +83,8 @@ class Cas3VoidBedspaceEntityFactory : Factory<Cas3VoidBedspaceEntity> {
     premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
     bed = this.bed?.invoke() ?: throw RuntimeException("Must provide a Bed"),
     cancellation = this.voidBedspaceCancellation?.invoke(),
+    bedspace = null,
+    cancellationDate = null,
+    cancellationNotes = null,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3VoidBedspaceCancellationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3VoidBedspaceCancellationJobTest.kt
@@ -1,0 +1,100 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas3
+
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+
+class Cas3VoidBedspaceCancellationJobTest : MigrationJobTestBase() {
+
+  @SpykBean
+  private lateinit var cas3VoidBedspacesRepository: Cas3VoidBedspacesRepository
+
+  @Autowired
+  private lateinit var cas3BedspacesRepository: Cas3BedspacesRepository
+
+  private fun createPremises(user: UserEntity): TemporaryAccommodationPremisesEntity {
+    val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+      withProbationRegion(user.probationRegion)
+    }
+
+    return temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion { user.probationRegion }
+      withProbationDeliveryUnit(probationDeliveryUnit)
+    }
+  }
+
+  private fun createVoidBedspaces(
+    premises: TemporaryAccommodationPremisesEntity,
+    amount: Int,
+  ): List<Cas3VoidBedspaceEntity> {
+    val voidBedspaces = mutableListOf<Cas3VoidBedspaceEntity>()
+    repeat(amount) {
+      voidBedspaces += cas3VoidBedspaceEntityFactory.produceAndPersist {
+        withStartDate(LocalDate.now().plusDays(2))
+        withEndDate(LocalDate.now().plusDays(4))
+        withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withRoom(
+              roomEntityFactory.produceAndPersist {
+                withPremises(premises)
+              },
+            )
+          },
+        )
+        withPremises(premises)
+      }
+    }
+    return voidBedspaces
+  }
+
+  @Test
+  fun `all cancellation data is added to void bedspaces`() {
+    givenAUser { user, _ ->
+
+      val premises = createPremises(user)
+      val voidBedspaces = createVoidBedspaces(premises, 25)
+
+      // this job needs to have ran first.
+      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceModelData)
+      val bedspaces = cas3BedspacesRepository.findAll().filter { it.premises.id == premises.id }
+      assertThat(bedspaces).hasSize(voidBedspaces.size)
+
+      val bedspacesToCancel = voidBedspaces.take(20)
+
+      // cancel some voids
+      bedspacesToCancel.forEach {
+        cas3VoidBedspaceCancellationEntityFactory.produceAndPersist {
+          withVoidBedspace(it)
+          withNotes(randomStringMultiCaseWithNumbers(50))
+        }
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas3VoidBedspaceCancellationData, 10)
+
+      val cancelledVoidBedspaces = cas3VoidBedspacesRepository.findAll().filter { it.cancellation != null }
+      assertThat(cancelledVoidBedspaces).hasSize(20)
+      cancelledVoidBedspaces.forEach {
+        assertThat(it.cancellationDate).isEqualTo(it.cancellation!!.createdAt)
+        assertThat(it.cancellationNotes).isEqualTo(it.cancellation!!.notes)
+        assertThat(it.bedspace!!.id).isEqualTo(it.bed.id)
+      }
+
+      // should be called twice - 20 cancelled bedspaces with a page size of 10
+      verify(exactly = 2) { cas3VoidBedspacesRepository.saveAllAndFlush<Cas3VoidBedspaceEntity>(any()) }
+    }
+  }
+}


### PR DESCRIPTION
This PR add's new fields to the Cas3VoidBedspace entity for cancellation date, cancellation notes, and bedspace id. This enables the removal of the Cas3VoidBedspaceCancellations table, as it's a 1-1 mapping, and also adds the link to the new Cas3Bedspace models, created as part of the larger migration work.