### PR TITLE
APS-2417 Add job to ‘flatten’ placement app dates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
@@ -38,7 +38,7 @@ data class PlacementDateEntity(
 
   @OneToOne
   @JoinColumn(name = "placement_application_id")
-  val placementApplication: PlacementApplicationEntity,
+  var placementApplication: PlacementApplicationEntity,
 
   @OneToOne
   @JoinColumn(name = "placement_request_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1Arson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillOfflineApplicationName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillUserApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1FixDatesLinkedToReallocatedPlacementRequestsJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1FlattenPlacementAppDatesJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1IsArsonSuitableBackfillJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1TaskDueMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UpdateApplicationLicenceExpiryDateJob
@@ -42,29 +43,30 @@ class MigrationJobService(
 
     try {
       val job: MigrationJob = when (migrationJobType) {
-        MigrationJobType.allUsersFromCommunityApi -> getBean(UpdateAllUsersFromDeliusJob::class)
-        MigrationJobType.sentenceTypeAndSituation -> getBean(UpdateSentenceTypeAndSituationJob::class)
-        MigrationJobType.bookingStatus -> getBean(BookingStatusMigrationJob::class)
-        MigrationJobType.taskDueDates -> getBean(Cas1TaskDueMigrationJob::class)
-        MigrationJobType.usersPduByApi -> getBean(UpdateUsersPduJob::class)
-        MigrationJobType.cas2ApplicationsWithAssessments -> getBean(Cas2AssessmentMigrationJob::class)
-        MigrationJobType.cas2StatusUpdatesWithAssessments -> getBean(Cas2StatusUpdateMigrationJob::class)
-        MigrationJobType.cas2NotesWithAssessments -> getBean(Cas2NoteMigrationJob::class)
-        MigrationJobType.cas1BackfillUserApArea -> getBean(Cas1BackfillUserApArea::class)
-        MigrationJobType.cas3ApplicationOffenderName -> getBean(Cas3UpdateApplicationOffenderNameJob::class)
-        MigrationJobType.cas3BookingOffenderName -> getBean(Cas3UpdateBookingOffenderNameJob::class)
-        MigrationJobType.cas3BedspaceStartDate -> getBean(Cas3UpdateBedSpaceStartDateJob::class)
-        MigrationJobType.cas3DomainEventTypeForPersonDepartedUpdated -> getBean(Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob::class)
-        MigrationJobType.cas1ApplicationsLicenceExpiryDate -> getBean(Cas1UpdateApplicationLicenceExpiryDateJob::class)
-        MigrationJobType.cas1BackfillOfflineApplicationName -> getBean(Cas1BackfillOfflineApplicationName::class)
-        MigrationJobType.cas1ArsonSuitableToArsonOffences -> getBean(Cas1ArsonSuitableToArsonOffencesJob::class)
-        MigrationJobType.cas1BackfillArsonSuitable -> getBean(Cas1IsArsonSuitableBackfillJob::class)
-        MigrationJobType.cas1ApprovedPremisesAssessmentReportProperties -> getBean(Cas1UpdateAssessmentReportPropertiesJob::class)
-        MigrationJobType.cas1RoomCodes -> getBean(Cas1UpdateRoomCodesJob::class)
-        MigrationJobType.cas1ApplicationsWithOffender -> getBean(Cas1UpdateApprovedPremisesApplicationWithOffenderJob::class)
-        MigrationJobType.cas3BedspaceModelData -> getBean(Cas3MigrateNewBedspaceModelDataJob::class)
-        MigrationJobType.cas3VoidBedspaceCancellationData -> getBean(Cas3VoidBedspaceCancellationJob::class)
-        MigrationJobType.cas1FixDatesLinkedToReallocatedPlacementRequests -> getBean(Cas1FixDatesLinkedToReallocatedPlacementRequestsJob::class)
+        MigrationJobType.updateAllUsersFromCommunityApi -> getBean(UpdateAllUsersFromDeliusJob::class)
+        MigrationJobType.updateSentenceTypeAndSituation -> getBean(UpdateSentenceTypeAndSituationJob::class)
+        MigrationJobType.updateBookingStatus -> getBean(BookingStatusMigrationJob::class)
+        MigrationJobType.updateTaskDueDates -> getBean(Cas1TaskDueMigrationJob::class)
+        MigrationJobType.updateUsersPduByApi -> getBean(UpdateUsersPduJob::class)
+        MigrationJobType.updateCas2ApplicationsWithAssessments -> getBean(Cas2AssessmentMigrationJob::class)
+        MigrationJobType.updateCas2StatusUpdatesWithAssessments -> getBean(Cas2StatusUpdateMigrationJob::class)
+        MigrationJobType.updateCas2NotesWithAssessments -> getBean(Cas2NoteMigrationJob::class)
+        MigrationJobType.updateCas1BackfillUserApArea -> getBean(Cas1BackfillUserApArea::class)
+        MigrationJobType.updateCas3ApplicationOffenderName -> getBean(Cas3UpdateApplicationOffenderNameJob::class)
+        MigrationJobType.updateCas3BookingOffenderName -> getBean(Cas3UpdateBookingOffenderNameJob::class)
+        MigrationJobType.updateCas3BedspaceStartDate -> getBean(Cas3UpdateBedSpaceStartDateJob::class)
+        MigrationJobType.updateCas3DomainEventTypeForPersonDepartedUpdated -> getBean(Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob::class)
+        MigrationJobType.updateCas1ApplicationsLicenceExpiryDate -> getBean(Cas1UpdateApplicationLicenceExpiryDateJob::class)
+        MigrationJobType.updateCas1BackfillOfflineApplicationName -> getBean(Cas1BackfillOfflineApplicationName::class)
+        MigrationJobType.updateCas1ArsonSuitableToArsonOffences -> getBean(Cas1ArsonSuitableToArsonOffencesJob::class)
+        MigrationJobType.updateCas1BackfillArsonSuitable -> getBean(Cas1IsArsonSuitableBackfillJob::class)
+        MigrationJobType.updateCas1ApprovedPremisesAssessmentReportProperties -> getBean(Cas1UpdateAssessmentReportPropertiesJob::class)
+        MigrationJobType.updateCas1RoomCodes -> getBean(Cas1UpdateRoomCodesJob::class)
+        MigrationJobType.updateCas1ApplicationsWithOffender -> getBean(Cas1UpdateApprovedPremisesApplicationWithOffenderJob::class)
+        MigrationJobType.updateCas3BedspaceModelData -> getBean(Cas3MigrateNewBedspaceModelDataJob::class)
+        MigrationJobType.updateCas3VoidBedspaceCancellationData -> getBean(Cas3VoidBedspaceCancellationJob::class)
+        MigrationJobType.updateCas1FixDatesLinkedToReallocatedPlacementRequests -> getBean(Cas1FixDatesLinkedToReallocatedPlacementRequestsJob::class)
+        MigrationJobType.cas1FlattenPlacementAppsWithMultipleDates -> getBean(Cas1FlattenPlacementAppDatesJob::class)
       }
 
       if (job.shouldRunInTransaction) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1FlattenPlacementAppDatesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1FlattenPlacementAppDatesJob.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import java.util.UUID
+
+@Service
+class Cas1FlattenPlacementAppDatesJob(
+  private val placementApplicationRepository: PlacementApplicationRepository,
+  private val placementDateRepository: PlacementDateRepository,
+  private val placementRequestRepository: PlacementRequestRepository,
+  private val migrationLogger: MigrationLogger,
+  override val shouldRunInTransaction: Boolean = true,
+) : MigrationJob() {
+  override fun process(pageSize: Int) {
+    val placementApplicationIds = placementApplicationRepository.findAllWithMultipleDates()
+
+    migrationLogger.info("There are ${placementApplicationIds.size} placement applications with multiple dates to flatten.")
+
+    placementApplicationIds.forEach { flattenPlacementApp(it) }
+  }
+
+  private fun flattenPlacementApp(id: UUID) {
+    val originalPlacementApp = placementApplicationRepository.findByIdOrNull(id)!!
+    val dates = originalPlacementApp.placementDates.sortedBy { it.expectedArrival }
+
+    migrationLogger.info("Flattening placement application $id with ${originalPlacementApp.placementDates.size} dates and decision ${originalPlacementApp.decision}")
+
+    val retainedDate = dates[0]
+    migrationLogger.info(
+      "Leaving date ${retainedDate.expectedArrival} (${retainedDate.id}) with placement request ${retainedDate.placementRequest?.id}" +
+        " linked to original application ${originalPlacementApp.id}",
+    )
+
+    // the first date remains attached to the original placement application
+    // all others will be assigned to a new placement application
+    val datesToMoveToNewPlacementApplication = dates.subList(1, originalPlacementApp.placementDates.size)
+
+    val createdApps = datesToMoveToNewPlacementApplication.map {
+      createPlacementAppForDate(originalPlacementApp, it)
+    }
+
+    val allApps = listOf(originalPlacementApp) + createdApps
+
+    migrationLogger.info(
+      """Have flattened placement application $id with ${originalPlacementApp.placementDates.size} dates and decision ${originalPlacementApp.decision}
+        |
+        |Result is ${allApps.size} placement applications:${allApps.map { "\n" + it.summarise() } }
+        |
+      """.trimMargin(),
+    )
+  }
+
+  private fun PlacementApplicationEntity.summarise(): String {
+    val date = placementDates[0]
+    val placementRequest = placementRequests.getOrNull(0)
+    return "$id - ${date.expectedArrival} (${date.id}) linked to placement request ${placementRequest?.id} (placement request on date is ${date.placementRequest?.id})"
+  }
+
+  private fun createPlacementAppForDate(
+    originalPlacementApp: PlacementApplicationEntity,
+    date: PlacementDateEntity,
+  ): PlacementApplicationEntity {
+    val newPlacementApp = placementApplicationRepository.save(
+      originalPlacementApp.copy(
+        id = UUID.randomUUID(),
+        placementDates = mutableListOf(),
+        placementRequests = mutableListOf(),
+      ),
+    )
+
+    date.placementApplication = newPlacementApp
+    placementDateRepository.save(date)
+
+    date.placementRequest?.let { placementRequest ->
+      placementRequest.placementApplication = newPlacementApp
+      placementRequestRepository.save(placementRequest)
+      // not strictly required, but makes logging the changes easier
+      newPlacementApp.placementRequests = mutableListOf(placementRequest)
+    }
+
+    // not strictly required, but makes logging the changes easier
+    newPlacementApp.placementDates = mutableListOf(date)
+
+    return newPlacementApp
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3373,6 +3373,7 @@ components:
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
         - update_cas1_fix_dates_linked_to_reallocated_placement_requests
+        - cas1_flatten_placement_apps_with_multiple_dates
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6525,6 +6525,7 @@ components:
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
         - update_cas1_fix_dates_linked_to_reallocated_placement_requests
+        - cas1_flatten_placement_apps_with_multiple_dates
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5777,6 +5777,7 @@ components:
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
         - update_cas1_fix_dates_linked_to_reallocated_placement_requests
+        - cas1_flatten_placement_apps_with_multiple_dates
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3887,6 +3887,7 @@ components:
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
         - update_cas1_fix_dates_linked_to_reallocated_placement_requests
+        - cas1_flatten_placement_apps_with_multiple_dates
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3908,6 +3908,7 @@ components:
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
         - update_cas1_fix_dates_linked_to_reallocated_placement_requests
+        - cas1_flatten_placement_apps_with_multiple_dates
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3903,6 +3903,7 @@ components:
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
         - update_cas1_fix_dates_linked_to_reallocated_placement_requests
+        - cas1_flatten_placement_apps_with_multiple_dates
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
@@ -3405,6 +3405,7 @@ components:
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
         - update_cas1_fix_dates_linked_to_reallocated_placement_requests
+        - cas1_flatten_placement_apps_with_multiple_dates
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/migration/Cas2MigrateAssessmentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/migration/Cas2MigrateAssessmentsTest.kt
@@ -53,7 +53,7 @@ class Cas2MigrateAssessmentsTest : MigrationJobTestBase() {
         withApplication(submittedWithAssessment)
       }
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas2ApplicationsWithAssessments, 1)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas2ApplicationsWithAssessments, 1)
 
       checkUnsubmittedDoesNotHaveAssessment(unsubmittedApp)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/migration/Cas2MigrateNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/migration/Cas2MigrateNotesTest.kt
@@ -90,7 +90,7 @@ class Cas2MigrateNotesTest : MigrationJobTestBase() {
           )
         }
 
-        migrationJobService.runMigrationJob(MigrationJobType.cas2NotesWithAssessments, 10)
+        migrationJobService.runMigrationJob(MigrationJobType.updateCas2NotesWithAssessments, 10)
 
         assessment1NoteIds.forEach {
           val updatedNote = realNotesRepository.findById(it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/migration/Cas2MigrateStatusUpdatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/migration/Cas2MigrateStatusUpdatesTest.kt
@@ -55,7 +55,7 @@ class Cas2MigrateStatusUpdatesTest : MigrationJobTestBase() {
           )
         }
 
-        migrationJobService.runMigrationJob(MigrationJobType.cas2StatusUpdatesWithAssessments, 10)
+        migrationJobService.runMigrationJob(MigrationJobType.updateCas2StatusUpdatesWithAssessments, 10)
 
         assessmentIds.forEach {
           val updatedStatusUpdate = realStatusUpdateRepository.findById(it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas1TaskDueMigrationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/Cas1TaskDueMigrationJobTest.kt
@@ -59,7 +59,7 @@ class Cas1TaskDueMigrationJobTest : IntegrationTestBase() {
     val placementRequests = List(5) { createPlacementRequest() }
     val placementApplications = List(2) { createPlacementApplication() }
 
-    migrationJobService.runMigrationJob(MigrationJobType.taskDueDates)
+    migrationJobService.runMigrationJob(MigrationJobType.updateTaskDueDates)
 
     assessments.forEach {
       val updatedAssessment = assessmentTestRepository.findByIdOrNull(it.id)!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateSentenceTypeAndSituationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/UpdateSentenceTypeAndSituationJobTest.kt
@@ -52,7 +52,7 @@ class UpdateSentenceTypeAndSituationJobTest : IntegrationTestBase() {
       }
     }.take(50).toList()
 
-    migrationJobService.runMigrationJob(MigrationJobType.sentenceTypeAndSituation, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateSentenceTypeAndSituation, 1)
 
     applications.forEach {
       val application = applicationRepository.findByIdOrNull(it.id)!! as ApprovedPremisesApplicationEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/MigrateCas1UserApAreaTest.kt
@@ -31,7 +31,7 @@ class MigrateCas1UserApAreaTest : MigrationJobTestBase() {
       assertThat(userEntity.apArea).isNull()
       assertThat(userEntity.teamCodes).isNull()
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillUserApArea)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas1BackfillUserApArea)
 
       val updatedUser = userRepository.findByIdOrNull(userEntity.id)!!
       assertThat(updatedUser.apArea!!.id).isEqualTo(apArea.id)
@@ -59,7 +59,7 @@ class MigrateCas1UserApAreaTest : MigrationJobTestBase() {
       assertThat(userEntity.apArea).isNull()
       assertThat(userEntity.teamCodes).isNull()
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillUserApArea)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas1BackfillUserApArea)
 
       val updatedUser = userRepository.findByIdOrNull(userEntity.id)!!
       assertThat(updatedUser.apArea!!.id).isEqualTo(apArea.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/MigrateBookingStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/MigrateBookingStatusTest.kt
@@ -26,7 +26,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
 
         assertBookingStatusIsNull(booking, approvedPremises)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatusIsNull(booking, approvedPremises)
       }
@@ -46,7 +46,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
 
         assertBookingStatus(booking, BookingStatus.arrived, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(booking, BookingStatus.arrived, ServiceName.temporaryAccommodation)
       }
@@ -61,7 +61,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
 
         assertBookingStatusIsNull(booking, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(booking, BookingStatus.cancelled, ServiceName.temporaryAccommodation)
       }
@@ -78,7 +78,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
         assertBookingStatusIsNull(booking1, ServiceName.temporaryAccommodation)
         assertBookingStatusIsNull(booking2, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(booking1, BookingStatus.cancelled, ServiceName.temporaryAccommodation)
         assertBookingStatus(booking2, BookingStatus.cancelled, ServiceName.temporaryAccommodation)
@@ -96,7 +96,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
         assertBookingStatusIsNull(booking1, ServiceName.temporaryAccommodation)
         assertBookingStatusIsNull(booking2, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(booking1, BookingStatus.departed, ServiceName.temporaryAccommodation)
         assertBookingStatus(booking2, BookingStatus.departed, ServiceName.temporaryAccommodation)
@@ -114,7 +114,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
         assertBookingStatusIsNull(booking1, ServiceName.temporaryAccommodation)
         assertBookingStatusIsNull(booking2, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(booking1, BookingStatus.provisional, ServiceName.temporaryAccommodation)
         assertBookingStatus(booking2, BookingStatus.provisional, ServiceName.temporaryAccommodation)
@@ -132,7 +132,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
         assertBookingStatusIsNull(booking1, ServiceName.temporaryAccommodation)
         assertBookingStatusIsNull(booking2, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(booking1, BookingStatus.arrived, ServiceName.temporaryAccommodation)
         assertBookingStatus(booking2, BookingStatus.arrived, ServiceName.temporaryAccommodation)
@@ -150,7 +150,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
         assertBookingStatusIsNull(booking1, ServiceName.temporaryAccommodation)
         assertBookingStatusIsNull(booking2, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(booking1, BookingStatus.confirmed, ServiceName.temporaryAccommodation)
         assertBookingStatus(booking2, BookingStatus.confirmed, ServiceName.temporaryAccommodation)
@@ -174,7 +174,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
         assertBookingStatusIsNull(confirmedBooking, ServiceName.temporaryAccommodation)
         assertBookingStatusIsNull(provisionalBooking, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(departedBooking1, BookingStatus.departed, ServiceName.temporaryAccommodation)
         assertBookingStatus(departedBooking2, BookingStatus.departed, ServiceName.temporaryAccommodation)
@@ -195,7 +195,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
         assertBookingStatusIsNull(cancelledBooking, ServiceName.temporaryAccommodation)
         assertBookingStatusIsNull(provisionalBooking, ServiceName.temporaryAccommodation)
 
-        migrationJobService.runMigrationJob(MigrationJobType.bookingStatus, 1)
+        migrationJobService.runMigrationJob(MigrationJobType.updateBookingStatus, 1)
 
         assertBookingStatus(provisionalBooking, BookingStatus.provisional, ServiceName.temporaryAccommodation)
         assertBookingStatus(cancelledBooking, BookingStatus.cancelled, ServiceName.temporaryAccommodation)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/MigrationJobScaffoldingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/MigrationJobScaffoldingTest.kt
@@ -14,7 +14,7 @@ class MigrationJobScaffoldingTest : SeedTestBase() {
       .uri("/migration-job")
       .bodyValue(
         MigrationJobRequest(
-          jobType = MigrationJobType.allUsersFromCommunityApi,
+          jobType = MigrationJobType.updateAllUsersFromCommunityApi,
         ),
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateAllUsersFromCommunityApiMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateAllUsersFromCommunityApiMigrationTest.kt
@@ -36,7 +36,7 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
     apDeliusContextAddStaffDetailResponse(staffUserDetail2)
 
     val startTime = System.currentTimeMillis()
-    migrationJobService.runMigrationJob(MigrationJobType.allUsersFromCommunityApi, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateAllUsersFromCommunityApi, 1)
     val endTime = System.currentTimeMillis()
 
     assertThat(endTime - startTime).isGreaterThan(50 * 2)
@@ -70,7 +70,7 @@ class UpdateAllUsersFromCommunityApiMigrationTest : MigrationJobTestBase() {
 
     apDeliusContextAddStaffDetailResponse(staffUserDetail)
 
-    migrationJobService.runMigrationJob(MigrationJobType.allUsersFromCommunityApi)
+    migrationJobService.runMigrationJob(MigrationJobType.updateAllUsersFromCommunityApi)
 
     val userOneAfterUpdate = userRepository.findByIdOrNull(userOne.id)!!
     val userTwoAfterUpdate = userRepository.findByIdOrNull(userTwo.id)!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateUsersPduMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/UpdateUsersPduMigrationTest.kt
@@ -143,7 +143,7 @@ class UpdateUsersPduMigrationTest : MigrationJobTestBase() {
     )
 
     val startTime = System.currentTimeMillis()
-    migrationJobService.runMigrationJob(MigrationJobType.usersPduByApi, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateUsersPduByApi, 1)
     val endTime = System.currentTimeMillis()
 
     Assertions.assertThat(endTime - startTime).isGreaterThan(50 * 2)
@@ -207,7 +207,7 @@ class UpdateUsersPduMigrationTest : MigrationJobTestBase() {
       ),
     )
 
-    migrationJobService.runMigrationJob(MigrationJobType.usersPduByApi)
+    migrationJobService.runMigrationJob(MigrationJobType.updateUsersPduByApi)
 
     val userOneAfterUpdate = userRepository.findByIdOrNull(userOne.id)!!
     val userTwoAfterUpdate = userRepository.findByIdOrNull(userTwo.id)!!
@@ -278,7 +278,7 @@ class UpdateUsersPduMigrationTest : MigrationJobTestBase() {
       ),
     )
 
-    migrationJobService.runMigrationJob(MigrationJobType.usersPduByApi)
+    migrationJobService.runMigrationJob(MigrationJobType.updateUsersPduByApi)
 
     val userOneAfterUpdate = userRepository.findByIdOrNull(userOne.id)!!
     val userTwoAfterUpdate = userRepository.findByIdOrNull(userTwo.id)!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1ArsonSuitableToArsonOffencesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1ArsonSuitableToArsonOffencesJobTest.kt
@@ -44,7 +44,7 @@ class Cas1ArsonSuitableToArsonOffencesJobTest : IntegrationTestBase() {
       essentialCharacteristics = listOf(characteristicEnSuite, characteristicArsonSuitable),
     )
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1ArsonSuitableToArsonOffences, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1ArsonSuitableToArsonOffences, 1)
 
     val noCriteriaUpdated = placementRequirementsRepository.findById(noCriteria.id).get()
     assertThat(noCriteriaUpdated.desirableCriteria).isEmpty()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1BackfillOfflineApplicationNameTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1BackfillOfflineApplicationNameTest.kt
@@ -34,7 +34,7 @@ class Cas1BackfillOfflineApplicationNameTest : MigrationJobTestBase() {
       ),
     )
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillOfflineApplicationName)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1BackfillOfflineApplicationName)
 
     val updatedApplication1 = offlineApplicationRepository.getReferenceById(application1.id)
     Assertions.assertThat(updatedApplication1.name).isEqualTo("John Doe")
@@ -55,7 +55,7 @@ class Cas1BackfillOfflineApplicationNameTest : MigrationJobTestBase() {
         .produce(),
     )
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillOfflineApplicationName)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1BackfillOfflineApplicationName)
 
     val updatedApplication = offlineApplicationRepository.getReferenceById(application.id)
     Assertions.assertThat(updatedApplication.name).isEqualTo("Jane Doe")
@@ -68,7 +68,7 @@ class Cas1BackfillOfflineApplicationNameTest : MigrationJobTestBase() {
 
     apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillOfflineApplicationName)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1BackfillOfflineApplicationName)
 
     val updatedApplication = offlineApplicationRepository.getReferenceById(application.id)
     Assertions.assertThat(updatedApplication.name).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest.kt
@@ -75,7 +75,7 @@ class Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest : MigrationJobTest
     placementDate3.placementRequest = placementRequest3Reallocated
     placementDateRepository.save(placementDate3)
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1FixDatesLinkedToReallocatedPlacementRequests)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1FixDatesLinkedToReallocatedPlacementRequests)
 
     assertThat(placementDateRepository.findByIdOrNull(placementDate1.id)!!.placementRequest!!.id).isEqualTo(placementRequest1.id)
     assertThat(placementDateRepository.findByIdOrNull(placementDate2.id)!!.placementRequest!!.id).isEqualTo(placementRequest2.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1FlattenPlacementAppDatesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1FlattenPlacementAppDatesJobTest.kt
@@ -1,0 +1,212 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.PlacementDate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import java.time.LocalDate
+
+class Cas1FlattenPlacementAppDatesJobTest : MigrationJobTestBase() {
+
+  @Test
+  fun `flatten placement apps with multiple dates and linked placement requests`() {
+    val placementAppWithOneDate = givenAPlacementApplication(
+      decision = PlacementApplicationDecision.ACCEPTED,
+      placementDates = listOf(
+        PlacementDate(
+          expectedArrival = LocalDate.of(2021, 2, 3),
+          duration = 3,
+        ),
+      ),
+    )
+    val placementRequest0 = givenAPlacementRequest(placementApplication = placementAppWithOneDate).first
+    val placementDate0 = placementAppWithOneDate.placementDates[0]
+    placementDate0.placementRequest = placementRequest0
+    placementDateRepository.save(placementDate0)
+
+    val placementAppWithMultipleDates = givenAPlacementApplication(
+      decision = PlacementApplicationDecision.ACCEPTED,
+      placementDates = listOf(
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 6, 1),
+          duration = 5,
+        ),
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 7, 1),
+          duration = 6,
+        ),
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 8, 1),
+          duration = 7,
+        ),
+      ),
+    )
+
+    val placementRequest1 = givenAPlacementRequest(placementApplication = placementAppWithMultipleDates).first
+    val placementRequest2 = givenAPlacementRequest(placementApplication = placementAppWithMultipleDates).first
+    val placementRequest3 = givenAPlacementRequest(placementApplication = placementAppWithMultipleDates).first
+
+    val placementDate1 = placementAppWithMultipleDates.placementDates.first { it.duration == 5 }
+    val placementDate2 = placementAppWithMultipleDates.placementDates.first { it.duration == 6 }
+    val placementDate3 = placementAppWithMultipleDates.placementDates.first { it.duration == 7 }
+
+    placementDate1.placementRequest = placementRequest1
+    placementDateRepository.save(placementDate1)
+
+    placementDate2.placementRequest = placementRequest2
+    placementDateRepository.save(placementDate2)
+
+    placementDate3.placementRequest = placementRequest3
+    placementDateRepository.save(placementDate3)
+
+    assertThat(placementApplicationRepository.findAll()).hasSize(2)
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1FlattenPlacementAppsWithMultipleDates)
+
+    val updatedPlacementApps = placementApplicationRepository.findAll()
+
+    assertThat(updatedPlacementApps).hasSize(4)
+
+    updatedPlacementApps.filter { it.id != placementAppWithOneDate.id }.forEach {
+      assertThat(it.placementRequests).hasSize(1)
+      assertThat(it.placementDates).hasSize(1)
+      assertThat(it.application.id).isEqualTo(placementAppWithMultipleDates.application.id)
+      assertThat(it.createdByUser.id).isEqualTo(placementAppWithMultipleDates.createdByUser.id)
+      assertThat(it.data).isEqualTo(placementAppWithMultipleDates.data)
+      assertThat(it.document).isEqualTo(placementAppWithMultipleDates.document)
+      assertThat(it.createdAt).isEqualTo(placementAppWithMultipleDates.createdAt)
+      assertThat(it.submittedAt).isEqualTo(placementAppWithMultipleDates.submittedAt)
+      assertThat(it.decision).isEqualTo(placementAppWithMultipleDates.decision)
+      assertThat(it.decisionMadeAt).isEqualTo(placementAppWithMultipleDates.decisionMadeAt)
+      assertThat(it.placementType).isEqualTo(placementAppWithMultipleDates.placementType)
+      assertThat(it.submissionGroupId).isEqualTo(placementAppWithMultipleDates.submissionGroupId)
+    }
+
+    val updatedPlacementAppWithOneDate = updatedPlacementApps.first { it.id == placementAppWithOneDate.id }
+    val updatedPlacementApp1 = updatedPlacementApps.first { it.placementDates[0].duration == 5 }
+    val updatedPlacementApp2 = updatedPlacementApps.first { it.placementDates[0].duration == 6 }
+    val updatedPlacementApp3 = updatedPlacementApps.first { it.placementDates[0].duration == 7 }
+
+    assertThat(updatedPlacementAppWithOneDate.placementRequests[0].id).isEqualTo(placementRequest0.id)
+    assertThat(updatedPlacementAppWithOneDate.placementDates[0].id).isEqualTo(placementDate0.id)
+    assertThat(updatedPlacementAppWithOneDate.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2021, 2, 3))
+    assertThat(updatedPlacementAppWithOneDate.placementDates[0].duration).isEqualTo(3)
+    assertThat(updatedPlacementAppWithOneDate.placementDates[0].placementRequest!!.id).isEqualTo(placementRequest0.id)
+
+    assertThat(updatedPlacementApp1.placementRequests[0].id).isEqualTo(placementRequest1.id)
+    assertThat(updatedPlacementApp1.placementDates[0].id).isEqualTo(placementDate1.id)
+    assertThat(updatedPlacementApp1.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 6, 1))
+    assertThat(updatedPlacementApp1.placementDates[0].duration).isEqualTo(5)
+    assertThat(updatedPlacementApp1.placementDates[0].placementRequest!!.id).isEqualTo(placementRequest1.id)
+
+    assertThat(updatedPlacementApp2.placementRequests[0].id).isEqualTo(placementRequest2.id)
+    assertThat(updatedPlacementApp2.placementDates[0].id).isEqualTo(placementDate2.id)
+    assertThat(updatedPlacementApp2.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 7, 1))
+    assertThat(updatedPlacementApp2.placementDates[0].duration).isEqualTo(6)
+    assertThat(updatedPlacementApp2.placementDates[0].placementRequest!!.id).isEqualTo(placementRequest2.id)
+
+    assertThat(updatedPlacementApp3.placementRequests[0].id).isEqualTo(placementRequest3.id)
+    assertThat(updatedPlacementApp3.placementDates[0].id).isEqualTo(placementDate3.id)
+    assertThat(updatedPlacementApp3.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 8, 1))
+    assertThat(updatedPlacementApp3.placementDates[0].duration).isEqualTo(7)
+    assertThat(updatedPlacementApp3.placementDates[0].placementRequest!!.id).isEqualTo(placementRequest3.id)
+  }
+
+  @Test
+  fun `flatten placement apps with multiple dates and no linked placement requests`() {
+    val placementAppWithOneDate = givenAPlacementApplication(
+      decision = PlacementApplicationDecision.ACCEPTED,
+      placementDates = listOf(
+        PlacementDate(
+          expectedArrival = LocalDate.of(2021, 2, 3),
+          duration = 3,
+        ),
+      ),
+    )
+    val placementRequest0 = givenAPlacementRequest(placementApplication = placementAppWithOneDate).first
+    val placementDate0 = placementAppWithOneDate.placementDates[0]
+    placementDate0.placementRequest = placementRequest0
+    placementDateRepository.save(placementDate0)
+
+    val placementAppWithMultipleDates = givenAPlacementApplication(
+      decision = PlacementApplicationDecision.REJECTED,
+      placementDates = listOf(
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 6, 1),
+          duration = 5,
+          placementRequest = null,
+        ),
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 7, 1),
+          duration = 6,
+          placementRequest = null,
+        ),
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 8, 1),
+          duration = 7,
+          placementRequest = null,
+        ),
+      ),
+    )
+
+    val placementDate1 = placementAppWithMultipleDates.placementDates.first { it.duration == 5 }
+    val placementDate2 = placementAppWithMultipleDates.placementDates.first { it.duration == 6 }
+    val placementDate3 = placementAppWithMultipleDates.placementDates.first { it.duration == 7 }
+
+    assertThat(placementApplicationRepository.findAll()).hasSize(2)
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1FlattenPlacementAppsWithMultipleDates)
+
+    val updatedPlacementApps = placementApplicationRepository.findAll()
+
+    assertThat(updatedPlacementApps).hasSize(4)
+
+    updatedPlacementApps.filter { it.id != placementAppWithOneDate.id }.forEach {
+      assertThat(it.placementRequests).isEmpty()
+      assertThat(it.placementDates).hasSize(1)
+      assertThat(it.application.id).isEqualTo(placementAppWithMultipleDates.application.id)
+      assertThat(it.createdByUser.id).isEqualTo(placementAppWithMultipleDates.createdByUser.id)
+      assertThat(it.data).isEqualTo(placementAppWithMultipleDates.data)
+      assertThat(it.document).isEqualTo(placementAppWithMultipleDates.document)
+      assertThat(it.createdAt).isEqualTo(placementAppWithMultipleDates.createdAt)
+      assertThat(it.submittedAt).isEqualTo(placementAppWithMultipleDates.submittedAt)
+      assertThat(it.decision).isEqualTo(placementAppWithMultipleDates.decision)
+      assertThat(it.decisionMadeAt).isEqualTo(placementAppWithMultipleDates.decisionMadeAt)
+      assertThat(it.placementType).isEqualTo(placementAppWithMultipleDates.placementType)
+      assertThat(it.submissionGroupId).isEqualTo(placementAppWithMultipleDates.submissionGroupId)
+    }
+
+    val updatedPlacementAppWithOneDate = updatedPlacementApps.first { it.id == placementAppWithOneDate.id }
+    val updatedPlacementApp1 = updatedPlacementApps.first { it.placementDates[0].duration == 5 }
+    val updatedPlacementApp2 = updatedPlacementApps.first { it.placementDates[0].duration == 6 }
+    val updatedPlacementApp3 = updatedPlacementApps.first { it.placementDates[0].duration == 7 }
+
+    assertThat(updatedPlacementAppWithOneDate.placementRequests[0].id).isEqualTo(placementRequest0.id)
+    assertThat(updatedPlacementAppWithOneDate.placementDates[0].id).isEqualTo(placementDate0.id)
+    assertThat(updatedPlacementAppWithOneDate.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2021, 2, 3))
+    assertThat(updatedPlacementAppWithOneDate.placementDates[0].duration).isEqualTo(3)
+    assertThat(updatedPlacementAppWithOneDate.placementDates[0].placementRequest!!.id).isEqualTo(placementRequest0.id)
+
+    assertThat(updatedPlacementApp1.placementRequests).isEmpty()
+    assertThat(updatedPlacementApp1.placementDates[0].id).isEqualTo(placementDate1.id)
+    assertThat(updatedPlacementApp1.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 6, 1))
+    assertThat(updatedPlacementApp1.placementDates[0].duration).isEqualTo(5)
+    assertThat(updatedPlacementApp1.placementDates[0].placementRequest).isNull()
+
+    assertThat(updatedPlacementApp2.placementRequests).isEmpty()
+    assertThat(updatedPlacementApp2.placementDates[0].id).isEqualTo(placementDate2.id)
+    assertThat(updatedPlacementApp2.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 7, 1))
+    assertThat(updatedPlacementApp2.placementDates[0].duration).isEqualTo(6)
+    assertThat(updatedPlacementApp2.placementDates[0].placementRequest).isNull()
+
+    assertThat(updatedPlacementApp3.placementRequests).isEmpty()
+    assertThat(updatedPlacementApp3.placementDates[0].id).isEqualTo(placementDate3.id)
+    assertThat(updatedPlacementApp3.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2024, 8, 1))
+    assertThat(updatedPlacementApp3.placementDates[0].duration).isEqualTo(7)
+    assertThat(updatedPlacementApp3.placementDates[0].placementRequest).isNull()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1IsArsonSuitableBackfillJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1IsArsonSuitableBackfillJobTest.kt
@@ -70,7 +70,7 @@ class Cas1IsArsonSuitableBackfillJobTest : IntegrationTestBase() {
       essentialCharacteristics = listOf(characteristicArsonOffences, characteristicArsonDesignated, characteristicArsonSuitable),
     )
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillArsonSuitable, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1BackfillArsonSuitable, 1)
 
     val noCriteriaUpdated = placementRequirementsRepository.findById(noCriteria.id).get()
     assertThat(noCriteriaUpdated.desirableCriteria).isEmpty()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateApplicationLicenceExpiryDateJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateApplicationLicenceExpiryDateJobTest.kt
@@ -56,7 +56,7 @@ class Cas1UpdateApplicationLicenceExpiryDateJobTest : IntegrationTestBase() {
       }
     }.take(10).toList()
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1ApplicationsLicenceExpiryDate, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1ApplicationsLicenceExpiryDate, 1)
 
     applications.forEach {
       val application = updateLicenceExpiryDateRepository.findByIdOrNull(it.id)!! as ApprovedPremisesApplicationEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateApprovedPremisesApplicationWithOffenderJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateApprovedPremisesApplicationWithOffenderJobTest.kt
@@ -67,7 +67,7 @@ class Cas1UpdateApprovedPremisesApplicationWithOffenderJobTest : IntegrationTest
     val existingOffenders = cas1OffenderRepository.findAll()
     assertThat(existingOffenders.size).isEqualTo(0)
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1ApplicationsWithOffender, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1ApplicationsWithOffender, 1)
 
     val newOffenders = cas1OffenderRepository.findAll()
     assertThat(newOffenders.size).isEqualTo(1)
@@ -126,7 +126,7 @@ class Cas1UpdateApprovedPremisesApplicationWithOffenderJobTest : IntegrationTest
     assertThat(existingOffenders.size).isEqualTo(1)
     assertThat(existingOffenders.first().name).isEqualTo("name")
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1ApplicationsWithOffender, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1ApplicationsWithOffender, 1)
 
     val offendersAfterMigration = cas1OffenderRepository.findAll()
     assertThat(offendersAfterMigration.size).isEqualTo(1)
@@ -176,7 +176,7 @@ class Cas1UpdateApprovedPremisesApplicationWithOffenderJobTest : IntegrationTest
     val existingOffenders = cas1OffenderRepository.findAll()
     assertThat(existingOffenders.size).isEqualTo(0)
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1ApplicationsWithOffender, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1ApplicationsWithOffender, 1)
 
     val offendersAfterMigration = cas1OffenderRepository.findAll()
     assertThat(offendersAfterMigration.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateAssessmentReportPropertiesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateAssessmentReportPropertiesJobTest.kt
@@ -102,7 +102,7 @@ class Cas1UpdateAssessmentReportPropertiesJobTest : IntegrationTestBase() {
       )
     }
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1ApprovedPremisesAssessmentReportProperties, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1ApprovedPremisesAssessmentReportProperties, 1)
 
     val assessment1AfterUpdate = updateAssessmentReportPropertiesRepository.findByIdOrNull(assessment1.id)!!
     assertThat(assessment1AfterUpdate.agreeWithShortNoticeReason).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateRoomCodesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1UpdateRoomCodesJobTest.kt
@@ -38,7 +38,7 @@ class Cas1UpdateRoomCodesJobTest : IntegrationTestBase() {
       name = "3",
     )
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas1RoomCodes)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas1RoomCodes)
 
     assertThat(roomRepository.findByIdOrNull(room1WithCorrectCode.id)!!.code).isEqualTo("Q001-1")
     assertThat(roomRepository.findByIdOrNull(room2WithIncorrectCode.id)!!.code).isEqualTo("Q001-2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3MigrateNewBedspaceModelDataJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3MigrateNewBedspaceModelDataJobTest.kt
@@ -62,18 +62,18 @@ class Cas3MigrateNewBedspaceModelDataJobTest : Cas3IntegrationTestBase() {
 
   @Test
   fun `should migrate all data required to new cas3 bedspace model tables`() {
-    migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceModelData, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceModelData, 1)
     val migratedPremises = assertExpectedNumberOfPremisesWereMigrated()
     assertThatAllCas3PremisesDataAndCas3BedspacesDataWasMigratedSuccessfully(migratedPremises)
   }
 
   @Test
   fun `running the migration job twice does not create duplicate rows`() {
-    migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceModelData, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceModelData, 1)
     var migratedPremises = assertExpectedNumberOfPremisesWereMigrated()
     assertThatAllCas3PremisesDataAndCas3BedspacesDataWasMigratedSuccessfully(migratedPremises)
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceModelData, 1)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceModelData, 1)
     migratedPremises = assertExpectedNumberOfPremisesWereMigrated()
     assertThatAllCas3PremisesDataAndCas3BedspacesDataWasMigratedSuccessfully(migratedPremises)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateApplicationOffenderNameJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateApplicationOffenderNameJobTest.kt
@@ -58,7 +58,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
 
       apDeliusContextAddListCaseSummaryToBulkResponse(cases)
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3ApplicationOffenderName, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3ApplicationOffenderName, 10)
 
       temporaryAccommodationApplications.forEach {
         val application = applicationRepository.findTemporaryAccommodationApplicationById(it.id)!!
@@ -108,7 +108,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
 
       apDeliusContextAddListCaseSummaryToBulkResponse(cases)
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3ApplicationOffenderName, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3ApplicationOffenderName, 10)
 
       temporaryAccommodationApplications.forEach {
         val application = applicationRepository.findTemporaryAccommodationApplicationById(it.id)!!
@@ -147,7 +147,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
 
       apDeliusContextEmptyCaseSummaryToBulkResponse(offenderDetails.otherIds.crn)
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3ApplicationOffenderName, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3ApplicationOffenderName, 10)
 
       Assertions.assertThat(logEntries)
         .withFailMessage("-> logEntries actually contains: $logEntries")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateBedSpaceStartDateJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateBedSpaceStartDateJobTest.kt
@@ -38,7 +38,7 @@ class Cas3UpdateBedSpaceStartDateJobTest : MigrationJobTestBase() {
         setCreatedAt(bed, OffsetDateTime.now().randomDateTimeBefore(360))
       }
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceStartDate, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceStartDate, 10)
 
       val savedBeds = bedRepository.findAll()
       assertThat(savedBeds).hasSize(5)
@@ -70,7 +70,7 @@ class Cas3UpdateBedSpaceStartDateJobTest : MigrationJobTestBase() {
         }
       }
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceStartDate, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceStartDate, 10)
 
       val savedBeds = bedRepository.findAll()
       assertThat(savedBeds).hasSize(5)
@@ -130,7 +130,7 @@ class Cas3UpdateBedSpaceStartDateJobTest : MigrationJobTestBase() {
         }
       }
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceStartDate, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceStartDate, 10)
 
       val savedBeds = bedRepository.findAll()
       assertThat(savedBeds).hasSize(3)
@@ -162,7 +162,7 @@ class Cas3UpdateBedSpaceStartDateJobTest : MigrationJobTestBase() {
 
       setCreatedAt(bed, null)
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceStartDate, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceStartDate, 10)
 
       val savedBed = bedRepository.findById(bed.id).get()
       assertThat(savedBed.startDate).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateBookingOffenderNameJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateBookingOffenderNameJobTest.kt
@@ -50,7 +50,7 @@ class Cas3UpdateBookingOffenderNameJobTest : MigrationJobTestBase() {
       apDeliusContextAddListCaseSummaryToBulkResponse(cases1)
       apDeliusContextAddListCaseSummaryToBulkResponse(cases2)
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3BookingOffenderName, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BookingOffenderName, 10)
 
       val savedBookings = bookingRepository.findAll()
       assertThat(savedBookings).hasSize(15)
@@ -89,7 +89,7 @@ class Cas3UpdateBookingOffenderNameJobTest : MigrationJobTestBase() {
         }
       }
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3BookingOffenderName, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BookingOffenderName, 10)
 
       val savedBookings = bookingRepository.findAll()
       assertThat(savedBookings).hasSize(8)
@@ -117,7 +117,7 @@ class Cas3UpdateBookingOffenderNameJobTest : MigrationJobTestBase() {
         withServiceName(temporaryAccommodation)
       }
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3BookingOffenderName, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BookingOffenderName, 10)
 
       Assertions.assertThat(logEntries)
         .withFailMessage("-> logEntries actually contains: $logEntries")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest.kt
@@ -68,7 +68,7 @@ class Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJobTest : MigrationJobTe
       }
     }.take(3).toList()
 
-    migrationJobService.runMigrationJob(MigrationJobType.cas3DomainEventTypeForPersonDepartedUpdated)
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas3DomainEventTypeForPersonDepartedUpdated)
 
     personDepartureUpdatedInvalidDomainEvents.forEach {
       val domainEvent = domainEventRepository.findById(it.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3VoidBedspaceCancellationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3VoidBedspaceCancellationJobTest.kt
@@ -69,7 +69,7 @@ class Cas3VoidBedspaceCancellationJobTest : MigrationJobTestBase() {
       val voidBedspaces = createVoidBedspaces(premises, 25)
 
       // this job needs to have ran first.
-      migrationJobService.runMigrationJob(MigrationJobType.cas3BedspaceModelData)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceModelData)
       val bedspaces = cas3BedspacesRepository.findAll().filter { it.premises.id == premises.id }
       assertThat(bedspaces).hasSize(voidBedspaces.size)
 
@@ -83,7 +83,7 @@ class Cas3VoidBedspaceCancellationJobTest : MigrationJobTestBase() {
         }
       }
 
-      migrationJobService.runMigrationJob(MigrationJobType.cas3VoidBedspaceCancellationData, 10)
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3VoidBedspaceCancellationData, 10)
 
       val cancelledVoidBedspaces = cas3VoidBedspacesRepository.findAll().filter { it.cancellation != null }
       assertThat(cancelledVoidBedspaces).hasSize(20)


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-2417

This commit adds a migration job to change the ‘in database’ cardinality of placement app -> placement date from one-to-many to one-to-one.

Once this has been done, we can update the JPA data model to reflect this

See here for more information: https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4776722438/CAS1+Proposal+Requests+for+Placements+Data+Model#%E2%80%98Flattening%E2%80%99-placement-apps-with-multiple-dates