### PR TITLE
APS-2417 Add job to fix incorrectly linked Placement Dates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
@@ -17,6 +17,15 @@ interface PlacementDateRepository : JpaRepository<PlacementDateEntity, UUID> {
 
   @Query("SELECT p FROM PlacementDateEntity p WHERE p.placementApplication = :placementApplication")
   fun findAllByPlacementApplication(placementApplication: PlacementApplicationEntity): List<PlacementDateEntity>
+
+  @Query(
+    """select pad.placement_application_id 
+       from placement_application_dates pad 
+       inner join placement_requests pr on pr.id = pad.placement_request_id 
+       where pr.reallocated_at is not null""",
+    nativeQuery = true,
+  )
+  fun findPlacementAppIdsWithDatesLinkedToReallocatedPlacementRequest(): List<UUID>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2Statu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1ArsonSuitableToArsonOffencesJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillOfflineApplicationName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillUserApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1FixDatesLinkedToReallocatedPlacementRequestsJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1IsArsonSuitableBackfillJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1TaskDueMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UpdateApplicationLicenceExpiryDateJob
@@ -63,6 +64,7 @@ class MigrationJobService(
         MigrationJobType.cas1ApplicationsWithOffender -> getBean(Cas1UpdateApprovedPremisesApplicationWithOffenderJob::class)
         MigrationJobType.cas3BedspaceModelData -> getBean(Cas3MigrateNewBedspaceModelDataJob::class)
         MigrationJobType.cas3VoidBedspaceCancellationData -> getBean(Cas3VoidBedspaceCancellationJob::class)
+        MigrationJobType.cas1FixDatesLinkedToReallocatedPlacementRequests -> getBean(Cas1FixDatesLinkedToReallocatedPlacementRequestsJob::class)
       }
 
       if (job.shouldRunInTransaction) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJob.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import java.util.UUID
+
+/**
+ * We maintain two (redundant) links from a placement application to placement requests
+ *
+ * 1. Placement Application <-> Placement Request
+ * 2. Placement Application <-> Placement Date <-> Placement Request
+ *
+ * Both (1) and (2) should refer to the same set of placement requests
+ *
+ * Some Placement Requests in (1) are different to those referenced by (2).
+ * Investigations has shown in the case of (2) that the placement requests
+ * referred to have been reallocated, and the new versions of hte placement
+ * requests are correctly linked in (1). This job fixes the references in (2)
+ * to match those in (1)
+ */
+@Service
+class Cas1FixDatesLinkedToReallocatedPlacementRequestsJob(
+  private val placementDateRepository: PlacementDateRepository,
+  private val placementApplicationRepository: PlacementApplicationRepository,
+  private val migrationLogger: MigrationLogger,
+  override val shouldRunInTransaction: Boolean = true,
+) : MigrationJob() {
+  override fun process(pageSize: Int) {
+    val placementApplicationsToFix = placementDateRepository.findPlacementAppIdsWithDatesLinkedToReallocatedPlacementRequest().toSet()
+
+    placementApplicationsToFix.forEach {
+      fixPlacementDateFk(it)
+    }
+  }
+
+  private fun fixPlacementDateFk(placementAppId: UUID) {
+    val placementApp = placementApplicationRepository.findByIdOrNull(placementAppId)!!
+    val placementDates = placementApp.placementDates
+
+    migrationLogger.info("Fixing placement dates for placement app $placementAppId with ${placementDates.size} dates")
+
+    val unassignedPlacementRequests = placementApp.placementRequests.toMutableList()
+
+    placementDates.forEach { date ->
+      val toAssign = unassignedPlacementRequests
+        .find { it.expectedArrival == date.expectedArrival && it.duration == date.duration }
+
+      if (toAssign == null) {
+        error("Couldn't find a placement request for placement date ${date.expectedArrival} with duration ${date.duration} linked to placement app $placementAppId")
+      }
+
+      if (toAssign.isReallocated()) {
+        error("Placement request ${toAssign.id} is unexpectedly reallocated")
+      }
+
+      migrationLogger.info("Reassigning placement date ${date.id} from reallocated PR ${date.placementRequest?.id} to ${toAssign.id}")
+
+      date.placementRequest = toAssign
+      placementDateRepository.save(date)
+
+      unassignedPlacementRequests.remove(toAssign)
+    }
+
+    if (unassignedPlacementRequests.isNotEmpty()) {
+      error("Still have remaining placement requests $unassignedPlacementRequests for placement app $placementAppId")
+    }
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3372,6 +3372,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - update_cas1_fix_dates_linked_to_reallocated_placement_requests
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6524,6 +6524,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - update_cas1_fix_dates_linked_to_reallocated_placement_requests
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5776,6 +5776,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - update_cas1_fix_dates_linked_to_reallocated_placement_requests
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3886,6 +3886,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - update_cas1_fix_dates_linked_to_reallocated_placement_requests
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3907,6 +3907,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - update_cas1_fix_dates_linked_to_reallocated_placement_requests
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3902,6 +3902,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - update_cas1_fix_dates_linked_to_reallocated_placement_requests
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
@@ -3404,6 +3404,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - update_cas1_fix_dates_linked_to_reallocated_placement_requests
     PlacementDates:
       type: object
       properties:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementDateEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementDateEntityFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -15,6 +16,7 @@ class PlacementDateEntityFactory : Factory<PlacementDateEntity> {
   private var placementApplication: Yielded<PlacementApplicationEntity?> = { null }
   private var expectedArrival: Yielded<LocalDate> = { LocalDate.now() }
   private var duration: Yielded<Int> = { 12 }
+  private var placementRequest: Yielded<PlacementRequestEntity?> = { null }
 
   fun withPlacementApplication(placementApplication: PlacementApplicationEntity) = apply {
     this.placementApplication = { placementApplication }
@@ -28,11 +30,16 @@ class PlacementDateEntityFactory : Factory<PlacementDateEntity> {
     this.duration = { duration }
   }
 
+  fun withPlacementRequest(placementRequest: PlacementRequestEntity?) = apply {
+    this.placementRequest = { placementRequest }
+  }
+
   override fun produce(): PlacementDateEntity = PlacementDateEntity(
     id = this.id(),
     createdAt = this.createdAt(),
     placementApplication = this.placementApplication() ?: throw RuntimeException("Must provide a placementApplication"),
     expectedArrival = this.expectedArrival(),
     duration = this.duration(),
+    placementRequest = this.placementRequest(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.PlacementDate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest : MigrationJobTestBase() {
+
+  @Test
+  fun success() {
+    val placementAppWithMultipleDates = givenAPlacementApplication(
+      decision = PlacementApplicationDecision.ACCEPTED,
+      placementDates = listOf(
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 6, 1),
+          duration = 1,
+        ),
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 7, 1),
+          duration = 2,
+        ),
+        PlacementDate(
+          expectedArrival = LocalDate.of(2024, 8, 1),
+          duration = 3,
+        ),
+      ),
+    )
+
+    val placementRequest1 = givenAPlacementRequest(
+      placementApplication = placementAppWithMultipleDates,
+      expectedArrival = LocalDate.of(2024, 6, 1),
+      duration = 1,
+    ).first
+    val placementRequest1Reallocated = placementRequestRepository.save(placementRequest1.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now(), placementApplication = null))
+
+    val placementRequest2 = givenAPlacementRequest(
+      placementApplication = placementAppWithMultipleDates,
+      expectedArrival = LocalDate.of(2024, 7, 1),
+      duration = 2,
+    ).first
+    val placementRequest2Reallocated = placementRequestRepository.save(placementRequest2.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now(), placementApplication = null))
+
+    val placementRequest3 = givenAPlacementRequest(
+      placementApplication = placementAppWithMultipleDates,
+      expectedArrival = LocalDate.of(2024, 8, 1),
+      duration = 3,
+    ).first
+    val placementRequest3Reallocated = placementRequestRepository.save(placementRequest3.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now(), placementApplication = null))
+
+    val placementDate1 = placementAppWithMultipleDates.placementDates.first { it.duration == 1 }
+    val placementDate2 = placementAppWithMultipleDates.placementDates.first { it.duration == 2 }
+    val placementDate3 = placementAppWithMultipleDates.placementDates.first { it.duration == 3 }
+
+    placementDate1.placementRequest = placementRequest1Reallocated
+    placementDateRepository.save(placementDate1)
+
+    placementDate2.placementRequest = placementRequest2Reallocated
+    placementDateRepository.save(placementDate2)
+
+    placementDate3.placementRequest = placementRequest3Reallocated
+    placementDateRepository.save(placementDate3)
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1FixDatesLinkedToReallocatedPlacementRequests)
+
+    assertThat(placementDateRepository.findByIdOrNull(placementDate1.id)!!.placementRequest!!.id).isEqualTo(placementRequest1.id)
+    assertThat(placementDateRepository.findByIdOrNull(placementDate2.id)!!.placementRequest!!.id).isEqualTo(placementRequest2.id)
+    assertThat(placementDateRepository.findByIdOrNull(placementDate3.id)!!.placementRequest!!.id).isEqualTo(placementRequest3.id)
+  }
+}


### PR DESCRIPTION
We maintain two (redundant) links from a placement application to placement requests

1. Placement Application <-> Placement Request
2. Placement Application <-> Placement Date <-> Placement Request

Both (1) and (2) should refer to the same set of placement requests

Some Placement Requests in (1) are different to those referenced by (2). Investigations have shown in the case of (2) that the placement requests referred to have been reallocated, and the new versions of the placement requests are correctly linked in (1). This job fixes the references in (2) to match those in (1)