### PR TITLE
APS-1032 Remove unused /applications/{id}/assessment API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -177,24 +177,6 @@ class AssessmentService(
     return CasResult.Success(assessment)
   }
 
-  fun getAssessmentForUserAndApplication(
-    user: UserEntity,
-    applicationID: UUID,
-  ): AuthorisableActionResult<AssessmentEntity> {
-    val latestSchema = jsonSchemaService.getNewestSchema(ApprovedPremisesAssessmentJsonSchemaEntity::class.java)
-
-    val assessment = assessmentRepository.findByApplicationIdAndReallocatedAtNull(applicationID)
-      ?: return AuthorisableActionResult.NotFound()
-
-    if (!user.hasRole(UserRole.CAS1_WORKFLOW_MANAGER) && assessment.allocatedToUser != user) {
-      return AuthorisableActionResult.Unauthorised()
-    }
-
-    assessment.schemaUpToDate = assessment.schemaVersion.id == latestSchema.id
-
-    return AuthorisableActionResult.Success(assessment)
-  }
-
   fun createApprovedPremisesAssessment(application: ApprovedPremisesApplicationEntity, createdFromAppeal: Boolean = false): ApprovedPremisesAssessmentEntity {
     val dateTimeNow = OffsetDateTime.now(clock)
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1549,28 +1549,6 @@ paths:
               schema:
                 $ref: '_shared.yml#/components/schemas/ValidationError'
 
-  /applications/{applicationId}/assessment:
-    get:
-      tags:
-        - Operations on applications
-      summary: Get the assessment for an application
-      operationId: applicationsApplicationIdAssessmentGet
-      parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                $ref: '_shared.yml#/components/schemas/Assessment'
-
   /applications/{applicationId}/withdrawablesWithNotes:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -1551,28 +1551,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
 
-  /applications/{applicationId}/assessment:
-    get:
-      tags:
-        - Operations on applications
-      summary: Get the assessment for an application
-      operationId: applicationsApplicationIdAssessmentGet
-      parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/Assessment'
-
   /applications/{applicationId}/withdrawablesWithNotes:
     get:
       tags:


### PR DESCRIPTION
This endpoint isn’t used by any CAS (and would only work for CAS1 requests anyway given permissions required)
