### PR TITLE
APS-1032 Clarify /premises/{id}/… API support

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -587,6 +587,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewExtension,
   ): ResponseEntity<Extension> {
+    requestContextService.ensureCas3Request()
+
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
     when (booking.premises) {
@@ -619,7 +621,7 @@ class PremisesController(
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
     val user = usersService.getUserForRequest()
 
-    if (!userAccessService.currentUserCanManagePremisesBookings(booking.premises)) {
+    if (!userAccessService.currentUserCanChangeBookingDate(booking.premises)) {
       throw ForbiddenProblem()
     }
 
@@ -858,6 +860,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewTurnaround,
   ): ResponseEntity<Turnaround> {
+    requestContextService.ensureCas3Request()
+
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
     when (booking.premises) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -415,6 +415,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewArrival,
   ): ResponseEntity<Arrival> {
+    requestContextService.ensureCas3Request()
+
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
     val user = usersService.getUserForRequest()
@@ -513,6 +515,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewConfirmation,
   ): ResponseEntity<Confirmation> {
+    requestContextService.ensureCas3Request()
+
     val user = usersService.getUserForRequest()
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
@@ -548,6 +552,8 @@ class PremisesController(
     bookingId: UUID,
     body: NewDeparture,
   ): ResponseEntity<Departure> {
+    requestContextService.ensureCas3Request()
+
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
     val user = usersService.getUserForRequest()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt
@@ -308,7 +308,7 @@ class PremisesController(
 
     val user = usersService.getUserForRequest()
 
-    if (!userAccessService.userCanManagePremisesBookings(user, premises)) {
+    if (!userAccessService.userCanManageCas3PremisesBookings(user, premises)) {
       throw ForbiddenProblem()
     }
 
@@ -360,7 +360,7 @@ class PremisesController(
     val premises = premisesService.getPremises(premisesId)
       ?: throw NotFoundProblem(premisesId, "Premises")
 
-    if (!userAccessService.userCanManagePremisesBookings(user, premises)) {
+    if (!userAccessService.userCanManageCas3PremisesBookings(user, premises)) {
       throw ForbiddenProblem()
     }
 
@@ -421,7 +421,7 @@ class PremisesController(
 
     val user = usersService.getUserForRequest()
 
-    if (!userAccessService.userCanManagePremisesBookings(user, booking.premises)) {
+    if (!userAccessService.userCanManageCas3PremisesBookings(user, booking.premises)) {
       throw ForbiddenProblem()
     }
 
@@ -520,7 +520,7 @@ class PremisesController(
     val user = usersService.getUserForRequest()
     val booking = getBookingForPremisesOrThrow(premisesId, bookingId)
 
-    if (!userAccessService.userCanManagePremisesBookings(user, booking.premises)) {
+    if (!userAccessService.userCanManageCas3PremisesBookings(user, booking.premises)) {
       throw ForbiddenProblem()
     }
 
@@ -558,7 +558,7 @@ class PremisesController(
 
     val user = usersService.getUserForRequest()
 
-    if (!userAccessService.userCanManagePremisesBookings(user, booking.premises)) {
+    if (!userAccessService.userCanManageCas3PremisesBookings(user, booking.premises)) {
       throw ForbiddenProblem()
     }
 
@@ -593,7 +593,7 @@ class PremisesController(
 
     when (booking.premises) {
       is TemporaryAccommodationPremisesEntity -> {
-        if (!userAccessService.currentUserCanManagePremisesBookings(booking.premises)) {
+        if (!userAccessService.currentUserCanManageCas3PremisesBookings(booking.premises)) {
           throw ForbiddenProblem()
         }
 
@@ -866,7 +866,7 @@ class PremisesController(
 
     when (booking.premises) {
       is TemporaryAccommodationPremisesEntity -> {
-        if (!userAccessService.currentUserCanManagePremisesBookings(booking.premises)) {
+        if (!userAccessService.currentUserCanManageCas3PremisesBookings(booking.premises)) {
           throw ForbiddenProblem()
         }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3PremisesController.kt
@@ -130,7 +130,7 @@ class Cas3PremisesController(
 
     val user = userService.getUserForRequest()
 
-    if (!userAccessService.userCanManagePremisesBookings(user, booking.premises)) {
+    if (!userAccessService.userCanManageCas3PremisesBookings(user, booking.premises)) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
@@ -56,6 +56,10 @@ enum class UserPermission(val cas1ApiValue: ApprovedPremisesUserPermission?) {
   CAS1_VIEW_CRU_DASHBOARD(ApprovedPremisesUserPermission.viewCruDashboard),
   CAS1_VIEW_MANAGE_TASKS(ApprovedPremisesUserPermission.viewManageTasks),
   CAS1_VIEW_OUT_OF_SERVICE_BEDS(ApprovedPremisesUserPermission.viewOutOfServiceBeds),
+
+  /**
+   * Also allows for space booking modification
+   */
   CAS1_SPACE_BOOKING_CREATE(ApprovedPremisesUserPermission.spaceBookingCreate),
   CAS1_SPACE_BOOKING_LIST(ApprovedPremisesUserPermission.spaceBookingList),
   CAS1_SPACE_BOOKING_RECORD_ARRIVAL(ApprovedPremisesUserPermission.spaceBookingRecordArrival),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -65,6 +65,12 @@ class UserAccessService(
     else -> false
   }
 
+  fun currentUserCanChangeBookingDate(premises: PremisesEntity) = when (premises) {
+    is ApprovedPremisesEntity -> userService.getUserForRequest().hasPermission(UserPermission.CAS1_BOOKING_CHANGE_DATES)
+    is TemporaryAccommodationPremisesEntity -> currentUserCanManagePremisesBookings(premises)
+    else -> false
+  }
+
   fun currentUserCanManagePremisesBookings(premises: PremisesEntity) = userCanManagePremisesBookings(userService.getUserForRequest(), premises)
 
   fun userCanViewBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -67,20 +67,19 @@ class UserAccessService(
 
   fun currentUserCanChangeBookingDate(premises: PremisesEntity) = when (premises) {
     is ApprovedPremisesEntity -> userService.getUserForRequest().hasPermission(UserPermission.CAS1_BOOKING_CHANGE_DATES)
-    is TemporaryAccommodationPremisesEntity -> currentUserCanManagePremisesBookings(premises)
+    is TemporaryAccommodationPremisesEntity -> currentUserCanManageCas3PremisesBookings(premises)
     else -> false
   }
 
-  fun currentUserCanManagePremisesBookings(premises: PremisesEntity) = userCanManagePremisesBookings(userService.getUserForRequest(), premises)
+  fun currentUserCanManageCas3PremisesBookings(premises: PremisesEntity) = userCanManageCas3PremisesBookings(userService.getUserForRequest(), premises)
 
   fun userCanViewBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {
     is ApprovedPremisesEntity -> true
-    is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
+    is TemporaryAccommodationPremisesEntity -> userCanManageCas3PremisesBookings(user, booking.premises)
     else -> false
   }
 
-  fun userCanManagePremisesBookings(user: UserEntity, premises: PremisesEntity) = when (premises) {
-    is ApprovedPremisesEntity -> user.hasAnyRole(UserRole.CAS1_FUTURE_MANAGER, UserRole.CAS1_WORKFLOW_MANAGER)
+  fun userCanManageCas3PremisesBookings(user: UserEntity, premises: PremisesEntity) = when (premises) {
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, ServiceName.temporaryAccommodation, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false
   }
@@ -95,7 +94,7 @@ class UserAccessService(
    */
   fun userMayCancelBooking(user: UserEntity, booking: BookingEntity) = when (booking.premises) {
     is ApprovedPremisesEntity -> user.hasPermission(UserPermission.CAS1_BOOKING_WITHDRAW)
-    is TemporaryAccommodationPremisesEntity -> userCanManagePremisesBookings(user, booking.premises)
+    is TemporaryAccommodationPremisesEntity -> userCanManageCas3PremisesBookings(user, booking.premises)
     else -> false
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3BookingService.kt
@@ -474,7 +474,7 @@ class Cas3BookingService(
     val premises = cas3PremisesService.getPremises(premisesId)
       ?: return CasResult.NotFound("Premises", premisesId.toString())
 
-    if (!userAccessService.userCanManagePremisesBookings(user, premises)) {
+    if (!userAccessService.userCanManageCas3PremisesBookings(user, premises)) {
       return CasResult.Unauthorised()
     }
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -213,7 +213,7 @@ paths:
     post:
       tags:
         - Operations on bookings
-      summary: Posts an arrival to a specified booking
+      summary: Posts an arrival to a specified booking for CAS3
       operationId: premisesPremisesIdBookingsBookingIdArrivalsPost
       parameters:
         - name: premisesId
@@ -357,7 +357,7 @@ paths:
     post:
       tags:
         - Operations on bookings
-      summary: Posts a departure to a specified booking
+      summary: Posts a departure to a specified booking for CAS3
       operationId: premisesPremisesIdBookingsBookingIdDeparturesPost
       parameters:
         - name: premisesId

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -215,7 +215,7 @@ paths:
     post:
       tags:
         - Operations on bookings
-      summary: Posts an arrival to a specified booking
+      summary: Posts an arrival to a specified booking for CAS3
       operationId: premisesPremisesIdBookingsBookingIdArrivalsPost
       parameters:
         - name: premisesId
@@ -359,7 +359,7 @@ paths:
     post:
       tags:
         - Operations on bookings
-      summary: Posts a departure to a specified booking
+      summary: Posts a departure to a specified booking for CAS3
       operationId: premisesPremisesIdBookingsBookingIdDeparturesPost
       parameters:
         - name: premisesId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -3412,7 +3412,7 @@ class BookingTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_CRU_MEMBER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_CRU_MEMBER"])
     fun `CAS1 Date Change with correct role returns 200, persists date change and raises domain event`(role: UserRole) {
       govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/BookingTest.kt
@@ -1867,6 +1867,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -1929,6 +1930,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -1953,7 +1955,7 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Create Arrival updates arrival and departure date for a Temporary Accommodation booking`() {
     givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
-      givenAnOffender { offenderDetails, inmateDetails ->
+      givenAnOffender { offenderDetails, _ ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion { userEntity.probationRegion }
@@ -1980,6 +1982,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -2012,11 +2015,8 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Create Arrival and departure date for a Temporary Accommodation booking and emit arrival domain event for new arrival`() {
     givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
-      givenAnOffender { offenderDetails, inmateDetails ->
-        val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-          withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-          withYieldedProbationRegion { userEntity.probationRegion }
-        }
+      givenAnOffender { offenderDetails, _ ->
+        val premises = givenATemporaryAccommodationPremises(region = userEntity.probationRegion)
 
         val bed = bedEntityFactory.produceAndPersist {
           withYieldedRoom {
@@ -2039,6 +2039,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -2078,7 +2079,7 @@ class BookingTest : IntegrationTestBase() {
   @Test
   fun `Create Arrival updates arrival for a Temporary Accommodation booking with existing arrival and updated domain event send`() {
     givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
-      givenAnOffender { offenderDetails, inmateDetails ->
+      givenAnOffender { offenderDetails, _ ->
         val premises = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
           withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
           withYieldedProbationRegion { userEntity.probationRegion }
@@ -2107,6 +2108,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewCas3Arrival(
               type = "CAS3",
@@ -2250,12 +2252,7 @@ class BookingTest : IntegrationTestBase() {
         givenAnOffender { offenderDetails, inmateDetails ->
           val booking = bookingEntityFactory.produceAndPersist {
             withCrn(offenderDetails.otherIds.crn)
-            withYieldedPremises {
-              temporaryAccommodationPremisesEntityFactory.produceAndPersist {
-                withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
-                withYieldedProbationRegion { userEntity.probationRegion }
-              }
-            }
+            withPremises(givenATemporaryAccommodationPremises(region = userEntity.probationRegion))
             withServiceName(ServiceName.temporaryAccommodation)
             withArrivalDate(LocalDate.parse("2022-08-10"))
             withDepartureDate(LocalDate.parse("2022-08-30"))
@@ -2272,6 +2269,7 @@ class BookingTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("$baseUrl/${booking.premises.id}/bookings/${booking.id}/departures")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
             .bodyValue(
               NewDeparture(
                 dateTime = Instant.parse("2022-09-01T12:34:56.789Z"),
@@ -2336,6 +2334,7 @@ class BookingTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("/premises/${booking.premises.id}/bookings/${booking.id}/departures")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
             .bodyValue(
               NewDeparture(
                 dateTime = Instant.parse("2022-09-01T12:34:56.789Z"),
@@ -3082,6 +3081,7 @@ class BookingTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("/premises/${premises.id}/bookings/${booking.id}/extensions")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
             .bodyValue(
               NewExtension(
                 newDepartureDate = LocalDate.parse("2022-07-16"),
@@ -3152,6 +3152,7 @@ class BookingTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("/premises/${premises.id}/bookings/${booking.id}/extensions")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
             .bodyValue(
               NewExtension(
                 newDepartureDate = LocalDate.parse("2022-07-13"),
@@ -3213,6 +3214,7 @@ class BookingTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("/premises/${premises.id}/bookings/${booking.id}/extensions")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
             .bodyValue(
               NewExtension(
                 newDepartureDate = LocalDate.parse("2022-07-16"),
@@ -3282,6 +3284,7 @@ class BookingTest : IntegrationTestBase() {
           webTestClient.post()
             .uri("/premises/${premises.id}/bookings/${booking.id}/extensions")
             .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
             .bodyValue(
               NewExtension(
                 newDepartureDate = LocalDate.parse("2022-07-13"),
@@ -3409,7 +3412,7 @@ class BookingTest : IntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_WORKFLOW_MANAGER"])
+    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_CRU_MEMBER"])
     fun `CAS1 Date Change with correct role returns 200, persists date change and raises domain event`(role: UserRole) {
       govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
 
@@ -3478,66 +3481,6 @@ class BookingTest : IntegrationTestBase() {
       .isUnauthorized
   }
 
-  @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_WORKFLOW_MANAGER"])
-  fun `Create Confirmation on Approved Premises Booking returns OK with correct body when user has one of roles FUTURE_MANAGER, WORKFLOW_MANAGER`(
-    role: UserRole,
-  ) {
-    givenAUser(roles = listOf(role)) { userEntity, jwt ->
-      val booking = bookingEntityFactory.produceAndPersist {
-        withYieldedPremises {
-          givenAnApprovedPremises()
-        }
-        withServiceName(ServiceName.approvedPremises)
-      }
-
-      webTestClient.post()
-        .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(
-          NewConfirmation(
-            notes = null,
-          ),
-        )
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectBody()
-        .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
-        .jsonPath("$.dateTime").value(withinSeconds(5L), OffsetDateTime::class.java)
-        .jsonPath("$.notes").isEqualTo(null)
-        .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
-    }
-  }
-
-  @Test
-  fun `Create Confirmation on Approved Premises Booking on a premises that does not exist returns 404 Not Found`() {
-    givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-      val booking = bookingEntityFactory.produceAndPersist {
-        withYieldedPremises {
-          givenAnApprovedPremises()
-        }
-        withServiceName(ServiceName.approvedPremises)
-      }
-
-      val premisesId = UUID.randomUUID()
-
-      webTestClient.post()
-        .uri("/premises/$premisesId/bookings/${booking.id}/confirmations")
-        .header("Authorization", "Bearer $jwt")
-        .bodyValue(
-          NewConfirmation(
-            notes = null,
-          ),
-        )
-        .exchange()
-        .expectStatus()
-        .isNotFound
-        .expectBody()
-        .jsonPath("$.detail").isEqualTo("No Premises with an ID of $premisesId could be found")
-    }
-  }
-
   @Test
   fun `Create Confirmation on Temporary Accommodation Booking returns OK with correct body`() {
     givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
@@ -3556,6 +3499,7 @@ class BookingTest : IntegrationTestBase() {
       webTestClient.post()
         .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewConfirmation(
             notes = null,
@@ -3615,6 +3559,7 @@ class BookingTest : IntegrationTestBase() {
         webTestClient.post()
           .uri("/premises/${booking.premises.id}/bookings/${booking.id}/confirmations")
           .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
           .bodyValue(
             NewConfirmation(
               notes = null,
@@ -3776,6 +3721,7 @@ class BookingTest : IntegrationTestBase() {
     webTestClient.post()
       .uri(url)
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(requestBody)
       .exchange()
       .expectStatus()
@@ -3834,6 +3780,7 @@ class BookingTest : IntegrationTestBase() {
     webTestClient.post()
       .uri("/premises/${booking.premises.id}/bookings/${booking.id}/extensions")
       .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
       .bodyValue(
         NewExtension(
           newDepartureDate = LocalDate.parse(newDate),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TurnaroundTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewTurnaround
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -18,6 +19,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
       webTestClient.post()
         .uri("/premises/${UUID.randomUUID()}/bookings/${UUID.randomUUID()}/turnarounds")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewTurnaround(
             workingDays = 2,
@@ -44,6 +46,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
       webTestClient.post()
         .uri("/premises/${premises.id}/bookings/${UUID.randomUUID()}/turnarounds")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewTurnaround(
             workingDays = 2,
@@ -83,6 +86,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
       webTestClient.post()
         .uri("/premises/${premises.id}/bookings/${booking.id}/turnarounds")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewTurnaround(
             workingDays = -1,
@@ -125,6 +129,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
       webTestClient.post()
         .uri("/premises/$premisesId/bookings/${booking.id}/turnarounds")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewTurnaround(
             workingDays = -1,
@@ -175,6 +180,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
       webTestClient.post()
         .uri("/premises/${premises.id}/bookings/${booking.id}/turnarounds")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewTurnaround(
             workingDays = 2,
@@ -230,6 +236,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
       webTestClient.post()
         .uri("/premises/${premises.id}/bookings/${booking.id}/turnarounds")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewTurnaround(
             workingDays = 2,
@@ -273,6 +280,7 @@ class TurnaroundTest : InitialiseDatabasePerClassTestBase() {
       webTestClient.post()
         .uri("/premises/${premises.id}/bookings/${booking.id}/turnarounds")
         .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
         .bodyValue(
           NewTurnaround(
             workingDays = 2,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1FutureManagerUserAccessTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/Cas1FutureManagerUserAccessTest.kt
@@ -81,10 +81,5 @@ class Cas1FutureManagerUserAccessTest {
 
       assertThat(userAccessService.userCanViewBooking(futureManager, booking)).isTrue
     }
-
-    @Test
-    fun `may manage premises booking`() {
-      assertThat(userAccessService.userCanManagePremisesBookings(futureManager, approvedPremises)).isTrue
-    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -1434,4 +1434,51 @@ class UserAccessServiceTest {
       assertThat(userAccessService.userCanAccessTemporaryAccommodationApplication(user, application)).isFalse
     }
   }
+
+  @Nested
+  inner class CurrentUserCanChangeBookingDate {
+
+    @ParameterizedTest
+    @EnumSource(value = UserRole::class, names = [ "CAS1_CRU_MEMBER" ])
+    fun `returns true if the given premises is an Approved Premises and the current user has the CRU_MEMBER role`(role: UserRole) {
+      currentRequestIsFor(ServiceName.approvedPremises)
+
+      user.addRoleForUnitTest(role)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(approvedPremises)).isTrue
+    }
+
+    @Test
+    fun `returns false if the given premises is an Approved Premises and the current user has no suitable role`() {
+      currentRequestIsFor(ServiceName.approvedPremises)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(approvedPremises)).isFalse
+    }
+
+    @Test
+    fun `returns true if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+      currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+      user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(temporaryAccommodationPremisesInUserRegion)).isTrue
+    }
+
+    @Test
+    fun `returns false if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+      currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+      user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+    }
+
+    @Test
+    fun `returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
+      currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+      assertThat(userAccessService.currentUserCanChangeBookingDate(temporaryAccommodationPremisesInUserRegion)).isFalse
+      assertThat(userAccessService.currentUserCanChangeBookingDate(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -444,33 +444,14 @@ class UserAccessServiceTest {
   @Nested
   inner class UserCanManagePremisesBookings {
 
-    @ParameterizedTest
-    @EnumSource(value = UserRole::class, names = ["CAS1_FUTURE_MANAGER", "CAS1_WORKFLOW_MANAGER"])
-    fun `userCanManagePremisesBookings returns true if the given premises is a CAS1 premises and the user has either the FUTURE_MANAGER or MATCHER user role`(
-      role: UserRole,
-    ) {
-      currentRequestIsFor(ServiceName.approvedPremises)
-
-      user.addRoleForUnitTest(role)
-
-      assertThat(userAccessService.userCanManagePremisesBookings(user, approvedPremises)).isTrue
-    }
-
     @Test
-    fun `userCanManagePremisesBookings returns false if the given premises is a CAS1 premises and the user has no suitable role`() {
-      currentRequestIsFor(ServiceName.approvedPremises)
-
-      assertThat(userAccessService.userCanManagePremisesBookings(user, approvedPremises)).isFalse
-    }
-
-    @Test
-    fun `userCanManagePremisesBookings returns true if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+    fun `returns true if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
       user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
       assertThat(
-        userAccessService.userCanManagePremisesBookings(
+        userAccessService.userCanManageCas3PremisesBookings(
           user,
           temporaryAccommodationPremisesInUserRegion,
         ),
@@ -478,13 +459,13 @@ class UserAccessServiceTest {
     }
 
     @Test
-    fun `userCanManagePremisesBookings returns false if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+    fun `returns false if the given premises is a CAS3 premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
       user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
       assertThat(
-        userAccessService.userCanManagePremisesBookings(
+        userAccessService.userCanManageCas3PremisesBookings(
           user,
           temporaryAccommodationPremisesNotInUserRegion,
         ),
@@ -492,17 +473,17 @@ class UserAccessServiceTest {
     }
 
     @Test
-    fun `userCanManagePremisesBookings returns false if the given premises is a CAS3 premises and the user does not have a suitable role`() {
+    fun `returns false if the given premises is a CAS3 premises and the user does not have a suitable role`() {
       currentRequestIsFor(ServiceName.temporaryAccommodation)
 
       assertThat(
-        userAccessService.userCanManagePremisesBookings(
+        userAccessService.userCanManageCas3PremisesBookings(
           user,
           temporaryAccommodationPremisesInUserRegion,
         ),
       ).isFalse
       assertThat(
-        userAccessService.userCanManagePremisesBookings(
+        userAccessService.userCanManageCas3PremisesBookings(
           user,
           temporaryAccommodationPremisesNotInUserRegion,
         ),
@@ -623,47 +604,32 @@ class UserAccessServiceTest {
     }
   }
 
-  @ParameterizedTest
-  @EnumSource(value = UserRole::class, names = [ "CAS1_FUTURE_MANAGER" ])
-  fun `currentUserCanManagePremisesBookings returns true if the given premises is an Approved Premises and the current user has the FUTURE_MANAGER role`(role: UserRole) {
-    currentRequestIsFor(ServiceName.approvedPremises)
-
-    user.addRoleForUnitTest(role)
-
-    assertThat(userAccessService.currentUserCanManagePremisesBookings(approvedPremises)).isTrue
-  }
-
   @Test
-  fun `currentUserCanManagePremisesBookings returns false if the given premises is an Approved Premises and the current user has no suitable role`() {
-    currentRequestIsFor(ServiceName.approvedPremises)
-
-    assertThat(userAccessService.currentUserCanManagePremisesBookings(approvedPremises)).isFalse
-  }
-
-  @Test
-  fun `currentUserCanManagePremisesBookings returns true if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+  fun `currentUserCanManageCas3PremisesBookings returns true if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
-    assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesInUserRegion)).isTrue
+    assertThat(userAccessService.currentUserCanManageCas3PremisesBookings(temporaryAccommodationPremisesInUserRegion)).isTrue
   }
 
   @Test
-  fun `currentUserCanManagePremisesBookings returns false if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+  fun `currentUserCanManageCas3PremisesBookings returns false if the given premises is CAS3 premises and the current user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
-    assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+    assertThat(
+      userAccessService.currentUserCanManageCas3PremisesBookings(temporaryAccommodationPremisesNotInUserRegion),
+    ).isFalse
   }
 
   @Test
-  fun `currentUserCanManagePremisesBookings returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
+  fun `currentUserCanManageCas3PremisesBookings returns false if the given premises is a Temporary Accommodation premises and the user does not have a suitable role`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
-    assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesInUserRegion)).isFalse
-    assertThat(userAccessService.currentUserCanManagePremisesBookings(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+    assertThat(userAccessService.currentUserCanManageCas3PremisesBookings(temporaryAccommodationPremisesInUserRegion)).isFalse
+    assertThat(userAccessService.currentUserCanManageCas3PremisesBookings(temporaryAccommodationPremisesNotInUserRegion)).isFalse
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3BookingServiceTest.kt
@@ -253,7 +253,7 @@ class Cas3BookingServiceTest {
     @Test
     fun `findFutureBookingsForPremises returns Unauthorised if the user cannot view the bookings`() {
       every { mockCas3PremisesService.getPremises(premises.id) } returns premises
-      every { mockUserAccessService.userCanManagePremisesBookings(user, premises) } returns false
+      every { mockUserAccessService.userCanManageCas3PremisesBookings(user, premises) } returns false
 
       val result = cas3BookingService.findFutureBookingsForPremises(premises.id, listOf(BookingStatus.provisional), user)
 
@@ -303,7 +303,7 @@ class Cas3BookingServiceTest {
           user.cas3LaoStrategy(),
         )
       } returns listOf(fullPersonSummaryInfo, restrictedPersonSummaryInfo)
-      every { mockUserAccessService.userCanManagePremisesBookings(user, premises) } returns true
+      every { mockUserAccessService.userCanManageCas3PremisesBookings(user, premises) } returns true
       every {
         mockBookingRepository.findFutureBookingsByPremisesIdAndStatus(
           ServiceName.temporaryAccommodation.value,


### PR DESCRIPTION
This PR makes it clear that arrival, departure and confirmation endpoints on ` /premises/{premisesId}/bookings/…` are not supported by CAS1, and adds an explicit check on the API call to verify this.

It then introduces a user access function `currentUserCanChangeBookingDate ` that allows us to remove all CAS1 usage of the function `currentUserCanManagePremisesBookings `

This change is being made as part of removing the workflow manager role. This removes the last usage of CAS1_WORKFLOW_MANAGER from the 'main' codebase