### PR TITLE
APS-1032 clarify /premises/{id}/… API support

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -587,6 +587,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewExtension,
   ): ResponseEntity<Extension> {
+    requestContextService.ensureCas3Request()
+
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
     when (booking.premises) {
@@ -619,7 +621,7 @@ class PremisesController(
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
     val user = usersService.getUserForRequest()
 
-    if (!userAccessService.currentUserCanManagePremisesBookings(booking.premises)) {
+    if (!userAccessService.currentUserCanChangeBookingDate(booking.premises)) {
       throw ForbiddenProblem()
     }
 
@@ -858,6 +860,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewTurnaround,
   ): ResponseEntity<Turnaround> {
+    requestContextService.ensureCas3Request()
+
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
     when (booking.premises) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -415,6 +415,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewArrival,
   ): ResponseEntity<Arrival> {
+    requestContextService.ensureCas3Request()
+
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
     val user = usersService.getUserForRequest()
@@ -513,6 +515,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewConfirmation,
   ): ResponseEntity<Confirmation> {
+    requestContextService.ensureCas3Request()
+
     val user = usersService.getUserForRequest()
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
@@ -548,6 +552,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewDeparture,
   ): ResponseEntity<Departure> {
+    requestContextService.ensureCas3Request()
+
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
     val user = usersService.getUserForRequest()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
@@ -56,6 +56,10 @@ enum class UserPermission(val cas1ApiValue: ApprovedPremisesUserPermission?) {
   CAS1_VIEW_CRU_DASHBOARD(ApprovedPremisesUserPermission.viewCruDashboard),
   CAS1_VIEW_MANAGE_TASKS(ApprovedPremisesUserPermission.viewManageTasks),
   CAS1_VIEW_OUT_OF_SERVICE_BEDS(ApprovedPremisesUserPermission.viewOutOfServiceBeds),
+
+  /**
+   * Also allows for space booking modification
+   */
   CAS1_SPACE_BOOKING_CREATE(ApprovedPremisesUserPermission.spaceBookingCreate),
   CAS1_SPACE_BOOKING_LIST(ApprovedPremisesUserPermission.spaceBookingList),
   CAS1_SPACE_BOOKING_RECORD_ARRIVAL(ApprovedPremisesUserPermission.spaceBookingRecordArrival),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -64,6 +64,12 @@ class UserAccessService(
     else -> false
   }
 
+  fun currentUserCanChangeBookingDate(premises: PremisesEntity) = when (premises) {
+    is ApprovedPremisesEntity -> userService.getUserForRequest().hasPermission(UserPermission.CAS1_BOOKING_CHANGE_DATES)
+    is TemporaryAccommodationPremisesEntity -> currentUserCanManagePremisesBookings(premises)
+    else -> false
+  }
+
   fun currentUserCanManagePremisesBookings(premises: PremisesEntity) = userCanManagePremisesBookings(userService.getUserForRequest(), premises)
 
   fun userCanViewBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -213,7 +213,7 @@ paths:
     post:
       tags:
         - Operations on bookings
-      summary: Posts an arrival to a specified booking
+      summary: Posts an arrival to a specified booking for CAS3
       operationId: premisesPremisesIdBookingsBookingIdArrivalsPost
       parameters:
         - name: premisesId
@@ -357,7 +357,7 @@ paths:
     post:
       tags:
         - Operations on bookings
-      summary: Posts a departure to a specified booking
+      summary: Posts a departure to a specified booking for CAS3
       operationId: premisesPremisesIdBookingsBookingIdDeparturesPost
       parameters:
         - name: premisesId

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -215,7 +215,7 @@ paths:
     post:
       tags:
         - Operations on bookings
-      summary: Posts an arrival to a specified booking
+      summary: Posts an arrival to a specified booking for CAS3
       operationId: premisesPremisesIdBookingsBookingIdArrivalsPost
       parameters:
         - name: premisesId
@@ -359,7 +359,7 @@ paths:
     post:
       tags:
         - Operations on bookings
-      summary: Posts a departure to a specified booking
+      summary: Posts a departure to a specified booking for CAS3
       operationId: premisesPremisesIdBookingsBookingIdDeparturesPost
       parameters:
         - name: premisesId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1867,6 +1867,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -1929,6 +1930,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -1953,7 +1955,7 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Create Arrival updates arrival and departure date for a Temporary Accommodation booking`() {
     givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
-      givenAnOffender { offenderDetails, inmateDetails ->
+      givenAnOffender { offenderDetails, _ ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion { userEntity.probationRegion }
@@ -1980,6 +1982,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -2012,11 +2015,8 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Create Arrival and departure date for a Temporary Accommodation booking and emit arrival domain event for new arrival`() {
     givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
-      givenAnOffender { offenderDetails, inmateDetails ->
-        val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { userEntity.probationRegion }
-        }
+      givenAnOffender { offenderDetails, _ ->
+        val premises = givenATemporaryAccommodationPremises(region = userEntity.probationRegion)
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -2039,6 +2039,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -2078,7 +2079,7 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Create Arrival updates arrival for a Temporary Accommodation booking with existing arrival and updated domain event send`() {
     givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
-      givenAnOffender { offenderDetails, inmateDetails ->
+      givenAnOffender { offenderDetails, _ ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion { userEntity.probationRegion }
@@ -2107,6 +2108,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -2250,12 +2252,7 @@ class BookingTest : IntegrationTestBase() {
         givenAnOffender { offenderDetails, inmateDetails ->
           val booking = bookingEntityFactory.produceAndPersist {
             withCrn(offenderDetails.otherIds.crn)
-            withYieldedPremises {
-              temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-                withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                withYieldedProbationRegion { userEntity.probationRegion }
-              }
-            }
+            withPremises(givenATemporaryAccommodationPremises(region = userEntity.probationRegion))
             withServiceName(ServiceName.temporaryAccommodation)
             withArrivalDate(LocalDate.parse("2022-08-10"))
             withDepartureDate(LocalDate.parse("2022-08-30"))
@@ -2272,6 +2269,7 @@ class BookingTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("$baseUrl/${booking.premises.id}/bookings/${booking.id}/departures")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
             .bodyValue(
               NewDeparture(
                 dateTime = Instant.parse("2022-09-01T12:34:56.789Z"),
@@ -2336,6 +2334,7 @@ class BookingTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("/premises/${booking.premises.id}/bookings/${booking.id}/departures")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
             .bodyValue(
               NewDeparture(
                 dateTime = Instant.parse("2022-09-01T12:34:56.789Z"),
@@ -3478,66 +3477,6 @@ class BookingTest : IntegrationTestBase() {
       .isUnauthorized
   }
 
-  @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_WORKFLOW_MANAGER"])
-  fun `Create Confirmation on Approved Premises Booking returns OK with correct body when user has one of roles FUTURE_MANAGER, WORKFLOW_MANAGER`(
-    role: UserRole,
-  ) {
-    givenAUser(roles = listOf(role)) { userEntity, jwt ->
-      val booking = bookingEntityFactory.produceAndPersist {
-        withYieldedPremises {
-          givenAnApprovedPremises()
-        }
-        withServiceName(ServiceName.approvedPremises)
-      }
-
-      webTestClient.post()
-        .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(
-          NewConfirmation(
-            notes = null,
-          ),
-        )
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectBody()
-        .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
-        .jsonPath("$.dateTime").value(withinSeconds(5L), OffsetDateTime::class.java)
-        .jsonPath("$.notes").isEqualTo(null)
-        .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
-    }
-  }
-
-  @Test
-  fun `Create Confirmation on Approved Premises Booking on a premises that does not exist returns 404 Not Found`() {
-    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-      val booking = bookingEntityFactory.produceAndPersist {
-        withYieldedPremises {
-          givenAnApprovedPremises()
-        }
-        withServiceName(ServiceName.approvedPremises)
-      }
-
-      val premisesId = UUID.randomUUID()
-
-      webTestClient.post()
-        .uri("/premises/$premisesId/bookings/${booking.id}/confirmations")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(
-          NewConfirmation(
-            notes = null,
-          ),
-        )
-        .exchange()
-        .expectStatus()
-        .isNotFound
-        .expectBody()
-        .jsonPath("$.detail").isEqualTo("No Premises with an ID of $premisesId could be found")
-    }
-  }
-
   @Test
   fun `Create Confirmation on Temporary Accommodation Booking returns OK with correct body`() {
     givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
@@ -3556,6 +3495,7 @@ class BookingTest : IntegrationTestBase() {
       webTestClient.post()
         .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewConfirmation(
             notes = null,
@@ -3615,6 +3555,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewConfirmation(
               notes = null,
@@ -3776,6 +3717,7 @@ class BookingTest : IntegrationTestBase() {
     webTestClient.post()
       .uri(url)
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(requestBody)
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -1370,4 +1370,51 @@ class UserAccessServiceTest {
       assertThat(userAccessService.userCanAccessTemporaryAccommodationApplication(user, application)).isFalse
     }
   }
+
+  @Nested
+  inner class CurrentUserCanChangeBookingDate {
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_CRU_MEMBER" ])
+    fun `returns true if the given premises is an Approved Premises and the current user has the CRU_MEMBER role`(role: UserRole) {
+      currentRequestIsFor(ServiceName.approvedPremises)
+
+      user.addRoleForUnitTest(role)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `returns false if the given premises is an Approved Premises and the current user has no suitable role`() {
+      currentRequestIsFor(ServiceName.approvedPremises)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(approvedPremises)).isFalse
+    }
+
+    @Test
+    fun `returns true if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+      currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+      user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(temporaryAccommodationPremisesInUserRegion)).isTrue
+    }
+
+    @Test
+    fun `returns false if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+      currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+      user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+    }
+
+    @Test
+    fun `returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
+      currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(temporaryAccommodationPremisesInUserRegion)).isFalse
+      assertThat(userAccessService.currentUserCanChangeBookingDate(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+    }
+  }
 }


### PR DESCRIPTION
This commit makes it clear that arrival, departure and confirmation endpoints on ` /premises/{premisesId}/bookings/…` is not supported by CAS1, and adds an explicit check on the API call to verify this.

This change is being made are part of removing the workflow manager role, as this API calls code that depends on that role for CAS1 calls