### PR TITLE
Tidy up UI type generation workflows

### DIFF
--- a/.github/workflows/generate-cas1-ui-types.yml
+++ b/.github/workflows/generate-cas1-ui-types.yml
@@ -1,11 +1,13 @@
-name: Generate CAS2 Bail UI Types
+name: Generate CAS1 UI Types
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'src/main/resources/static/codegen/built-cas2v2-api-spec.yml'
+      - 'src/main/resources/static/codegen/built-api-spec.yml'
+      - 'src/main/resources/static/codegen/built-cas1-api-spec.yml'
+      - 'src/main/resources/static/codegen/built-cas1-roles.json'
 
 jobs:
   generate-ui:
@@ -17,7 +19,7 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - name: Trigger CAS-2 Bail UI Type Generation Workflow
+      - name: Trigger CAS1 UI Type Generation Workflow
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/github-script@v6
         with:
@@ -25,7 +27,7 @@ jobs:
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
-              repo: 'hmpps-community-accommodation-tier-2-bail-ui',
+              repo: 'hmpps-approved-premises-ui',
               workflow_id: 'generate-types.yml',
               ref: 'main'
             })

--- a/.github/workflows/generate-cas2-ui-types.yml
+++ b/.github/workflows/generate-cas2-ui-types.yml
@@ -1,4 +1,4 @@
-name: Generate UI Types
+name: Generate CAS2 UI Types
 
 on:
   push:
@@ -19,7 +19,6 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Trigger CAS-2 UI Type Generation Workflow
         if: ${{ github.ref == 'refs/heads/main' }}
-        id: sa-trigger-ui-workflow
         uses: actions/github-script@v6
         with:
           github-token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/generate-ui-types.yml
+++ b/.github/workflows/generate-ui-types.yml
@@ -1,4 +1,4 @@
-name: Generate UI Types
+name: Generate CAS3 UI Types
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'src/main/resources/static/codegen/built-api-spec.yml'
+      - 'src/main/resources/static/codegen/built-cas3-api-spec.yml'
 
 jobs:
   generate-ui:
@@ -17,22 +18,8 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - name: Trigger AP UI Type Generation Workflow
+      - name: Trigger CAS3 UI Type Generation Workflow
         if: ${{ github.ref == 'refs/heads/main' }}
-        id: ap-trigger-ui-workflow
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: 'hmpps-approved-premises-ui',
-              workflow_id: 'generate-types.yml',
-              ref: 'main'
-            })
-      - name: Trigger TA UI Type Generation Workflow
-        if: ${{ github.ref == 'refs/heads/main' }}
-        id: ta-trigger-ui-workflow
         uses: actions/github-script@v6
         with:
           github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
This splits the workflows so changes to the relevant files for each UI are taken into account. The workflows are renamed so they can be differentiated easily in the Github Actions UI.
