### PR TITLE
CAS-1631 - Remove deprecated AssignmentTypes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationsController.kt
@@ -49,7 +49,6 @@ class Cas2ApplicationsController(
         user,
         pageCriteria,
         assignmentType,
-        forPrison = prisonCode != null,
       )
       return ResponseEntity.ok().headers(
         metadata?.toHeaders(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
@@ -59,7 +59,6 @@ class Cas2ApplicationService(
     user: NomisUserEntity,
     pageCriteria: PageCriteria<String>,
     assignmentType: AssignmentType,
-    forPrison: Boolean = false,
   ): Pair<MutableList<Cas2ApplicationSummaryEntity>, PaginationMetadata?> {
     val response = when (assignmentType) {
       AssignmentType.UNALLOCATED -> applicationSummaryRepository.findUnallocatedApplicationsInSamePrisonAsUser(
@@ -67,8 +66,7 @@ class Cas2ApplicationService(
         getPageableOrAllPages(pageCriteria),
       )
 
-      // CREATED will be removed when the UI is updated.
-      AssignmentType.CREATED, AssignmentType.IN_PROGRESS -> applicationSummaryRepository.findInProgressApplications(
+      AssignmentType.IN_PROGRESS -> applicationSummaryRepository.findInProgressApplications(
         user.id.toString(),
         getPageableOrAllPages(pageCriteria),
       )
@@ -80,14 +78,7 @@ class Cas2ApplicationService(
         )
       }
 
-      // this will be removed when the UI updatss
-      AssignmentType.ALLOCATED -> if (forPrison) {
-        // applications that are submitted and assigned in the same prison as the user
-        applicationSummaryRepository.findAllocatedApplicationsInSamePrisonAsUser(
-          user.activeCaseloadId!!,
-          getPageableOrAllPages(pageCriteria),
-        )
-      } else {
+      AssignmentType.ALLOCATED -> {
         applicationSummaryRepository.findApplicationsAssignedToUser(
           user.id,
           getPageableOrAllPages(pageCriteria),

--- a/src/main/resources/static/cas2-schemas.yml
+++ b/src/main/resources/static/cas2-schemas.yml
@@ -2,8 +2,8 @@ components:
   schemas:
     AssignmentType:
       type: string
-      enum: [ ALLOCATED, CREATED, DEALLOCATED, IN_PROGRESS, PRISON, UNALLOCATED ]
-      x-enum-varnames: [ ALLOCATED, CREATED, DEALLOCATED, IN_PROGRESS, PRISON, UNALLOCATED ]
+      enum: [ ALLOCATED, DEALLOCATED, IN_PROGRESS, PRISON, UNALLOCATED ]
+      x-enum-varnames: [ ALLOCATED, DEALLOCATED, IN_PROGRESS, PRISON, UNALLOCATED ]
     SubmitCas2Application:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -4959,8 +4959,8 @@ components:
         - departed
     AssignmentType:
       type: string
-      enum: [ ALLOCATED, CREATED, DEALLOCATED, IN_PROGRESS, PRISON, UNALLOCATED ]
-      x-enum-varnames: [ ALLOCATED, CREATED, DEALLOCATED, IN_PROGRESS, PRISON, UNALLOCATED ]
+      enum: [ ALLOCATED, DEALLOCATED, IN_PROGRESS, PRISON, UNALLOCATED ]
+      x-enum-varnames: [ ALLOCATED, DEALLOCATED, IN_PROGRESS, PRISON, UNALLOCATED ]
     SubmitCas2Application:
       type: object
       properties:


### PR DESCRIPTION
This removes deprecated enum values that the UI no longer uses.

Ticket for the completed Ui work: https://dsdmoj.atlassian.net/browse/CAS-1629