### PR TITLE
APS-1032 Temporarily re-add all permissions to workflow man

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserRole.kt
@@ -67,6 +67,8 @@ enum class UserRole(val service: ServiceName, val cas1ApiValue: ApprovedPremises
       UserPermission.CAS1_BOOKING_WITHDRAW,
       UserPermission.CAS1_PREMISES_VIEW,
       UserPermission.CAS1_REQUEST_FOR_PLACEMENT_WITHDRAW_OTHERS,
+      UserPermission.CAS1_TASKS_LIST,
+      UserPermission.CAS1_USER_LIST,
       UserPermission.CAS1_VIEW_CRU_DASHBOARD,
       UserPermission.CAS1_VIEW_MANAGE_TASKS,
     ),

--- a/src/main/resources/static/codegen/built-cas1-roles.json
+++ b/src/main/resources/static/codegen/built-cas1-roles.json
@@ -34,6 +34,8 @@
       "cas1_booking_withdraw",
       "cas1_premises_view",
       "cas1_request_for_placement_withdraw_others",
+      "cas1_tasks_list",
+      "cas1_user_list",
       "cas1_view_cru_dashboard",
       "cas1_view_manage_tasks"
     ]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UsersTest.kt
@@ -25,7 +25,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(
       value = UserRole::class,
-      names = ["CAS1_CRU_MEMBER", "CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA", "CAS1_JANITOR", "CAS1_USER_MANAGER"],
+      names = ["CAS1_WORKFLOW_MANAGER", "CAS1_CRU_MEMBER", "CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA", "CAS1_JANITOR", "CAS1_USER_MANAGER"],
       mode = EnumSource.Mode.EXCLUDE,
     )
     fun `GET users with an unapproved role is forbidden`(role: UserRole) {
@@ -377,7 +377,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(
       value = UserRole::class,
-      names = ["CAS1_CRU_MEMBER", "CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA", "CAS1_JANITOR", "CAS1_USER_MANAGER"],
+      names = ["CAS1_WORKFLOW_MANAGER", "CAS1_CRU_MEMBER", "CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA", "CAS1_JANITOR", "CAS1_USER_MANAGER"],
       mode = EnumSource.Mode.EXCLUDE,
     )
     fun `GET user summary with an unapproved role is forbidden`(role: UserRole) {
@@ -666,7 +666,7 @@ class UsersTest : InitialiseDatabasePerClassTestBase() {
     @ParameterizedTest
     @EnumSource(
       value = UserRole::class,
-      names = ["CAS1_CRU_MEMBER", "CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA", "CAS1_JANITOR", "CAS1_USER_MANAGER"],
+      names = ["CAS1_WORKFLOW_MANAGER", "CAS1_CRU_MEMBER", "CAS1_CRU_MEMBER_FIND_AND_BOOK_BETA", "CAS1_JANITOR", "CAS1_USER_MANAGER"],
       mode = EnumSource.Mode.EXCLUDE,
     )
     fun `GET to user search with an unapproved role is forbidden`(role: UserRole) {


### PR DESCRIPTION
This is being done until we can ensure that all users in production that currently rely on this role have been migrated to an appropriate other rule (e.g. cru member)

