### PR TITLE
CAS-1669: Changed SQL order by for bedspace migration job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -65,6 +65,7 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
         INNER JOIN rooms r ON b.room_id = r.id
         INNER JOIN premises p ON r.premises_id = p.id
         WHERE p.service = :service
+        ORDER BY b.id
     """,
     nativeQuery = true,
   )


### PR DESCRIPTION
Order by bed.id to ensure the paging is predictable.