### PR TITLE
Fix type for Cas1ApplicationSummary.arrivalDate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -392,6 +392,11 @@ class ApprovedPremisesApplicationEntity(
   var releaseType: String?,
   var sentenceType: String?,
   var situation: String?,
+  /**
+   * The arrival date at midnight in UTC (See ApplicationService.getArrivalDate)
+   *
+   * Ideally we'd persist this as a date only (as is provided by the UI)
+   */
   var arrivalDate: OffsetDateTime?,
   /**
    * The offender name. This should only be used for search purposes (i.e. SQL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -23,6 +23,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1ApplicationUserDetailsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1CruManagementAreaTransformer
+import java.time.LocalDate
+import java.time.ZoneOffset
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSummary as ApiApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationStatus as ApiApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplicationSummary as ApiApprovedPremisesApplicationSummary
@@ -175,7 +177,7 @@ class ApplicationsTransformer(
       submittedAt = domain.getSubmittedAt(),
       isWomensApplication = domain.getIsWomensApplication(),
       isPipeApplication = domain.getIsPipeApplication(),
-      arrivalDate = domain.getArrivalDate(),
+      arrivalDate = domain.getArrivalDate()?.let { LocalDate.ofInstant(domain.getArrivalDate(), ZoneOffset.UTC) },
       risks = if (riskRatings != null) risksTransformer.transformDomainToApi(riskRatings, domain.getCrn()) else null,
       status = getStatusFromSummary(domain),
       tier = domain.getTier(),

--- a/src/main/resources/static/cas1-schemas.yml
+++ b/src/main/resources/static/cas1-schemas.yml
@@ -1518,7 +1518,7 @@ components:
           type: boolean
         arrivalDate:
           type: string
-          format: date-time
+          format: date
         risks:
           $ref: '_shared.yml#/components/schemas/PersonRisks'
         createdByUserId:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -8354,7 +8354,7 @@ components:
           type: boolean
         arrivalDate:
           type: string
-          format: date-time
+          format: date
         risks:
           $ref: '#/components/schemas/PersonRisks'
         createdByUserId:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -482,9 +482,9 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             .bodyAsListOfObjects<Cas1ApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(3)
-          assertThat(responseBody[0].arrivalDate).isEqualTo(date3.toInstant())
-          assertThat(responseBody[1].arrivalDate).isEqualTo(date2.toInstant())
-          assertThat(responseBody[2].arrivalDate).isEqualTo(date1.toInstant())
+          assertThat(responseBody[0].arrivalDate).isEqualTo("2022-12-24")
+          assertThat(responseBody[1].arrivalDate).isEqualTo("2022-09-24")
+          assertThat(responseBody[2].arrivalDate).isEqualTo("2022-08-24")
         }
       }
     }
@@ -535,9 +535,9 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             .bodyAsListOfObjects<Cas1ApplicationSummary>()
 
           assertThat(responseBody.count()).isEqualTo(3)
-          assertThat(responseBody[0].arrivalDate).isEqualTo(date1.toInstant())
-          assertThat(responseBody[1].arrivalDate).isEqualTo(date2.toInstant())
-          assertThat(responseBody[2].arrivalDate).isEqualTo(date3.toInstant())
+          assertThat(responseBody[0].arrivalDate).isEqualTo("2022-08-24")
+          assertThat(responseBody[1].arrivalDate).isEqualTo("2022-09-24")
+          assertThat(responseBody[2].arrivalDate).isEqualTo("2022-12-24")
         }
       }
     }


### PR DESCRIPTION
Use a `date` when returning arrival date in `Cas1ApplicationSummary` instead of a `date-time`. Ideally we’d be persisting this as a `date` only, as that’s how it is originally provided by the UI.

This ‘in-place’ change is safe as the UI only cares about the date element of the String, and we’ve tested this locally