### PR TITLE
Fix CAS1 test instability

### DIFF
--- a/src/main/resources/static/codegen/built-cas1-roles.json
+++ b/src/main/resources/static/codegen/built-cas1-roles.json
@@ -34,7 +34,6 @@
       "cas1_booking_withdraw",
       "cas1_premises_view",
       "cas1_request_for_placement_withdraw_others",
-      "cas1_tasks_list",
       "cas1_view_cru_dashboard",
       "cas1_view_manage_tasks"
     ]

--- a/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
@@ -3393,6 +3393,7 @@ components:
         - update_cas1_backfill_user_ap_area
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
+        - update_cas3_bedspace_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name
@@ -4690,6 +4691,70 @@ components:
         - id
         - reference
         - characteristics
+    Cas3Premises:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        reference:
+          type: string
+          example: Hope House
+        addressLine1:
+          type: string
+          example: one something street
+        addressLine2:
+          type: string
+          example: Blackmore End
+        town:
+          type: string
+          example: Braintree
+        postcode:
+          type: string
+          example: LS1 3AD
+        localAuthorityArea:
+          $ref: '#/components/schemas/LocalAuthorityArea'
+        probationRegion:
+          $ref: '#/components/schemas/ProbationRegion'
+        probationDeliveryUnit:
+          $ref: '#/components/schemas/ProbationDeliveryUnit'
+        characteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Characteristic'
+        startDate:
+          type: string
+          format: date
+          example: 2024-03-30
+          description: Start date of the property.
+        status:
+          $ref: '#/components/schemas/Cas3PremisesStatus'
+        notes:
+          type: string
+          example: some notes about this property
+        turnaroundWorkingDayCount:
+          type: integer
+          example: 2
+        totalOnlineBedspaces:
+          type: integer
+          example: 5
+        totalUpcomingBedspaces:
+          type: integer
+          example: 1
+        totalArchivedBedspaces:
+          type: integer
+          example: 2
+      required:
+        - id
+        - reference
+        - addressLine1
+        - postcode
+        - probationRegion
+        - probationDeliveryUnit
+        - status
+        - totalOnlineBedspaces
+        - totalUpcomingBedspaces
+        - totalArchivedBedspaces
     Cas3NewBedspace:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -844,7 +844,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             .isOk
             .bodyAsListOfObjects<Cas1ApplicationSummary>()
 
-          val sortedDates = createdApplications.map { it.createdAt.toString() }.sorted()
+          val sortedDates = createdApplications.map { it.createdAt.toInstant() }.sorted()
 
           assertThat(responseBody.count()).isEqualTo(12)
 


### PR DESCRIPTION
This test could previously fail with errors like the following:

```
  java.time.format.DateTimeParseException: Text '2025-05-22T05:22Z' could not be parsed at index 16
      at uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1ApplicationTest$GetApplicationsMe.Get_applications_me_returns_twelve_items_sorted_by_created_at_asc$lambda$3$lambda$2(Cas1ApplicationTest.kt:852)
```

I think this happens when the time is on 0 seconds. This commit should fix that issue by no longer converting dates to a string.

This commit also adds some generated components missed by prioir commits

