### PR TITLE
Feature/cas 1634 remove deprecated application summary code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationsController.kt
@@ -32,34 +32,24 @@ class Cas2ApplicationsController(
   private val userService: NomisUserService,
 ) : ApplicationsCas2Delegate {
 
-  override fun getCas2Applications(
-    isSubmitted: Boolean?,
+  override fun getCas2ApplicationSummaries(
+    assignmentType: AssignmentType,
     page: Int?,
-    prisonCode: String?,
-    assignmentType: AssignmentType?,
   ): ResponseEntity<List<Cas2ApplicationSummary>> {
     val user = userService.getUserForRequest()
 
-    prisonCode?.let { if (user.activeCaseloadId == null || prisonCode != user.activeCaseloadId) throw ForbiddenProblem() }
+    if (user.activeCaseloadId == null) throw ForbiddenProblem()
 
     val pageCriteria = PageCriteria("createdAt", SortDirection.desc, page)
 
-    if (assignmentType != null) {
-      val (results, metadata) = applicationService.getApplicationSummaries(
-        user,
-        pageCriteria,
-        assignmentType,
-      )
-      return ResponseEntity.ok().headers(
-        metadata?.toHeaders(),
-      ).body(getPersonNamesAndTransformToSummaries(results))
-    }
-
-    val (applications, metadata) = applicationService.getApplications(prisonCode, isSubmitted, user, pageCriteria)
-
+    val (results, metadata) = applicationService.getApplicationSummaries(
+      user,
+      pageCriteria,
+      assignmentType,
+    )
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),
-    ).body(getPersonNamesAndTransformToSummaries(applications))
+    ).body(getPersonNamesAndTransformToSummaries(results))
   }
 
   override fun getCas2Application(applicationId: UUID): ResponseEntity<Cas2Application> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationSummaryEntity.kt
@@ -38,17 +38,7 @@ interface ApplicationSummaryRepository : JpaRepository<Cas2ApplicationSummaryEnt
 
   fun findAllByIdIn(ids: List<UUID>, pageable: Pageable): Page<Cas2ApplicationSummaryEntity>
 
-  fun findByUserId(userId: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
-
-  fun findByUserIdAndSubmittedAtIsNotNull(userId: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
-
-  fun findByUserIdAndSubmittedAtIsNull(userId: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
-
   fun findByPrisonCode(prisonCode: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
-
-  fun findByPrisonCodeAndSubmittedAtIsNotNull(prisonCode: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
-
-  fun findByPrisonCodeAndSubmittedAtIsNull(prisonCode: String, pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
 
   fun findBySubmittedAtIsNotNull(pageable: Pageable?): Page<Cas2ApplicationSummaryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
@@ -99,34 +99,6 @@ class Cas2ApplicationService(
     return Pair(response.content, metadata)
   }
 
-  val repositoryUserFunctionMap = mapOf(
-    null to applicationSummaryRepository::findByUserId,
-    true to applicationSummaryRepository::findByUserIdAndSubmittedAtIsNotNull,
-    false to applicationSummaryRepository::findByUserIdAndSubmittedAtIsNull,
-  )
-
-  val repositoryPrisonFunctionMap = mapOf(
-    null to applicationSummaryRepository::findByPrisonCode,
-    true to applicationSummaryRepository::findByPrisonCodeAndSubmittedAtIsNotNull,
-    false to applicationSummaryRepository::findByPrisonCodeAndSubmittedAtIsNull,
-  )
-
-  @Deprecated(message = "This will be removed when the UI begins passing the assignmentType parameter")
-  fun getApplications(
-    prisonCode: String?,
-    isSubmitted: Boolean?,
-    user: NomisUserEntity,
-    pageCriteria: PageCriteria<String>,
-  ): Pair<MutableList<Cas2ApplicationSummaryEntity>, PaginationMetadata?> {
-    val response = if (prisonCode == null) {
-      repositoryUserFunctionMap.get(isSubmitted)!!(user.id.toString(), getPageableOrAllPages(pageCriteria))
-    } else {
-      repositoryPrisonFunctionMap.get(isSubmitted)!!(prisonCode, getPageableOrAllPages(pageCriteria))
-    }
-    val metadata = getMetadata(response, pageCriteria)
-    return Pair(response.content, metadata)
-  }
-
   fun findMostRecentApplication(nomsNumber: String): Cas2ApplicationEntity? = applicationRepository.findFirstByNomsNumberAndSubmittedAtIsNotNullOrderBySubmittedAtDesc(nomsNumber)
 
   fun findApplicationToAssign(nomsNumber: String): Cas2ApplicationEntity? = findMostRecentApplication(nomsNumber)?.takeIf { !it.isMostRecentStatusUpdateANonAssignableStatus() }

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -42,26 +42,16 @@ paths:
       tags:
         - Operations on CAS2 applications
       summary: List summaries of all CAS2 applications authorised for the logged in user
-      operationId: getCas2Applications
+      operationId: getCas2ApplicationSummaries
       parameters:
-        - name: isSubmitted
-          deprecated: true
-          in: query
-          description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
-          schema:
-            type: boolean
         - name: page
           in: query
           description: Page number of results to return.  If blank, returns all results
           schema:
             type: integer
-        - name: prisonCode
-          in: query
-          description: Prison code of applications to return.  If blank, returns all results.
-          schema:
-            type: string
         - name: assignmentType
           in: query
+          required: true
           description: The relationship of the application to the user - created by them, allocated to them, deallocated from them, or unallocated & in the same prison. All applications returned are submitted.
           schema:
             $ref: 'cas2-schemas.yml#/components/schemas/AssignmentType'

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -44,26 +44,16 @@ paths:
       tags:
         - Operations on CAS2 applications
       summary: List summaries of all CAS2 applications authorised for the logged in user
-      operationId: getCas2Applications
+      operationId: getCas2ApplicationSummaries
       parameters:
-        - name: isSubmitted
-          deprecated: true
-          in: query
-          description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
-          schema:
-            type: boolean
         - name: page
           in: query
           description: Page number of results to return.  If blank, returns all results
           schema:
             type: integer
-        - name: prisonCode
-          in: query
-          description: Prison code of applications to return.  If blank, returns all results.
-          schema:
-            type: string
         - name: assignmentType
           in: query
+          required: true
           description: The relationship of the application to the user - created by them, allocated to them, deallocated from them, or unallocated & in the same prison. All applications returned are submitted.
           schema:
             $ref: '#/components/schemas/AssignmentType'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationServiceTest.kt
@@ -56,7 +56,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -320,127 +319,6 @@ class Cas2ApplicationServiceTest {
 
         )
       }
-    }
-  }
-
-  @Nested
-  inner class GetApplicationsWithPrisonCode {
-    val applicationSummary = Cas2ApplicationSummaryEntityFactory.produce()
-    val page = mockk<Page<Cas2ApplicationSummaryEntity>>()
-    val pageCriteria = PageCriteria(sortBy = "submitted_at", sortDirection = SortDirection.asc, page = 3)
-    val user = NomisUserEntityFactory().produce()
-    val prisonCode = "BRI"
-
-    fun testPrisonCodeWithIsSubmitted(isSubmitted: Boolean?) {
-      every { page.content } returns listOf(applicationSummary)
-      every { page.totalPages } returns 10
-      every { page.totalElements } returns 100
-
-      val (applicationSummaries, _) = applicationService.getApplications(prisonCode, isSubmitted, user, pageCriteria)
-
-      assertThat(applicationSummaries).isEqualTo(listOf(applicationSummary))
-    }
-
-    @Test
-    fun `return all applications when prisonCode is specified and isSubmitted is null`() {
-      PaginationConfig(defaultPageSize = 10).postInit()
-
-      every {
-        mockApplicationSummaryRepository.findByPrisonCode(
-          prisonCode,
-          getPageableOrAllPages(pageCriteria),
-        )
-      } returns page
-
-      testPrisonCodeWithIsSubmitted(null)
-    }
-
-    @Test
-    fun `return submitted prison applications when prisonCode is specified and isSubmitted is true`() {
-      PaginationConfig(defaultPageSize = 10).postInit()
-
-      every {
-        mockApplicationSummaryRepository.findByPrisonCodeAndSubmittedAtIsNotNull(
-          prisonCode,
-          getPageableOrAllPages(pageCriteria),
-        )
-      } returns page
-
-      testPrisonCodeWithIsSubmitted(true)
-    }
-
-    @Test
-    fun `return unsubmitted prison applications when prisonCode is specified and isSubmitted is false`() {
-      PaginationConfig(defaultPageSize = 10).postInit()
-
-      every {
-        mockApplicationSummaryRepository.findByPrisonCodeAndSubmittedAtIsNull(
-          prisonCode,
-          getPageableOrAllPages(pageCriteria),
-        )
-      } returns page
-
-      testPrisonCodeWithIsSubmitted(false)
-    }
-  }
-
-  @Nested
-  inner class GetApplicationsWithoutPrisonCode {
-    val applicationSummary = Cas2ApplicationSummaryEntityFactory.produce()
-    val page = mockk<Page<Cas2ApplicationSummaryEntity>>()
-    val pageCriteria = PageCriteria(sortBy = "createdAt", sortDirection = SortDirection.asc, page = 3)
-    val user = NomisUserEntityFactory().withId(UUID.fromString(applicationSummary.getCreatedById())).produce()
-
-    fun testNullPrisonCodeWithIsSubmitted(isSubmitted: Boolean?) {
-      every { page.content } returns listOf(applicationSummary)
-      every { page.totalPages } returns 10
-      every { page.totalElements } returns 100
-
-      val (applicationSummaries, _) = applicationService.getApplications(null, isSubmitted, user, pageCriteria)
-
-      assertThat(applicationSummaries).isEqualTo(listOf(applicationSummary))
-    }
-
-    @Test
-    fun `return submitted prison applications when prisonCode is null and isSubmitted is null`() {
-      PaginationConfig(defaultPageSize = 10).postInit()
-
-      every {
-        mockApplicationSummaryRepository.findByUserId(
-          applicationSummary.getCreatedById(),
-          getPageableOrAllPages(pageCriteria),
-        )
-      } returns page
-
-      testNullPrisonCodeWithIsSubmitted(null)
-    }
-
-    @Test
-    fun `return submitted prison applications when prisonCode is null and isSubmitted is true`() {
-      PaginationConfig(defaultPageSize = 10).postInit()
-
-      every {
-        mockApplicationSummaryRepository.findByUserIdAndSubmittedAtIsNotNull(
-          applicationSummary.getCreatedById(),
-          getPageableOrAllPages(pageCriteria),
-        )
-      } returns page
-
-      testNullPrisonCodeWithIsSubmitted(true)
-    }
-
-    @Test
-    fun `return unsubmitted prison applications when prisonCode is null and isSubmitted is false`() {
-      PaginationConfig(defaultPageSize = 10).postInit()
-
-      every {
-        mockApplicationSummaryRepository.findByUserIdAndSubmittedAtIsNull(
-          applicationSummary.getCreatedById(),
-          getPageableOrAllPages(pageCriteria),
-        )
-      } returns page
-
-      testNullPrisonCodeWithIsSubmitted(false)
     }
   }
 


### PR DESCRIPTION
This removes deprecated code that is no longer used, and updates the integration tests to work with the new code, which uses assignmentType enum as a url parameter.