### PR TITLE
Move to CAS3 models for GET /cas3/v2/premises/{premisesId}/bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/v2/Cas3v2PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/v2/Cas3v2PremisesController.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.runBlocking
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas3.v2.PremisesCas3v2Delegate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
@@ -26,7 +26,7 @@ class Cas3v2PremisesController(
   private val bookingTransformer: Cas3BookingTransformer,
 ) : PremisesCas3v2Delegate {
 
-  override fun premisesPremisesIdBookingsGet(premisesId: UUID): ResponseEntity<List<Booking>> = runBlocking {
+  override fun premisesPremisesIdBookingsGet(premisesId: UUID): ResponseEntity<List<Cas3Booking>> = runBlocking {
     val premises = cas3PremisesService.getPremises(premisesId)
       ?: throw NotFoundProblem(premisesId, "Premises")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BookingEntity.kt
@@ -82,6 +82,10 @@ data class Cas3BookingEntity(
   val arrival: Cas3ArrivalEntity?
     get() = arrivals.maxByOrNull { it.createdAt }
 
+  fun hasNonZeroDayTurnaround() = turnaround != null && turnaround!!.workingDayCount != 0
+
+  fun hasZeroDayTurnaround() = turnaround == null || turnaround!!.workingDayCount == 0
+
   fun isActive() = !isCancelled
 
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ArrivalTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ArrivalTransformer.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Arrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ArrivalEntity
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -9,7 +9,7 @@ import java.time.format.DateTimeFormatter
 @Component
 class Cas3ArrivalTransformer {
   fun transformJpaToApi(jpa: Cas3ArrivalEntity?) = jpa?.let {
-    Arrival(
+    Cas3Arrival(
       bookingId = jpa.booking.id,
       arrivalDate = jpa.arrivalDate,
       arrivalTime = DateTimeFormatter.ISO_LOCAL_TIME.format(jpa.arrivalDateTime.atZone(ZoneOffset.UTC)),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BedspaceCharacteristicTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BedspaceCharacteristicTransformer.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3BedspaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspaceCharacteristicEntity
+
+@Component
+class Cas3BedspaceCharacteristicTransformer {
+
+  fun transformJpaToApi(jpa: Cas3BedspaceCharacteristicEntity) = Cas3BedspaceCharacteristic(
+    id = jpa.id,
+    name = jpa.name,
+    description = jpa.description,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BedspaceTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BedspaceTransformer.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Bed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Bedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3BedspaceStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.Characterist
 @Component
 class Cas3BedspaceTransformer(
   private val characteristicTransformer: CharacteristicTransformer,
+  private val cas3BedspaceCharacteristicTransformer: Cas3BedspaceCharacteristicTransformer,
 ) {
   fun transformJpaToApi(bed: BedEntity) = Cas3Bedspace(
     id = bed.id,
@@ -21,10 +22,13 @@ class Cas3BedspaceTransformer(
     characteristics = bed.room.characteristics.map(characteristicTransformer::transformJpaToApi),
   )
 
-  fun transformJpaToApi(jpa: Cas3BedspacesEntity) = Bed(
+  fun transformJpaToApi(jpa: Cas3BedspacesEntity) = Cas3Bedspace(
     id = jpa.id,
-    name = jpa.reference,
-    code = null,
-    bedEndDate = jpa.endDate,
+    reference = jpa.reference,
+    startDate = jpa.startDate,
+    endDate = jpa.endDate,
+    notes = jpa.notes,
+    status = Cas3BedspaceStatus.online, // sets online as default for now - will change when we get there
+    bedspaceCharacteristics = jpa.characteristics.map(cas3BedspaceCharacteristicTransformer::transformJpaToApi),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3CancellationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3CancellationTransformer.kt
@@ -1,14 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Cancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 
 @Component
 class Cas3CancellationTransformer(private val cancellationReasonTransformer: CancellationReasonTransformer) {
   fun transformJpaToApi(jpa: Cas3CancellationEntity?) = jpa?.let {
-    Cancellation(
+    Cas3Cancellation(
       id = jpa.id,
       bookingId = jpa.booking.id,
       date = jpa.date,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ConfirmationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ConfirmationTransformer.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
@@ -17,8 +18,8 @@ class Cas3ConfirmationTransformer {
     )
   }
 
-  fun transformJpaToApi(jpa: Cas3v2ConfirmationEntity?): Confirmation? = jpa?.let {
-    Confirmation(
+  fun transformJpaToApi(jpa: Cas3v2ConfirmationEntity?) = jpa?.let {
+    Cas3Confirmation(
       id = it.id,
       bookingId = it.booking.id,
       dateTime = it.dateTime.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3DepartureTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3DepartureTransformer.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Departure
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Departure
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
@@ -26,7 +25,7 @@ class Cas3DepartureTransformer(
   }
 
   fun transformJpaToApi(jpa: Cas3DepartureEntity?) = jpa?.let {
-    Departure(
+    Cas3Departure(
       id = jpa.id,
       bookingId = jpa.booking.id,
       dateTime = jpa.dateTime.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ExtensionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3ExtensionTransformer.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Extension
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Extension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ExtensionEntity
 
 @Component
 class Cas3ExtensionTransformer {
-  fun transformJpaToApi(jpa: Cas3ExtensionEntity) = Extension(
+  fun transformJpaToApi(jpa: Cas3ExtensionEntity) = Cas3Extension(
     id = jpa.id,
     bookingId = jpa.booking.id,
     previousDepartureDate = jpa.previousDepartureDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3NonArrivalTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3NonArrivalTransformer.kt
@@ -1,14 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Nonarrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3NonArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalReasonTransformer
 
 @Component
 class Cas3NonArrivalTransformer(private val nonArrivalReasonTransformer: NonArrivalReasonTransformer) {
   fun transformJpaToApi(jpa: Cas3NonArrivalEntity?) = jpa?.let {
-    Nonarrival(
+    Cas3NonArrival(
       id = jpa.id,
       bookingId = jpa.booking.id,
       date = jpa.date,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3TurnaroundTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3TurnaroundTransformer.kt
@@ -1,9 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Turnaround
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Turnaround
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3TurnaroundEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundEntity as Cas3v2TurnaroundEntity
 
 @Component
 class Cas3TurnaroundTransformer {
@@ -14,7 +15,7 @@ class Cas3TurnaroundTransformer {
     createdAt = jpa.createdAt.toInstant(),
   )
 
-  fun transformJpaToApi(jpa: Cas3v2TurnaroundEntity) = Turnaround(
+  fun transformJpaToApi(jpa: Cas3v2TurnaroundEntity) = Cas3Turnaround(
     id = jpa.id,
     bookingId = jpa.booking.id,
     workingDays = jpa.workingDayCount,

--- a/src/main/resources/static/cas3-schemas.yml
+++ b/src/main/resources/static/cas3-schemas.yml
@@ -245,11 +245,14 @@ components:
           type: array
           items:
             $ref: '_shared.yml#/components/schemas/Characteristic'
+        bedspaceCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3BedspaceCharacteristic'
       required:
         - id
         - reference
         - status
-        - characteristics
     Cas3Premises:
       type: object
       properties:
@@ -635,3 +638,295 @@ components:
           format: date-time
       required:
         - hasApplicableAssessment
+    Cas3Booking:
+      allOf:
+        - $ref: '#/components/schemas/Cas3BookingBody'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/Cas3BookingStatus'
+            extensions:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Extension'
+            arrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Arrival'
+            departure:
+              description: The latest version of the departure, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Departure'
+            departures:
+              description: The full history of the departure
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Departure'
+            nonArrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3NonArrival'
+            cancellation:
+              description: The latest version of the cancellation, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Cancellation'
+            cancellations:
+              description: The full history of the cancellation
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Cancellation'
+            confirmation:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Confirmation'
+            turnaround:
+              description: The latest version of the turnaround, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Turnaround'
+            turnarounds:
+              description: The full history of turnarounds
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Turnaround'
+            turnaroundStartDate:
+              type: string
+              format: date
+            effectiveEndDate:
+              type: string
+              format: date
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
+            premises:
+              $ref: '#/components/schemas/Cas3BookingPremisesSummary'
+          required:
+            - status
+            - extensions
+            - departures
+            - cancellations
+            - premises
+    Cas3BookingBody:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '_shared.yml#/components/schemas/Person'
+        arrivalDate:
+          type: string
+          format: date
+        originalArrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        originalDepartureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        bedspace:
+          $ref: '#/components/schemas/Cas3Bedspace'
+      required:
+        - id
+        - person
+        - arrivalDate
+        - originalArrivalDate
+        - departureDate
+        - originalDepartureDate
+        - createdAt
+        - bedspace
+    Cas3BookingStatus:
+      type: string
+      enum:
+        - arrived
+        - notMinusArrived
+        - departed
+        - cancelled
+        - provisional
+        - confirmed
+        - closed
+    Cas3Extension:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        previousDepartureDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - previousDepartureDate
+        - newDepartureDate
+        - createdAt
+    Cas3Arrival:
+      type: object
+      properties:
+        expectedDepartureDate:
+          type: string
+          format: date
+        arrivalDate:
+          type: string
+          format: date
+        arrivalTime:
+          type: string
+          format: time
+        notes:
+          type: string
+        bookingId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - type
+        - bookingId
+        - expectedDepartureDate
+        - createdAt
+        - arrivalDate
+        - arrivalTime
+    Cas3NonArrival:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '_shared.yml#/components/schemas/NonArrivalReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - date
+        - reason
+        - createdAt
+    Cas3Cancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '_shared.yml#/components/schemas/CancellationReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        premisesName:
+          type: string
+        otherReason:
+          type: string
+      required:
+        - bookingId
+        - date
+        - reason
+        - createdAt
+        - premisesName
+    Cas3Confirmation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - dateTime
+        - createdAt
+    Cas3Turnaround:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        workingDays:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - workingDays
+        - createdAt
+    Cas3BookingPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    Cas3BedspaceCharacteristic:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        description:
+          type: string
+          example: Is this premises catered (rather than self-catered)?
+        name:
+          type: string
+          example: isCatered
+      required:
+        - id
+        - description

--- a/src/main/resources/static/cas3v2-api.yml
+++ b/src/main/resources/static/cas3v2-api.yml
@@ -27,4 +27,4 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '_shared.yml#/components/schemas/Booking'
+                  $ref: 'cas3-schemas.yml#/components/schemas/Cas3Booking'

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -5210,11 +5210,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Characteristic'
+        bedspaceCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3BedspaceCharacteristic'
       required:
         - id
         - reference
         - status
-        - characteristics
     Cas3Premises:
       type: object
       properties:
@@ -5600,3 +5603,295 @@ components:
           format: date-time
       required:
         - hasApplicableAssessment
+    Cas3Booking:
+      allOf:
+        - $ref: '#/components/schemas/Cas3BookingBody'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/Cas3BookingStatus'
+            extensions:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Extension'
+            arrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Arrival'
+            departure:
+              description: The latest version of the departure, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Departure'
+            departures:
+              description: The full history of the departure
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Departure'
+            nonArrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3NonArrival'
+            cancellation:
+              description: The latest version of the cancellation, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Cancellation'
+            cancellations:
+              description: The full history of the cancellation
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Cancellation'
+            confirmation:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Confirmation'
+            turnaround:
+              description: The latest version of the turnaround, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Turnaround'
+            turnarounds:
+              description: The full history of turnarounds
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Turnaround'
+            turnaroundStartDate:
+              type: string
+              format: date
+            effectiveEndDate:
+              type: string
+              format: date
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
+            premises:
+              $ref: '#/components/schemas/Cas3BookingPremisesSummary'
+          required:
+            - status
+            - extensions
+            - departures
+            - cancellations
+            - premises
+    Cas3BookingBody:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        arrivalDate:
+          type: string
+          format: date
+        originalArrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        originalDepartureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        bedspace:
+          $ref: '#/components/schemas/Cas3Bedspace'
+      required:
+        - id
+        - person
+        - arrivalDate
+        - originalArrivalDate
+        - departureDate
+        - originalDepartureDate
+        - createdAt
+        - bedspace
+    Cas3BookingStatus:
+      type: string
+      enum:
+        - arrived
+        - notMinusArrived
+        - departed
+        - cancelled
+        - provisional
+        - confirmed
+        - closed
+    Cas3Extension:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        previousDepartureDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - previousDepartureDate
+        - newDepartureDate
+        - createdAt
+    Cas3Arrival:
+      type: object
+      properties:
+        expectedDepartureDate:
+          type: string
+          format: date
+        arrivalDate:
+          type: string
+          format: date
+        arrivalTime:
+          type: string
+          format: time
+        notes:
+          type: string
+        bookingId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - type
+        - bookingId
+        - expectedDepartureDate
+        - createdAt
+        - arrivalDate
+        - arrivalTime
+    Cas3NonArrival:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/NonArrivalReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - date
+        - reason
+        - createdAt
+    Cas3Cancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/CancellationReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        premisesName:
+          type: string
+        otherReason:
+          type: string
+      required:
+        - bookingId
+        - date
+        - reason
+        - createdAt
+        - premisesName
+    Cas3Confirmation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - dateTime
+        - createdAt
+    Cas3Turnaround:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        workingDays:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - workingDays
+        - createdAt
+    Cas3BookingPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    Cas3BedspaceCharacteristic:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        description:
+          type: string
+          example: Is this premises catered (rather than self-catered)?
+        name:
+          type: string
+          example: isCatered
+      required:
+        - id
+        - description

--- a/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
@@ -29,7 +29,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Booking'
+                  $ref: '#/components/schemas/Cas3Booking'
 components:
   headers:
     X-Pagination-CurrentPage:
@@ -4712,11 +4712,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Characteristic'
+        bedspaceCharacteristics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cas3BedspaceCharacteristic'
       required:
         - id
         - reference
         - status
-        - characteristics
     Cas3Premises:
       type: object
       properties:
@@ -5102,3 +5105,295 @@ components:
           format: date-time
       required:
         - hasApplicableAssessment
+    Cas3Booking:
+      allOf:
+        - $ref: '#/components/schemas/Cas3BookingBody'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/Cas3BookingStatus'
+            extensions:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Extension'
+            arrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Arrival'
+            departure:
+              description: The latest version of the departure, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Departure'
+            departures:
+              description: The full history of the departure
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Departure'
+            nonArrival:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3NonArrival'
+            cancellation:
+              description: The latest version of the cancellation, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Cancellation'
+            cancellations:
+              description: The full history of the cancellation
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Cancellation'
+            confirmation:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Confirmation'
+            turnaround:
+              description: The latest version of the turnaround, if it exists
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Cas3Turnaround'
+            turnarounds:
+              description: The full history of turnarounds
+              type: array
+              items:
+                $ref: '#/components/schemas/Cas3Turnaround'
+            turnaroundStartDate:
+              type: string
+              format: date
+            effectiveEndDate:
+              type: string
+              format: date
+            applicationId:
+              type: string
+              format: uuid
+            assessmentId:
+              type: string
+              format: uuid
+            premises:
+              $ref: '#/components/schemas/Cas3BookingPremisesSummary'
+          required:
+            - status
+            - extensions
+            - departures
+            - cancellations
+            - premises
+    Cas3BookingBody:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/Person'
+        arrivalDate:
+          type: string
+          format: date
+        originalArrivalDate:
+          type: string
+          format: date
+        departureDate:
+          type: string
+          format: date
+        originalDepartureDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        bedspace:
+          $ref: '#/components/schemas/Cas3Bedspace'
+      required:
+        - id
+        - person
+        - arrivalDate
+        - originalArrivalDate
+        - departureDate
+        - originalDepartureDate
+        - createdAt
+        - bedspace
+    Cas3BookingStatus:
+      type: string
+      enum:
+        - arrived
+        - notMinusArrived
+        - departed
+        - cancelled
+        - provisional
+        - confirmed
+        - closed
+    Cas3Extension:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        previousDepartureDate:
+          type: string
+          format: date
+        newDepartureDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - previousDepartureDate
+        - newDepartureDate
+        - createdAt
+    Cas3Arrival:
+      type: object
+      properties:
+        expectedDepartureDate:
+          type: string
+          format: date
+        arrivalDate:
+          type: string
+          format: date
+        arrivalTime:
+          type: string
+          format: time
+        notes:
+          type: string
+        bookingId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - type
+        - bookingId
+        - expectedDepartureDate
+        - createdAt
+        - arrivalDate
+        - arrivalTime
+    Cas3NonArrival:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/NonArrivalReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - date
+        - reason
+        - createdAt
+    Cas3Cancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        date:
+          type: string
+          format: date
+        reason:
+          $ref: '#/components/schemas/CancellationReason'
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        premisesName:
+          type: string
+        otherReason:
+          type: string
+      required:
+        - bookingId
+        - date
+        - reason
+        - createdAt
+        - premisesName
+    Cas3Confirmation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - dateTime
+        - createdAt
+    Cas3Turnaround:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        bookingId:
+          type: string
+          format: uuid
+        workingDays:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - bookingId
+        - workingDays
+        - createdAt
+    Cas3BookingPremisesSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+      required:
+        - id
+        - name
+    Cas3BedspaceCharacteristic:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 952790c0-21d7-4fd6-a7e1-9018f08d8bb0
+        description:
+          type: string
+          example: Is this premises catered (rather than self-catered)?
+        name:
+          type: string
+          example: isCatered
+      required:
+        - id
+        - description

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ArrivalEntityFactory.kt
@@ -54,6 +54,10 @@ class Cas3ArrivalEntityFactory : Factory<Cas3ArrivalEntity> {
     this.createdAt = { createdAt }
   }
 
+  fun withDefaults() = apply {
+    withBooking(Cas3BookingEntityFactory().withDefaults().produce())
+  }
+
   @SuppressWarnings("TooGenericExceptionThrown")
   override fun produce(): Cas3ArrivalEntity = Cas3ArrivalEntity(
     id = this.id(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BedspaceCharacteristicEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BedspaceCharacteristicEntityFactory.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspaceCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.util.UUID
+
+class Cas3BedspaceCharacteristicEntityFactory : Factory<Cas3BedspaceCharacteristicEntity> {
+
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var description: Yielded<String> = { randomStringUpperCase(10) }
+  private var name: Yielded<String> = { randomStringUpperCase(7) }
+  private var isActive: Yielded<Boolean> = { true }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withDescription(description: String) = apply {
+    this.description = { description }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+
+  fun withIsActive(isActive: Boolean) = apply {
+    this.isActive = { isActive }
+  }
+
+  override fun produce(): Cas3BedspaceCharacteristicEntity = Cas3BedspaceCharacteristicEntity(
+    id = this.id(),
+    description = this.description(),
+    name = this.name(),
+    isActive = this.isActive(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3DepartureEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3DepartureEntityFactory.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
@@ -69,6 +71,12 @@ class Cas3DepartureEntityFactory : Factory<Cas3DepartureEntity> {
 
   fun withCreatedAt(createdAt: OffsetDateTime) = apply {
     this.createdAt = { createdAt }
+  }
+
+  fun withDefaults() = apply {
+    withReason(DepartureReasonEntityFactory().produce())
+    withMoveOnCategory(MoveOnCategoryEntityFactory().produce())
+    withBooking(Cas3BookingEntityFactory().withDefaults().produce())
   }
 
   @SuppressWarnings("TooGenericExceptionThrown")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ExtensionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3ExtensionEntityFactory.kt
@@ -47,6 +47,10 @@ class Cas3ExtensionEntityFactory : Factory<Cas3ExtensionEntity> {
     this.createdAt = { createdAt }
   }
 
+  fun withDefaults() = apply {
+    withBooking(Cas3BookingEntityFactory().withDefaults().produce())
+  }
+
   @SuppressWarnings("TooGenericExceptionThrown")
   override fun produce(): Cas3ExtensionEntity = Cas3ExtensionEntity(
     id = this.id(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3NonArrivalEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3NonArrivalEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3NonArrivalEntity
@@ -50,6 +51,11 @@ class Cas3NonArrivalEntityFactory : Factory<Cas3NonArrivalEntity> {
 
   fun withCreatedAt(createdAt: OffsetDateTime) = apply {
     this.createdAt = { createdAt }
+  }
+
+  fun withDefaults() = apply {
+    withReason(NonArrivalReasonEntityFactory().produce())
+    withBooking(Cas3BookingEntityFactory().withDefaults().produce())
   }
 
   @SuppressWarnings("TooGenericExceptionThrown")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/v2/Cas3TurnaroundEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/v2/Cas3TurnaroundEntityFactory.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.v2
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3TurnaroundEntityFactory : Factory<Cas3v2TurnaroundEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var workingDayCount: Yielded<Int> = { randomInt(0, 14) }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
+  private var booking: Yielded<Cas3BookingEntity>? = null
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withWorkingDayCount(workingDayCount: Int) = apply {
+    this.workingDayCount = { workingDayCount }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withBooking(booking: Cas3BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  fun withYieldedBooking(booking: Yielded<Cas3BookingEntity>) = apply {
+    this.booking = booking
+  }
+
+  fun withDefaults() = apply {
+    withBooking(Cas3BookingEntityFactory().withDefaults().produce())
+  }
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  override fun produce() = Cas3v2TurnaroundEntity(
+    id = this.id(),
+    workingDayCount = this.workingDayCount(),
+    createdAt = this.createdAt(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Must provide a Booking"),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3ArrivalTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3ArrivalTransformerTest.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Arrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ArrivalTransformer
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+class Cas3ArrivalTransformerTest {
+
+  private val transformer = Cas3ArrivalTransformer()
+
+  @Test
+  fun `transformJpaToApi transforms a Arrival correctly`() {
+    val arrivalEntity = Cas3ArrivalEntityFactory().withDefaults().produce()
+    val result = transformer.transformJpaToApi(arrivalEntity)
+    assertThat(result).isEqualTo(
+      Cas3Arrival(
+        bookingId = arrivalEntity.booking.id,
+        arrivalDate = arrivalEntity.arrivalDate,
+        arrivalTime = DateTimeFormatter.ISO_LOCAL_TIME.format(arrivalEntity.arrivalDateTime.atZone(ZoneOffset.UTC)),
+        expectedDepartureDate = arrivalEntity.expectedDepartureDate,
+        notes = arrivalEntity.notes,
+        createdAt = arrivalEntity.createdAt.toInstant(),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3BedspaceCharacteristicTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3BedspaceCharacteristicTransformerTest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3BedspaceCharacteristic
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BedspaceCharacteristicEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BedspaceCharacteristicTransformer
+
+class Cas3BedspaceCharacteristicTransformerTest {
+
+  private val transformer = Cas3BedspaceCharacteristicTransformer()
+
+  @Test
+  fun `transformJpaToApi transforms a Bedspace characteristic correctly`() {
+    val characteristicEntity = Cas3BedspaceCharacteristicEntityFactory().produce()
+    val result = transformer.transformJpaToApi(characteristicEntity)
+    assertThat(result).isEqualTo(
+      Cas3BedspaceCharacteristic(
+        id = characteristicEntity.id,
+        name = characteristicEntity.name,
+        description = characteristicEntity.description,
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3BedspaceTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3BedspaceTransformerTest.kt
@@ -7,7 +7,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3BedspaceSt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BedspaceCharacteristicTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BedspaceTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -16,7 +19,8 @@ import java.time.LocalDate
 class Cas3BedspaceTransformerTest {
 
   private val characteristicTransformer = CharacteristicTransformer()
-  private val cas3BedspaceTransformer = Cas3BedspaceTransformer(characteristicTransformer)
+  private val cas3BedspaceCharacteristicTransformer = Cas3BedspaceCharacteristicTransformer()
+  private val cas3BedspaceTransformer = Cas3BedspaceTransformer(characteristicTransformer, cas3BedspaceCharacteristicTransformer)
 
   @Test
   fun `transformJpaToApi transforms the BedEntity into Cas3Bedspace correctly`() {
@@ -48,6 +52,31 @@ class Cas3BedspaceTransformerTest {
         status = Cas3BedspaceStatus.online,
         notes = room.notes,
         characteristics = emptyList(),
+      ),
+    )
+  }
+
+  @Test
+  fun `transformJpaToApi transforms the BedspaceEntity into Cas3Bedspace correctly`() {
+    val premises = Cas3PremisesEntityFactory()
+      .withDefaults()
+      .produce()
+
+    val bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val result = cas3BedspaceTransformer.transformJpaToApi(bedspace)
+
+    assertThat(result).isEqualTo(
+      Cas3Bedspace(
+        id = bedspace.id,
+        reference = bedspace.reference,
+        startDate = bedspace.startDate,
+        endDate = bedspace.endDate,
+        notes = bedspace.notes,
+        status = Cas3BedspaceStatus.online,
+        bedspaceCharacteristics = bedspace.characteristics.map(cas3BedspaceCharacteristicTransformer::transformJpaToApi),
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3ConfirmationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3ConfirmationTransformerTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -9,7 +10,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ConfirmationTransformer
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -18,7 +23,7 @@ class Cas3ConfirmationTransformerTest {
   private val cas3ConfirmationTransformer = Cas3ConfirmationTransformer()
 
   @Test
-  fun `transformJpaToApi transforms the Cas3TurnaroundEntity into a Turnaround`() {
+  fun `transformJpaToApi transforms the Cas3ConfirmationEntity into a Confirmation`() {
     val booking = BookingEntityFactory()
       .withPremises(
         TemporaryAccommodationPremisesEntityFactory()
@@ -46,6 +51,44 @@ class Cas3ConfirmationTransformerTest {
 
     assertThat(result).isEqualTo(
       Confirmation(
+        id = confirmationId,
+        bookingId = booking.id,
+        dateTime = OffsetDateTime.parse("2025-04-08T00:00:00Z").toInstant(),
+        notes = "Test notes",
+        createdAt = OffsetDateTime.parse("2025-04-08T00:00:00Z").toInstant(),
+      ),
+    )
+  }
+
+  @Test
+  fun `transformJpaToApi transforms the Cas3v2ConfirmationEntity into a Cas3Confirmation`() {
+    val premises = Cas3PremisesEntityFactory()
+      .withDefaults()
+      .produce()
+
+    val bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val booking = Cas3BookingEntityFactory()
+      .withPremises(premises)
+      .withBedspace(bedspace)
+      .withServiceName(ServiceName.temporaryAccommodation)
+      .produce()
+
+    val confirmationId = UUID.randomUUID()
+    val cas3ConfirmationEntity = Cas3v2ConfirmationEntity(
+      id = confirmationId,
+      dateTime = OffsetDateTime.parse("2025-04-08T00:00:00Z"),
+      notes = "Test notes",
+      createdAt = OffsetDateTime.parse("2025-04-08T00:00:00Z"),
+      booking = booking,
+    )
+
+    val result = cas3ConfirmationTransformer.transformJpaToApi(cas3ConfirmationEntity)
+
+    assertThat(result).isEqualTo(
+      Cas3Confirmation(
         id = confirmationId,
         bookingId = booking.id,
         dateTime = OffsetDateTime.parse("2025-04-08T00:00:00Z").toInstant(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3DepartureTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3DepartureTransformerTest.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Departure
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3DepartureEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.MoveOnCategoryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3DepartureTransformer
+
+class Cas3DepartureTransformerTest {
+
+  private val departureReasonTransformer = DepartureReasonTransformer()
+  private val moveOnCategoryTransformer = MoveOnCategoryTransformer()
+  private val transformer = Cas3DepartureTransformer(departureReasonTransformer, moveOnCategoryTransformer)
+
+  @Test
+  fun `transformJpaToApi transforms a Departure correctly`() {
+    val arrivalEntity = Cas3DepartureEntityFactory().withDefaults().produce()
+    val result = transformer.transformJpaToApi(arrivalEntity)
+    assertThat(result).isEqualTo(
+      Cas3Departure(
+        id = arrivalEntity.id,
+        bookingId = arrivalEntity.booking.id,
+        dateTime = arrivalEntity.dateTime.toInstant(),
+        reason = departureReasonTransformer.transformJpaToApi(arrivalEntity.reason),
+        moveOnCategory = moveOnCategoryTransformer.transformJpaToApi(arrivalEntity.moveOnCategory),
+        notes = arrivalEntity.notes,
+        createdAt = arrivalEntity.createdAt.toInstant(),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3ExtensionTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3ExtensionTransformerTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Extension
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3ExtensionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3ExtensionTransformer
+
+class Cas3ExtensionTransformerTest {
+
+  private val transformer = Cas3ExtensionTransformer()
+
+  @Test
+  fun `transformJpaToApi transforms an Extension correctly`() {
+    val extensionEntity = Cas3ExtensionEntityFactory().withDefaults().produce()
+    val result = transformer.transformJpaToApi(extensionEntity)
+    assertThat(result).isEqualTo(
+      Cas3Extension(
+        id = extensionEntity.id,
+        bookingId = extensionEntity.booking.id,
+        previousDepartureDate = extensionEntity.previousDepartureDate,
+        newDepartureDate = extensionEntity.newDepartureDate,
+        notes = extensionEntity.notes,
+        createdAt = extensionEntity.createdAt.toInstant(),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3NonArrivalTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3NonArrivalTransformerTest.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3NonArrival
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3NonArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.NonArrivalReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3NonArrivalTransformer
+
+class Cas3NonArrivalTransformerTest {
+
+  private val nonArrivalReasonTransformer = NonArrivalReasonTransformer()
+  private val transformer = Cas3NonArrivalTransformer(nonArrivalReasonTransformer)
+
+  @Test
+  fun `transformJpaToApi transforms a Non-arrival correctly`() {
+    val nonArrivalEntity = Cas3NonArrivalEntityFactory().withDefaults().produce()
+    val result = transformer.transformJpaToApi(nonArrivalEntity)
+    assertThat(result).isEqualTo(
+      Cas3NonArrival(
+        id = nonArrivalEntity.id,
+        bookingId = nonArrivalEntity.booking.id,
+        date = nonArrivalEntity.date,
+        reason = nonArrivalReasonTransformer.transformJpaToApi(nonArrivalEntity.reason),
+        notes = nonArrivalEntity.notes,
+        createdAt = nonArrivalEntity.createdAt.toInstant(),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3TurnoverTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3TurnoverTransformerTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3Turnaround
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.v2.Cas3TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3TurnaroundTransformer
+
+class Cas3TurnoverTransformerTest {
+
+  private val transformer = Cas3TurnaroundTransformer()
+
+  @Test
+  fun `transformJpaToApi transforms a Turnover correctly`() {
+    val turnoverEntity = Cas3TurnaroundEntityFactory().withDefaults().produce()
+    val result = transformer.transformJpaToApi(turnoverEntity)
+    assertThat(result).isEqualTo(
+      Cas3Turnaround(
+        id = turnoverEntity.id,
+        bookingId = turnoverEntity.booking.id,
+        workingDays = turnoverEntity.workingDayCount,
+        createdAt = turnoverEntity.createdAt.toInstant(),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
Follow up PR to: [3693](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3693)
As mentioned on last PR the intention was to migrate from the sahred `Booking` model to a new `Cas3Booking` model. 

**PR includes:**
* New models
* Implementation code refactoring to new models
* Test code refactoring to new models