### PR TITLE
Bedspace model refactor - GET /v2/cas3/premises/{premisesId}/bookings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -294,6 +294,14 @@ registerAdditionalOpenApiGenerateTask(
 )
 
 registerAdditionalOpenApiGenerateTask(
+  name = "openApiGenerateCas3v2Namespace",
+  ymlPath = "$rootDir/src/main/resources/static/codegen/built-cas3v2-api-spec.yml",
+  apiPackageName = "uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas3.v2",
+  modelPackageName = "uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model",
+  apiSuffix = "Cas3v2",
+)
+
+registerAdditionalOpenApiGenerateTask(
   name = "openApiGenerateCas2DomainEvents",
   ymlPath = "$rootDir/src/main/resources/static/cas2-domain-events-api.yml",
   apiPackageName = "uk.gov.justice.digital.hmpps.approvedpremisesapi.api",
@@ -415,6 +423,11 @@ tasks.register("openApiPreCompilation") {
     inputSpec = "cas3-api.yml",
     inputSchemas = "cas3-schemas.yml",
   )
+  buildSpecWithSharedComponentsAppended(
+    outputFileName = "built-cas3v2-api-spec.yml",
+    inputSpec = "cas3v2-api.yml",
+    inputSchemas = "cas3-schemas.yml",
+  )
 }
 
 tasks.get("openApiGenerate").dependsOn(
@@ -425,6 +438,7 @@ tasks.get("openApiGenerate").dependsOn(
   "openApiGenerateCas2Namespace",
   "openApiGenerateCas2v2Namespace",
   "openApiGenerateCas3Namespace",
+  "openApiGenerateCas3v2Namespace",
 )
 
 tasks.get("openApiGenerate").doLast {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/v2/Cas3v2PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/v2/Cas3v2PremisesController.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas3.v2
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas3.v2.PremisesCas3v2Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.v2.Cas3v2PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BookingTransformer
+import java.util.UUID
+
+@Service
+class Cas3v2PremisesController(
+  private val usersService: UserService,
+  private val userAccessService: UserAccessService,
+  private val cas3PremisesService: Cas3v2PremisesService,
+  private val offenderService: OffenderService,
+  private val bookingTransformer: Cas3BookingTransformer,
+) : PremisesCas3v2Delegate {
+
+  override fun premisesPremisesIdBookingsGet(premisesId: UUID): ResponseEntity<List<Booking>> = runBlocking {
+    val premises = cas3PremisesService.getPremises(premisesId)
+      ?: throw NotFoundProblem(premisesId, "Premises")
+
+    val user = usersService.getUserForRequest()
+    if (!userAccessService.userCanManagePremisesBookings(user, premises)) {
+      throw ForbiddenProblem()
+    }
+
+    val personInfoResults = async {
+      offenderService.getPersonInfoResults(
+        crns = premises.bookings.map { it.crn }.toSet(),
+        laoStrategy = user.cas3LaoStrategy(),
+      )
+    }.await()
+
+    return@runBlocking ResponseEntity.ok(
+      premises.bookings.map { booking ->
+        bookingTransformer.transformJpaToApi(
+          jpa = booking,
+          personInfo = personInfoResults.firstOrNull { pi -> pi.crn == booking.crn } ?: PersonInfoResult.Unknown(booking.crn),
+        )
+      },
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3ArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3ArrivalEntity.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.Objects
+import java.util.UUID
+
+@Entity
+@Table(name = "arrivals")
+data class Cas3ArrivalEntity(
+  @Id
+  val id: UUID,
+  val arrivalDate: LocalDate,
+  val arrivalDateTime: Instant,
+  val expectedDepartureDate: LocalDate,
+  val notes: String?,
+  val createdAt: OffsetDateTime,
+  @ManyToOne
+  @JoinColumn(name = "booking_id")
+  var booking: Cas3BookingEntity,
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Cas3ArrivalEntity) return false
+
+    if (id != other.id) return false
+    if (arrivalDate != other.arrivalDate) return false
+    if (expectedDepartureDate != other.expectedDepartureDate) return false
+    if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(arrivalDate, expectedDepartureDate, notes, createdAt)
+
+  override fun toString() = "Cas3ArrivalEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingEntity.kt
@@ -1,0 +1,116 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundEntity
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.Objects
+import java.util.UUID
+
+@Entity
+@Table(name = "bookings")
+data class Cas3BookingEntity(
+  @Id
+  val id: UUID,
+  var crn: String,
+  var arrivalDate: LocalDate,
+  var departureDate: LocalDate,
+  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
+  var arrivals: MutableList<Cas3ArrivalEntity>,
+  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
+  var departures: MutableList<Cas3DepartureEntity>,
+  @OneToOne(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
+  var nonArrival: Cas3NonArrivalEntity?,
+  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
+  var cancellations: MutableList<Cas3CancellationEntity>,
+  @OneToOne(mappedBy = "booking", fetch = FetchType.LAZY)
+  var confirmation: Cas3v2ConfirmationEntity?,
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "application_id")
+  var application: TemporaryAccommodationApplicationEntity?,
+  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
+  var extensions: MutableList<Cas3ExtensionEntity>,
+  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY, cascade = [ CascadeType.REMOVE ])
+  var dateChanges: MutableList<DateChangeEntity>,
+  var service: String,
+  var originalArrivalDate: LocalDate,
+  var originalDepartureDate: LocalDate,
+  val createdAt: OffsetDateTime,
+  @OneToMany(mappedBy = "booking", fetch = FetchType.LAZY)
+  var turnarounds: MutableList<Cas3v2TurnaroundEntity>,
+  var nomsNumber: String?,
+  @Enumerated(value = EnumType.STRING)
+  var status: BookingStatus?,
+  @Version
+  var version: Long = 1,
+  var offenderName: String?,
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "premises_id")
+  val premises: Cas3PremisesEntity,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "bed_id")
+  var bedspace: Cas3BedspacesEntity,
+) {
+  val departure: Cas3DepartureEntity?
+    get() = departures.maxByOrNull { it.createdAt }
+
+  val cancellation: Cas3CancellationEntity?
+    get() = cancellations.maxByOrNull { it.createdAt }
+
+  val turnaround: Cas3v2TurnaroundEntity?
+    get() = turnarounds.maxByOrNull { it.createdAt }
+
+  val isCancelled: Boolean
+    get() = cancellation != null
+
+  val arrival: Cas3ArrivalEntity?
+    get() = arrivals.maxByOrNull { it.createdAt }
+
+  fun isActive() = !isCancelled
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Cas3BookingEntity) return false
+
+    if (id != other.id) return false
+    if (crn != other.crn) return false
+    if (arrivalDate != other.arrivalDate) return false
+    if (departureDate != other.departureDate) return false
+    if (nonArrival != other.nonArrival) return false
+    if (confirmation != other.confirmation) return false
+    if (originalArrivalDate != other.originalArrivalDate) return false
+    if (originalDepartureDate != other.originalDepartureDate) return false
+    if (createdAt != other.createdAt) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(
+    crn,
+    arrivalDate,
+    departureDate,
+    nonArrival,
+    confirmation,
+    originalArrivalDate,
+    originalDepartureDate,
+    createdAt,
+  )
+
+  override fun toString() = "Cas3BookingEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3CancellationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3CancellationEntity.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.Objects
+import java.util.UUID
+
+@Entity
+@Table(name = "cancellations")
+data class Cas3CancellationEntity(
+  @Id
+  val id: UUID,
+  val date: LocalDate,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cancellation_reason_id")
+  val reason: CancellationReasonEntity,
+  val notes: String?,
+  val createdAt: OffsetDateTime,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "booking_id")
+  var booking: Cas3BookingEntity,
+  val otherReason: String?,
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Cas3CancellationEntity) return false
+
+    if (id != other.id) return false
+    if (date != other.date) return false
+    if (reason != other.reason) return false
+    if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(date, reason, notes, createdAt)
+
+  override fun toString() = "Cas3CancellationEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3DepartureEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3DepartureEntity.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
+import java.time.OffsetDateTime
+import java.util.Objects
+import java.util.UUID
+
+@Entity
+@Table(name = "departures")
+data class Cas3DepartureEntity(
+  @Id
+  val id: UUID,
+  val dateTime: OffsetDateTime,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "departure_reason_id")
+  val reason: DepartureReasonEntity,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "move_on_category_id")
+  val moveOnCategory: MoveOnCategoryEntity,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "destination_provider_id")
+  val destinationProvider: DestinationProviderEntity?,
+  val notes: String?,
+  val createdAt: OffsetDateTime,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "booking_id")
+  var booking: Cas3BookingEntity,
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Cas3DepartureEntity) return false
+
+    if (id != other.id) return false
+    if (dateTime != other.dateTime) return false
+    if (reason != other.reason) return false
+    if (moveOnCategory != other.moveOnCategory) return false
+    if (destinationProvider != other.destinationProvider) return false
+    if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(dateTime, reason, moveOnCategory, destinationProvider, notes, createdAt)
+
+  override fun toString() = "Cas3DepartureEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3ExtensionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3ExtensionEntity.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.Objects
+import java.util.UUID
+
+@Entity
+@Table(name = "extensions")
+data class Cas3ExtensionEntity(
+  @Id
+  val id: UUID,
+  val previousDepartureDate: LocalDate,
+  val newDepartureDate: LocalDate,
+  val notes: String?,
+  val createdAt: OffsetDateTime,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "booking_id")
+  var booking: Cas3BookingEntity,
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Cas3ExtensionEntity) return false
+
+    if (id != other.id) return false
+    if (previousDepartureDate != other.previousDepartureDate) return false
+    if (newDepartureDate != other.newDepartureDate) return false
+    if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(id, previousDepartureDate, newDepartureDate, notes, createdAt)
+
+  override fun toString() = "Cas3ExtensionEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3NonArrivalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3NonArrivalEntity.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.Objects
+import java.util.UUID
+
+@Entity
+@Table(name = "non_arrivals")
+data class Cas3NonArrivalEntity(
+  @Id
+  val id: UUID,
+  val date: LocalDate,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "non_arrival_reason_id")
+  val reason: NonArrivalReasonEntity,
+  val notes: String?,
+  val createdAt: OffsetDateTime,
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "booking_id")
+  var booking: Cas3BookingEntity,
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Cas3NonArrivalEntity) return false
+
+    if (id != other.id) return false
+    if (date != other.date) return false
+    if (reason != other.reason) return false
+    if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(id, date, reason, notes, createdAt)
+
+  override fun toString() = "Cas3NonArrivalEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3PremisesEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.Inheritance
 import jakarta.persistence.InheritanceType
@@ -23,7 +24,7 @@ import java.util.UUID
 @Entity
 @Table(name = "cas3_premises")
 @Inheritance(strategy = InheritanceType.JOINED)
-class Cas3PremisesEntity(
+data class Cas3PremisesEntity(
   @Id
   val id: UUID,
   var name: String,
@@ -36,18 +37,21 @@ class Cas3PremisesEntity(
   var status: PropertyStatus,
   var notes: String,
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "probation_delivery_unit_id")
   var probationDeliveryUnit: ProbationDeliveryUnitEntity,
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "local_authority_area_id")
   var localAuthorityArea: LocalAuthorityAreaEntity?,
 
-  @OneToMany(mappedBy = "premises")
+  @OneToMany(mappedBy = "premises", fetch = FetchType.LAZY)
   var bedspaces: MutableList<Cas3BedspacesEntity>,
 
-  @ManyToMany
+  @OneToMany(mappedBy = "premises", fetch = FetchType.LAZY)
+  var bookings: MutableList<Cas3BookingEntity>,
+
+  @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
     name = "cas3_premises_characteristic_assignments",
     joinColumns = [JoinColumn(name = "premises_id")],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/v2/Cas3v2ConfirmationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/v2/Cas3v2ConfirmationEntity.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import java.time.OffsetDateTime
+import java.util.Objects
+import java.util.UUID
+
+@Entity
+@Table(name = "cas3_confirmations")
+data class Cas3v2ConfirmationEntity(
+  @Id
+  val id: UUID,
+  val dateTime: OffsetDateTime,
+  val notes: String?,
+  val createdAt: OffsetDateTime,
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "booking_id")
+  var booking: Cas3BookingEntity,
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Cas3v2ConfirmationEntity) return false
+
+    if (id != other.id) return false
+    if (dateTime != other.dateTime) return false
+    if (notes != other.notes) return false
+    if (createdAt != other.createdAt) return false
+
+    return true
+  }
+
+  override fun hashCode() = Objects.hash(dateTime, notes, createdAt)
+
+  override fun toString() = "Cas3v2ConfirmationEntity:$id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/v2/Cas3v2TurnaroundEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/v2/Cas3v2TurnaroundEntity.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "cas3_turnarounds")
+data class Cas3v2TurnaroundEntity(
+  @Id
+  val id: UUID,
+  val workingDayCount: Int,
+  val createdAt: OffsetDateTime,
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "booking_id")
+  val booking: Cas3BookingEntity,
+) {
+  override fun toString() = "Cas3v2TurnaroundEntity: $id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3MigrateNewBedspaceModelDataJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3MigrateNewBedspaceModelDataJob.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3Beds
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspaceCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesCharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
@@ -85,6 +86,7 @@ class Cas3MigrateNewBedspaceModelDataJob(
       probationDeliveryUnit = premise.probationDeliveryUnit!!,
       bedspaces = emptyList<Cas3BedspacesEntity>().toMutableList(),
       characteristics = emptyList<Cas3PremisesCharacteristicEntity>().toMutableList(),
+      bookings = emptyList<Cas3BookingEntity>().toMutableList(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_REPORTER
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import java.util.UUID
 
@@ -77,6 +78,9 @@ class UserAccessService(
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, ServiceName.temporaryAccommodation, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
+
+  fun userCanManagePremisesBookings(user: UserEntity, premises: Cas3PremisesEntity) = userCanAccessRegion(user, ServiceName.temporaryAccommodation, premises.probationDeliveryUnit.probationRegion.id) &&
+    user.hasRole(UserRole.CAS3_ASSESSOR)
 
   /**
    * This function only checks if the user has the correct permissions to cancel the given booking.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/v2/Cas3v2PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/v2/Cas3v2PremisesService.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.v2
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesRepository
+import java.util.UUID
+
+@Service
+class Cas3v2PremisesService(private val cas3PremisesRepository: Cas3PremisesRepository) {
+  fun getPremises(premisesId: UUID): Cas3PremisesEntity? = cas3PremisesRepository.findByIdOrNull(premisesId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ArrivalTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ArrivalTransformer.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Arrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ArrivalEntity
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+@Component
+class Cas3ArrivalTransformer {
+  fun transformJpaToApi(jpa: Cas3ArrivalEntity?) = jpa?.let {
+    Arrival(
+      bookingId = jpa.booking.id,
+      arrivalDate = jpa.arrivalDate,
+      arrivalTime = DateTimeFormatter.ISO_LOCAL_TIME.format(jpa.arrivalDateTime.atZone(ZoneOffset.UTC)),
+      expectedDepartureDate = jpa.expectedDepartureDate,
+      notes = jpa.notes,
+      createdAt = jpa.createdAt.toInstant(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BedspaceTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BedspaceTransformer.kt
@@ -3,9 +3,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Bed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Bedspace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
 
 @Component
@@ -38,5 +40,12 @@ class Cas3BedspaceTransformer(
     endDate = bed.endDate,
     notes = bed.room.notes,
     characteristics = bed.room.characteristics.map(characteristicTransformer::transformJpaToApi),
+  )
+
+  fun transformJpaToApi(jpa: Cas3BedspacesEntity) = Bed(
+    id = jpa.id,
+    name = jpa.reference,
+    code = null,
+    bedEndDate = jpa.endDate,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BookingTransformer.kt
@@ -1,0 +1,97 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import java.time.LocalDate
+
+@Component
+class Cas3BookingTransformer(
+  private val personTransformer: PersonTransformer,
+  private val arrivalTransformer: Cas3ArrivalTransformer,
+  private val departureTransformer: Cas3DepartureTransformer,
+  private val nonArrivalTransformer: Cas3NonArrivalTransformer,
+  private val cancellationTransformer: Cas3CancellationTransformer,
+  private val confirmationTransformer: Cas3ConfirmationTransformer,
+  private val extensionTransformer: Cas3ExtensionTransformer,
+  private val cas3BedspaceTransformer: Cas3BedspaceTransformer,
+  private val cas3TurnaroundTransformer: Cas3TurnaroundTransformer,
+  private val enumConverterFactory: EnumConverterFactory,
+  private val workingDayService: WorkingDayService,
+) {
+
+  fun transformJpaToApi(jpa: Cas3BookingEntity, personInfo: PersonInfoResult): Booking {
+    val hasNonZeroDayTurnaround = jpa.turnaround != null && jpa.turnaround!!.workingDayCount != 0
+
+    return Booking(
+      id = jpa.id,
+      person = personTransformer.transformModelToPersonApi(personInfo),
+      arrivalDate = jpa.arrivalDate,
+      departureDate = jpa.departureDate,
+      serviceName = enumConverterFactory.getConverter(ServiceName::class.java).convert(jpa.service) ?: throw InternalServerErrorProblem("Could not convert '${jpa.service}' to a ServiceName"),
+      // key worker is a legacy CAS1 only field that is no longer populated. This will be removed once migration to space bookings is complete
+      keyWorker = null,
+      status = determineStatus(jpa),
+      arrival = arrivalTransformer.transformJpaToApi(jpa.arrival),
+      departure = departureTransformer.transformJpaToApi(jpa.departure),
+      departures = jpa.departures.map { departureTransformer.transformJpaToApi(it)!! },
+      nonArrival = nonArrivalTransformer.transformJpaToApi(jpa.nonArrival),
+      cancellation = cancellationTransformer.transformJpaToApi(jpa.cancellation),
+      cancellations = jpa.cancellations.map { cancellationTransformer.transformJpaToApi(it)!! },
+      confirmation = confirmationTransformer.transformJpaToApi(jpa.confirmation),
+      extensions = jpa.extensions.map(extensionTransformer::transformJpaToApi),
+      bed = cas3BedspaceTransformer.transformJpaToApi(jpa.bedspace),
+      originalArrivalDate = jpa.originalArrivalDate,
+      originalDepartureDate = jpa.originalDepartureDate,
+      createdAt = jpa.createdAt.toInstant(),
+      turnaround = jpa.turnaround?.let(cas3TurnaroundTransformer::transformJpaToApi),
+      turnarounds = jpa.turnarounds.map(cas3TurnaroundTransformer::transformJpaToApi),
+      turnaroundStartDate = if (hasNonZeroDayTurnaround) workingDayService.addWorkingDays(jpa.departureDate, 1) else null,
+      effectiveEndDate = if (hasNonZeroDayTurnaround) workingDayService.addWorkingDays(jpa.departureDate, jpa.turnaround!!.workingDayCount) else jpa.departureDate,
+      applicationId = jpa.application?.id,
+      assessmentId = jpa.application?.getLatestAssessment()?.id,
+      premises = jpa.premises.let { BookingPremisesSummary(it.id, it.name) },
+    )
+  }
+
+  fun transformToWithdrawable(jpa: Cas3BookingEntity) = Withdrawable(
+    jpa.id,
+    WithdrawableType.booking,
+    listOf(DatePeriod(jpa.arrivalDate, jpa.departureDate)),
+  )
+
+  fun determineStatus(jpa: Cas3BookingEntity): BookingStatus {
+    val (hasNonZeroDayTurnaround, hasZeroDayTurnaround, turnaroundPeriodEnded) = isTurnaroundPeriodEnded(jpa)
+    return when {
+      jpa.cancellation != null -> BookingStatus.cancelled
+      jpa.departure != null && hasNonZeroDayTurnaround && !turnaroundPeriodEnded -> BookingStatus.departed
+      jpa.departure != null && (turnaroundPeriodEnded || hasZeroDayTurnaround) -> BookingStatus.closed
+      jpa.arrival != null -> BookingStatus.arrived
+      jpa.nonArrival != null -> BookingStatus.notMinusArrived
+      jpa.confirmation != null -> BookingStatus.confirmed
+      else -> BookingStatus.provisional
+    }
+  }
+
+  private fun isTurnaroundPeriodEnded(jpa: Cas3BookingEntity): Triple<Boolean, Boolean, Boolean> {
+    val hasNonZeroDayTurnaround = jpa.turnaround != null && jpa.turnaround!!.workingDayCount != 0
+    val hasZeroDayTurnaround = jpa.turnaround == null || jpa.turnaround!!.workingDayCount == 0
+    val turnaroundPeriodEnded = if (!hasNonZeroDayTurnaround) {
+      false
+    } else {
+      workingDayService.addWorkingDays(jpa.departureDate, jpa.turnaround!!.workingDayCount).isBefore(LocalDate.now())
+    }
+    return Triple(hasNonZeroDayTurnaround, hasZeroDayTurnaround, turnaroundPeriodEnded)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3CancellationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3CancellationTransformer.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
+
+@Component
+class Cas3CancellationTransformer(private val cancellationReasonTransformer: CancellationReasonTransformer) {
+  fun transformJpaToApi(jpa: Cas3CancellationEntity?) = jpa?.let {
+    Cancellation(
+      id = jpa.id,
+      bookingId = jpa.booking.id,
+      date = jpa.date,
+      reason = cancellationReasonTransformer.transformJpaToApi(jpa.reason),
+      notes = jpa.notes,
+      createdAt = jpa.createdAt.toInstant(),
+      premisesName = jpa.booking.premises.name,
+      otherReason = jpa.otherReason,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ConfirmationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ConfirmationTransformer.kt
@@ -3,10 +3,21 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
 
 @Component
 class Cas3ConfirmationTransformer {
   fun transformJpaToApi(jpa: Cas3ConfirmationEntity?): Confirmation? = jpa?.let {
+    Confirmation(
+      id = it.id,
+      bookingId = it.booking.id,
+      dateTime = it.dateTime.toInstant(),
+      notes = it.notes,
+      createdAt = jpa.createdAt.toInstant(),
+    )
+  }
+
+  fun transformJpaToApi(jpa: Cas3v2ConfirmationEntity?): Confirmation? = jpa?.let {
     Confirmation(
       id = it.id,
       bookingId = it.booking.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3DepartureTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3DepartureTransformer.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Departure
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Departure
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
 
@@ -13,6 +15,18 @@ class Cas3DepartureTransformer(
 ) {
   fun transformJpaToApi(jpa: DepartureEntity?) = jpa?.let {
     Cas3Departure(
+      id = jpa.id,
+      bookingId = jpa.booking.id,
+      dateTime = jpa.dateTime.toInstant(),
+      reason = departureReasonTransformer.transformJpaToApi(jpa.reason),
+      moveOnCategory = moveOnCategoryTransformer.transformJpaToApi(jpa.moveOnCategory),
+      notes = jpa.notes,
+      createdAt = jpa.createdAt.toInstant(),
+    )
+  }
+
+  fun transformJpaToApi(jpa: Cas3DepartureEntity?) = jpa?.let {
+    Departure(
       id = jpa.id,
       bookingId = jpa.booking.id,
       dateTime = jpa.dateTime.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ExtensionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ExtensionTransformer.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Extension
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ExtensionEntity
+
+@Component
+class Cas3ExtensionTransformer {
+  fun transformJpaToApi(jpa: Cas3ExtensionEntity) = Extension(
+    id = jpa.id,
+    bookingId = jpa.booking.id,
+    previousDepartureDate = jpa.previousDepartureDate,
+    newDepartureDate = jpa.newDepartureDate,
+    notes = jpa.notes,
+    createdAt = jpa.createdAt.toInstant(),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3NonArrivalTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3NonArrivalTransformer.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3NonArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalReasonTransformer
+
+@Component
+class Cas3NonArrivalTransformer(private val nonArrivalReasonTransformer: NonArrivalReasonTransformer) {
+  fun transformJpaToApi(jpa: Cas3NonArrivalEntity?) = jpa?.let {
+    Nonarrival(
+      id = jpa.id,
+      bookingId = jpa.booking.id,
+      date = jpa.date,
+      reason = nonArrivalReasonTransformer.transformJpaToApi(jpa.reason),
+      notes = jpa.notes,
+      createdAt = jpa.createdAt.toInstant(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3TurnaroundTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3TurnaroundTransformer.kt
@@ -3,10 +3,18 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Turnaround
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundEntity
 
 @Component
 class Cas3TurnaroundTransformer {
   fun transformJpaToApi(jpa: Cas3TurnaroundEntity) = Turnaround(
+    id = jpa.id,
+    bookingId = jpa.booking.id,
+    workingDays = jpa.workingDayCount,
+    createdAt = jpa.createdAt.toInstant(),
+  )
+
+  fun transformJpaToApi(jpa: Cas3v2TurnaroundEntity) = Turnaround(
     id = jpa.id,
     bookingId = jpa.booking.id,
     workingDays = jpa.workingDayCount,

--- a/src/main/resources/db/migration/all/20250618140659__bookings_table_drop_foreign_key_contraint_on_beds_table.sql
+++ b/src/main/resources/db/migration/all/20250618140659__bookings_table_drop_foreign_key_contraint_on_beds_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bookings DROP CONSTRAINT bookings_bed_id_fkey;

--- a/src/main/resources/static/cas3v2-api.yml
+++ b/src/main/resources/static/cas3v2-api.yml
@@ -1,0 +1,30 @@
+openapi: 3.0.1
+info:
+  version: 1.0.1
+  title: 'Transitional Accommodation Services (CAS3 version 2)'
+servers:
+  - url: /cas3/v2
+paths:
+  /premises/{premisesId}/bookings:
+    get:
+      tags:
+        - Operations on premises
+      summary: Returns all bookings for cas3 premises
+      operationId: premisesPremisesIdBookingsGet
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to get bookings for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '_shared.yml#/components/schemas/Booking'

--- a/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
@@ -1,0 +1,5008 @@
+# DO NOT EDIT.
+# This is a build artefact for use in code generation.
+openapi: 3.0.1
+info:
+  version: 1.0.1
+  title: 'Transitional Accommodation Services (CAS3 version 2)'
+servers:
+  - url: /cas3/v2
+paths:
+  /premises/{premisesId}/bookings:
+    get:
+      tags:
+        - Operations on premises
+      summary: Returns all bookings for cas3 premises
+      operationId: premisesPremisesIdBookingsGet
+      parameters:
+        - name: premisesId
+          in: path
+          description: ID of the premises to get bookings for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Booking'
+components:
+  headers:
+    X-Pagination-CurrentPage:
+      schema:
+        type: integer
+      description: The current page number
+    X-Pagination-TotalPages:
+      schema:
+        type: integer
+      description: The total number of pages
+    X-Pagination-TotalResults:
+      schema:
+        type: integer
+      description: The total number of results
+    X-Pagination-PageSize:
+      schema:
+        type: integer
+      description: The size of each page
+  schemas:
+    Premises:
+      type: object
+      properties:
+        service:
+          type: string
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        addressLine1:
+          type: string
+          example: one something street
+        addressLine2:
+          type: string
+          example: Blackmore End
+        town:
+          type: string
+          example: Braintree
+        postcode:
+          type: string
+          example: LS1 3AD
+        bedCount:
+          type: integer
+          example: 22
+        availableBedsForToday:
+          type: integer
+          example: 20
+        notes:
+          type: string
+          example: some notes about this property
+        probationRegion:
+          $ref: '#/components/schemas/ProbationRegion'
+        apArea:
+          $ref: '#/components/schemas/ApArea'
+        localAuthorityArea:
+          $ref: '#/components/schemas/LocalAuthorityArea'
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Characteristic'
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremises'
+          CAS3: '#/components/schemas/TemporaryAccommodationPremises'
+      required:
+        - service
+        - id
+        - name
+        - addressLine1
+        - postcode
+        - bedCount
+        - availableBedsForToday
+        - probationRegion
+        - apArea
+        - status
+    ApprovedPremises:
+      allOf:
+        - $ref: '#/components/schemas/Premises'
+        - type: object
+          properties:
+            apCode:
+              type: string
+              example: NEHOPE1
+      required:
+        - apCode
+        - localAuthorityArea
+    TemporaryAccommodationPremises:
+      allOf:
+        - $ref: '#/components/schemas/Premises'
+        - type: object
+          properties:
+            pdu:
+              type: string
+            probationDeliveryUnit:
+              $ref: '#/components/schemas/ProbationDeliveryUnit'
+            turnaroundWorkingDayCount:
+              type: integer
+              example: 2
+      required:
+        - pdu
+    NewPremises:
+      type: object
+      properties:
+        name:
+          type: string
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+        notes:
+          type: string
+          example: some notes about this property
+        localAuthorityAreaId:
+          type: string
+          format: uuid
+        probationRegionId:
+          type: string
+          format: uuid
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+        pdu:
+          type: string
+        probationDeliveryUnitId:
+          type: string
+          format: uuid
+        turnaroundWorkingDayCount:
+          type: integer
+      required:
+        - name
+        - addressLine1
+        - postcode
+        - probationRegionId
+        - characteristicIds
+        - status
+    TaskWrapper:
+      type: object
+      properties:
+        task:
+          $ref: '#/components/schemas/Task'
+        users:
+          type: array
+          description: Users to whom this task can be allocated
+          items:
+            $ref: '#/components/schemas/UserWithWorkload'
+      required:
+        - task
+        - users
+    Task:
+      type: object
+      properties:
+        taskType:
+          $ref: '#/components/schemas/TaskType'
+        id:
+          type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
+        applicationId:
+          type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
+        personSummary:
+          $ref: '#/components/schemas/PersonSummary'
+        personName:
+          type: string
+          deprecated: true
+          description: Superseded by personSummary which provides 'name' as well as 'personType' and 'crn'.
+        crn:
+          type: string
+        dueDate:
+          type: string
+          format: date
+          deprecated: true
+          description: The Due date of the task - this is deprecated in favour of the `dueAt` field
+        dueAt:
+          type: string
+          format: date-time
+        expectedArrivalDate:
+          type: string
+          format: date
+        allocatedToStaffMember:
+          $ref: '#/components/schemas/ApprovedPremisesUser'
+        status:
+          $ref: '#/components/schemas/TaskStatus'
+        apArea:
+          $ref: '#/components/schemas/ApArea'
+        probationDeliveryUnit:
+          $ref: '#/components/schemas/ProbationDeliveryUnit'
+        outcomeRecordedAt:
+          type: string
+          format: date-time
+        apType:
+          $ref: '#/components/schemas/ApType'
+      discriminator:
+        propertyName: taskType
+        mapping:
+          Assessment: '#/components/schemas/AssessmentTask'
+          PlacementApplication: '#/components/schemas/PlacementApplicationTask'
+      required:
+        - id
+        - taskType
+        - applicationId
+        - personName
+        - personSummary
+        - dueDate
+        - status
+        - crn
+        - dueAt
+        - apType
+    TaskStatus:
+      type: string
+      enum:
+        - not_started
+        - in_progress
+        - complete
+        - info_requested
+    TaskSortField:
+      type: string
+      enum:
+        - createdAt
+        - dueAt
+        - person
+        - allocatedTo
+        - completedAt
+        - taskType
+        - decision
+        - expectedArrivalDate
+        - apType
+    AssessmentTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            createdFromAppeal:
+              type: boolean
+            outcome:
+              $ref: '#/components/schemas/AssessmentDecision'
+          required:
+            - createdFromAppeal
+    PlacementApplicationTask:
+      allOf:
+        - $ref: '#/components/schemas/Task'
+        - type: object
+          properties:
+            tier:
+              $ref: '#/components/schemas/RiskTierEnvelope'
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            placementType:
+              $ref: '#/components/schemas/PlacementType'
+            placementDates:
+              type: array
+              items:
+                $ref: '#/components/schemas/PlacementDates'
+            outcome:
+              $ref: '#/components/schemas/PlacementApplicationDecision'
+          required:
+            - id
+            - tier
+            - releaseType
+            - placementType
+    TaskType:
+      type: string
+      enum:
+        - Assessment
+        - PlacementApplication
+    LocalAuthorityArea:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 6abb5fa3-e93f-4445-887b-30d081688f44
+        identifier:
+          type: string
+          example: LEEDS
+        name:
+          type: string
+          example: Leeds City Council
+      required:
+        - id
+        - identifier
+        - name
+    ApArea:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: cd1c2d43-0b0b-4438-b0e3-d4424e61fb6a
+        identifier:
+          type: string
+          example: LON
+        name:
+          type: string
+          example: Yorkshire & The Humber
+      required:
+        - id
+        - identifier
+        - name
+    Cas1CruManagementArea:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    ProbationRegion:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        name:
+          type: string
+          example: NPS North East Central Referrals
+      required:
+        - id
+        - name
+    Characteristic:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        name:
+          type: string
+          example: Is this premises catered (rather than self-catered)?
+        propertyName:
+          type: string
+          example: isCatered
+        serviceScope:
+          type: string
+          enum:
+            - approved-premises
+            - temporary-accommodation
+            - "*"
+        modelScope:
+          type: string
+          enum:
+            - premises
+            - room
+            - "*"
+      required:
+        - id
+        - name
+        - serviceScope
+        - modelScope
+    BookingBody:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        arrivalDate:
+          type: string
+          format: date
+        originalArrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        originalDepartureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        keyWorker:
+          deprecated: true
+          description: KeyWorker is a legacy field only used by CAS1. It is not longer being captured or populated
+          allOf:
+            - $ref: '#/components/schemas/StaffMember'
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
+        bed:
+          $ref: '#/components/schemas/Bed'
+      required:
+        - id
+        - person
+        - arrivalDate
+        - originalArrivalDate
+        - departureDate
+        - originalDepartureDate
+        - createdAt
+        - serviceName
+    NewBooking:
+      type: object
+      properties:
+        crn:
+          type: string
+          example: A123456
+        arrivalDate:
+          type: string
+          format: date
+          example: 2022-07-28
+        departureDate:
+          type: string
+          format: date
+          example: 2022-09-30
+        bedId:
+          type: string
+          format: uuid
+        serviceName:
+          $ref: '#/components/schemas/ServiceName'
+        enableTurnarounds:
+          type: boolean
+        assessmentId:
+          type: string
+          format: uuid
+        eventNumber:
+          type: string
+      required:
+        - crn
+        - arrivalDate
+        - departureDate
+        - serviceName
+    NewPlacementRequestBooking:
+      type: object
+      properties:
+        arrivalDate:
+          type: string
+          format: date
+          example: 2022-07-28
+        departureDate:
+          type: string
+          format: date
+          example: 2022-09-30
+        bedId:
+          type: string
+          format: uuid
+        premisesId:
+          type: string
+          format: uuid
+      required:
+        - arrivalDate
+        - departureDate
+    WithdrawPlacementRequest:
+      type: object
+      properties:
+        reason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+      required:
+        - reason
+    WithdrawPlacementRequestReason:
+      type: string
+      enum:
+        - DuplicatePlacementRequest
+        - AlternativeProvisionIdentified
+        - ChangeInCircumstances
+        - ChangeInReleaseDecision
+        - NoCapacityDueToLostBed
+        - NoCapacityDueToPlacementPrioritisation
+        - NoCapacity
+        - ErrorInPlacementRequest
+        - WithdrawnByPP
+        - RelatedApplicationWithdrawn
+        - RelatedPlacementRequestWithdrawn
+        - RelatedPlacementApplicationWithdrawn
+    PlacementApplicationType:
+      type: string
+      description: |
+        'Initial' means that the request for placement was created for the arrival date included on the original application. 
+        'Additional' means the request for placement was created after the application had been assessed as suitable.
+        A given application should only have, at most, one request for placement of type 'Initial'.
+      enum:
+        - Initial
+        - Additional
+    Booking:
+      allOf:
+        - $ref: '#/components/schemas/BookingBody'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/BookingStatus'
+            extensions:
+              type: array
+              items:
+                $ref: '#/components/schemas/Extension'
+            arrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Arrival'
+            departure:
+              description: The latest version of the departure, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Departure'
+            departures:
+              description: The full history of the departure
+              type: array
+              items:
+                $ref: '#/components/schemas/Departure'
+            nonArrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Nonarrival'
+            cancellation:
+              description: The latest version of the cancellation, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cancellation'
+            cancellations:
+              description: The full history of the cancellation
+              type: array
+              items:
+                $ref: '#/components/schemas/Cancellation'
+            confirmation:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Confirmation'
+            turnaround:
+              description: The latest version of the turnaround, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Turnaround'
+            turnarounds:
+              description: The full history of turnarounds
+              type: array
+              items:
+                $ref: '#/components/schemas/Turnaround'
+            turnaroundStartDate:
+              type: string
+              format: date
+            effectiveEndDate:
+              type: string
+              format: date
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
+            premises:
+              $ref: '#/components/schemas/BookingPremisesSummary'
+          required:
+            - status
+            - extensions
+            - departures
+            - cancellations
+            - premises
+    BookingPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    PremisesBooking:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        arrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        person:
+          $ref: '#/components/schemas/Person'
+        bed:
+          $ref: '#/components/schemas/Bed'
+        status:
+          $ref: '#/components/schemas/BookingStatus'
+    PlacementRequestBookingSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        premisesId:
+          type: string
+          format: uuid
+        premisesName:
+          type: string
+        arrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        type:
+          type: string
+          enum:
+            - space
+            - legacy
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+      required:
+        - id
+        - premisesId
+        - premisesName
+        - arrivalDate
+        - departureDate
+        - createdAt
+        - type
+    Person:
+      type: object
+      properties:
+        crn:
+          type: string
+        type:
+          $ref: '#/components/schemas/PersonType'
+      discriminator:
+        propertyName: type
+        mapping:
+          FullPerson: '#/components/schemas/FullPerson'
+          RestrictedPerson: '#/components/schemas/RestrictedPerson'
+          UnknownPerson: '#/components/schemas/UnknownPerson'
+      required:
+        - crn
+        - type
+    UnknownPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+    RestrictedPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+    FullPerson:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+        - type: object
+          properties:
+            name:
+              type: string
+            dateOfBirth:
+              type: string
+              format: date
+            nomsNumber:
+              type: string
+            pncNumber:
+              type: string
+            ethnicity:
+              type: string
+            nationality:
+              type: string
+            religionOrBelief:
+              type: string
+            sex:
+              type: string
+            genderIdentity:
+              type: string
+            status:
+              $ref: '#/components/schemas/PersonStatus'
+            prisonName:
+              type: string
+            isRestricted:
+              type: boolean
+          required:
+            - name
+            - dateOfBirth
+            - sex
+            - status
+    PersonSummary:
+      type: object
+      properties:
+        crn:
+          type: string
+        personType:
+          $ref: '#/components/schemas/PersonSummaryDiscriminator'
+      discriminator:
+        propertyName: personType
+        mapping:
+          FullPersonSummary: '#/components/schemas/FullPersonSummary'
+          RestrictedPersonSummary: '#/components/schemas/RestrictedPersonSummary'
+          UnknownPersonSummary: '#/components/schemas/UnknownPersonSummary'
+      required:
+        - crn
+        - type
+        - personType
+    PersonStatus:
+      type: string
+      enum:
+        - InCustody
+        - InCommunity
+        - Unknown
+    NewArrival:
+      type: object
+      properties:
+        type:
+          type: string
+        expectedDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        keyWorkerStaffCode:
+          type: string
+      required:
+        - type
+        - expectedDepartureDate
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS2: '#/components/schemas/NewCas2Arrival'
+          CAS3: '#/components/schemas/NewCas3Arrival'
+    NewCas2Arrival:
+      allOf:
+        - $ref: '#/components/schemas/NewArrival'
+        - type: object
+          properties:
+            arrivalDate:
+              type: string
+              format: date
+          required:
+            - arrivalDate
+    NewCas3Arrival:
+      allOf:
+        - $ref: '#/components/schemas/NewArrival'
+        - type: object
+          properties:
+            arrivalDate:
+              type: string
+              format: date
+          required:
+            - arrivalDate
+    Arrival:
+      type: object
+      properties:
+        expectedDepartureDate:
+          type: string
+          format: date
+        arrivalDate:
+          type: string
+          format: date
+        arrivalTime:
+          type: string
+          format: time
+        notes:
+          type: string
+        keyWorkerStaffCode:
+          type: string
+        bookingId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - type
+        - bookingId
+        - expectedDepartureDate
+        - createdAt
+        - arrivalDate
+        - arrivalTime
+    Nonarrival:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/NonArrivalReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - date
+        - reason
+        - createdAt
+    NewCancellation:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        notes:
+          type: string
+        otherReason:
+          type: string
+      required:
+        - bookingId
+        - date
+        - reason
+    NewWithdrawal:
+      type: object
+      properties:
+        reason:
+          $ref: '#/components/schemas/WithdrawalReason'
+        otherReason:
+          type: string
+      required:
+        - reason
+    Cancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/CancellationReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        premisesName:
+          type: string
+        otherReason:
+          type: string
+      required:
+        - bookingId
+        - date
+        - reason
+        - createdAt
+        - premisesName
+    Extension:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        previousDepartureDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - previousDepartureDate
+        - newDepartureDate
+        - createdAt
+    NewExtension:
+      type: object
+      properties:
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+      required:
+        - newDepartureDate
+    DateChange:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        previousArrivalDate:
+          type: string
+          format: date
+        newArrivalDate:
+          type: string
+          format: date
+        previousDepartureDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - previousArrivalDate
+        - newArrivalDate
+        - previousDepartureDate
+        - newDepartureDate
+        - createdAt
+    NewDateChange:
+      type: object
+      properties:
+        newArrivalDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+    NewDeparture:
+      type: object
+      properties:
+        dateTime:
+          type: string
+          format: date-time
+        reasonId:
+          type: string
+          format: uuid
+        notes:
+          type: string
+        moveOnCategoryId:
+          type: string
+          format: uuid
+        destinationProviderId:
+          type: string
+          format: uuid
+      required:
+        - dateTime
+        - reasonId
+        - moveOnCategoryId
+    Departure:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        reason:
+          $ref: '#/components/schemas/DepartureReason'
+        notes:
+          type: string
+        moveOnCategory:
+          $ref: '#/components/schemas/MoveOnCategory'
+        destinationProvider:
+          $ref: '#/components/schemas/DestinationProvider'
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - dateTime
+        - reason
+        - moveOnCategory
+        - createdAt
+    Confirmation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - dateTime
+        - createdAt
+    NewConfirmation:
+      type: object
+      properties:
+        notes:
+          type: string
+    Turnaround:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        workingDays:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - workingDays
+        - createdAt
+    NewTurnaround:
+      type: object
+      properties:
+        workingDays:
+          type: integer
+      required:
+        - workingDays
+    Problem:
+      type: object
+      properties:
+        type:
+          type: string
+          example: https://example.net/validation-error
+        title:
+          type: string
+          example: Invalid request parameters
+        status:
+          type: integer
+          example: 400
+        detail:
+          type: string
+          example: You provided invalid request parameters
+        instance:
+          type: string
+          example: f7493e12-546d-42c3-b838-06c12671ab5b
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/Problem'
+        - type: object
+          properties:
+            invalid-params:
+              type: array
+              items:
+                $ref: '#/components/schemas/InvalidParam'
+    InvalidParam:
+      type: object
+      properties:
+        propertyName:
+          type: string
+          example: arrivalDate
+        errorType:
+          type: string
+    LostBed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        bedId:
+          type: string
+          format: uuid
+        bedName:
+          type: string
+        roomName:
+          type: string
+        reason:
+          $ref: '#/components/schemas/LostBedReason'
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        status:
+          $ref: '#/components/schemas/LostBedStatus'
+        cancellation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/LostBedCancellation'
+      required:
+        - id
+        - startDate
+        - endDate
+        - bedId
+        - bedName
+        - roomName
+        - reason
+        - status
+    NewLostBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+        bedId:
+          type: string
+          format: uuid
+      required:
+        - startDate
+        - endDate
+        - reason
+        - bedId
+    UpdateLostBed:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        reason:
+          type: string
+          format: uuid
+        referenceNumber:
+          type: string
+        notes:
+          type: string
+      required:
+        - startDate
+        - endDate
+        - reason
+    LostBedCancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - createdAt
+    NewLostBedCancellation:
+      type: object
+      properties:
+        notes:
+          type: string
+    LostBedStatus:
+      type: string
+      enum:
+        - active
+        - cancelled
+    DepartureReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Admitted to Hospital
+        serviceScope:
+          type: string
+        parentReasonId:
+          type: string
+          format: uuid
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
+    MoveOnCategory:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Housing Association - Rented
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
+    DestinationProvider:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Ext - North East Region
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive
+    StaffMember:
+      type: object
+      properties:
+        code:
+          type: string
+        keyWorker:
+          type: boolean
+        name:
+          type: string
+          example: Brown, James (PS - PSO)
+      required:
+        - code
+        - keyWorker
+        - name
+    LostBedReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Double Room with Single Occupancy - Other (Non-FM)
+        isActive:
+          type: boolean
+        serviceScope:
+          type: string
+      required:
+        - id
+        - name
+        - isActive
+        - serviceScope
+    CancellationReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Recall
+        isActive:
+          type: boolean
+        serviceScope:
+          type: string
+      required:
+        - id
+        - name
+        - isActive
+        - serviceScope
+    NonArrivalReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Recall
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - isActive
+    DateCapacity:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        availableBeds:
+          type: integer
+          example: 10
+      required:
+        - date
+        - availableBeds
+    PersonRisks:
+      type: object
+      properties:
+        crn:
+          type: string
+        roshRisks:
+          $ref: '#/components/schemas/RoshRisksEnvelope'
+        mappa:
+          $ref: '#/components/schemas/MappaEnvelope'
+        tier:
+          $ref: '#/components/schemas/RiskTierEnvelope'
+        flags:
+          $ref: '#/components/schemas/FlagsEnvelope'
+      required:
+        - crn
+        - roshRisks
+        - tier
+        - flags
+    RoshRisksEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/RoshRisks'
+      required:
+        - status
+    RoshRisks:
+      type: object
+      properties:
+        overallRisk:
+          type: string
+        riskToChildren:
+          type: string
+        riskToPublic:
+          type: string
+        riskToKnownAdult:
+          type: string
+        riskToStaff:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - overallRisk
+        - riskToChildren
+        - riskToPublic
+        - riskToKnownAdult
+        - riskToStaff
+    MappaEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/Mappa'
+      required:
+        - status
+    Mappa:
+      type: object
+      properties:
+        level:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - level
+        - lastUpdated
+    RiskTierEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          $ref: '#/components/schemas/RiskTier'
+      required:
+        - status
+    RiskTier:
+      type: object
+      properties:
+        level:
+          type: string
+        lastUpdated:
+          type: string
+          format: date
+      required:
+        - level
+        - lastUpdated
+    FlagsEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/RiskEnvelopeStatus'
+        value:
+          type: array
+          items:
+            type: string
+      required:
+        - status
+    RiskEnvelopeStatus:
+      type: string
+      enum:
+        - retrieved
+        - not_found
+        - error
+    PersonAcctAlert:
+      type: object
+      properties:
+        alertId:
+          type: integer
+          format: int64
+        comment:
+          type: string
+        description:
+          type: string
+        dateCreated:
+          type: string
+          format: date
+        dateExpires:
+          type: string
+          format: date
+        alertTypeDescription:
+            type: string
+      required:
+        - alertId
+        - dateCreated
+    Application:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+      discriminator:
+        propertyName: type
+        mapping:
+          Offline: '#/components/schemas/OfflineApplication'
+          CAS1: '#/components/schemas/ApprovedPremisesApplication'
+          CAS2: '#/components/schemas/Cas2Application'
+          CAS2V2: '#/components/schemas/Cas2v2Application'
+          CAS3: '#/components/schemas/TemporaryAccommodationApplication'
+      required:
+        - type
+        - id
+        - person
+        - createdAt
+    Cas2v2Application:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties:
+            createdBy:
+              $ref: '#/components/schemas/Cas2v2User'
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/Unit'
+            document:
+              $ref: '#/components/schemas/Unit'
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+            submittedAt:
+              type: string
+              format: date-time
+            telephoneNumber:
+              type: string
+            assessment:
+              $ref: '#/components/schemas/Cas2v2Assessment'
+            timelineEvents:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas2TimelineEvent'
+            applicationOrigin:
+              $ref: "#/components/schemas/ApplicationOrigin"
+            bailHearingDate:
+              type: string
+              format: date
+          required:
+            - createdBy
+            - schemaVersion
+            - outdatedSchema
+            - status
+            - applicationOrigin
+    Cas2v2Assessment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        nacroReferralId:
+          type: string
+        assessorName:
+          type: string
+        statusUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2v2StatusUpdate'
+      required:
+        - id
+    Cas2v2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
+    Cas2User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        username:
+          type: string
+          example: 'SMITHR_GEN'
+        authSource:
+          type: string
+          enum:
+            - nomis
+            - delius
+            - auth
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - username
+        - authSource
+        - isActive
+    Cas2v2StatusUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+        description:
+          type: string
+          example: 'More information about the application has been requested from the HMPPS user.'
+        updatedBy:
+          $ref: '#/components/schemas/Cas2v2User'
+        updatedAt:
+          type: string
+          format: date-time
+        statusUpdateDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas2v2StatusUpdateDetail'
+      required:
+        - id
+        - name
+        - label
+        - description
+    Cas2v2StatusUpdateDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'moreInfoRequested'
+        label:
+          type: string
+          example: 'More information requested'
+      required:
+        - id
+        - name
+        - label
+    OfflineApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+    ApprovedPremisesApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties:
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              deprecated: true
+              description: Use apType
+              type: boolean
+            isEmergencyApplication:
+              type: boolean
+            isEsapApplication:
+              deprecated: true
+              description: Use apType
+              type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
+            arrivalDate:
+              type: string
+              format: date-time
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/Unit'
+            document:
+              $ref: '#/components/schemas/Unit'
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+            assessmentId:
+              type: string
+              format: uuid
+            assessmentDecision:
+              $ref: '#/components/schemas/AssessmentDecision'
+            assessmentDecisionDate:
+              type: string
+              format: date
+            submittedAt:
+              type: string
+              format: date-time
+            personStatusOnSubmission:
+              $ref: '#/components/schemas/PersonStatus'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
+            cruManagementArea:
+              $ref: '#/components/schemas/Cas1CruManagementArea'
+            applicantUserDetails:
+              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            caseManagerIsNotApplicant:
+              description: "If true, caseManagerUserDetails will provide case manager details. Otherwise, applicantUserDetails can be used for case manager details"
+              type: boolean
+            caseManagerUserDetails:
+              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            licenceExpiryDate:
+              type: string
+              format: date
+          required:
+            - createdByUserId
+            - schemaVersion
+            - outdatedSchema
+            - status
+    TemporaryAccommodationApplication:
+      allOf:
+        - $ref: '#/components/schemas/Application'
+        - type: object
+          properties:
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            data:
+              $ref: '#/components/schemas/Unit'
+            document:
+              $ref: '#/components/schemas/Unit'
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            submittedAt:
+              type: string
+              format: date-time
+            arrivalDate:
+              type: string
+              format: date-time
+            offenceId:
+              type: string
+            assessmentId:
+              type: string
+              format: uuid
+          required:
+            - createdByUserId
+            - schemaVersion
+            - outdatedSchema
+            - status
+            - offenceId
+    ApplicationSummary:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+      discriminator:
+        propertyName: type
+        mapping:
+          Offline: '#/components/schemas/OfflineApplicationSummary'
+          CAS1: '#/components/schemas/ApprovedPremisesApplicationSummary'
+          CAS2: '#/components/schemas/Cas2ApplicationSummary'
+          CAS3: '#/components/schemas/TemporaryAccommodationApplicationSummary'
+      required:
+        - type
+        - id
+        - person
+        - createdAt
+    OfflineApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+    ApprovedPremisesApplicationSummary:
+      deprecated: true
+      description: Use Cas1ApplicationSummary
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties:
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              type: boolean
+            isEmergencyApplication:
+              type: boolean
+            isEsapApplication:
+              type: boolean
+            arrivalDate:
+              type: string
+              format: date-time
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            createdByUserId:
+              type: string
+              format: uuid
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesApplicationStatus'
+            tier:
+              type: string
+            isWithdrawn:
+              type: boolean
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            hasRequestsForPlacement:
+              type: boolean
+          required:
+            - createdByUserId
+            - status
+            - isWithdrawn
+            - hasRequestsForPlacement
+    TemporaryAccommodationApplicationSummary:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties:
+            createdByUserId:
+              type: string
+              format: uuid
+            status:
+              $ref: '#/components/schemas/ApplicationStatus'
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+          required:
+            - createdByUserId
+            - status
+    ApplicationStatus:
+      type: string
+      enum:
+        - inProgress
+        - submitted
+        - requestedFurtherInformation
+        - pending
+        - rejected
+        - awaitingPlacement
+        - placed
+        - inapplicable
+        - withdrawn
+    ApprovedPremisesApplicationStatus:
+      type: string
+      enum:
+        - started
+        - submitted
+        - rejected
+        - awaitingAssesment
+        - unallocatedAssesment
+        - assesmentInProgress
+        - awaitingPlacement
+        - placementAllocated
+        - inapplicable
+        - withdrawn
+        - requestedFurtherInformation
+        - pendingPlacementRequest
+        - expired
+    Unit:
+      description: Any object
+      type: object
+    ApplicationTimelineNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
+        note:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - createdByUserId
+        - note
+      description: Notes added to an application
+    NewApplicationTimelineNote:
+      type: object
+      properties:
+        note:
+          type: string
+      required:
+        - note
+      description: A note to add to an application
+    ApplicationOrigin:
+        type: string
+        default: homeDetentionCurfew
+        enum:
+          - courtBail
+          - prisonBail
+          - homeDetentionCurfew
+    NewApplication:
+      type: object
+      properties:
+        crn:
+          type: string
+        convictionId:
+          type: integer
+          format: int64
+          example: 1502724704
+        deliusEventNumber:
+          type: string
+          example: "7"
+        offenceId:
+          type: string
+          example: "M1502750438"
+        #BAIL-WIP - this should be a mandatory field once migration is complete in API & UI
+        applicationOrigin:
+          $ref: "#/components/schemas/ApplicationOrigin"
+      required:
+        - crn
+    UpdateApplicationType:
+      type: string
+      enum:
+        - CAS1
+        - CAS2
+        - CAS3
+        - CAS2V2
+      x-enum-varnames:
+        - CAS1
+        - CAS2
+        - CAS3
+        - CAS2V2
+    UpdateApplication:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/UpdateApplicationType'
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Unit'
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/UpdateApprovedPremisesApplication'
+          CAS2: '#/components/schemas/UpdateCas2Application'
+          CAS3: '#/components/schemas/UpdateTemporaryAccommodationApplication'
+          CAS2V2: '#/components/schemas/UpdateCas2v2Application'
+      required:
+        - type
+        - data
+    UpdateCas2v2Application:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
+        - type: object
+          properties:
+            bailHearingDate:
+              type: string
+              format: date
+    UpdateApprovedPremisesApplication:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
+        - type: object
+          properties:
+            isInapplicable:
+              type: boolean
+            isWomensApplication:
+              type: boolean
+            isPipeApplication:
+              deprecated: true
+              description: Use apType
+              type: boolean
+            isEmergencyApplication:
+              deprecated: true
+              description: noticeType should be used to indicate if an emergency application
+              type: boolean
+            isEsapApplication:
+              deprecated: true
+              description: Use apType
+              type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
+            targetLocation:
+              type: string
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            arrivalDate:
+              type: string
+              format: date
+            noticeType:
+              $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
+    UpdateTemporaryAccommodationApplication:
+      allOf:
+        - $ref: '#/components/schemas/UpdateApplication'
+    SubmitApplication:
+      type: object
+      properties:
+        type:
+          type: string
+        translatedDocument:
+          $ref: '#/components/schemas/Unit'
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/SubmitApprovedPremisesApplication'
+          CAS3: '#/components/schemas/SubmitTemporaryAccommodationApplication'
+          CAS2: '#/components/schemas/SubmitCas2Application'
+      # Ideally translatedDocument would be marked required here, but there is a bug
+      # in open api generator that leads to the subclass marking this as kotlin.Any?
+      # whilst in the superclass it has the type kotlin.Any. This leads to a compilation
+      # error as the override has the incorrect type.
+      required:
+        - type
+    SubmitApprovedPremisesApplication:
+      allOf:
+        - $ref: '#/components/schemas/SubmitApplication'
+        - type: object
+          properties:
+            isPipeApplication:
+              deprecated: true
+              description: Use apType
+              type: boolean
+            isWomensApplication:
+              type: boolean
+            isEmergencyApplication:
+              deprecated: true
+              description: noticeType should be used to indicate if this an emergency application
+              type: boolean
+            isEsapApplication:
+              deprecated: true
+              description: Use apType
+              type: boolean
+            apType:
+              $ref: '#/components/schemas/ApType'
+            targetLocation:
+              type: string
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            sentenceType:
+              $ref: '#/components/schemas/SentenceTypeOption'
+            situation:
+              $ref: '#/components/schemas/SituationOption'
+            arrivalDate:
+              type: string
+              format: date
+            apAreaId:
+              description: If the user's ap area id is incorrect, they can optionally override it for the application
+              type: string
+              format: uuid
+            applicantUserDetails:
+              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            caseManagerIsNotApplicant:
+              type: boolean
+            caseManagerUserDetails:
+              $ref: '#/components/schemas/Cas1ApplicationUserDetails'
+            noticeType:
+              $ref: '#/components/schemas/Cas1ApplicationTimelinessCategory'
+            reasonForShortNotice:
+              type: string
+            reasonForShortNoticeOther:
+              type: string
+            licenseExpiryDate:
+              type: string
+              format: date
+          required:
+            - targetLocation
+            - releaseType
+            - sentenceType
+    SubmitTemporaryAccommodationApplication:
+      allOf:
+        - $ref: '#/components/schemas/SubmitApplication'
+        - type: object
+          properties:
+            arrivalDate:
+              type: string
+              format: date
+            isRegisteredSexOffender:
+              type: boolean
+            needsAccessibleProperty:
+              type: boolean
+            hasHistoryOfArson:
+              type: boolean
+            isDutyToReferSubmitted:
+              type: boolean
+            dutyToReferSubmissionDate:
+              type: string
+              format: date
+            dutyToReferOutcome:
+              type: string
+              example: 'Pending'
+            isApplicationEligible:
+              type: boolean
+            eligibilityReason:
+              type: string
+            dutyToReferLocalAuthorityAreaName:
+              type: string
+            personReleaseDate:
+              type: string
+              format: date
+              example: '2024-02-21'
+            probationDeliveryUnitId:
+              type: string
+              format: uuid
+            isHistoryOfSexualOffence:
+              type: boolean
+            isConcerningSexualBehaviour:
+              type: boolean
+            isConcerningArsonBehaviour:
+              type: boolean
+            prisonReleaseTypes:
+              type: array
+              items:
+                type: string
+                example: 'PSS'
+            summaryData:
+              $ref: '#/components/schemas/Unit'
+          required:
+            - probationDeliveryUnitId
+            - arrivalDate
+            - summaryData
+    ReleaseTypeOption:
+      type: string
+      enum:
+        - licence
+        - rotl
+        - hdc
+        - pss
+        - in_community
+        - not_applicable
+        - extendedDeterminateLicence
+        - paroleDirectedLicence
+        - reReleasedPostRecall
+    SentenceTypeOption:
+      type: string
+      enum:
+        - standardDeterminate
+        - life
+        - ipp
+        - extendedDeterminate
+        - communityOrder
+        - bailPlacement
+        - nonStatutory
+    SituationOption:
+      type: string
+      enum:
+        - riskManagement
+        - residencyManagement
+        - bailAssessment
+        - bailSentence
+        - awaitingSentence
+    Cas1ApplicationTimelinessCategory:
+      type: string
+      enum:
+        - standard
+        - emergency
+        - shortNotice
+    PrisonCaseNote:
+      type: object
+      properties:
+        id:
+          type: string
+        sensitive:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        occurredAt:
+          type: string
+          format: date-time
+        authorName:
+          type: string
+        type:
+          type: string
+        subType:
+          type: string
+        note:
+          type: string
+      required:
+        - id
+        - sensitive
+        - createdAt
+        - occurredAt
+        - authorName
+        - type
+        - subType
+        - note
+    Adjudication:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        reportedAt:
+          type: string
+          format: date-time
+        establishment:
+          type: string
+        offenceDescription:
+          type: string
+          example: "Wounding or inflicting grievous bodily harm (inflicting bodily injury with or without weapon) (S20) - 00801"
+        hearingHeld:
+          type: boolean
+        finding:
+          type: string
+      required:
+        - id
+        - reportedAt
+        - establishment
+        - offenceDescription
+        - hearingHeld
+    Assessment:
+      type: object
+      properties:
+        service:
+          type: string
+        id:
+          type: string
+          format: uuid
+        schemaVersion:
+          type: string
+          format: uuid
+        outdatedSchema:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        allocatedAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        decision:
+          $ref: '#/components/schemas/AssessmentDecision'
+        rejectionRationale:
+          type: string
+        data:
+          $ref: '#/components/schemas/Unit'
+        clarificationNotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClarificationNote'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesAssessment'
+          CAS3: '#/components/schemas/TemporaryAccommodationAssessment'
+      required:
+        - service
+        - id
+        - allocatedToUser
+        - schemaVersion
+        - outdatedSchema
+        - createdAt
+        - clarificationNotes
+    AssessmentStatus:
+      type: string
+      enum:
+        - awaiting_response
+        - completed
+        - reallocated
+        - in_progress
+        - not_started
+        - unallocated
+        - in_review
+        - ready_to_place
+        - closed
+        - rejected
+      x-enum-varnames:
+        - cas1AwaitingResponse
+        - cas1Completed
+        - cas1Reallocated
+        - cas1InProgress
+        - cas1NotStarted
+        - cas3Unallocated
+        - cas3InReview
+        - cas3ReadyToPlace
+        - cas3Closed
+        - cas3Rejected
+    ApprovedPremisesAssessmentStatus:
+      type: string
+      enum:
+        - awaiting_response
+        - completed
+        - reallocated
+        - in_progress
+        - not_started
+    TemporaryAccommodationAssessmentStatus:
+      type: string
+      enum:
+        - unallocated
+        - in_review
+        - ready_to_place
+        - closed
+        - rejected
+    ApprovedPremisesAssessment:
+      allOf:
+        - $ref: '#/components/schemas/Assessment'
+        - type: object
+          properties:
+            application:
+              $ref: '#/components/schemas/ApprovedPremisesApplication'
+            allocatedToStaffMember:
+              $ref: '#/components/schemas/ApprovedPremisesUser'
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            createdFromAppeal:
+              type: boolean
+            document:
+              $ref: '#/components/schemas/Unit'
+          required:
+            - application
+            - createdFromAppeal
+    TemporaryAccommodationAssessment:
+      allOf:
+        - $ref: '#/components/schemas/Assessment'
+        - type: object
+          properties:
+            application:
+              $ref: '#/components/schemas/TemporaryAccommodationApplication'
+            allocatedToStaffMember:
+              $ref: '#/components/schemas/TemporaryAccommodationUser'
+            status:
+              $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            summaryData:
+              $ref: '#/components/schemas/Unit'
+            releaseDate:
+              type: string
+              format: date
+            accommodationRequiredFromDate:
+              type: string
+              format: date
+
+          required:
+            - application
+            - summaryData
+    AssessmentSummary:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+          format: uuid
+        applicationId:
+          type: string
+          format: uuid
+        arrivalDate:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        dateOfInfoRequest:
+          type: string
+          format: date-time
+        decision:
+          $ref: '#/components/schemas/AssessmentDecision'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        person:
+          $ref: '#/components/schemas/Person'
+      required:
+        - type
+        - id
+        - applicationId
+        - createdAt
+        - person
+      discriminator:
+        propertyName: type
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesAssessmentSummary'
+          CAS3: '#/components/schemas/TemporaryAccommodationAssessmentSummary'
+    ApprovedPremisesAssessmentSummary:
+      deprecated: true
+      description: Please use the Cas1AssessmentSummary endpoint instead
+      allOf:
+        - $ref: '#/components/schemas/AssessmentSummary'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/ApprovedPremisesAssessmentStatus'
+            dueAt:
+              type: string
+              format: date-time
+          required:
+            - status
+            - dueAt
+    TemporaryAccommodationAssessmentSummary:
+      allOf:
+        - $ref: '#/components/schemas/AssessmentSummary'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/TemporaryAccommodationAssessmentStatus'
+            probationDeliveryUnitName:
+              type: string
+          required:
+            - status
+    AssessmentSortField:
+      type: string
+      enum:
+        - name
+        - crn
+        - arrivalDate
+        - status
+        - createdAt
+        - dueAt
+        - probationDeliveryUnitName
+      x-enum-varnames:
+        - personName
+        - personCrn
+        - assessmentArrivalDate
+        - assessmentStatus
+        - assessmentCreatedAt
+        - assessmentDueAt
+        - applicationProbationDeliveryUnitName
+    AssessmentDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected
+    UpdatePremises:
+      type: object
+      properties:
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+        notes:
+          type: string
+        localAuthorityAreaId:
+          type: string
+          format: uuid
+        probationRegionId:
+          type: string
+          format: uuid
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+        pdu:
+          type: string
+        probationDeliveryUnitId:
+          type: string
+          format: uuid
+        turnaroundWorkingDayCount:
+          type: integer
+        name:
+          type: string
+      required:
+        - addressLine1
+        - postcode
+        - probationRegionId
+        - characteristicIds
+        - status
+    UpdateAssessment:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Unit'
+        releaseDate:
+          type: string
+          format: date
+        accommodationRequiredFromDate:
+          type: string
+          format: date
+      required:
+        - data
+    AssessmentAcceptance:
+      type: object
+      properties:
+        document:
+          $ref: '#/components/schemas/Unit'
+        requirements:
+          $ref: '#/components/schemas/PlacementRequirements'
+        placementDates:
+          $ref: '#/components/schemas/PlacementDates'
+        apType:
+          $ref: '#/components/schemas/ApType'
+        notes:
+          type: string
+        agreeWithShortNoticeReason:
+          type: boolean
+        agreeWithShortNoticeReasonComments:
+          type: string
+        reasonForLateApplication:
+          type: string
+      required:
+        - document
+    AssessmentRejection:
+      type: object
+      properties:
+        document:
+          $ref: '#/components/schemas/Unit'
+        rejectionRationale:
+          type: string
+        referralRejectionReasonId:
+          description: Only used by CAS3
+          type: string
+          format: uuid
+        referralRejectionReasonDetail:
+          description: Only used by CAS3
+          type: string
+        isWithdrawn:
+          type: boolean
+        agreeWithShortNoticeReason:
+          type: boolean
+        agreeWithShortNoticeReasonComments:
+          type: string
+        reasonForLateApplication:
+          type: string
+      required:
+        - document
+        - rejectionRationale
+    ClarificationNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        responseReceivedOn:
+          type: string
+          format: date
+        createdByStaffMemberId:
+          type: string
+          format: uuid
+        query:
+          type: string
+        response:
+          type: string
+      required:
+        - id
+        - createdAt
+        - createdByStaffMemberId
+        - query
+    UpdatedClarificationNote:
+      type: object
+      properties:
+        response:
+          type: string
+        responseReceivedOn:
+          type: string
+          format: date
+          example: 2022-07-28
+      required:
+        - response
+        - responseReceivedOn
+    NewClarificationNote:
+      type: object
+      properties:
+        query:
+          type: string
+      required:
+        - query
+    ReferralHistoryNote:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        message:
+          type: string
+        messageDetails:
+          $ref: '#/components/schemas/ReferralHistoryNoteMessageDetails'
+        createdByUserName:
+          type: string
+        type:
+          type: string
+      required:
+        - id
+        - createdAt
+        - createdByUserName
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          user: '#/components/schemas/ReferralHistoryUserNote'
+          system: '#/components/schemas/ReferralHistorySystemNote'
+          domainEvent: '#/components/schemas/ReferralHistoryDomainEventNote'
+    ReferralHistoryNoteMessageDetails:
+      type: object
+      properties:
+        rejectionReason:
+          type: string
+        rejectionReasonDetails:
+          type: string
+        isWithdrawn:
+          type: boolean
+        domainEvent:
+          $ref: '#/components/schemas/Unit'
+    ReferralHistoryDomainEventNote:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ReferralHistoryNote'
+    ReferralHistoryUserNote:
+      allOf:
+        - $ref: '#/components/schemas/ReferralHistoryNote'
+    ReferralHistorySystemNote:
+      allOf:
+        - $ref: '#/components/schemas/ReferralHistoryNote'
+        - type: object
+          properties:
+            category:
+              type: string
+              enum:
+                - submitted
+                - unallocated
+                - in_review
+                - ready_to_place
+                - rejected
+                - completed
+          required:
+            - category
+    NewReferralHistoryUserNote:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
+    NewReallocation:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+    Reallocation:
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/ApprovedPremisesUser'
+        taskType:
+          $ref: '#/components/schemas/TaskType'
+      required:
+        - user
+        - taskType
+    ExternalUser:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+          example: 'CAS2_ASSESSOR_USER'
+        name:
+          type: string
+          example: 'Roger Smith'
+        email:
+          type: string
+          example: 'roger@external.example.com'
+        origin:
+          type: string
+          example: 'NACRO'
+      required:
+        - id
+        - username
+        - name
+        - email
+    NomisUser:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: 'Roger Smith'
+        nomisUsername:
+          type: string
+          example: 'SMITHR_GEN'
+        email:
+          type: string
+          example: 'Roger.Smith@justice.gov.uk'
+        isActive:
+          type: boolean
+          example: true
+      required:
+        - id
+        - name
+        - nomisUsername
+        - isActive
+    User:
+      type: object
+      properties:
+        service:
+          type: string
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        deliusUsername:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
+        isActive:
+          type: boolean
+        region:
+          $ref: '#/components/schemas/ProbationRegion'
+        probationDeliveryUnit:
+          $ref: '#/components/schemas/ProbationDeliveryUnit'
+      discriminator:
+        propertyName: service
+        mapping:
+          CAS1: '#/components/schemas/ApprovedPremisesUser'
+          CAS3: '#/components/schemas/TemporaryAccommodationUser'
+      required:
+        - service
+        - id
+        - name
+        - deliusUsername
+        - region
+    UserSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    UserWithWorkload:
+      description: This should be changed to embed the user as a property of this type, instead of 'extending' User. Currently this causes unmarshalling issues in integration tests, if using Jackson, due to discriminators not being logically correct
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            numTasksPending:
+              type: integer
+            numTasksCompleted7Days:
+              type: integer
+            numTasksCompleted30Days:
+              type: integer
+            qualifications:
+              type: array
+              items:
+                $ref: '#/components/schemas/UserQualification'
+            roles:
+              type: array
+              items:
+                $ref: '#/components/schemas/ApprovedPremisesUserRole'
+            apArea:
+              deprecated: true
+              description: This is deprecated. Used cruManagementArea instead as this is used to group task management
+              allOf:
+                - $ref: '#/components/schemas/ApArea'
+            cruManagementArea:
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+    ApprovedPremisesUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            qualifications:
+              type: array
+              items:
+                $ref: '#/components/schemas/UserQualification'
+            roles:
+              type: array
+              items:
+                $ref: '#/components/schemas/ApprovedPremisesUserRole'
+            permissions:
+              type: array
+              items:
+                $ref: '#/components/schemas/ApprovedPremisesUserPermission'
+            apArea:
+              $ref: '#/components/schemas/ApArea'
+            cruManagementArea:
+              description: CRU Management Area to use. This will be the same as cruManagementAreaDefault unless cruManagementAreaOverride is defined
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaDefault:
+              description: The CRU Management Area used if no override is defined. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            cruManagementAreaOverride:
+              description: The CRU Management Area manually set on this user. This is provided to support the user configuration page.
+              allOf:
+                - $ref: "#/components/schemas/NamedId"
+            version:
+              type: integer
+          required:
+            - qualifications
+            - roles
+            - apArea
+            - cruManagementArea
+            - cruManagementAreaDefault
+    UserRolesAndQualifications:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovedPremisesUserRole'
+        qualifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserQualification'
+      required:
+        - roles
+        - qualifications
+    ProfileResponse:
+      type: object
+      properties:
+        deliusUsername:
+          type: string
+        loadError:
+          type: string
+          enum:
+            - staff_record_not_found
+        user:
+          $ref: '#/components/schemas/User'
+      required:
+        - deliusUsername
+    TemporaryAccommodationUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            roles:
+              type: array
+              items:
+                $ref: '#/components/schemas/TemporaryAccommodationUserRole'
+          required:
+            - roles
+    ApprovedPremisesUserRole:
+      type: string
+      enum:
+        - assessor
+        - future_manager
+        - workflow_manager
+        - change_request_dev
+        - cru_member
+        - cru_member_find_and_book_beta
+        - cru_member_enable_out_of_service_beds
+        - applicant
+        - report_viewer
+        - report_viewer_with_pii
+        - excluded_from_assess_allocation
+        - excluded_from_match_allocation
+        - excluded_from_placement_application_allocation
+        - appeals_manager
+        - janitor
+        - user_manager
+    ApprovedPremisesUserPermission:
+      type: string
+      enum:
+        - cas1_adhoc_booking_create
+        - cas1_application_withdraw_others
+        - cas1_assess_appealed_application
+        - cas1_assess_application
+        - cas1_assess_placement_application
+        - cas1_assess_placement_request
+        - cas1_booking_create
+        - cas1_booking_change_dates
+        - cas1_booking_withdraw
+        - cas1_change_request_list
+        - cas1_change_request_view
+        - cas1_offline_application_view
+        - cas1_out_of_service_bed_create
+        - cas1_out_of_service_bed_create_bed_on_hold
+        - cas1_out_of_service_bed_cancel
+        - cas1_placement_appeal_create
+        - cas1_placement_appeal_assess
+        - cas1_placement_request_record_unable_to_match
+        - cas1_process_an_appeal
+        - cas1_transfer_create
+        - cas1_transfer_assess
+        - cas1_user_list
+        - cas1_user_management
+        - cas1_view_assigned_assessments
+        - cas1_view_cru_dashboard
+        - cas1_view_manage_tasks
+        - cas1_view_out_of_service_beds
+        - cas1_request_for_placement_withdraw_others
+        - cas1_space_booking_create
+        - cas1_space_booking_list
+        - cas1_space_booking_record_arrival
+        - cas1_space_booking_record_departure
+        - cas1_space_booking_record_non_arrival
+        - cas1_space_booking_record_keyworker
+        - cas1_space_booking_view
+        - cas1_space_booking_withdraw
+        - cas1_space_booking_shorten
+        - cas1_premises_capacity_report_view
+        - cas1_tasks_list
+        - cas1_premises_view
+        - cas1_premises_manage
+        - cas1_reports_view
+        - cas1_reports_view_with_pii
+    TemporaryAccommodationUserRole:
+      type: string
+      enum:
+        - assessor
+        - referrer
+        - reporter
+    UserQualification:
+      type: string
+      enum:
+        - pipe
+        - lao
+        - emergency
+        - esap
+        - recovery_focused
+        - mental_health_specialist
+    ServiceName:
+      type: string
+      enum:
+        - approved-premises
+        - cas2
+        - cas2v2
+        - temporary-accommodation
+      x-enum-varnames:
+        - approvedPremises
+        - cas2
+        - cas2v2
+        - temporaryAccommodation
+    NewRoom:
+      type: object
+      properties:
+        name:
+          type: string
+        notes:
+          type: string
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified.
+      required:
+        - name
+        - characteristicIds
+    UpdateRoom:
+      type: object
+      properties:
+        notes:
+          type: string
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        name:
+          type: string
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified
+      required:
+        - characteristicIds
+    Room:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        code:
+          type: string
+          example: NEABC-4
+        notes:
+          type: string
+        beds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bed'
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Characteristic'
+      required:
+        - id
+        - name
+        - characteristics
+    Bed:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        code:
+          type: string
+          example: NEABC04
+        bedEndDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: End date of the bed availability, open for availability if not specified
+      required:
+        - id
+        - name
+    BedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        roomName:
+          type: string
+        status:
+          $ref: '#/components/schemas/BedStatus'
+      required:
+        - id
+        - name
+        - roomName
+        - status
+    BedStatus:
+      type: string
+      enum:
+        - occupied
+        - available
+        - out_of_service
+    PropertyStatus:
+      type: string
+      enum:
+        - pending
+        - active
+        - archived
+    OASysAssessmentId:
+      description: The ID of assessment being used. This should always be the latest Layer 3 assessment, regardless of state.
+      type: integer
+      format: int64
+      example: 138985987
+    OASysSupportingInformationQuestion:
+      type: object
+      properties:
+        label:
+          type: string
+        sectionNumber:
+          type: integer
+        questionNumber:
+          type: string
+        linkedToHarm:
+          type: boolean
+        linkedToReOffending:
+          type: boolean
+        answer:
+          type: string
+      required:
+        - label
+        - questionNumber
+    OASysQuestion:
+      type: object
+      properties:
+        label:
+          type: string
+        questionNumber:
+          type: string
+        answer:
+          type: string
+      required:
+        - label
+        - questionNumber
+    OASysSections:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/OASysAssessmentId'
+        assessmentState:
+          $ref: '#/components/schemas/OASysAssessmentState'
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+        offenceDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysQuestion'
+        roshSummary:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysQuestion'
+        supportingInformation:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysSupportingInformationQuestion'
+        riskToSelf:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysQuestion'
+        riskManagementPlan:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysQuestion'
+      required:
+        - assessmentId
+        - assessmentState
+        - dateStarted
+        - offenceDetails
+        - roshSummary
+        - supportingInformation
+        - riskToSelf
+        - riskManagementPlan
+    OASysRiskToSelf:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/OASysAssessmentId'
+        assessmentState:
+          $ref: '#/components/schemas/OASysAssessmentState'
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+        riskToSelf:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysQuestion'
+      required:
+        - assessmentId
+        - assessmentState
+        - dateStarted
+        - riskToSelf
+    OASysRiskOfSeriousHarm:
+      type: object
+      properties:
+        assessmentId:
+          $ref: '#/components/schemas/OASysAssessmentId'
+        assessmentState:
+          $ref: '#/components/schemas/OASysAssessmentState'
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+        rosh:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysQuestion'
+      required:
+        - assessmentId
+        - assessmentState
+        - dateStarted
+        - rosh
+    OASysSection:
+      type: object
+      properties:
+        section:
+          type: integer
+          example: 10
+        name:
+          type: string
+          example: Emotional wellbeing
+        linkedToHarm:
+          type: boolean
+        linkedToReOffending:
+          type: boolean
+      required:
+        - section
+        - name
+    OASysAssessmentState:
+      type: string
+      enum:
+        - Completed
+        - Incomplete
+    ActiveOffence:
+      type: object
+      properties:
+        deliusEventNumber:
+          type: string
+          example: "7"
+        offenceDescription:
+          type: string
+        offenceId:
+          type: string
+          example: "M1502750438"
+        convictionId:
+          type: integer
+          format: int64
+          example: 1502724704
+        offenceDate:
+          type: string
+          format: date
+      required:
+        - deliusEventNumber
+        - offenceDescription
+        - offenceId
+        - convictionId
+    DocumentLevel:
+      type: string
+      description: The level at which a Document is associated - i.e. to the Offender or to a specific Conviction
+      enum:
+        - Offender
+        - Conviction
+    Document:
+      type: object
+      description: Meta Info about a file relating to an Offender
+      properties:
+        id:
+          type: string
+        level:
+          $ref: '#/components/schemas/DocumentLevel'
+        fileName:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        typeCode:
+          type: string
+        typeDescription:
+          type: string
+        description:
+          type: string
+      required:
+        - id
+        - level
+        - fileName
+        - createdAt
+        - typeCode
+        - typeDescription
+    TimelineEventType:
+      type: string
+      enum:
+        - cas3_person_arrived
+        - cas3_person_departed
+        - application_timeline_note
+        - cas2_application_submitted
+        - cas2_note
+        - cas2_status_update
+        - cas2_prison_transfer
+        - cas2_new_pom_assigned
+    Cas2TimelineEvent:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/TimelineEventType'
+        occurredAt:
+          type: string
+          format: date-time
+        label:
+          type: string
+        body:
+          type: string
+        createdByName:
+          type: string
+      required:
+        - type
+        - occurredAt
+        - label
+    SeedRequest:
+      type: object
+      properties:
+        seedType:
+          $ref: '#/components/schemas/SeedFileType'
+        fileName:
+          type: string
+      required:
+        - seedType
+        - fileName
+    SeedFromExcelFileRequest:
+      type: object
+      properties:
+        seedType:
+          $ref: '#/components/schemas/SeedFromExcelFileType'
+        fileName:
+          description: File within the pre-configured seed directory
+          type: string
+      required:
+        - seedType
+        - fileName
+    SeedFromExcelDirectoryRequest:
+      type: object
+      properties:
+        seedType:
+          $ref: '#/components/schemas/SeedFromExcelFileType'
+        directoryName:
+          description: Directory within the pre-configured seed directory
+          type: string
+      required:
+        - seedType
+        - directoryName
+    SeedFileType:
+      type: string
+      enum:
+        - approved_premises
+        - approved_premises_rooms
+        - temporary_accommodation_premises
+        - temporary_accommodation_bedspace
+        - user
+        - nomis_users
+        - external_users
+        - cas2_applications
+        - cas2v2_applications
+        - cas2v2_users
+        - temporary_accommodation_users
+        - approved_premises_users
+        - characteristics
+        - update_noms_number
+        - update_users_from_api
+        - users_basic
+        - approved_premises_assessment_more_info_bug_fix
+        - approved_premises_redact_assessment_details
+        - approved_premises_booking_to_space_booking
+        - approved_premises_withdraw_placement_request
+        - approved_premises_replay_domain_events
+        - approved_premises_duplicate_application
+        - approved_premises_update_event_number
+        - approved_premises_link_booking_to_placement_request
+        - approved_premises_out_of_service_beds
+        - approved_premises_cru_management_areas
+        - approved_premises_space_planning_dry_run
+        - approved_premises_import_delius_referrals
+        - approved_premises_update_space_booking
+        - approved_premises_backfill_active_space_bookings_created_in_delius
+        - approved_premises_create_test_applications
+        - approved_premises_delete_application_timeline_notes
+        - approved_premises_update_actual_arrival_date
+        - approved_premises_update_premises_status
+        - temporary_accommodation_referral_rejection
+        - approved_premises_remap_bed_codes
+        - short_term_accommodation_create_omus
+        - temporary_accommodation_assign_application_to_pdu
+    SeedFromExcelFileType:
+      type: string
+      enum:
+        - cas1_import_site_survey_rooms
+        - cas1_import_site_survey_premises
+      x-enum-varnames:
+        - CAS1_IMPORT_SITE_SURVEY_ROOMS
+        - CAS1_IMPORT_SITE_SURVEY_PREMISES
+    MigrationJobRequest:
+      type: object
+      properties:
+        jobType:
+          $ref: '#/components/schemas/MigrationJobType'
+      required:
+        - jobType
+    MigrationJobType:
+      type: string
+      enum:
+        - update_all_users_from_community_api
+        - update_sentence_type_and_situation
+        - update_booking_status
+        - update_task_due_dates
+        - update_users_pdu_by_api
+        - update_cas2_applications_with_assessments
+        - update_cas2_status_updates_with_assessments
+        - update_cas2_notes_with_assessments
+        - update_cas1_backfill_user_ap_area
+        - update_cas3_application_offender_name
+        - update_cas3_booking_offender_name
+        - update_cas3_domain_event_type_for_person_departed_updated
+        - update_cas1_applications_licence_expiry_date
+        - update_cas1_backfill_offline_application_name
+        - update_cas1_arson_suitable_to_arson_offences
+        - update_cas1_backfill_arson_suitable
+        - update_cas1_approved_premises_assessment_report_properties
+        - update_cas1_room_codes
+        - update_cas1_applications_with_offender
+        - update_cas3_bedspace_model_data
+    PlacementDates:
+      type: object
+      properties:
+        expectedArrival:
+          type: string
+          format: date
+        duration:
+          type: integer
+      required:
+        - expectedArrival
+        - duration
+    PlacementRequirements:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ApType'
+        location:
+          type: string
+          description: Postcode outcode
+          example: B74
+        radius:
+          type: integer
+        essentialCriteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementCriteria'
+        desirableCriteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementCriteria'
+      required:
+        - type
+        - location
+        - radius
+        - essentialCriteria
+        - desirableCriteria
+    PlacementApplication:
+      allOf:
+        - $ref: '#/components/schemas/NewPlacementApplication'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field provides a PlacementRequest ID.
+              format: uuid
+            createdByUserId:
+              type: string
+              format: uuid
+            schemaVersion:
+              type: string
+              format: uuid
+            outdatedSchema:
+              type: boolean
+            createdAt:
+              type: string
+              format: date-time
+            submittedAt:
+              type: string
+              format: date-time
+            assessmentId:
+              type: string
+              description: If type is 'Additional', provides the PlacementApplication ID. If type is 'Initial' this field shouldn't be used.
+              format: uuid
+            assessmentCompletedAt:
+              type: string
+              format: date-time
+            applicationCompletedAt:
+              type: string
+              format: date-time
+            data:
+              $ref: '#/components/schemas/Unit'
+            document:
+              $ref: '#/components/schemas/Unit'
+            canBeWithdrawn:
+              type: boolean
+            isWithdrawn:
+              type: boolean
+            withdrawalReason:
+              $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+            type:
+              $ref: '#/components/schemas/PlacementApplicationType'
+            placementDates:
+              type: array
+              items:
+                $ref: '#/components/schemas/PlacementDates'
+          required:
+            - id
+            - createdByUserId
+            - schemaVersion
+            - outdatedScheme
+            - createdAt
+            - assessmentId
+            - assessmentCompletedAt
+            - applicationCompletedAt
+            - canBeWithdrawn
+            - isWithdrawn
+            - type
+            - placementDates
+    NewPlacementApplication:
+      type: object
+      properties:
+        applicationId:
+          type: string
+          format: uuid
+      required:
+        - applicationId
+    UpdatePlacementApplication:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Unit'
+      required:
+        - data
+    SubmitPlacementApplication:
+      type: object
+      properties:
+        translatedDocument:
+          $ref: '#/components/schemas/Unit'
+        placementType:
+          $ref: '#/components/schemas/PlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
+      required:
+        - translatedDocument
+        - placementType
+        - placementDates
+    PlacementApplicationDecisionEnvelope:
+      type: object
+      properties:
+        decision:
+          $ref: '#/components/schemas/PlacementApplicationDecision'
+        summaryOfChanges:
+          type: string
+        decisionSummary:
+          type: string
+      required:
+        - decision
+        - summaryOfChanges
+        - decisionSummary
+    PlacementApplicationDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected
+        - withdraw
+        - withdrawn_by_pp
+    PlacementType:
+      type: string
+      enum:
+        - rotl
+        - release_following_decision
+        - additional_placement
+    WithdrawPlacementApplication:
+      type: object
+      properties:
+        reason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+      required:
+        - reason
+    RequestForPlacement:
+      type: object
+      properties:
+        id:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the `PlacementApplication` ID.
+            If `type` is `"automatic"` this field provides a `PlacementRequest` ID.
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        requestReviewedAt:
+          type: string
+          description: |
+            If `type` is `"manual"`, provides the value of `PlacementApplication.decisionMadeAt`.
+            If `type` is `"automatic"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
+          format: date-time
+        document:
+          $ref: '#/components/schemas/Unit'
+        canBeDirectlyWithdrawn:
+          description: |
+            If true, the user making this request can withdraw this request for placement. 
+            If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application.
+          type: boolean
+        isWithdrawn:
+          type: boolean
+        withdrawalReason:
+          $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+        type:
+          $ref: '#/components/schemas/RequestForPlacementType'
+        placementDates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacementDates'
+        status:
+          $ref: '#/components/schemas/RequestForPlacementStatus'
+      required:
+        - id
+        - createdByUserId
+        - createdAt
+        - canBeDirectlyWithdrawn
+        - isWithdrawn
+        - type
+        - placementDates
+        - status
+    RequestForPlacementType:
+      type: string
+      enum:
+        - manual
+        - automatic
+    RequestForPlacementStatus:
+      type: string
+      enum:
+        - request_unsubmitted
+        - request_rejected
+        - request_submitted
+        - awaiting_match
+        - request_withdrawn
+        - placement_booked
+        - person_arrived
+        - person_not_arrived
+        - person_departed
+    PlacementRequest:
+      description: This type is to broad for use in search results, and as such we're moving towards using Cas1PlacementRequestSummary instead for that purpose.
+      allOf:
+        - $ref: '#/components/schemas/PlacementRequirements'
+        - $ref: '#/components/schemas/PlacementDates'
+        - type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            person:
+              $ref: '#/components/schemas/Person'
+            risks:
+              $ref: '#/components/schemas/PersonRisks'
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
+            releaseType:
+              $ref: '#/components/schemas/ReleaseTypeOption'
+            status:
+              $ref: '#/components/schemas/PlacementRequestStatus'
+            assessmentDecision:
+              $ref: '#/components/schemas/AssessmentDecision'
+            assessmentDate:
+              type: string
+              format: date-time
+            applicationDate:
+              type: string
+              format: date-time
+            assessor:
+              $ref: '#/components/schemas/ApprovedPremisesUser'
+            isParole:
+              type: boolean
+            notes:
+              description: Notes from the assessor for the CRU Manager
+              type: string
+            booking:
+              description: Information about the legacy booking or space booking associated with the placement request
+              $ref: '#/components/schemas/PlacementRequestBookingSummary'
+            requestType:
+              $ref: '#/components/schemas/PlacementRequestRequestType'
+            isWithdrawn:
+              type: boolean
+            withdrawalReason:
+              $ref: '#/components/schemas/WithdrawPlacementRequestReason'
+          required:
+            - person
+            - risks
+            - id
+            - applicationId
+            - assessmentId
+            - releaseType
+            - status
+            - assessmentDecision
+            - assessmentDate
+            - applicationDate
+            - assessor
+            - isParole
+            - isWithdrawn
+    PlacementRequestRequestType:
+      type: string
+      enum:
+        - parole
+        - standardRelease
+    PlacementRequestDetail:
+      allOf:
+        - $ref: '#/components/schemas/PlacementRequest'
+        - type: object
+          properties:
+            cancellations:
+              deprecated: true
+              description: Not used by UI. Space Booking cancellations to be provided if cancellations are required in future.
+              type: array
+              items:
+                $ref: '#/components/schemas/Cancellation'
+            application:
+              $ref: '#/components/schemas/Application'
+            legacyBooking:
+              description: The legacy booking associated with this placement request
+              $ref: '#/components/schemas/PlacementRequestBookingSummary'
+            spaceBookings:
+              description: The space bookings associated with this placement request
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas1SpaceBookingSummary'
+          required:
+            - cancellations
+            - application
+            - spaceBookings
+    PlacementRequestStatus:
+      type: string
+      enum:
+        - notMatched
+        - unableToMatch
+        - matched
+    PlacementCriteria:
+      type: string
+      enum:
+        - isPIPE
+        - isESAP
+        - isMHAPStJosephs
+        - isMHAPElliottHouse
+        - isSemiSpecialistMentalHealth
+        - isRecoveryFocussed
+        - hasBrailleSignage
+        - hasTactileFlooring
+        - hasHearingLoop
+        - isStepFreeDesignated
+        - isArsonDesignated
+        - isWheelchairDesignated
+        - isSingle
+        - isCatered
+        - isSuitedForSexOffenders
+        - isSuitableForVulnerable
+        - acceptsSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsChildSexOffenders
+        - acceptsNonSexualChildOffenders
+        - isArsonSuitable
+        - isGroundFloor
+        - hasEnSuite
+        - arsonOffences
+    Gender:
+      type: string
+      enum:
+        - male
+        - female
+    ApType:
+      type: string
+      enum:
+        - normal
+        - pipe
+        - esap
+        - rfap
+        - mhapStJosephs
+        - mhapElliottHouse
+    BedSearchResultPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+        probationDeliveryUnitName:
+          type: string
+        notes:
+          type: string
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacteristicPair'
+        bedCount:
+          type: integer
+          description: the total number of Beds in the Premises
+        bookedBedCount:
+          type: integer
+          description: the total number of booked Beds in the Premises
+      required:
+        - id
+        - name
+        - addressLine1
+        - postcode
+        - characteristics
+        - bedCount
+    BedSearchResultRoomSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacteristicPair'
+      required:
+        - id
+        - name
+        - characteristics
+    BedSearchResultBedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    CharacteristicPair:
+      type: object
+      properties:
+        propertyName:
+          type: string
+        name:
+          type: string
+      required:
+        - name
+    SortOrder:
+      type: string
+      enum:
+        - ascending
+        - descending
+    BookingStatus:
+      type: string
+      enum:
+        - arrived
+        - awaiting-arrival
+        - not-arrived
+        - departed
+        - cancelled
+        - provisional
+        - confirmed
+        - closed
+    BookingSearchSortField:
+      type: string
+      enum:
+        - name
+        - crn
+        - startDate
+        - endDate
+        - createdAt
+      x-enum-varnames:
+        - personName
+        - personCrn
+        - bookingStartDate
+        - bookingEndDate
+        - bookingCreatedAt
+    BookingSearchResults:
+      type: object
+      properties:
+        resultsCount:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/BookingSearchResult"
+      required:
+        - resultsCount
+        - results
+    BookingSearchResult:
+      type: object
+      properties:
+        person:
+          $ref: "#/components/schemas/BookingSearchResultPersonSummary"
+        booking:
+          $ref: "#/components/schemas/BookingSearchResultBookingSummary"
+        premises:
+          $ref: "#/components/schemas/BookingSearchResultPremisesSummary"
+        room:
+          $ref: "#/components/schemas/BookingSearchResultRoomSummary"
+        bed:
+          $ref: "#/components/schemas/BookingSearchResultBedSummary"
+      required:
+        - person
+        - booking
+        - premises
+        - room
+        - bed
+    BookingSearchResultPersonSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        crn:
+          type: string
+      required:
+        - crn
+    BookingSearchResultBookingSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: "#/components/schemas/BookingStatus"
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - status
+        - startDate
+        - endDate
+        - createdAt
+    BookingSearchResultPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        addressLine1:
+          type: string
+        addressLine2:
+          type: string
+        town:
+          type: string
+        postcode:
+          type: string
+      required:
+        - id
+        - name
+        - addressLine1
+        - postcode
+    BookingSearchResultRoomSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    BookingSearchResultBedSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    NewPlacementRequestBookingConfirmation:
+      type: object
+      properties:
+        premisesName:
+          type: string
+        arrivalDate:
+          type: string
+          format: date
+          example: 2022-07-28
+        departureDate:
+          type: string
+          format: date
+          example: 2022-09-30
+      required:
+        - premisesName
+        - arrivalDate
+        - departureDate
+    NewBedMove:
+      type: object
+      properties:
+        bedId:
+          type: string
+          format: uuid
+        notes:
+          type: string
+      required:
+        - bedId
+    NewBookingNotMade:
+      type: object
+      properties:
+        notes:
+          type: string
+    BookingNotMade:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        placementRequestId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+      required:
+        - id
+        - placementRequestId
+        - createdAt
+    ProbationDeliveryUnit:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    ReferralRejectionReason:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: There was not enough time to place them
+        serviceScope:
+          type: string
+        isActive:
+          type: boolean
+      required:
+        - id
+        - name
+        - serviceScope
+        - isActive
+    CacheType:
+      type: string
+      enum:
+        - qCodeStaffMembers
+        - userAccess
+        - staffDetails
+        - teamsManagingCase
+        - ukBankHolidays
+        - inmateDetails
+        - crnGetCaseDetailCache
+    PersonType:
+      type: string
+      enum:
+        - FullPerson
+        - RestrictedPerson
+        - UnknownPerson
+    FullPersonSummary:
+      allOf:
+        - $ref: '#/components/schemas/PersonSummary'
+        - type: object
+          properties:
+            name:
+              type: string
+            isRestricted:
+              type: boolean
+          required:
+            - name
+            - isRestricted
+    RestrictedPersonSummary:
+      allOf:
+        - $ref: '#/components/schemas/PersonSummary'
+    UnknownPersonSummary:
+      allOf:
+        - $ref: '#/components/schemas/PersonSummary'
+    PersonSummaryDiscriminator:
+      type: string
+      enum:
+        - FullPersonSummary
+        - RestrictedPersonSummary
+        - UnknownPersonSummary
+    Withdrawables:
+      type: object
+      properties:
+        notes:
+          type: array
+          items:
+            type: string
+        withdrawables:
+          type: array
+          items:
+            $ref: '#/components/schemas/Withdrawable'
+      required:
+        - notes
+        - withdrawables
+    Withdrawable:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          $ref: '#/components/schemas/WithdrawableType'
+        dates:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatePeriod'
+          description: 0, 1 or more dates can be specified depending upon the WithdrawableType
+      required:
+        - id
+        - type
+        - dates
+    DatePeriod:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+      required:
+        - startDate
+        - endDate
+    WithdrawableType:
+      type: string
+      enum:
+        - application
+        - booking
+        - placement_application
+        - placement_request
+        - space_booking
+    WithdrawalReason:
+      type: string
+      enum:
+        - change_in_circumstances_new_application_to_be_submitted
+        - error_in_application
+        - duplicate_application
+        - death
+        - other_accommodation_identified
+        - other
+    PlacementRequestSortField:
+      type: string
+      enum:
+        - duration
+        - expected_arrival
+        - created_at
+        - application_date
+        - request_type
+        - person_name
+        - person_risks_tier
+      x-enum-varnames:
+        - duration
+        - expectedArrival
+        - createdAt
+        - applicationSubmittedAt
+    UserSortField:
+      type: string
+      enum:
+        - name
+      x-enum-varnames:
+        - personName
+    SortDirection:
+      type: string
+      enum:
+        - asc
+        - desc
+    AllocatedFilter:
+      type: string
+      enum:
+        - allocated
+        - unallocated
+    ApplicationSortField:
+      type: string
+      enum:
+        - tier
+        - createdAt
+        - arrivalDate
+        - releaseType
+    RiskTierLevel:
+      type: string
+      enum:
+        - D0
+        - D1
+        - D2
+        - D3
+        - C0
+        - C1
+        - C2
+        - C3
+        - B0
+        - B1
+        - B2
+        - B3
+        - A0
+        - A1
+        - A2
+        - A3
+    NewAppeal:
+      type: object
+      properties:
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+      required:
+        - appealDate
+        - appealDetail
+        - decision
+        - decisionDetail
+    Appeal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        appealDate:
+          type: string
+          format: date
+        appealDetail:
+          type: string
+        decision:
+          $ref: '#/components/schemas/AppealDecision'
+        decisionDetail:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        applicationId:
+          type: string
+          format: uuid
+        assessmentId:
+          type: string
+          format: uuid
+        createdByUser:
+          $ref: '#/components/schemas/User'
+      required:
+        - id
+        - appealDate
+        - appealDetail
+        - decision
+        - decisionDetail
+        - createdAt
+        - applicationId
+        - createdByUser
+    AppealDecision:
+      type: string
+      enum:
+        - accepted
+        - rejected
+    Cas1ApplicationUserDetails:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        telephoneNumber:
+          type: string
+      required:
+        - name
+    NamedId:
+      type: object
+      description: A generic stub for an object with a name and an ID.
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    Temporality:
+      type: string
+      enum:
+        - past
+        - current
+        - future
+    Cas1SpaceCharacteristic:
+      type: string
+      description: All of the characteristics of both premises and rooms
+      enum:
+        - acceptsChildSexOffenders
+        - acceptsHateCrimeOffenders
+        - acceptsNonSexualChildOffenders
+        - acceptsSexOffenders
+        - additionalRestrictions
+        - hasArsonInsuranceConditions
+        - hasBrailleSignage
+        - hasCallForAssistance
+        - hasCrib7Bedding
+        - hasEnSuite
+        - hasFixedMobilityAids
+        - hasHearingLoop
+        - hasLift
+        - hasNearbySprinkler
+        - hasSmokeDetector
+        - hasStepFreeAccess
+        - hasStepFreeAccessToCommunalAreas
+        - hasTactileFlooring
+        - hasTurningSpace
+        - hasWheelChairAccessibleBathrooms
+        - hasWideAccessToCommunalAreas
+        - hasWideDoor
+        - hasWideStepFreeAccess
+        - isArsonDesignated
+        - isArsonSuitable
+        - isCatered
+        - isESAP
+        - isFullyFm
+        - isGroundFloor
+        - isGroundFloorNrOffice
+        - isIAP
+        - isMHAPElliottHouse
+        - isMHAPStJosephs
+        - isPIPE
+        - isRecoveryFocussed
+        - isSemiSpecialistMentalHealth
+        - isSingle
+        - isStepFreeDesignated
+        - isSuitableForVulnerable
+        - isSuitedForSexOffenders
+        - isTopFloorVulnerable
+        - isWheelchairAccessible
+        - isWheelchairDesignated
+        - arsonOffences
+    Cas1SpaceBookingSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: "#/components/schemas/PersonSummary"
+        premises:
+          $ref: "#/components/schemas/NamedId"
+        canonicalArrivalDate:
+          deprecated: true
+          description: actual arrival date or, if not known, the expected arrival date
+          type: string
+          format: date
+        canonicalDepartureDate:
+          deprecated: true
+          description: actual departure date or, if not known, the expected departure date
+          type: string
+          format: date
+        expectedArrivalDate:
+          description: expected arrival date
+          type: string
+          format: date
+        actualArrivalDate:
+          description: actual arrival date if known
+          type: string
+          format: date
+        expectedDepartureDate:
+          description: expected departure date
+          type: string
+          format: date
+        actualDepartureDate:
+          description: actual departure date if known
+          type: string
+          format: date
+        isNonArrival:
+          type: boolean
+        tier:
+          description: Risk rating tier level of corresponding application
+          type: string
+        keyWorkerAllocation:
+          $ref: '#/components/schemas/Cas1KeyWorkerAllocation'
+        status:
+          $ref: '#/components/schemas/Cas1SpaceBookingSummaryStatus'
+        characteristics:
+          description: "Room and premise characteristics"
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1SpaceCharacteristic'
+          default: []
+        deliusEventNumber:
+          type: string
+        isCancelled:
+          type: boolean
+        plannedTransferRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
+          type: boolean
+        appealRequested:
+          deprecated: true
+          description: Use 'openChangeRequestTypes'
+          type: boolean
+        openChangeRequestTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas1ChangeRequestType'
+      required:
+        - id
+        - person
+        - premises
+        - canonicalArrivalDate
+        - canonicalDepartureDate
+        - characteristics
+        - expectedArrivalDate
+        - expectedDepartureDate
+        - isCancelled
+        - openChangeRequestTypes
+    Cas1ChangeRequestType:
+      type: string
+      enum:
+        - placementAppeal
+        - placementExtension
+        - plannedTransfer
+      x-enum-varnames:
+        - PLACEMENT_APPEAL
+        - PLACEMENT_EXTENSION
+        - PLANNED_TRANSFER
+    Cas1KeyWorkerAllocation:
+      type: object
+      properties:
+        keyWorker:
+          $ref: '#/components/schemas/StaffMember'
+        allocatedAt:
+          type: string
+          format: date
+      required:
+        - keyWorker
+    Cas1SpaceBookingSummaryStatus:
+      deprecated: true
+      type: string
+      enum:
+        - arrivingWithin6Weeks
+        - arrivingWithin2Weeks
+        - arrivingToday
+        - overdueArrival
+        - arrived
+        - notArrived
+        - departingWithin2Weeks
+        - departingToday
+        - overdueDeparture
+        - departed
+    Cas3NewApplication:
+      type: object
+      properties:
+        crn:
+          type: string
+        convictionId:
+          type: integer
+          format: int64
+          example: 1502724704
+        deliusEventNumber:
+          type: string
+          example: "7"
+        offenceId:
+          type: string
+          example: "M1502750438"
+      required:
+        - crn
+    Cas3Application:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        schemaVersion:
+          type: string
+          format: uuid
+        outdatedSchema:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/Unit'
+        document:
+          $ref: '#/components/schemas/Unit'
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+        submittedAt:
+          type: string
+          format: date-time
+        arrivalDate:
+          type: string
+          format: date-time
+        offenceId:
+          type: string
+        assessmentId:
+          type: string
+          format: uuid
+      required:
+        - id
+        - person
+        - createdAt
+        - createdByUserId
+        - schemaVersion
+        - outdatedSchema
+        - status
+        - offenceId
+    Cas3ApplicationSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        createdAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ApplicationStatus'
+        risks:
+          $ref: '#/components/schemas/PersonRisks'
+      required:
+        - id
+        - person
+        - createdAt
+        - createdByUserId
+        - status
+    Cas3UpdateApplication:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Unit'
+      required:
+        - type
+        - data
+    Cas3SubmitApplication:
+      type: object
+      properties:
+        arrivalDate:
+          type: string
+          format: date
+        isRegisteredSexOffender:
+          type: boolean
+        needsAccessibleProperty:
+          type: boolean
+        hasHistoryOfArson:
+          type: boolean
+        isDutyToReferSubmitted:
+          type: boolean
+        dutyToReferSubmissionDate:
+          type: string
+          format: date
+        dutyToReferOutcome:
+          type: string
+          example: 'Pending'
+        isApplicationEligible:
+          type: boolean
+        eligibilityReason:
+          type: string
+        dutyToReferLocalAuthorityAreaName:
+          type: string
+        personReleaseDate:
+          type: string
+          format: date
+          example: '2024-02-21'
+        probationDeliveryUnitId:
+          type: string
+          format: uuid
+        isHistoryOfSexualOffence:
+          type: boolean
+        isConcerningSexualBehaviour:
+          type: boolean
+        isConcerningArsonBehaviour:
+          type: boolean
+        prisonReleaseTypes:
+          type: array
+          items:
+            type: string
+            example: 'PSS'
+        summaryData:
+          $ref: '#/components/schemas/Unit'
+        translatedDocument:
+          $ref: '#/components/schemas/Unit'
+      required:
+        - probationDeliveryUnitId
+        - arrivalDate
+        - summaryData
+    FutureBooking:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        arrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        bed:
+          $ref: '#/components/schemas/Bed'
+      required:
+        - id
+        - person
+        - arrivalDate
+        - departureDate
+    Cas3BedspaceSearchParameters:
+      type: object
+      properties:
+        startDate:
+          type: string
+          format: date
+        durationDays:
+          type: integer
+          format: int64
+          description: The number of days the Bed will need to be free from the start_date until
+        probationDeliveryUnits:
+          type: array
+          description: The list of pdus Ids to search within
+          items:
+            type: string
+            format: uuid
+        premisesFilters:
+          $ref: '#/components/schemas/PremisesFilters'
+        bedspaceFilters:
+          $ref: '#/components/schemas/BedspaceFilters'
+      required:
+        - probationDeliveryUnits
+        - startDate
+        - durationDays
+    Cas3Bedspace:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        reference:
+          type: string
+        startDate:
+          type: string
+          format: date
+          example: 2024-07-30
+          description: Start date of the bedspace availability
+        endDate:
+          type: string
+          format: date
+          example: 2024-12-30
+          description: End date of the bedspace availability
+        notes:
+          type: string
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Characteristic'
+      required:
+        - id
+        - reference
+        - characteristics
+    Cas3NewBedspace:
+      type: object
+      properties:
+        reference:
+          type: string
+        startDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: Start date of the bedspace availability.
+        notes:
+          type: string
+        characteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
+        - reference
+        - startDate
+        - characteristicIds
+    PremisesFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BedspaceFilters:
+      type: object
+      properties:
+        includedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        excludedCharacteristicIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    Cas3BedspaceSearchResults:
+      type: object
+      properties:
+        resultsRoomCount:
+          type: integer
+          description: How many distinct Rooms the Beds in the results belong to
+        resultsPremisesCount:
+          type: integer
+          description: How many distinct Premises the Beds in the results belong to
+        resultsBedCount:
+          type: integer
+          description: How many Beds are in the results
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3BedspaceSearchResult'
+      required:
+        - resultsRoomCount
+        - resultsPremisesCount
+        - resultsBedCount
+        - results
+    Cas3BedspaceSearchResult:
+      type: object
+      properties:
+        premises:
+          $ref: '#/components/schemas/BedSearchResultPremisesSummary'
+        room:
+          $ref: '#/components/schemas/BedSearchResultRoomSummary'
+        bed:
+          $ref: '#/components/schemas/BedSearchResultBedSummary'
+        overlaps:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3BedspaceSearchResultOverlap'
+      required:
+        - premises
+        - room
+        - bed
+        - overlaps
+    Cas3BedspaceSearchResultOverlap:
+      type: object
+      properties:
+        name:
+          type: string
+        crn:
+          type: string
+        sex:
+          type: string
+        personType:
+          $ref: '#/components/schemas/PersonType'
+        days:
+          type: integer
+        bookingId:
+          type: string
+          format: uuid
+        roomId:
+          type: string
+          format: uuid
+        assessmentId:
+          type: string
+          format: uuid
+        isSexualRisk:
+          type: boolean
+      required:
+        - name
+        - crn
+        - personType
+        - days
+        - bookingId
+        - roomId
+        - isSexualRisk
+    Cas3PremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Hope House
+        addressLine1:
+          type: string
+          example: one something street
+        addressLine2:
+          type: string
+          example: Blackmore End
+        postcode:
+          type: string
+          example: LS1 3AD
+        pdu:
+          type: string
+        localAuthorityAreaName:
+          type: string
+        bedspaceCount:
+          type: integer
+          example: 22
+        status:
+          $ref: '#/components/schemas/PropertyStatus'
+      required:
+        - id
+        - name
+        - addressLine1
+        - postcode
+        - pdu
+        - bedspaceCount
+        - status
+    Cas3PremisesSearchResults:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3PremisesSearchResult'
+        totalPremises:
+          type: integer
+          example: 50
+        totalOnlineBedspaces:
+          type: integer
+          example: 15
+        totalUpcomingBedspaces:
+          type: integer
+          example: 3
+      required:
+        - totalPremises
+    Cas3PremisesSearchResult:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        reference:
+          type: string
+          example: Hope House
+        addressLine1:
+          type: string
+          example: one something street
+        addressLine2:
+          type: string
+          example: Blackmore End
+        town:
+          type: string
+          example: Leeds
+        postcode:
+          type: string
+          example: LS1 3AD
+        pdu:
+          type: string
+        localAuthorityAreaName:
+          type: string
+        bedspaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3BedspacePremisesSearchResult'
+        totalArchivedBedspaces:
+          type: integer
+          example: 4
+      required:
+        - id
+        - reference
+        - addressLine1
+        - postcode
+        - pdu
+    Cas3BedspacePremisesSearchResult:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        reference:
+          type: string
+        status:
+          $ref: '#/components/schemas/Cas3BedspaceStatus'
+      required:
+        - id
+        - reference
+        - status
+    Cas3PremisesStatus:
+      type: string
+      enum:
+        - online
+        - archived
+    Cas3BedspaceStatus:
+      type: string
+      enum:
+        - online
+        - archived
+        - upcoming
+    Cas3Departure:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        reason:
+          $ref: '#/components/schemas/DepartureReason'
+        notes:
+          type: string
+        moveOnCategory:
+          $ref: '#/components/schemas/MoveOnCategory'
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - dateTime
+        - reason
+        - moveOnCategory
+        - createdAt
+    Cas3NewDeparture:
+      type: object
+      properties:
+        dateTime:
+          type: string
+          format: date-time
+        reasonId:
+          type: string
+          format: uuid
+        notes:
+          type: string
+        moveOnCategoryId:
+          type: string
+          format: uuid
+      required:
+        - dateTime
+        - reasonId
+        - moveOnCategoryId
+    Cas3ReportType:
+      type: string
+      enum:
+        - referral
+        - booking
+        - bedUsage
+        - bedOccupancy
+        - futureBookings
+        - futureBookingsCsv
+        - bookingGap
+    Cas3OASysGroup:
+      type: object
+      description: Groups questions and answers from OAsys
+      properties:
+        assessmentMetadata:
+          $ref: '#/components/schemas/Cas3OASysAssessmentMetadata'
+        answers:
+          type: array
+          items:
+            $ref: '#/components/schemas/OASysQuestion'
+      required:
+        - assessmentMetadata
+        - answers
+    Cas3OASysAssessmentMetadata:
+      type: object
+      properties:
+        hasApplicableAssessment:
+          type: boolean
+        dateStarted:
+          type: string
+          format: date-time
+        dateCompleted:
+          type: string
+          format: date-time
+      required:
+        - hasApplicableAssessment

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ArrivalEntityFactory.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3ArrivalEntityFactory : Factory<Cas3ArrivalEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
+  private var arrivalDateTime: Yielded<Instant> = { Instant.now().randomDateTimeBefore(14) }
+  private var expectedDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(14) }
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var booking: Yielded<Cas3BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withArrivalDate(arrivalDate: LocalDate) = apply {
+    this.arrivalDate = { arrivalDate }
+  }
+
+  fun withArrivalDateTime(arrivalDateTime: Instant) = apply {
+    this.arrivalDateTime = { arrivalDateTime }
+  }
+
+  fun withExpectedDepartureDate(expectedDepartureDate: LocalDate) = apply {
+    this.expectedDepartureDate = { expectedDepartureDate }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withYieldedBooking(booking: Yielded<Cas3BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  fun withBooking(booking: Cas3BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce(): Cas3ArrivalEntity = Cas3ArrivalEntity(
+    id = this.id(),
+    arrivalDate = this.arrivalDate(),
+    arrivalDateTime = this.arrivalDateTime(),
+    expectedDepartureDate = this.expectedDepartureDate(),
+    notes = this.notes(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BedspaceEntityFactory.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspaceCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var premises: Yielded<Cas3PremisesEntity>? = null
+  private var characteristics: Yielded<MutableList<Cas3BedspaceCharacteristicEntity>> = { mutableListOf() }
+  private var reference: Yielded<String> = { randomStringUpperCase(6) }
+  private var notes: Yielded<String?> = { null }
+  private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
+  private var endDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(6) }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withPremises(premises: Cas3PremisesEntity) = apply {
+    this.premises = { premises }
+  }
+
+  fun withCharacteristics(characteristics: MutableList<Cas3BedspaceCharacteristicEntity>) = apply {
+    this.characteristics = { characteristics }
+  }
+
+  fun withReference(reference: String) = apply {
+    this.reference = { reference }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce(): Cas3BedspacesEntity = Cas3BedspacesEntity(
+    id = this.id(),
+    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
+    characteristics = this.characteristics(),
+    reference = this.reference(),
+    notes = this.notes(),
+    startDate = this.startDate(),
+    endDate = this.endDate(),
+    createdAt = this.createdAt(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BookingEntityFactory.kt
@@ -1,0 +1,214 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ExtensionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3NonArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3BookingEntityFactory : Factory<Cas3BookingEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var crn: Yielded<String> = { randomStringUpperCase(6) }
+  private var arrivalDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
+  private var departureDate: Yielded<LocalDate> = { LocalDate.now().randomDateAfter(14) }
+  private var originalArrivalDate: Yielded<LocalDate>? = null
+  private var originalDepartureDate: Yielded<LocalDate>? = null
+  private var keyWorkerStaffCode: Yielded<String?> = { null }
+  private var arrivals: Yielded<MutableList<Cas3ArrivalEntity>>? = null
+  private var departures: Yielded<MutableList<Cas3DepartureEntity>>? = null
+  private var nonArrival: Yielded<Cas3NonArrivalEntity>? = null
+  private var cancellations: Yielded<MutableList<Cas3CancellationEntity>>? = null
+  private var confirmation: Yielded<Cas3v2ConfirmationEntity>? = null
+  private var extensions: Yielded<MutableList<Cas3ExtensionEntity>>? = null
+  private var dateChanges: Yielded<MutableList<DateChangeEntity>>? = null
+  private var premises: Yielded<Cas3PremisesEntity>? = null
+  private var serviceName: Yielded<ServiceName> = { randomOf(listOf(ServiceName.approvedPremises, ServiceName.temporaryAccommodation)) }
+  private var bedspace: Yielded<Cas3BedspacesEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
+  private var application: Yielded<TemporaryAccommodationApplicationEntity?> = { null }
+  private var turnarounds: Yielded<MutableList<Cas3v2TurnaroundEntity>>? = null
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
+  private var placementRequest: Yielded<PlacementRequestEntity?> = { null }
+  private var status: Yielded<BookingStatus?> = { null }
+  private var offenderName: Yielded<String?> = { null }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCrn(crn: String) = apply {
+    this.crn = { crn }
+  }
+
+  fun withArrivalDate(arrivalDate: LocalDate) = apply {
+    this.arrivalDate = { arrivalDate }
+  }
+
+  fun withOriginalArrivalDate(arrivalDate: LocalDate) = apply {
+    this.originalArrivalDate = { arrivalDate }
+  }
+
+  fun withDepartureDate(departureDate: LocalDate) = apply {
+    this.departureDate = { departureDate }
+  }
+
+  fun withOriginalDepartureDate(departureDate: LocalDate) = apply {
+    this.originalDepartureDate = { departureDate }
+  }
+
+  fun withStaffKeyWorkerCode(staffKeyWorkerCode: String?) = apply {
+    this.keyWorkerStaffCode = { staffKeyWorkerCode }
+  }
+
+  fun withYieldedArrivals(arrivals: Yielded<MutableList<Cas3ArrivalEntity>>) = apply {
+    this.arrivals = arrivals
+  }
+
+  fun withArrivals(arrivals: MutableList<Cas3ArrivalEntity>) = apply {
+    this.arrivals = { arrivals }
+  }
+
+  fun withYieldedDepartures(departures: Yielded<MutableList<Cas3DepartureEntity>>) = apply {
+    this.departures = departures
+  }
+
+  fun withDepartures(departures: MutableList<Cas3DepartureEntity>) = apply {
+    this.departures = { departures }
+  }
+
+  fun withYieldedNonArrival(nonArrival: Yielded<Cas3NonArrivalEntity>) = apply {
+    this.nonArrival = nonArrival
+  }
+
+  fun withNonArrival(nonArrival: Cas3NonArrivalEntity) = apply {
+    this.nonArrival = { nonArrival }
+  }
+
+  fun withYieldedCancellations(cancellations: Yielded<MutableList<Cas3CancellationEntity>>) = apply {
+    this.cancellations = cancellations
+  }
+
+  fun withCancellations(cancellations: MutableList<Cas3CancellationEntity>) = apply {
+    this.cancellations = { cancellations }
+  }
+
+  fun withYieldedConfirmation(confirmation: Yielded<Cas3v2ConfirmationEntity>) = apply {
+    this.confirmation = confirmation
+  }
+
+  fun withConfirmation(confirmation: Cas3v2ConfirmationEntity) = apply {
+    this.confirmation = { confirmation }
+  }
+
+  fun withYieldedExtensions(extensions: Yielded<MutableList<Cas3ExtensionEntity>>) = apply {
+    this.extensions = extensions
+  }
+
+  fun withExtensions(extensions: MutableList<Cas3ExtensionEntity>) = apply {
+    this.extensions = { extensions }
+  }
+
+  fun withDateChanges(dateChanges: MutableList<DateChangeEntity>) = apply {
+    this.dateChanges = { dateChanges }
+  }
+
+  fun withYieldedPremises(premises: Yielded<Cas3PremisesEntity>) = apply {
+    this.premises = premises
+  }
+
+  fun withPremises(premises: Cas3PremisesEntity) = apply {
+    this.premises = { premises }
+  }
+
+  fun withServiceName(serviceName: ServiceName) = apply {
+    this.serviceName = { serviceName }
+  }
+
+  fun withBedspace(bedspace: Cas3BedspacesEntity) = apply {
+    this.bedspace = { bedspace }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withApplication(application: TemporaryAccommodationApplicationEntity?) = apply {
+    this.application = { application }
+  }
+
+  fun withNomsNumber(nomsNumber: String?) = apply {
+    this.nomsNumber = { nomsNumber }
+  }
+
+  fun withPlacementRequest(placementRequest: PlacementRequestEntity) = apply {
+    this.placementRequest = { placementRequest }
+  }
+
+  fun withStatus(status: BookingStatus) = apply {
+    this.status = { status }
+  }
+
+  fun withOffenderName(offenderName: String?) = apply {
+    this.offenderName = { offenderName }
+  }
+
+  fun withDefaults() = apply {
+    val premises = Cas3PremisesEntityFactory()
+      .withDefaults()
+      .produce()
+    withPremises(premises)
+    withDefaultBedspace(premises)
+  }
+
+  private fun withDefaultBedspace(premises: Cas3PremisesEntity) = withBedspace(
+    Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .produce(),
+  )
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce(): Cas3BookingEntity = Cas3BookingEntity(
+    id = this.id(),
+    crn = this.crn(),
+    arrivalDate = this.arrivalDate(),
+    departureDate = this.departureDate(),
+    arrivals = this.arrivals?.invoke() ?: mutableListOf(),
+    departures = this.departures?.invoke() ?: mutableListOf(),
+    nonArrival = this.nonArrival?.invoke(),
+    cancellations = this.cancellations?.invoke() ?: mutableListOf(),
+    confirmation = this.confirmation?.invoke(),
+    extensions = this.extensions?.invoke() ?: mutableListOf(),
+    dateChanges = this.dateChanges?.invoke() ?: mutableListOf(),
+    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
+    bedspace = this.bedspace?.invoke() ?: throw RuntimeException("Must provide a Bedspace"),
+    service = this.serviceName.invoke().value,
+    originalArrivalDate = this.originalArrivalDate?.invoke() ?: this.arrivalDate(),
+    originalDepartureDate = this.originalDepartureDate?.invoke() ?: this.departureDate(),
+    createdAt = this.createdAt(),
+    application = this.application(),
+    turnarounds = this.turnarounds?.invoke() ?: mutableListOf(),
+    nomsNumber = this.nomsNumber(),
+    status = this.status.invoke(),
+    offenderName = this.offenderName(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3CancellationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3CancellationEntityFactory.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3CancellationEntityFactory : Factory<Cas3CancellationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
+  private var reason: Yielded<CancellationReasonEntity>? = null
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var booking: Yielded<Cas3BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
+  private var otherReason: Yielded<String?> = { null }
+
+  fun withDefaults() = apply {
+    withReason(CancellationReasonEntityFactory().produce())
+  }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withDate(date: LocalDate) = apply {
+    this.date = { date }
+  }
+
+  fun withYieldedReason(reason: Yielded<CancellationReasonEntity>) = apply {
+    this.reason = reason
+  }
+
+  fun withReason(reason: CancellationReasonEntity) = apply {
+    this.reason = { reason }
+  }
+
+  fun withDefaultReason() = withReason(CancellationReasonEntityFactory().produce())
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withYieldedBooking(booking: Yielded<Cas3BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  fun withBooking(booking: Cas3BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withOtherReason(otherReason: String?) = apply {
+    this.otherReason = { otherReason }
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce(): Cas3CancellationEntity = Cas3CancellationEntity(
+    id = this.id(),
+    notes = this.notes(),
+    date = this.date(),
+    reason = this.reason?.invoke() ?: throw RuntimeException("Reason must be provided"),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
+    otherReason = this.otherReason(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3DepartureEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3DepartureEntityFactory.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3DepartureEntityFactory : Factory<Cas3DepartureEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeAfter(14) }
+  private var reason: Yielded<DepartureReasonEntity>? = null
+  private var moveOnCategory: Yielded<MoveOnCategoryEntity>? = null
+  private var destinationProvider: Yielded<DestinationProviderEntity>? = null
+  private var notes: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
+  private var booking: Yielded<Cas3BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withDateTime(dateTime: OffsetDateTime) = apply {
+    this.dateTime = { dateTime }
+  }
+
+  fun withYieldedReason(reason: Yielded<DepartureReasonEntity>) = apply {
+    this.reason = reason
+  }
+
+  fun withReason(reason: DepartureReasonEntity) = apply {
+    this.reason = { reason }
+  }
+
+  fun withYieldedMoveOnCategory(moveOnCategory: Yielded<MoveOnCategoryEntity>) = apply {
+    this.moveOnCategory = moveOnCategory
+  }
+
+  fun withMoveOnCategory(moveOnCategory: MoveOnCategoryEntity) = apply {
+    this.moveOnCategory = { moveOnCategory }
+  }
+
+  fun withNotes(notes: String?) = apply {
+    this.notes = { notes }
+  }
+
+  fun withYieldedDestinationProvider(destinationProvider: Yielded<DestinationProviderEntity>) = apply {
+    this.destinationProvider = destinationProvider
+  }
+
+  fun withDestinationProvider(destinationProvider: DestinationProviderEntity) = apply {
+    this.destinationProvider = { destinationProvider }
+  }
+
+  fun withYieldedBooking(booking: Yielded<Cas3BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  fun withBooking(booking: Cas3BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce(): Cas3DepartureEntity = Cas3DepartureEntity(
+    id = this.id(),
+    dateTime = this.dateTime(),
+    reason = this.reason?.invoke() ?: throw RuntimeException("Reason must be provided"),
+    moveOnCategory = this.moveOnCategory?.invoke() ?: throw RuntimeException("MoveOnCategory must be provided"),
+    destinationProvider = this.destinationProvider?.invoke(),
+    notes = this.notes(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ExtensionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ExtensionEntityFactory.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ExtensionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3ExtensionEntityFactory : Factory<Cas3ExtensionEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var previousDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
+  private var newDepartureDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var booking: Yielded<Cas3BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withPreviousDepartureDate(previousDepartureDate: LocalDate) = apply {
+    this.previousDepartureDate = { previousDepartureDate }
+  }
+
+  fun withNewDepartureDate(newDepartureDate: LocalDate) = apply {
+    this.newDepartureDate = { newDepartureDate }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withYieldedBooking(booking: Yielded<Cas3BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  fun withBooking(booking: Cas3BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce(): Cas3ExtensionEntity = Cas3ExtensionEntity(
+    id = this.id(),
+    previousDepartureDate = this.previousDepartureDate(),
+    newDepartureDate = this.newDepartureDate(),
+    notes = this.notes(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3NonArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3NonArrivalEntityFactory.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3NonArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3NonArrivalEntityFactory : Factory<Cas3NonArrivalEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var date: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(14) }
+  private var reason: Yielded<NonArrivalReasonEntity>? = null
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var booking: Yielded<Cas3BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withDate(date: LocalDate) = apply {
+    this.date = { date }
+  }
+
+  fun withYieldedReason(reason: Yielded<NonArrivalReasonEntity>) = apply {
+    this.reason = reason
+  }
+
+  fun withReason(reason: NonArrivalReasonEntity) = apply {
+    this.reason = { reason }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withYieldedBooking(booking: Yielded<Cas3BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  fun withBooking(booking: Cas3BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce(): Cas3NonArrivalEntity = Cas3NonArrivalEntity(
+    id = this.id(),
+    date = this.date(),
+    reason = this.reason?.invoke() ?: throw RuntimeException("Reason must be provided"),
+    notes = this.notes(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3PremisesEntityFactory.kt
@@ -1,0 +1,121 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class Cas3PremisesEntityFactory : Factory<Cas3PremisesEntity> {
+  private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity>? = null
+  private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>? = null
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
+  private var postcode: Yielded<String> = { randomPostCode() }
+  private var addressLine1: Yielded<String> = { randomStringUpperCase(10) }
+  private var addressLine2: Yielded<String?> = { randomStringUpperCase(10) }
+  private var town: Yielded<String?> = { randomStringUpperCase(10) }
+  private var notes: Yielded<String> = { randomStringUpperCase(15) }
+  private var service: Yielded<String> = { "CAS3" }
+  private var characteristics: Yielded<MutableList<Cas3PremisesCharacteristicEntity>> = { mutableListOf() }
+  private var bedspaces: Yielded<MutableList<Cas3BedspacesEntity>> = { mutableListOf() }
+  private var status: Yielded<PropertyStatus> = { randomOf(PropertyStatus.entries) }
+
+  fun withDefaults() = apply {
+    withDefaultProbationDeliveryUnit()
+    withDefaultLocalAuthorityArea()
+  }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withAddressLine1(addressLine1: String) = apply {
+    this.addressLine1 = { addressLine1 }
+  }
+
+  fun withAddressLine2(addressLine2: String?) = apply {
+    this.addressLine2 = { addressLine2 }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withService(service: String) = apply {
+    this.service = { service }
+  }
+
+  fun withPostcode(postcode: String) = apply {
+    this.postcode = { postcode }
+  }
+
+  fun withLocalAuthorityArea(localAuthorityAreaEntity: LocalAuthorityAreaEntity) = apply {
+    this.localAuthorityArea = { localAuthorityAreaEntity }
+  }
+
+  private fun withDefaultLocalAuthorityArea() = withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+
+  fun withYieldedLocalAuthorityArea(localAuthorityAreaEntity: Yielded<LocalAuthorityAreaEntity>) = apply {
+    this.localAuthorityArea = localAuthorityAreaEntity
+  }
+
+  fun withProbationDeliveryUnit(probationDeliveryUnit: ProbationDeliveryUnitEntity) = apply {
+    this.probationDeliveryUnit = { probationDeliveryUnit }
+  }
+
+  private fun withDefaultProbationDeliveryUnit() = withProbationDeliveryUnit(
+    ProbationDeliveryUnitEntityFactory()
+      .withDefaults()
+      .produce(),
+  )
+
+  fun withYieldedProbationDeliveryUnit(probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>) = apply {
+    this.probationDeliveryUnit = probationDeliveryUnit
+  }
+
+  fun withCharacteristics(characteristics: MutableList<Cas3PremisesCharacteristicEntity>) = apply {
+    this.characteristics = { characteristics }
+  }
+
+  fun withBedspaces(bedspaces: MutableList<Cas3BedspacesEntity>) = apply {
+    this.bedspaces = { bedspaces }
+  }
+
+  fun withStatus(status: PropertyStatus) = apply {
+    this.status = { status }
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce(): Cas3PremisesEntity = Cas3PremisesEntity(
+    id = this.id(),
+    name = this.name(),
+    postcode = this.postcode(),
+    localAuthorityArea = this.localAuthorityArea?.invoke()
+      ?: throw RuntimeException("Must provide a local authority area"),
+    bookings = mutableListOf(),
+    addressLine1 = this.addressLine1(),
+    addressLine2 = this.addressLine2(),
+    town = this.town(),
+    notes = this.notes(),
+    characteristics = this.characteristics(),
+    status = this.status(),
+    probationDeliveryUnit = this.probationDeliveryUnit?.invoke()
+      ?: throw RuntimeException("Must provide a local authority area"),
+    bedspaces = this.bedspaces(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -115,7 +115,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeR
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestRejectionReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3CancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ConfirmationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3DepartureEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ExtensionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3NonArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
@@ -208,7 +216,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1Chan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ExtensionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3NonArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
@@ -241,7 +257,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas1OutOfServiceBedTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas2ApplicationJsonSchemaTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3ArrivalTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3BedspaceTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3BookingTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3CancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3ConfirmationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3DepartureTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3ExtensionTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3NonArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3TurnaroundTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceReasonTestRepository
@@ -338,6 +361,27 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var bookingRepository: BookingTestRepository
+
+  @Autowired
+  lateinit var cas3ArrivalTestRepository: Cas3ArrivalTestRepository
+
+  @Autowired
+  lateinit var cas3BedspaceTestRepository: Cas3BedspaceTestRepository
+
+  @Autowired
+  lateinit var cas3BookingRepository: Cas3BookingTestRepository
+
+  @Autowired
+  lateinit var cas3CancellationTestRepository: Cas3CancellationTestRepository
+
+  @Autowired
+  lateinit var cas3DepartureTestRepository: Cas3DepartureTestRepository
+
+  @Autowired
+  lateinit var cas3ExtensionTestRepository: Cas3ExtensionTestRepository
+
+  @Autowired
+  lateinit var cas3NonArrivalTestRepository: Cas3NonArrivalTestRepository
 
   @Autowired
   lateinit var bedMoveRepository: BedMoveRepository
@@ -585,6 +629,14 @@ abstract class IntegrationTestBase {
   lateinit var localAuthorityEntityFactory: PersistedFactory<LocalAuthorityAreaEntity, UUID, LocalAuthorityEntityFactory>
   lateinit var approvedPremisesEntityFactory: PersistedFactory<ApprovedPremisesEntity, UUID, ApprovedPremisesEntityFactory>
   lateinit var temporaryAccommodationPremisesEntityFactory: PersistedFactory<TemporaryAccommodationPremisesEntity, UUID, TemporaryAccommodationPremisesEntityFactory>
+  lateinit var cas3ArrivalEntityFactory: PersistedFactory<Cas3ArrivalEntity, UUID, Cas3ArrivalEntityFactory>
+  lateinit var cas3BedspaceEntityFactory: PersistedFactory<Cas3BedspacesEntity, UUID, Cas3BedspaceEntityFactory>
+  lateinit var cas3BookingEntityFactory: PersistedFactory<Cas3BookingEntity, UUID, Cas3BookingEntityFactory>
+  lateinit var cas3CancellationEntityFactory: PersistedFactory<Cas3CancellationEntity, UUID, Cas3CancellationEntityFactory>
+  lateinit var cas3DepartureEntityFactory: PersistedFactory<Cas3DepartureEntity, UUID, Cas3DepartureEntityFactory>
+  lateinit var cas3ExtensionEntityFactory: PersistedFactory<Cas3ExtensionEntity, UUID, Cas3ExtensionEntityFactory>
+  lateinit var cas3NonArrivalEntityFactory: PersistedFactory<Cas3NonArrivalEntity, UUID, Cas3NonArrivalEntityFactory>
+  lateinit var cas3PremisesEntityFactory: PersistedFactory<Cas3PremisesEntity, UUID, Cas3PremisesEntityFactory>
   lateinit var bookingEntityFactory: PersistedFactory<BookingEntity, UUID, BookingEntityFactory>
   lateinit var arrivalEntityFactory: PersistedFactory<ArrivalEntity, UUID, ArrivalEntityFactory>
   lateinit var cas3ConfirmationEntityFactory: PersistedFactory<Cas3ConfirmationEntity, UUID, Cas3ConfirmationEntityFactory>
@@ -700,6 +752,14 @@ abstract class IntegrationTestBase {
     localAuthorityEntityFactory = PersistedFactory({ LocalAuthorityEntityFactory() }, localAuthorityAreaRepository)
     approvedPremisesEntityFactory = PersistedFactory({ ApprovedPremisesEntityFactory() }, approvedPremisesRepository)
     temporaryAccommodationPremisesEntityFactory = PersistedFactory({ TemporaryAccommodationPremisesEntityFactory() }, temporaryAccommodationPremisesRepository)
+    cas3ArrivalEntityFactory = PersistedFactory({ Cas3ArrivalEntityFactory() }, cas3ArrivalTestRepository)
+    cas3BedspaceEntityFactory = PersistedFactory({ Cas3BedspaceEntityFactory() }, cas3BedspaceTestRepository)
+    cas3BookingEntityFactory = PersistedFactory({ Cas3BookingEntityFactory() }, cas3BookingRepository)
+    cas3CancellationEntityFactory = PersistedFactory({ Cas3CancellationEntityFactory() }, cas3CancellationTestRepository)
+    cas3DepartureEntityFactory = PersistedFactory({ Cas3DepartureEntityFactory() }, cas3DepartureTestRepository)
+    cas3ExtensionEntityFactory = PersistedFactory({ Cas3ExtensionEntityFactory() }, cas3ExtensionTestRepository)
+    cas3NonArrivalEntityFactory = PersistedFactory({ Cas3NonArrivalEntityFactory() }, cas3NonArrivalTestRepository)
+    cas3PremisesEntityFactory = PersistedFactory({ Cas3PremisesEntityFactory() }, cas3PremisesRepository)
     bookingEntityFactory = PersistedFactory({ BookingEntityFactory() }, bookingRepository)
     arrivalEntityFactory = PersistedFactory({ ArrivalEntityFactory() }, arrivalRepository)
     cas3ConfirmationEntityFactory = PersistedFactory({ Cas3ConfirmationEntityFactory() }, confirmationRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/v2/Cas3v2BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/v2/Cas3v2BookingTest.kt
@@ -1,0 +1,258 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas3.v2
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.expectBodyList
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas3Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BookingTransformer
+import java.util.UUID
+
+class Cas3v2BookingTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var bookingTransformer: Cas3BookingTransformer
+
+  lateinit var probationRegion: ProbationRegionEntity
+
+  @BeforeEach
+  fun before() {
+    probationRegion = givenAProbationRegion()
+  }
+
+  @Test
+  fun `Get all Bookings without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/cas3/v2/premises/${UUID.randomUUID()}/bookings")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Get all Bookings on non existent Premises returns 404`() {
+    val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+    webTestClient.get()
+      .uri("/cas3/v2/premises/${UUID.randomUUID()}/bookings")
+      .header("Authorization", "Bearer $jwt")
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `Get all Bookings when user has the CAS3_ASSESSOR role but user does not have same probation region as premises`() {
+    givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
+      val premises = givenACas3Premises(
+        probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+          withProbationRegion(probationRegionEntityFactory.produceAndPersist())
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/premises/${premises.id}/bookings")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Test
+  fun `Get all Bookings on Premises when user does not have the CAS3_ASSESSOR role and user has same probation region as premises`() {
+    givenAUser(roles = listOf(UserRole.CAS1_ASSESSOR)) { user, jwt ->
+      val premises = givenACas3Premises(
+        probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+          withProbationRegion(user.probationRegion)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/premises/${premises.id}/bookings")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Test
+  fun `Get all Bookings on Premises without any Bookings returns empty list when user has the CAS3_ASSESSOR role and user has same probation region as premises`() {
+    givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+      val premises = givenACas3Premises(
+        probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+          withProbationRegion(user.probationRegion)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/premises/${premises.id}/bookings")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBodyList<Any>()
+        .hasSize(0)
+    }
+  }
+
+  @Test
+  fun `Get all Bookings returns OK with correct body when user has CAS3_ASSESSOR role`() {
+    givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val cas3Premises = givenACas3Premises(
+          probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(user.probationRegion)
+          },
+        )
+
+        val bookings = cas3BookingEntityFactory.produceAndPersistMultiple(5) {
+          withPremises(cas3Premises)
+          withCrn(offenderDetails.otherIds.crn)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withBedspace(
+            cas3BedspaceEntityFactory.produceAndPersist {
+              withPremises(cas3Premises)
+            },
+          )
+        }
+
+        bookings[1].let {
+          it.arrivals = cas3ArrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
+        }
+        bookings[2].let {
+          it.arrivals = cas3ArrivalEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
+          it.extensions = cas3ExtensionEntityFactory.produceAndPersistMultiple(1) { withBooking(it) }.toMutableList()
+          it.departures = cas3DepartureEntityFactory.produceAndPersistMultiple(1) {
+            withBooking(it)
+            withYieldedDestinationProvider { destinationProviderEntityFactory.produceAndPersist() }
+            withYieldedReason { departureReasonEntityFactory.produceAndPersist() }
+            withYieldedMoveOnCategory { moveOnCategoryEntityFactory.produceAndPersist() }
+          }.toMutableList()
+        }
+        bookings[3].let {
+          it.cancellations = cas3CancellationEntityFactory.produceAndPersistMultiple(1) {
+            withBooking(it)
+            withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+          }.toMutableList()
+        }
+        bookings[4].let {
+          it.nonArrival = cas3NonArrivalEntityFactory.produceAndPersist {
+            withBooking(it)
+            withYieldedReason { nonArrivalReasonEntityFactory.produceAndPersist() }
+          }
+        }
+
+        val expectedJson = objectMapper.writeValueAsString(
+          bookings.map {
+            bookingTransformer.transformJpaToApi(
+              it,
+              PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
+            )
+          },
+        )
+
+        webTestClient.get()
+          .uri("/cas3/v2/premises/${cas3Premises.id}/bookings")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(expectedJson)
+      }
+    }
+  }
+
+  @Test
+  fun `Get all Bookings for premises returns OK with correct body when person details for a booking could not be found`() {
+    givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+      val cas3Premises = givenACas3Premises(
+        probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+          withProbationRegion(user.probationRegion)
+        },
+      )
+      val booking = cas3BookingEntityFactory.produceAndPersist {
+        withPremises(cas3Premises)
+        withCrn("SOME-CRN")
+        withServiceName(ServiceName.temporaryAccommodation)
+        withBedspace(
+          cas3BedspaceEntityFactory.produceAndPersist {
+            withPremises(cas3Premises)
+          },
+        )
+      }
+
+      val expectedJson = objectMapper.writeValueAsString(
+        listOf(
+          bookingTransformer.transformJpaToApi(
+            booking,
+            PersonInfoResult.NotFound("SOME-CRN"),
+          ),
+        ),
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/premises/${cas3Premises.id}/bookings")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
+    }
+  }
+
+  @Test
+  fun `Get all Bookings for premises returns OK with correct body when inmate details for a booking could not be found`() {
+    givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender(mockServerErrorForPrisonApi = true) { offenderDetails, _ ->
+        val cas3Premises = givenACas3Premises(
+          probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(user.probationRegion)
+          },
+        )
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(cas3Premises)
+          withCrn(offenderDetails.otherIds.crn)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withBedspace(
+            cas3BedspaceEntityFactory.produceAndPersist {
+              withPremises(cas3Premises)
+            },
+          )
+        }
+
+        val expectedJson = objectMapper.writeValueAsString(
+          listOf(
+            bookingTransformer.transformJpaToApi(
+              booking,
+              PersonInfoResult.Success.Full(
+                crn = offenderDetails.otherIds.crn,
+                offenderDetailSummary = offenderDetails,
+                inmateDetail = null,
+              ),
+            ),
+          ),
+        )
+
+        webTestClient.get()
+          .uri("/cas3/v2/premises/${cas3Premises.id}/bookings")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(expectedJson)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas3Premises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas3Premises.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.util.UUID
+
+fun IntegrationTestBase.givenACas3Premises(
+  name: String = randomStringMultiCaseWithNumbers(8),
+  probationDeliveryUnit: ProbationDeliveryUnitEntity = probationDeliveryUnitFactory.produceAndPersist {
+    withProbationRegion(probationRegionEntityFactory.produceAndPersist())
+  },
+  localAuthorityArea: LocalAuthorityAreaEntity = localAuthorityEntityFactory.produceAndPersist(),
+  status: PropertyStatus = randomOf(PropertyStatus.entries),
+  postCode: String = randomPostCode(),
+  characteristics: List<Cas3PremisesCharacteristicEntity> = emptyList(),
+  id: UUID = UUID.randomUUID(),
+): Cas3PremisesEntity = cas3PremisesEntityFactory
+  .produceAndPersist {
+    withId(id)
+    withName(name)
+    withProbationDeliveryUnit(probationDeliveryUnit)
+    withLocalAuthorityArea(localAuthorityArea)
+    withStatus(status)
+    withPostcode(postCode)
+    withCharacteristics(characteristics.toMutableList())
+  }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3ArrivalTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3ArrivalTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ArrivalEntity
+import java.util.UUID
+
+@Repository
+interface Cas3ArrivalTestRepository : JpaRepository<Cas3ArrivalEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3BedspaceTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3BedspaceTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
+import java.util.UUID
+
+@Repository
+interface Cas3BedspaceTestRepository : JpaRepository<Cas3BedspacesEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3BookingTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3BookingTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import java.util.UUID
+
+@Repository
+interface Cas3BookingTestRepository : JpaRepository<Cas3BookingEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3CancellationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3CancellationTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3CancellationEntity
+import java.util.UUID
+
+@Repository
+interface Cas3CancellationTestRepository : JpaRepository<Cas3CancellationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3DepartureTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3DepartureTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3DepartureEntity
+import java.util.UUID
+
+@Repository
+interface Cas3DepartureTestRepository : JpaRepository<Cas3DepartureEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3ExtensionTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3ExtensionTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ExtensionEntity
+import java.util.UUID
+
+@Repository
+interface Cas3ExtensionTestRepository : JpaRepository<Cas3ExtensionEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3NonArrivalTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3NonArrivalTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3NonArrivalEntity
+import java.util.UUID
+
+@Repository
+interface Cas3NonArrivalTestRepository : JpaRepository<Cas3NonArrivalEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3BookingTransformerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
 
 import io.mockk.every
 import io.mockk.mockk
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Arrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Bed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingPremisesSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
@@ -30,59 +31,57 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Turnaround
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3CancellationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3NonArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ArrivalTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BedTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ExtensionTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ArrivalTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BedspaceTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BookingTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3CancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ConfirmationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3DepartureTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ExtensionTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3NonArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class BookingTransformerTest {
+@SuppressWarnings("LargeClass")
+class Cas3BookingTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
-  private val mockArrivalTransformer = mockk<ArrivalTransformer>()
-  private val mockNonArrivalTransformer = mockk<NonArrivalTransformer>()
-  private val mockCancellationTransformer = mockk<CancellationTransformer>()
+  private val mockArrivalTransformer = mockk<Cas3ArrivalTransformer>()
+  private val mockNonArrivalTransformer = mockk<Cas3NonArrivalTransformer>()
+  private val mockCancellationTransformer = mockk<Cas3CancellationTransformer>()
   private val mockCas3ConfirmationTransformer = mockk<Cas3ConfirmationTransformer>()
-  private val mockDepartureTransformer = mockk<DepartureTransformer>()
-  private val mockExtensionTransformer = mockk<ExtensionTransformer>()
-  private val mockBedTransformer = mockk<BedTransformer>()
+  private val mockDepartureTransformer = mockk<Cas3DepartureTransformer>()
+  private val mockExtensionTransformer = mockk<Cas3ExtensionTransformer>()
+  private val mockBedspaceTransformer = mockk<Cas3BedspaceTransformer>()
   private val mockCas3TurnaroundTransformer = mockk<Cas3TurnaroundTransformer>()
   private val enumConverterFactory = EnumConverterFactory()
   private val mockWorkingDayService = mockk<WorkingDayService>()
 
-  private val bookingTransformer = BookingTransformer(
+  private val bookingTransformer = Cas3BookingTransformer(
     mockPersonTransformer,
     mockArrivalTransformer,
     mockDepartureTransformer,
@@ -90,21 +89,15 @@ class BookingTransformerTest {
     mockCancellationTransformer,
     mockCas3ConfirmationTransformer,
     mockExtensionTransformer,
-    mockBedTransformer,
+    mockBedspaceTransformer,
     mockCas3TurnaroundTransformer,
     enumConverterFactory,
     mockWorkingDayService,
   )
 
-  private val premisesEntity = TemporaryAccommodationPremisesEntity(
+  private val premisesEntity = Cas3PremisesEntity(
     id = UUID.fromString("9703eaaf-164f-4f35-b038-f4de79e4847b"),
     name = "AP",
-    probationRegion = ProbationRegionEntity(
-      id = UUID.fromString("4eae0059-af28-4436-a4d8-7106523866d9"),
-      name = "region",
-      deliusCode = "ABC",
-      apArea = null,
-    ),
     localAuthorityArea = LocalAuthorityAreaEntity(
       id = UUID.fromString("ee39d3bc-e9ad-4408-a21d-cf763aa1d981"),
       identifier = "AUTHORITY",
@@ -112,28 +105,32 @@ class BookingTransformerTest {
       premises = mutableListOf(),
     ),
     bookings = mutableListOf(),
-    lostBeds = mutableListOf(),
     addressLine1 = "1 somewhere",
     addressLine2 = "Some district",
     town = "Somewhere",
     postcode = "ST8ST8",
-    latitude = null,
-    longitude = null,
     notes = "",
-    emailAddress = "some@email",
-    rooms = mutableListOf(),
     characteristics = mutableListOf(),
     status = PropertyStatus.active,
-    probationDeliveryUnit = null,
-    startDate = null,
-    turnaroundWorkingDayCount = 2,
+    probationDeliveryUnit = ProbationDeliveryUnitEntityFactory().withProbationRegion(
+      ProbationRegionEntity(
+        id = UUID.fromString("4eae0059-af28-4436-a4d8-7106523866d9"),
+        name = "region",
+        deliusCode = "ABC",
+        apArea = null,
+      ),
+    ).produce(),
+    bedspaces = mutableListOf(),
   )
 
-  private val baseBookingEntity = BookingEntity(
+  private val bedspaceEntity = Cas3BedspaceEntityFactory()
+    .withPremises(premisesEntity)
+    .produce()
+
+  private val baseBookingEntity = Cas3BookingEntity(
     id = UUID.fromString("c0cffa2a-490a-4e8b-a970-80aea3922a18"),
     arrivalDate = LocalDate.parse("2022-08-10"),
     departureDate = LocalDate.parse("2022-08-30"),
-    keyWorkerStaffCode = "789",
     crn = "CRN123",
     arrivals = mutableListOf(),
     departures = mutableListOf(),
@@ -143,16 +140,14 @@ class BookingTransformerTest {
     extensions = mutableListOf(),
     dateChanges = mutableListOf(),
     premises = premisesEntity,
-    bed = null,
-    service = ServiceName.approvedPremises.value,
+    bedspace = bedspaceEntity,
+    service = ServiceName.temporaryAccommodation.value,
     originalArrivalDate = LocalDate.parse("2022-08-10"),
     originalDepartureDate = LocalDate.parse("2022-08-30"),
     createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
     application = null,
-    offlineApplication = null,
     turnarounds = mutableListOf(),
     nomsNumber = "NOMS123",
-    placementRequest = null,
     status = null,
     offenderName = null,
   )
@@ -168,14 +163,23 @@ class BookingTransformerTest {
     .withOffenderNo("NOMS321")
     .produce()
 
-  private val nullConfirmationEntity: Cas3ConfirmationEntity? = null
+  private val nullDepartureEntity: Cas3DepartureEntity? = null
+  private val nullConfirmationEntity: Cas3v2ConfirmationEntity? = null
+
+  private val bedModel = Bed(
+    id = bedspaceEntity.id,
+    name = bedspaceEntity.reference,
+    code = null,
+    bedEndDate = bedspaceEntity.endDate,
+  )
 
   init {
     every { mockArrivalTransformer.transformJpaToApi(null) } returns null
     every { mockNonArrivalTransformer.transformJpaToApi(null) } returns null
     every { mockCancellationTransformer.transformJpaToApi(null) } returns null
     every { mockCas3ConfirmationTransformer.transformJpaToApi(nullConfirmationEntity) } returns null
-    every { mockDepartureTransformer.transformJpaToApi(null) } returns null
+    every { mockBedspaceTransformer.transformJpaToApi(bedspaceEntity) } returns bedModel
+    every { mockDepartureTransformer.transformJpaToApi(nullDepartureEntity) } returns null
 
     every { mockPersonTransformer.transformModelToPersonApi(PersonInfoResult.Success.Full("crn", offenderDetails, inmateDetail)) } returns FullPerson(
       type = PersonType.fullPerson,
@@ -198,129 +202,7 @@ class BookingTransformerTest {
   }
 
   @Test
-  fun `Approved Premises Awaiting Arrival entity is correctly transformed`() {
-    val awaitingArrivalBooking = baseBookingEntity.copy(id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"))
-
-    val transformedBooking = bookingTransformer.transformJpaToApi(
-      awaitingArrivalBooking,
-      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-    )
-
-    assertThat(transformedBooking).isEqualTo(
-      Booking(
-        id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
-        person = FullPerson(
-          type = PersonType.fullPerson,
-          crn = "crn",
-          name = "first last",
-          dateOfBirth = LocalDate.parse("2022-09-08"),
-          sex = "Male",
-          status = PersonStatus.inCommunity,
-          nomsNumber = "NOMS321",
-          nationality = "English",
-          religionOrBelief = null,
-          genderIdentity = null,
-          prisonName = null,
-        ),
-        arrivalDate = LocalDate.parse("2022-08-10"),
-        departureDate = LocalDate.parse("2022-08-30"),
-        status = BookingStatus.awaitingMinusArrival,
-        extensions = listOf(),
-        serviceName = ServiceName.approvedPremises,
-        originalArrivalDate = LocalDate.parse("2022-08-10"),
-        originalDepartureDate = LocalDate.parse("2022-08-30"),
-        createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-        departures = listOf(),
-        cancellations = listOf(),
-        turnarounds = listOf(),
-        effectiveEndDate = LocalDate.parse("2022-08-30"),
-        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
-      ),
-    )
-  }
-
-  @Test
-  fun `Approved Premises entity with application and assessment is correctly transformed`() {
-    val application = ApprovedPremisesApplicationEntityFactory()
-      .withCreatedByUser(
-        UserEntityFactory().withYieldedProbationRegion {
-          ProbationRegionEntityFactory()
-            .withYieldedApArea { ApAreaEntityFactory().produce() }
-            .produce()
-        }.produce(),
-      )
-      .produce()
-
-    val oldAssessment = ApprovedPremisesAssessmentEntityFactory()
-      .withApplication(application)
-      .withCreatedAt(OffsetDateTime.now().minusDays(5))
-      .withAllocatedToUser(
-        UserEntityFactory().withYieldedProbationRegion {
-          ProbationRegionEntityFactory()
-            .withYieldedApArea { ApAreaEntityFactory().produce() }
-            .produce()
-        }.produce(),
-      )
-      .produce()
-
-    val latestAssessment = ApprovedPremisesAssessmentEntityFactory()
-      .withApplication(application)
-      .withCreatedAt(OffsetDateTime.now().minusDays(2))
-      .withAllocatedToUser(
-        UserEntityFactory().withYieldedProbationRegion {
-          ProbationRegionEntityFactory()
-            .withYieldedApArea { ApAreaEntityFactory().produce() }
-            .produce()
-        }.produce(),
-      )
-      .produce()
-
-    application.assessments = mutableListOf(oldAssessment, latestAssessment)
-
-    val awaitingArrivalBooking = baseBookingEntity.copy(id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"), application = application)
-
-    val transformedBooking = bookingTransformer.transformJpaToApi(
-      awaitingArrivalBooking,
-      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-    )
-
-    assertThat(transformedBooking).isEqualTo(
-      Booking(
-        id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
-        person = FullPerson(
-          type = PersonType.fullPerson,
-          crn = "crn",
-          name = "first last",
-          dateOfBirth = LocalDate.parse("2022-09-08"),
-          sex = "Male",
-          status = PersonStatus.inCommunity,
-          nomsNumber = "NOMS321",
-          nationality = "English",
-          religionOrBelief = null,
-          genderIdentity = null,
-          prisonName = null,
-        ),
-        arrivalDate = LocalDate.parse("2022-08-10"),
-        departureDate = LocalDate.parse("2022-08-30"),
-        status = BookingStatus.awaitingMinusArrival,
-        extensions = listOf(),
-        serviceName = ServiceName.approvedPremises,
-        originalArrivalDate = LocalDate.parse("2022-08-10"),
-        originalDepartureDate = LocalDate.parse("2022-08-30"),
-        createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-        departures = listOf(),
-        cancellations = listOf(),
-        turnarounds = listOf(),
-        effectiveEndDate = LocalDate.parse("2022-08-30"),
-        applicationId = application.id,
-        assessmentId = latestAssessment.id,
-        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
-      ),
-    )
-  }
-
-  @Test
-  fun `Temporary Accommodation Provisional entity is correctly transformed`() {
+  fun `Premises Provisional entity is correctly transformed`() {
     val awaitingArrivalBooking = baseBookingEntity.copy(
       id = UUID.fromString("5bbe785f-5ff3-46b9-b9fe-d9e6ca7a18e8"),
       service = ServiceName.temporaryAccommodation.value,
@@ -360,14 +242,15 @@ class BookingTransformerTest {
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
   @Test
-  fun `Approved Premises Non Arrival entity is correctly transformed`() {
+  fun `Premises Non Arrival entity is correctly transformed`() {
     val nonArrivalBooking = baseBookingEntity.copy(id = UUID.fromString("655f72ba-51eb-4965-b6ac-45bcc6271b19")).apply {
-      nonArrival = NonArrivalEntity(
+      nonArrival = Cas3NonArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         date = LocalDate.parse("2022-08-10"),
         reason = NonArrivalReasonEntity(id = UUID.fromString("7a87f93d-b9d6-423d-a87a-dfc693ab82f9"), name = "Unknown", isActive = true, legacyDeliusReasonCode = "A"),
@@ -420,7 +303,7 @@ class BookingTransformerTest {
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         ),
         extensions = listOf(),
-        serviceName = ServiceName.approvedPremises,
+        serviceName = ServiceName.temporaryAccommodation,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
         createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -429,14 +312,15 @@ class BookingTransformerTest {
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
   @Test
-  fun `Approved Premises Arrived entity is correctly transformed`() {
+  fun `Premises Arrived entity is correctly transformed`() {
     val arrivalBooking = baseBookingEntity.copy(id = UUID.fromString("443e79a9-b10a-4ad7-8be1-ffe301d2bbf3")).apply {
-      arrivals += ArrivalEntity(
+      arrivals += Cas3ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -490,7 +374,7 @@ class BookingTransformerTest {
           createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
         ),
         extensions = listOf(),
-        serviceName = ServiceName.approvedPremises,
+        serviceName = ServiceName.temporaryAccommodation,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
         createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -499,15 +383,16 @@ class BookingTransformerTest {
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
   @Test
-  fun `Approved Premises Cancelled entity is correctly transformed`() {
+  fun `Premises Cancelled entity is correctly transformed`() {
     val cancellationBooking = baseBookingEntity.copy(id = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d")).apply {
       cancellations = mutableListOf(
-        CancellationEntity(
+        Cas3CancellationEntity(
           id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
           date = LocalDate.parse("2022-08-10"),
           reason = CancellationReasonEntity(id = UUID.fromString("aa4ee8cf-3580-44e1-a3e1-6f3ee7d5ec67"), name = "Because", isActive = true, serviceScope = "approved-premises", sortOrder = 0),
@@ -562,7 +447,7 @@ class BookingTransformerTest {
           premisesName = premisesEntity.name,
         ),
         extensions = listOf(),
-        serviceName = ServiceName.approvedPremises,
+        serviceName = ServiceName.temporaryAccommodation,
         originalArrivalDate = LocalDate.parse("2022-08-10"),
         originalDepartureDate = LocalDate.parse("2022-08-30"),
         createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
@@ -580,16 +465,17 @@ class BookingTransformerTest {
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
   @Test
-  fun `Temporary Accommodation Entity with edited cancellation is correctly transformed`() {
+  fun `Premises with edited cancellation is correctly transformed`() {
     val cancellationBooking = baseBookingEntity.copy(id = UUID.fromString("d182c0b8-1f5f-433b-9a0e-b0e51fee8b8d")).apply {
       service = ServiceName.temporaryAccommodation.value
       cancellations = mutableListOf(
-        CancellationEntity(
+        Cas3CancellationEntity(
           id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
           date = LocalDate.parse("2022-08-10"),
           reason = CancellationReasonEntity(
@@ -604,7 +490,7 @@ class BookingTransformerTest {
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
           otherReason = null,
         ),
-        CancellationEntity(
+        Cas3CancellationEntity(
           id = UUID.fromString("d34415c3-d128-45a0-9950-b84491ab8d11"),
           date = LocalDate.parse("2022-08-10"),
           reason = CancellationReasonEntity(
@@ -623,7 +509,7 @@ class BookingTransformerTest {
     }
 
     every { mockCancellationTransformer.transformJpaToApi(any()) } answers { answer ->
-      val arg = answer.invocation.args[0] as CancellationEntity
+      val arg = answer.invocation.args[0] as Cas3CancellationEntity
 
       when (arg.id) {
         UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c") -> Cancellation(
@@ -706,189 +592,16 @@ class BookingTransformerTest {
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
   @Test
-  fun `Approved Premises Departed entity is correctly transformed`() {
-    val bookingId = UUID.fromString("e0a3f9d7-0677-40bf-85a9-6673a7af33ee")
-    val departedBooking = baseBookingEntity.copy(id = bookingId).apply {
-      arrivals += ArrivalEntity(
-        id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
-        arrivalDate = LocalDate.parse("2022-08-10"),
-        arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
-        expectedDepartureDate = LocalDate.parse("2022-08-16"),
-        notes = null,
-        booking = this,
-        createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-      )
-      departures = mutableListOf(
-        DepartureEntity(
-          id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
-          dateTime = OffsetDateTime.parse("2022-08-30T15:30:15+01:00"),
-          reason = DepartureReasonEntity(
-            id = UUID.fromString("09e74ead-cf5a-40a1-a1be-739d3b97788f"),
-            name = "Departure Reason",
-            isActive = true,
-            serviceScope = "*",
-            legacyDeliusReasonCode = "A",
-            parentReasonId = null,
-          ),
-          moveOnCategory = MoveOnCategoryEntity(
-            id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
-            name = "Move on Category",
-            isActive = true,
-            serviceScope = "*",
-            legacyDeliusCategoryCode = "CAT",
-          ),
-          destinationProvider = DestinationProviderEntity(
-            id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
-            name = "Destination Provider",
-            isActive = true,
-          ),
-          notes = null,
-          booking = this,
-          createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
-        ),
-      )
-    }
-
-    every { mockArrivalTransformer.transformJpaToApi(departedBooking.arrival) } returns Arrival(
-      bookingId = bookingId,
-      arrivalDate = LocalDate.parse("2022-08-10"),
-      expectedDepartureDate = LocalDate.parse("2022-08-16"),
-      notes = null,
-      arrivalTime = "00:00:00",
-      createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-    )
-
-    every { mockDepartureTransformer.transformJpaToApi(departedBooking.departure) } returns Departure(
-      id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
-      bookingId = bookingId,
-      dateTime = Instant.parse("2022-08-30T15:30:15+01:00"),
-      reason = DepartureReason(
-        id = UUID.fromString("09e74ead-cf5a-40a1-a1be-739d3b97788f"),
-        name = "Departure Reason",
-        isActive = true,
-        serviceScope = "*",
-      ),
-      moveOnCategory = MoveOnCategory(
-        id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
-        name = "Move on Category",
-        isActive = true,
-        serviceScope = "*",
-      ),
-      destinationProvider = DestinationProvider(
-        id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
-        name = "Destination Provider",
-        isActive = true,
-      ),
-      notes = null,
-      createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-    )
-
-    val transformedBooking = bookingTransformer.transformJpaToApi(
-      departedBooking,
-      PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetail),
-    )
-
-    assertThat(transformedBooking).isEqualTo(
-      Booking(
-        id = bookingId,
-        person = FullPerson(
-          type = PersonType.fullPerson,
-          crn = "crn",
-          name = "first last",
-          dateOfBirth = LocalDate.parse("2022-09-08"),
-          sex = "Male",
-          status = PersonStatus.inCommunity,
-          nomsNumber = "NOMS321",
-          nationality = "English",
-          religionOrBelief = null,
-          genderIdentity = null,
-          prisonName = null,
-        ),
-        arrivalDate = LocalDate.parse("2022-08-10"),
-        departureDate = LocalDate.parse("2022-08-30"),
-        keyWorker = null,
-        status = BookingStatus.departed,
-        arrival = Arrival(
-          bookingId = bookingId,
-          arrivalDate = LocalDate.parse("2022-08-10"),
-          expectedDepartureDate = LocalDate.parse("2022-08-16"),
-          notes = null,
-          arrivalTime = "00:00:00",
-          createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-        ),
-        departure = Departure(
-          id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
-          bookingId = bookingId,
-          dateTime = Instant.parse("2022-08-30T15:30:15+01:00"),
-          reason = DepartureReason(
-            id = UUID.fromString("09e74ead-cf5a-40a1-a1be-739d3b97788f"),
-            name = "Departure Reason",
-            isActive = true,
-            serviceScope = "*",
-          ),
-          moveOnCategory = MoveOnCategory(
-            id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
-            name = "Move on Category",
-            isActive = true,
-            serviceScope = "*",
-          ),
-          destinationProvider = DestinationProvider(
-            id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
-            name = "Destination Provider",
-            isActive = true,
-          ),
-          notes = null,
-          createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-        ),
-        extensions = listOf(),
-        serviceName = ServiceName.approvedPremises,
-        originalArrivalDate = LocalDate.parse("2022-08-10"),
-        originalDepartureDate = LocalDate.parse("2022-08-30"),
-        createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-        departures = listOf(
-          Departure(
-            id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
-            bookingId = bookingId,
-            dateTime = Instant.parse("2022-08-30T15:30:15+01:00"),
-            reason = DepartureReason(
-              id = UUID.fromString("09e74ead-cf5a-40a1-a1be-739d3b97788f"),
-              name = "Departure Reason",
-              isActive = true,
-              serviceScope = "*",
-            ),
-            moveOnCategory = MoveOnCategory(
-              id = UUID.fromString("bcfbb1b6-f89d-45eb-ae70-308cc6930633"),
-              name = "Move on Category",
-              isActive = true,
-              serviceScope = "*",
-            ),
-            destinationProvider = DestinationProvider(
-              id = UUID.fromString("29669658-c8f2-492c-8eab-2dd73a208d30"),
-              name = "Destination Provider",
-              isActive = true,
-            ),
-            notes = null,
-            createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
-          ),
-        ),
-        cancellations = listOf(),
-        turnarounds = listOf(),
-        effectiveEndDate = LocalDate.parse("2022-08-30"),
-        premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
-      ),
-    )
-  }
-
-  @Test
-  fun `Temporary Accommodation entity with zero day turnaround period and departure is correctly transformed to closed status`() {
+  fun `Premises entity with zero day turnaround period and departure is correctly transformed to closed status`() {
     val bookingId = UUID.fromString("e0a3f9d7-0677-40bf-85a9-6673a7af33ee")
     val departedBooking = baseBookingEntity.copy(id = bookingId, service = ServiceName.temporaryAccommodation.value).apply {
-      arrivals += ArrivalEntity(
+      arrivals += Cas3ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -898,7 +611,7 @@ class BookingTransformerTest {
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
       departures = mutableListOf(
-        DepartureEntity(
+        Cas3DepartureEntity(
           id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
           dateTime = OffsetDateTime.parse("2022-08-30T15:30:15+01:00"),
           reason = DepartureReasonEntity(
@@ -927,7 +640,7 @@ class BookingTransformerTest {
         ),
       )
 
-      turnarounds += Cas3TurnaroundEntity(
+      turnarounds += Cas3v2TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 0,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
@@ -1081,12 +794,14 @@ class BookingTransformerTest {
         ),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
+  @SuppressWarnings("LongMethod")
   @Test
-  fun `Temporary Accommodation entity with non-zero day turnaround period and departure within turnaround period is correctly transformed to departed status`() {
+  fun `Premises entity with non-zero day turnaround period and departure within turnaround period is correctly transformed to departed status`() {
     mockkStatic(OffsetDateTime::class, LocalDate::class)
 
     val timeNow = OffsetDateTime.parse("2022-08-17T15:30:00Z")
@@ -1099,7 +814,7 @@ class BookingTransformerTest {
     val departedBooking = baseBookingEntity.copy(id = bookingId, service = ServiceName.temporaryAccommodation.value).apply {
       departureDate = departedAt.toLocalDate()
 
-      arrivals += ArrivalEntity(
+      arrivals += Cas3ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -1109,7 +824,7 @@ class BookingTransformerTest {
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
       departures = mutableListOf(
-        DepartureEntity(
+        Cas3DepartureEntity(
           id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
           dateTime = departedAt,
           reason = DepartureReasonEntity(
@@ -1138,7 +853,7 @@ class BookingTransformerTest {
         ),
       )
 
-      turnarounds += Cas3TurnaroundEntity(
+      turnarounds += Cas3v2TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 2,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
@@ -1296,12 +1011,14 @@ class BookingTransformerTest {
         turnaroundStartDate = departedAt.toLocalDate().plusDays(1),
         effectiveEndDate = expectedEffectiveEndDate,
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
+  @SuppressWarnings("LongMethod")
   @Test
-  fun `Temporary Accommodation entity with non-zero day turnaround period and departure with turnaround period in past is correctly transformed to closed status`() {
+  fun `Premises entity with non-zero day turnaround period and departure with turnaround period in past is correctly transformed to closed status`() {
     mockkStatic(OffsetDateTime::class, LocalDate::class)
 
     val timeNow = OffsetDateTime.parse("2022-08-19T15:30:00Z")
@@ -1314,7 +1031,7 @@ class BookingTransformerTest {
     val departedBooking = baseBookingEntity.copy(id = bookingId, service = ServiceName.temporaryAccommodation.value).apply {
       departureDate = departedAt.toLocalDate()
 
-      arrivals += ArrivalEntity(
+      arrivals += Cas3ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -1324,7 +1041,7 @@ class BookingTransformerTest {
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
       departures = mutableListOf(
-        DepartureEntity(
+        Cas3DepartureEntity(
           id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
           dateTime = departedAt,
           reason = DepartureReasonEntity(
@@ -1353,7 +1070,7 @@ class BookingTransformerTest {
         ),
       )
 
-      turnarounds += Cas3TurnaroundEntity(
+      turnarounds += Cas3v2TurnaroundEntity(
         id = UUID.fromString("8c87e15d-f236-479e-b9fd-f4c5cc6bef8f"),
         workingDayCount = 2,
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
@@ -1511,16 +1228,18 @@ class BookingTransformerTest {
         turnaroundStartDate = departedAt.toLocalDate().plusDays(1),
         effectiveEndDate = expectedEffectiveEndDate,
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
+  @SuppressWarnings("LongMethod")
   @Test
-  fun `Temporary Accommodation Entity with edited departure is correctly transformed`() {
+  fun `Premises Entity with edited departure is correctly transformed`() {
     val bookingId = UUID.fromString("e0a3f9d7-0677-40bf-85a9-6673a7af33ee")
     val departedBooking = baseBookingEntity.copy(id = bookingId).apply {
       service = ServiceName.temporaryAccommodation.value
-      arrivals += ArrivalEntity(
+      arrivals += Cas3ArrivalEntity(
         id = UUID.fromString("77e66712-b0a0-4968-b284-77ac1babe09c"),
         arrivalDate = LocalDate.parse("2022-08-10"),
         arrivalDateTime = Instant.parse("2022-08-10T00:00:00Z"),
@@ -1530,7 +1249,7 @@ class BookingTransformerTest {
         createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       )
       departures = mutableListOf(
-        DepartureEntity(
+        Cas3DepartureEntity(
           id = UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd"),
           dateTime = OffsetDateTime.parse("2022-08-30T15:30:15+01:00"),
           reason = DepartureReasonEntity(
@@ -1557,7 +1276,7 @@ class BookingTransformerTest {
           booking = this,
           createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
         ),
-        DepartureEntity(
+        Cas3DepartureEntity(
           id = UUID.fromString("f184e3e9-474d-4083-9f3d-628f462907fc"),
           dateTime = OffsetDateTime.parse("2022-08-30T15:30:15+01:00"),
           reason = DepartureReasonEntity(
@@ -1596,8 +1315,8 @@ class BookingTransformerTest {
       createdAt = Instant.parse("2022-07-01T12:34:56.789Z"),
     )
 
-    every { mockDepartureTransformer.transformJpaToApi(any()) } answers { answer ->
-      val arg = answer.invocation.args[0] as DepartureEntity
+    every { mockDepartureTransformer.transformJpaToApi(any(Cas3DepartureEntity::class)) } answers { answer ->
+      val arg = answer.invocation.args[0] as Cas3DepartureEntity
 
       when (arg.id) {
         UUID.fromString("0d68d5b9-44c7-46cd-a52b-8185477b5edd") -> Departure(
@@ -1769,17 +1488,18 @@ class BookingTransformerTest {
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
 
   @Test
-  fun `Temporary Accommodation Confirmed entity is correctly transformed`() {
+  fun `Premises Confirmed entity is correctly transformed`() {
     val confirmationBooking = baseBookingEntity.copy(
       id = UUID.fromString("1c29a729-6059-4939-8641-1caa61a38815"),
       service = ServiceName.temporaryAccommodation.value,
     ).apply {
-      confirmation = Cas3ConfirmationEntity(
+      confirmation = Cas3v2ConfirmationEntity(
         id = UUID.fromString("69fc6350-b2ec-4e99-9a2f-e829e83535e8"),
         dateTime = OffsetDateTime.parse("2022-11-23T12:34:56.789Z"),
         notes = null,
@@ -1839,6 +1559,7 @@ class BookingTransformerTest {
         turnarounds = listOf(),
         effectiveEndDate = LocalDate.parse("2022-08-30"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }
@@ -1851,19 +1572,19 @@ class BookingTransformerTest {
       turnarounds = mutableListOf(),
     )
 
-    val turnaround1 = Cas3TurnaroundEntity(
+    val turnaround1 = Cas3v2TurnaroundEntity(
       id = UUID.fromString("34ae3124-cf7a-47d5-86c1-ef9ab4255e30"),
       workingDayCount = 2,
       createdAt = OffsetDateTime.parse("2022-07-01T12:34:56.789Z"),
       booking = awaitingArrivalBooking,
     )
-    val turnaround2 = Cas3TurnaroundEntity(
+    val turnaround2 = Cas3v2TurnaroundEntity(
       id = UUID.fromString("b2af671a-997d-443e-906d-3a1a28c71416"),
       workingDayCount = 3,
       createdAt = OffsetDateTime.parse("2022-07-02T10:11:12.345Z"),
       booking = awaitingArrivalBooking,
     )
-    val turnaround3 = Cas3TurnaroundEntity(
+    val turnaround3 = Cas3v2TurnaroundEntity(
       id = UUID.fromString("146d05f8-ba83-42ae-a6d7-807a16b7946d"),
       workingDayCount = 4,
       createdAt = OffsetDateTime.parse("2022-07-03T09:08:07.654Z"),
@@ -1956,6 +1677,7 @@ class BookingTransformerTest {
         turnaroundStartDate = LocalDate.parse("2022-08-31"),
         effectiveEndDate = LocalDate.parse("2022-09-05"),
         premises = BookingPremisesSummary(premisesEntity.id, premisesEntity.name),
+        bed = bedModel,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3CancellationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3CancellationTransformerTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3CancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3CancellationTransformer
+
+class Cas3CancellationTransformerTest {
+
+  private val transformer = Cas3CancellationTransformer(CancellationReasonTransformer())
+
+  @Test
+  fun transformJpaToApi() {
+    val result = transformer.transformJpaToApi(
+      Cas3CancellationEntityFactory()
+        .withDefaults()
+        .withBooking(Cas3BookingEntityFactory().withDefaults().produce())
+        .withOtherReason("the other reason")
+        .produce(),
+    )
+
+    assertThat(result!!.otherReason).isEqualTo("the other reason")
+  }
+}


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" alt="Screenshot 2025-06-19 at 13 21 13 (2)" src="https://github.com/user-attachments/assets/ef2dd1c0-8e0d-4929-9839-a3d2a5e53a92" />

**Background**

This is the first PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**NOT included in this PR**

* After discussions with @muhammad-elabdulla his suggestion is not to share the `Booking` model so that we get separation on all models between `CAS3` and other `CAS` services. This makes sense in terms of splitting `CAS3` out into a separate service in future. So on board! For example; `Booking -> Cas3Booking`
* For now this is not included in this PR because (1) this proves we have not broken the contract and (2) the PR is already getting huge. I will do a follow up PR with this work

**PR includes**

1. The new endpoints are being delivered under `/v2/cas3/*` - this was neccessary as there are new `/cas3/` versions being delievred in parallel. We are targeting the endpoints that will not change so that theuy are not a moving target
2. The new `CAS3` tables have a `cas3_` prefix and have already been delivered as part of the data layer PRs that have already been merged
3. The new `Cas3BookingEntity` is mapped to the same `bookings` table that the `BookingEntity` is mapped to. This was necessary as we are sharing the `bookings` table and the `bookings.premises_id` goes to the new `cas3_premises` tables and the `bookings.bed_id` goes to the new `cas3_bedspaces` table. So the joins on the new `Cas3BookingEntity` are different.
4. To make the above work I have dropped the foreign-key constraint for `bookings.bed_id -> beds.id`. This was discussed/validated/approved in the `All dev checkin` on June 18th. There was no foreign-key on `bookings.premises_id -> premiese.id` so nothing to drop there
6. As a result of creating the new `Cas3BookingEntity` table a lot fo the child tables needed new `Cas3` specific entities also as these join up to booking table. For example `ArrivalEntity` becomes `Cas3ArrivalEntity` the only difference on these new entities is the join up to the `Cas3BookingEntity` (instead of `BookingEntity`).
7. As a result of these new `Cas3*Entity` classes I needed to create new transformers which lead to new transformer tests. Although this looks like a lot of code - they are straight duplicates of the original transformers and transformer tests with tweaks only to the types to accommodated the new `Cas3*Entity` classes
8. The only transformer that has some major(ish) changes to it in the `Cas3BookingTransformer` as `BookingTransformer` has approved-premises specific business-logic which has been removed. The `Cas3BookingTransformerTest` has less tests than `BookingTransformerTest` as a result. Importantly the business-logic has not changed at all for CAS3 related code. A few cleanup changes due to detect also 
