### PR TITLE
CAS-1669: C3 BE Migration process to assign start date to bedspaces

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -10,6 +10,8 @@ import jakarta.persistence.NamedNativeQuery
 import jakarta.persistence.SqlResultSetMapping
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -54,6 +56,18 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
     nativeQuery = true,
   )
   fun findAllCas1BedSummariesForPremises(premisesId: UUID): List<Cas1PremisesBedSummary>
+
+  @Query(
+    """
+        SELECT b.*
+        FROM beds b
+        INNER JOIN rooms r ON b.room_id = r.id
+        INNER JOIN premises p ON r.premises_id = p.id
+        WHERE p.service = :service
+    """,
+    nativeQuery = true,
+  )
+  fun findAllByService(service: String, pageable: Pageable): Slice<BedEntity>
 
   @Modifying
   @Query("UPDATE BedEntity b SET b.code = :code WHERE b.id = :id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -12,9 +12,11 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.persistence.Version
+import org.springframework.data.domain.Limit
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -149,6 +151,8 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
     "SELECT b FROM BookingEntity b WHERE b.service = :serviceName AND b.premises.id = :premisesId AND b.departureDate >= :date AND b.status in :statuses",
   )
   fun findFutureBookingsByPremisesIdAndStatus(serviceName: String, premisesId: UUID, date: LocalDate, statuses: List<BookingStatus>): List<BookingEntity>
+
+  fun findByBedId(id: UUID, by: Sort, limit: Limit): List<BookingEntity>
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1Updat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UpdateRoomCodesJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3MigrateNewBedspaceModelDataJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateApplicationOffenderNameJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateBedSpaceStartDateJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateBookingOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob
 import kotlin.reflect.KClass
@@ -50,6 +51,7 @@ class MigrationJobService(
         MigrationJobType.cas1BackfillUserApArea -> getBean(Cas1BackfillUserApArea::class)
         MigrationJobType.cas3ApplicationOffenderName -> getBean(Cas3UpdateApplicationOffenderNameJob::class)
         MigrationJobType.cas3BookingOffenderName -> getBean(Cas3UpdateBookingOffenderNameJob::class)
+        MigrationJobType.cas3BedspaceStartDate -> getBean(Cas3UpdateBedSpaceStartDateJob::class)
         MigrationJobType.cas3DomainEventTypeForPersonDepartedUpdated -> getBean(Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob::class)
         MigrationJobType.cas1ApplicationsLicenceExpiryDate -> getBean(Cas1UpdateApplicationLicenceExpiryDateJob::class)
         MigrationJobType.cas1BackfillOfflineApplicationName -> getBean(Cas1BackfillOfflineApplicationName::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3UpdateBedSpaceStartDateJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3UpdateBedSpaceStartDateJob.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3
+
+import jakarta.persistence.EntityManager
+import org.springframework.data.domain.Limit
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction.ASC
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName.temporaryAccommodation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+
+@Component
+class Cas3UpdateBedSpaceStartDateJob(
+  private val entityManager: EntityManager,
+  private val migrationLogger: MigrationLogger,
+  private val bookingRepository: BookingRepository,
+  private val bedRepository: BedRepository,
+) : MigrationJob() {
+  override val shouldRunInTransaction = false
+
+  @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught", "NestedBlockDepth")
+  override fun process(pageSize: Int) {
+    var page = 0
+    var hasNext = true
+    var slice: Slice<BedEntity>
+    var currentSliceBeds = setOf<String>()
+
+    try {
+      while (hasNext) {
+        migrationLogger.info("Getting page $page for max page size $pageSize")
+        slice = bedRepository.findAllByService(temporaryAccommodation.value, PageRequest.of(page, pageSize))
+
+        currentSliceBeds = slice.map { it.id.toString() }.toSet()
+
+        for (bed in slice.content) {
+          if (bed.startDate == null) {
+            migrationLogger.info("Updating bed start_date for bed id ${bed.id}")
+            if (bed.createdAt != null) {
+              migrationLogger.info("Using created_date as start_date for bed id ${bed.id}")
+              val updatedBed = bed.copy(startDate = bed.createdAt!!.toLocalDate()!!)
+              bedRepository.save(updatedBed)
+            } else {
+              migrationLogger.info("Using oldest booking arrival_date as start_date for bed id ${bed.id}")
+              val oldestBooking = bookingRepository.findByBedId(bed.id, Sort.by(ASC, "arrivalDate"), Limit.of(1))
+              if (oldestBooking.isEmpty()) {
+                migrationLogger.info("No bookings found for bed id ${bed.id}")
+              } else {
+                val updatedBed = bed.copy(startDate = oldestBooking[0].arrivalDate)
+                bedRepository.save(updatedBed)
+                migrationLogger.info("Updated start_date for bed id ${bed.id} from booking arrival_date")
+              }
+            }
+          }
+        }
+        entityManager.clear()
+        hasNext = slice.hasNext()
+        page++
+      }
+    } catch (exception: Exception) {
+      migrationLogger.error("Unable to update bed(s) start_date with id ${currentSliceBeds.joinToString()}", exception)
+    }
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3361,6 +3361,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
+        - update_cas3_bedspace_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6542,6 +6542,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
+        - update_cas3_bedspace_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5765,6 +5765,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
+        - update_cas3_bedspace_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3885,6 +3885,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
+        - update_cas3_bedspace_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3896,6 +3896,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
+        - update_cas3_bedspace_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3889,6 +3889,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
+        - update_cas3_bedspace_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateBedSpaceStartDateJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateBedSpaceStartDateJobTest.kt
@@ -1,0 +1,176 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName.temporaryAccommodation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+class Cas3UpdateBedSpaceStartDateJobTest : MigrationJobTestBase() {
+
+  @Test
+  fun `beds with null startDate are updated using createdAt date`() {
+    givenAUser { user, jwt ->
+
+      val premisesTemporaryAccommodation = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withProbationRegion(user.probationRegion)
+        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withPremises(premisesTemporaryAccommodation)
+        withName("Test Room")
+      }
+
+      val beds = (1..5).map {
+        val bed = bedEntityFactory.produceAndPersist {
+          withRoom(room)
+          withName("Bed $it")
+          withStartDate(null)
+        }
+        setCreatedAt(bed, OffsetDateTime.now().randomDateTimeBefore(360))
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceStartDate, 10)
+
+      val savedBeds = bedRepository.findAll()
+      assertThat(savedBeds).hasSize(5)
+      savedBeds.forEach {
+        assertThat(it.startDate).isEqualTo(it.createdAt!!.toLocalDate())
+      }
+    }
+  }
+
+  fun `non cas3 beds remain unchanged`() {
+    givenAUser { user, jwt ->
+
+      val premisesTemporaryAccommodation = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withProbationRegion(user.probationRegion)
+        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withPremises(premisesTemporaryAccommodation)
+        withName("Test Room")
+      }
+
+      val createdAt = OffsetDateTime.now().randomDateTimeBefore(360)
+      val beds = (1..5).map {
+        bedEntityFactory.produceAndPersist {
+          withRoom(room)
+          withName("Bed $it")
+          withStartDate(null)
+        }
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceStartDate, 10)
+
+      val savedBeds = bedRepository.findAll()
+      assertThat(savedBeds).hasSize(5)
+      savedBeds.forEach {
+        assertThat(it.startDate).isEqualTo(createdAt.toLocalDate())
+      }
+    }
+  }
+
+  @Test
+  fun `beds with null startDate and null createdAt are updated using oldest booking arrival date`() {
+    givenAUser { user, jwt ->
+
+      val premisesTemporaryAccommodation = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withProbationRegion(user.probationRegion)
+        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withPremises(premisesTemporaryAccommodation)
+        withName("Test Room")
+      }
+
+      val beds = (1..3).map {
+        bedEntityFactory.produceAndPersist {
+          withRoom(room)
+          withName("Bed $it")
+          withStartDate(null)
+        }
+      }
+
+      beds.map {
+        setCreatedAt(it, null)
+      }
+
+      val oldestArrivalDate = LocalDate.now().randomDateBefore(60)
+      val newerArrivalDate = LocalDate.now().randomDateAfter(59)
+
+      beds.forEachIndexed { index, bed ->
+
+        bookingEntityFactory.produceAndPersist {
+          withPremises(premisesTemporaryAccommodation)
+          withServiceName(temporaryAccommodation)
+          withBed(bed)
+          withArrivalDate(oldestArrivalDate)
+          withDepartureDate(oldestArrivalDate.plusDays(7))
+          withServiceName(temporaryAccommodation)
+        }
+
+        bookingEntityFactory.produceAndPersist {
+          withPremises(premisesTemporaryAccommodation)
+          withServiceName(temporaryAccommodation)
+          withBed(bed)
+          withArrivalDate(newerArrivalDate)
+          withDepartureDate(newerArrivalDate.plusDays(7))
+          withServiceName(temporaryAccommodation)
+        }
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceStartDate, 10)
+
+      val savedBeds = bedRepository.findAll()
+      assertThat(savedBeds).hasSize(3)
+      savedBeds.forEach {
+        assertThat(it.startDate).isEqualTo(oldestArrivalDate)
+      }
+    }
+  }
+
+  @Test
+  fun `beds with null startDate and no bookings remain unchanged`() {
+    givenAUser { user, jwt ->
+
+      val premisesTemporaryAccommodation = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withProbationRegion(user.probationRegion)
+        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withPremises(premisesTemporaryAccommodation)
+        withName("Test Room")
+      }
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withRoom(room)
+        withName("Bed with no bookings")
+        withStartDate(null)
+      }
+
+      setCreatedAt(bed, null)
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceStartDate, 10)
+
+      val savedBed = bedRepository.findById(bed.id).get()
+      assertThat(savedBed.startDate).isNull()
+    }
+  }
+
+  private fun setCreatedAt(bed: BedEntity, createdAt: OffsetDateTime?) {
+    bed.createdAt = createdAt
+    bedRepository.save(bed)
+  }
+}


### PR DESCRIPTION
This PR adds a new migration script that sets the start date for beds, taking them from either the `created_date` or `arrival_date`