### PR TITLE
APS-2165 Move CAS1 app withdrawal logic into CAS1 service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/ApplicationsController.kt
@@ -256,7 +256,7 @@ class ApplicationsController(
     val applicationResult = when (body) {
       is UpdateApprovedPremisesApplication -> cas1ApplicationCreationService.updateApprovedPremisesApplication(
         applicationId = applicationId,
-        ApplicationService.Cas1ApplicationUpdateFields(
+        Cas1ApplicationCreationService.Cas1ApplicationUpdateFields(
           data = serializedData,
           isWomensApplication = body.isWomensApplication,
           isPipeApplication = body.isPipeApplication,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
@@ -35,7 +35,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostcodeDistr
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -63,7 +62,6 @@ class Cas1ApplicationSeedService(
   private val bookingRepository: BookingRepository,
   private val cas1ApplicationTimelineNoteService: Cas1ApplicationTimelineNoteService,
   private val spaceBookingRepository: Cas1SpaceBookingRepository,
-  private val applicationService: ApplicationService,
   private val cas1ApplicationCreationService: Cas1ApplicationCreationService,
   private val cas1ApplicationService: Cas1ApplicationService,
   private val userService: UserService,
@@ -310,7 +308,7 @@ class Cas1ApplicationSeedService(
   private fun withdrawApplication(
     application: ApprovedPremisesApplicationEntity,
   ) {
-    applicationService.withdrawApprovedPremisesApplication(
+    cas1ApplicationService.withdrawApprovedPremisesApplication(
       applicationId = application.id,
       user = application.createdByUser,
       withdrawalReason = "error_in_application",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1ApplicationSeedService.kt
@@ -210,7 +210,7 @@ class Cas1ApplicationSeedService(
     val updatedApplication = extractEntityFromCasResult(
       cas1ApplicationCreationService.updateApprovedPremisesApplication(
         applicationId = newApplicationEntity.id,
-        updateFields = ApplicationService.Cas1ApplicationUpdateFields(
+        updateFields = Cas1ApplicationCreationService.Cas1ApplicationUpdateFields(
           isWomensApplication = false,
           isPipeApplication = null,
           isEmergencyApplication = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1DuplicateApplicationSeedJob.kt
@@ -93,7 +93,7 @@ class Cas1DuplicateApplicationSeedJob(
 
     cas1ApplicationCreationService.updateApprovedPremisesApplication(
       applicationId = newApplicationEntity.id,
-      updateFields = ApplicationService.Cas1ApplicationUpdateFields(
+      updateFields = Cas1ApplicationCreationService.Cas1ApplicationUpdateFields(
         isWomensApplication = sourceApplication.isWomensApplication,
         isPipeApplication = null,
         isEmergencyApplication = sourceApplication.isEmergencyApplication,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -1,14 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
-import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -17,7 +14,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.ApplicationListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -26,9 +22,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationDomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationEmailService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.WithdrawableState
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.OffsetDateTime
@@ -50,12 +43,8 @@ class ApplicationService(
   private val offenderService: OffenderService,
   private val offenderRisksService: OffenderRisksService,
   private val userService: UserService,
-  private val assessmentService: AssessmentService,
   private val offlineApplicationRepository: OfflineApplicationRepository,
   private val userAccessService: UserAccessService,
-  private val cas1ApplicationDomainEventService: Cas1ApplicationDomainEventService,
-  private val cas1ApplicationEmailService: Cas1ApplicationEmailService,
-  private val applicationListener: ApplicationListener,
 ) {
   fun getApplication(applicationId: UUID) = applicationRepository.findByIdOrNull(applicationId)
 
@@ -230,61 +219,6 @@ class ApplicationService(
   fun updateApprovedPremisesApplicationStatus(applicationId: UUID, status: ApprovedPremisesApplicationStatus) {
     applicationRepository.updateStatus(applicationId, status)
   }
-
-  /**
-   * This function should not be called directly. Instead, use [WithdrawableService.withdrawApplication] that
-   * will indirectly invoke this function. It will also ensure that:
-   *
-   * 1. The entity is withdrawable, and error if not
-   * 2. The user is allowed to withdraw it, and error if not
-   * 3. If withdrawn, all descdents entities are withdrawn, where applicable
-   */
-  @Transactional
-  fun withdrawApprovedPremisesApplication(
-    applicationId: UUID,
-    user: UserEntity,
-    withdrawalReason: String,
-    otherReason: String?,
-  ): CasResult<Unit> {
-    val application = applicationRepository.findByIdOrNull(applicationId)
-      ?: return CasResult.NotFound(entityType = "application", applicationId.toString())
-
-    if (application !is ApprovedPremisesApplicationEntity) {
-      return CasResult.GeneralValidationError("onlyCas1Supported")
-    }
-
-    if (application.isWithdrawn) {
-      return CasResult.Success(Unit)
-    }
-
-    val updatedApplication = application.apply {
-      this.isWithdrawn = true
-      this.withdrawalReason = withdrawalReason
-      this.otherWithdrawalReason = if (withdrawalReason == WithdrawalReason.other.value) {
-        otherReason
-      } else {
-        null
-      }
-    }
-    applicationListener.preUpdate(updatedApplication)
-
-    applicationRepository.save(updatedApplication)
-
-    cas1ApplicationDomainEventService.applicationWithdrawn(updatedApplication, withdrawingUser = user)
-    cas1ApplicationEmailService.applicationWithdrawn(updatedApplication, user)
-
-    updatedApplication.assessments.map {
-      assessmentService.updateCas1AssessmentWithdrawn(it.id, user)
-    }
-
-    return CasResult.Success(Unit)
-  }
-
-  fun getWithdrawableState(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableState = WithdrawableState(
-    withdrawable = !application.isWithdrawn,
-    withdrawn = application.isWithdrawn,
-    userMayDirectlyWithdraw = userAccessService.userMayWithdrawApplication(user, application),
-  )
 
   fun updateTemporaryAccommodationApplication(
     applicationId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -227,22 +225,6 @@ class ApplicationService(
     isConcerningArsonBehaviour = null,
     prisonReleaseTypes = null,
     probationDeliveryUnit = null,
-  )
-
-  data class Cas1ApplicationUpdateFields(
-    val isWomensApplication: Boolean?,
-    @Deprecated("use apType")
-    val isPipeApplication: Boolean?,
-    @Deprecated("use noticeType")
-    val isEmergencyApplication: Boolean?,
-    @Deprecated("use apType")
-    val isEsapApplication: Boolean?,
-    val apType: ApType?,
-    val releaseType: String?,
-    val arrivalDate: LocalDate?,
-    val data: String,
-    val isInapplicable: Boolean?,
-    val noticeType: Cas1ApplicationTimelinessCategory?,
   )
 
   fun updateApprovedPremisesApplicationStatus(applicationId: UUID, status: ApprovedPremisesApplicationStatus) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
@@ -37,7 +38,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService.Cas1ApplicationUpdateFields
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
@@ -432,4 +432,20 @@ class Cas1ApplicationCreationService(
 
   private val SubmitApprovedPremisesApplication.isUsingNewApTypeField: Boolean
     get() = apType != null
+
+  data class Cas1ApplicationUpdateFields(
+    val isWomensApplication: Boolean?,
+    @Deprecated("use apType")
+    val isPipeApplication: Boolean?,
+    @Deprecated("use noticeType")
+    val isEmergencyApplication: Boolean?,
+    @Deprecated("use apType")
+    val isEsapApplication: Boolean?,
+    val apType: ApType?,
+    val releaseType: String?,
+    val arrivalDate: LocalDate?,
+    val data: String,
+    val isInapplicable: Boolean?,
+    val noticeType: Cas1ApplicationTimelinessCategory?,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
@@ -1,15 +1,24 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
+import jakarta.transaction.Transactional
 import org.springframework.data.domain.Limit
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.ApplicationListener
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
 import java.util.UUID
@@ -19,7 +28,14 @@ class Cas1ApplicationService(
   private val approvedPremisesApplicationRepository: ApprovedPremisesApplicationRepository,
   private val applicationRepository: ApplicationRepository,
   private val offlineApplicationRepository: OfflineApplicationRepository,
+  private val applicationListener: ApplicationListener,
+  private val cas1ApplicationDomainEventService: Cas1ApplicationDomainEventService,
+  private val cas1ApplicationEmailService: Cas1ApplicationEmailService,
+  private val assessmentService: AssessmentService,
+  private val userAccessService: UserAccessService,
 ) {
+  fun getApplication(applicationId: UUID) = approvedPremisesApplicationRepository.findByIdOrNull(applicationId)
+
   fun getApplicationsForCrn(crn: String, limit: Int) = approvedPremisesApplicationRepository.findByCrn(crn, Limit.of(limit))
 
   fun getOfflineApplicationsForCrn(crn: String, limit: Int) = offlineApplicationRepository.findAllByCrn(crn, Limit.of(limit))
@@ -58,4 +74,55 @@ class Cas1ApplicationService(
 
     return Pair(response.content, getMetadata(response, page, pageSize))
   }
+
+  /**
+   * This function should not be called directly. Instead, use [Cas1WithdrawableService.withdrawApplication] that
+   * will indirectly invoke this function. It will also ensure that:
+   *
+   * 1. The entity is withdrawable, and error if not
+   * 2. The user is allowed to withdraw it, and error if not
+   * 3. If withdrawn, all descdents entities are withdrawn, where applicable
+   */
+  @Transactional
+  fun withdrawApprovedPremisesApplication(
+    applicationId: UUID,
+    user: UserEntity,
+    withdrawalReason: String,
+    otherReason: String?,
+  ): CasResult<Unit> {
+    val application = approvedPremisesApplicationRepository.findByIdOrNull(applicationId)
+      ?: return CasResult.NotFound(entityType = "application", applicationId.toString())
+
+    if (application.isWithdrawn) {
+      return CasResult.Success(Unit)
+    }
+
+    val updatedApplication = application.apply {
+      this.isWithdrawn = true
+      this.withdrawalReason = withdrawalReason
+      this.otherWithdrawalReason = if (withdrawalReason == WithdrawalReason.other.value) {
+        otherReason
+      } else {
+        null
+      }
+    }
+    applicationListener.preUpdate(updatedApplication)
+
+    approvedPremisesApplicationRepository.save(updatedApplication)
+
+    cas1ApplicationDomainEventService.applicationWithdrawn(updatedApplication, withdrawingUser = user)
+    cas1ApplicationEmailService.applicationWithdrawn(updatedApplication, user)
+
+    updatedApplication.assessments.map {
+      assessmentService.updateCas1AssessmentWithdrawn(it.id, user)
+    }
+
+    return CasResult.Success(Unit)
+  }
+
+  fun getWithdrawableState(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableState = WithdrawableState(
+    withdrawable = !application.isWithdrawn,
+    withdrawn = application.isWithdrawn,
+    userMayDirectlyWithdraw = userAccessService.userMayWithdrawApplication(user, application),
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableService.kt
@@ -14,14 +14,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import java.time.LocalDate
 import java.util.UUID
 
 @Service
 class Cas1WithdrawableService(
-  private val applicationService: ApplicationService,
+  private val cas1ApplicationService: Cas1ApplicationService,
   private val placementRequestService: PlacementRequestService,
   private val cas1PlacementApplicationService: Cas1PlacementApplicationService,
   private val bookingService: BookingService,
@@ -76,10 +75,7 @@ class Cas1WithdrawableService(
     withdrawalReason: String,
     otherReason: String?,
   ): CasResult<Unit> {
-    val application = applicationService.getApplication(applicationId) ?: return CasResult.NotFound(entityType = "Application", applicationId.toString())
-    if (application !is ApprovedPremisesApplicationEntity) {
-      return CasResult.GeneralValidationError("Only CAS1 Apps are supported")
-    }
+    val application = cas1ApplicationService.getApplication(applicationId) ?: return CasResult.NotFound(entityType = "Application", applicationId.toString())
 
     val withdrawalContext = WithdrawalContext(
       withdrawalTriggeredBy = WithdrawalTriggeredByUser(user),
@@ -91,7 +87,7 @@ class Cas1WithdrawableService(
       cas1WithdrawableTreeBuilder.treeForApp(application, user).rootNode,
       withdrawalContext,
     ) {
-      applicationService.withdrawApprovedPremisesApplication(applicationId, user, withdrawalReason, otherReason)
+      cas1ApplicationService.withdrawApprovedPremisesApplication(applicationId, user, withdrawalReason, otherReason)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import java.util.UUID
 
@@ -31,7 +30,7 @@ class Cas1WithdrawableTreeBuilder(
   @Lazy private val placementRequestService: PlacementRequestService,
   @Lazy private val bookingService: BookingService,
   @Lazy private val cas1PlacementApplicationService: Cas1PlacementApplicationService,
-  @Lazy private val applicationService: ApplicationService,
+  @Lazy private val cas1ApplicationService: Cas1ApplicationService,
   @Lazy private val cas1SpaceBookingService: Cas1SpaceBookingService,
 ) {
   fun treeForApp(application: ApprovedPremisesApplicationEntity, user: UserEntity): WithdrawableTree {
@@ -54,7 +53,7 @@ class Cas1WithdrawableTreeBuilder(
         applicationId = application.id,
         entityType = WithdrawableEntityType.Application,
         entityId = application.id,
-        status = applicationService.getWithdrawableState(application, user),
+        status = cas1ApplicationService.getWithdrawableState(application, user),
         dates = emptyList(),
         children = children,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
@@ -59,7 +59,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Mana
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService.Cas1ApplicationUpdateFields
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationCreationService.Cas1ApplicationUpdateFields
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
@@ -59,12 +59,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Mana
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationCreationService.Cas1ApplicationUpdateFields
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JsonSchemaService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationCreationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationCreationService.Cas1ApplicationUpdateFields
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OffenderService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationServiceTest.kt
@@ -1,0 +1,275 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.listeners.ApplicationListener
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationDomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
+import java.util.UUID
+
+@SuppressWarnings("UnusedPrivateProperty")
+@ExtendWith(MockKExtension::class)
+class Cas1ApplicationServiceTest {
+
+  @MockK
+  private lateinit var approvedPremisesApplicationRepository: ApprovedPremisesApplicationRepository
+
+  @MockK
+  private lateinit var applicationRepository: ApplicationRepository
+
+  @MockK
+  private lateinit var offlineApplicationRepository: OfflineApplicationRepository
+
+  @MockK
+  private lateinit var applicationListener: ApplicationListener
+
+  @MockK
+  private lateinit var cas1ApplicationDomainEventService: Cas1ApplicationDomainEventService
+
+  @MockK
+  private lateinit var cas1ApplicationEmailService: Cas1ApplicationEmailService
+
+  @MockK
+  private lateinit var assessmentService: AssessmentService
+
+  @MockK
+  private lateinit var userAccessService: UserAccessService
+
+  @InjectMockKs
+  private lateinit var service: Cas1ApplicationService
+
+  @Nested
+  inner class WithdrawApprovedPremisesApplication {
+
+    @Test
+    fun `withdrawApprovedPremisesApplication returns NotFound if Application does not exist`() {
+      val user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      val applicationId = UUID.fromString("bb13d346-f278-43d7-9c23-5c4077c031ca")
+
+      every { approvedPremisesApplicationRepository.findByIdOrNull(applicationId) } returns null
+
+      val result = service.withdrawApprovedPremisesApplication(
+        applicationId,
+        user,
+        "alternative_identified_placement_no_longer_required",
+        null,
+      )
+
+      assertThat(result is CasResult.NotFound).isTrue
+    }
+
+    @Test
+    fun `withdrawApprovedPremisesApplication is idempotent and returns success if already withdrawn`() {
+      val user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withIsWithdrawn(true)
+        .produce()
+
+      every { approvedPremisesApplicationRepository.findByIdOrNull(application.id) } returns application
+      every { userAccessService.userMayWithdrawApplication(user, application) } returns true
+
+      val result = service.withdrawApprovedPremisesApplication(application.id, user, "other", null)
+
+      assertThat(result is CasResult.Success).isTrue
+    }
+
+    @Test
+    fun `withdrawApprovedPremisesApplication returns Success and saves Application with isWithdrawn set to true, triggers domain event and email`() {
+      val user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      every { approvedPremisesApplicationRepository.findByIdOrNull(application.id) } returns application
+      every { userAccessService.userMayWithdrawApplication(user, application) } returns true
+      every { applicationListener.preUpdate(any()) } returns Unit
+      every { approvedPremisesApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesApplicationEntity }
+      every { cas1ApplicationDomainEventService.applicationWithdrawn(any(), any()) } just Runs
+      every { cas1ApplicationEmailService.applicationWithdrawn(any(), any()) } just Runs
+
+      val result = service.withdrawApprovedPremisesApplication(
+        application.id,
+        user,
+        "alternative_identified_placement_no_longer_required",
+        null,
+      )
+
+      assertThat(result is CasResult.Success).isTrue
+
+      verify {
+        approvedPremisesApplicationRepository.save(
+          match {
+            it.id == application.id &&
+              it is ApprovedPremisesApplicationEntity &&
+              it.isWithdrawn &&
+              it.withdrawalReason == "alternative_identified_placement_no_longer_required"
+          },
+        )
+      }
+
+      verify { cas1ApplicationDomainEventService.applicationWithdrawn(application, user) }
+      verify { cas1ApplicationEmailService.applicationWithdrawn(application, user) }
+    }
+
+    @Test
+    fun `withdrawApprovedPremisesApplication returns Success and saves Application with isWithdrawn set to true, triggers domain event when other reason is set`() {
+      val user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      every { approvedPremisesApplicationRepository.findByIdOrNull(application.id) } returns application
+      every { userAccessService.userMayWithdrawApplication(user, application) } returns true
+      every { applicationListener.preUpdate(any()) } returns Unit
+      every { approvedPremisesApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesApplicationEntity }
+      every { cas1ApplicationDomainEventService.applicationWithdrawn(any(), any()) } just Runs
+      every { cas1ApplicationEmailService.applicationWithdrawn(any(), any()) } just Runs
+
+      val result = service.withdrawApprovedPremisesApplication(application.id, user, "other", "Some other reason")
+
+      assertThat(result is CasResult.Success).isTrue
+
+      verify {
+        approvedPremisesApplicationRepository.save(
+          match {
+            it.id == application.id &&
+              it is ApprovedPremisesApplicationEntity &&
+              it.isWithdrawn &&
+              it.withdrawalReason == "other" &&
+              it.otherWithdrawalReason == "Some other reason"
+          },
+        )
+      }
+
+      verify { cas1ApplicationDomainEventService.applicationWithdrawn(application, user) }
+      verify { cas1ApplicationEmailService.applicationWithdrawn(application, user) }
+    }
+
+    @Test
+    fun `withdrawApprovedPremisesApplication does not persist otherWithdrawalReason if withdrawlReason is not other`() {
+      val user = UserEntityFactory()
+        .withUnitTestControlProbationRegion()
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      every { approvedPremisesApplicationRepository.findByIdOrNull(application.id) } returns application
+      every { userAccessService.userMayWithdrawApplication(user, application) } returns true
+      every { applicationListener.preUpdate(any()) } returns Unit
+      every { approvedPremisesApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesApplicationEntity }
+      every { cas1ApplicationEmailService.applicationWithdrawn(any(), any()) } returns Unit
+      every { cas1ApplicationDomainEventService.applicationWithdrawn(any(), any()) } just Runs
+
+      service.withdrawApprovedPremisesApplication(
+        application.id,
+        user,
+        "alternative_identified_placement_no_longer_required",
+        "Some other reason",
+      )
+
+      verify {
+        approvedPremisesApplicationRepository.save(
+          match {
+            it.id == application.id &&
+              it is ApprovedPremisesApplicationEntity &&
+              it.isWithdrawn &&
+              it.withdrawalReason == "alternative_identified_placement_no_longer_required" &&
+              it.otherWithdrawalReason == null
+          },
+        )
+      }
+
+      verify { cas1ApplicationDomainEventService.applicationWithdrawn(application, user) }
+      verify { cas1ApplicationEmailService.applicationWithdrawn(application, user) }
+    }
+  }
+
+  @Nested
+  inner class GetWithdrawableState {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    @Test
+    fun `getWithdrawableState withdrawable if application not withdrawn`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withIsWithdrawn(false)
+        .produce()
+
+      every { userAccessService.userMayWithdrawApplication(user, application) } returns true
+
+      val result = service.getWithdrawableState(application, user)
+
+      assertThat(result.withdrawn).isFalse()
+      assertThat(result.withdrawable).isTrue()
+    }
+
+    @Test
+    fun `getWithdrawableState not withdrawable if application already withdrawn `() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withIsWithdrawn(true)
+        .produce()
+
+      every { userAccessService.userMayWithdrawApplication(user, application) } returns true
+
+      val result = service.getWithdrawableState(application, user)
+
+      assertThat(result.withdrawn).isTrue()
+      assertThat(result.withdrawable).isFalse()
+    }
+
+    @ParameterizedTest
+    @CsvSource("true", "false")
+    fun `getWithdrawableState userMayDirectlyWithdraw delegates to user access service`(canWithdraw: Boolean) {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withIsWithdrawn(false)
+        .produce()
+
+      every { userAccessService.userMayWithdrawApplication(user, application) } returns canWithdraw
+
+      val result = service.getWithdrawableState(application, user)
+
+      assertThat(result.userMayDirectlyWithdraw).isEqualTo(canWithdraw)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
@@ -20,10 +20,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.BlockingReason.ArrivalRecordedInCas1
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.BlockingReason.ArrivalRecordedInDelius
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableTreeBuilder
@@ -35,14 +35,14 @@ class Cas1WithdrawableTreeBuilderTest {
   private val placementRequestService = mockk<PlacementRequestService>()
   private val bookingService = mockk<BookingService>()
   private val cas1PlacementApplicationService = mockk<Cas1PlacementApplicationService>()
-  private val applicationService = mockk<ApplicationService>()
+  private val cas1ApplicationService = mockk<Cas1ApplicationService>()
   private val cas1SpaceBookingService = mockk<Cas1SpaceBookingService>()
 
   private val service = Cas1WithdrawableTreeBuilder(
     placementRequestService,
     bookingService,
     cas1PlacementApplicationService,
-    applicationService,
+    cas1ApplicationService,
     cas1SpaceBookingService,
   )
 
@@ -79,7 +79,7 @@ class Cas1WithdrawableTreeBuilderTest {
   @Test
   fun `tree for app returns all potential elements`() {
     every {
-      applicationService.getWithdrawableState(application, user)
+      cas1ApplicationService.getWithdrawableState(application, user)
     } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     val initialPlacementRequest = createPlacementRequest()
@@ -144,7 +144,7 @@ Notes: []
   @Test
   fun `tree for app excludes placement request's bookings if bookings are adhoc or potentially adhoc`() {
     every {
-      applicationService.getWithdrawableState(application, user)
+      cas1ApplicationService.getWithdrawableState(application, user)
     } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     val initialPlacementRequest = createPlacementRequest()
@@ -205,7 +205,7 @@ Notes: []
   @Test
   fun `tree for app blocks withdrawal if booking has arrival in CAS1`() {
     every {
-      applicationService.getWithdrawableState(application, user)
+      cas1ApplicationService.getWithdrawableState(application, user)
     } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     val initialPlacementRequest = createPlacementRequest()
@@ -268,7 +268,7 @@ Notes: [1 or more placements cannot be withdrawn as they have an arrival]
   @Test
   fun `tree for app blocks withdrawal if booking has arrival in Delius`() {
     every {
-      applicationService.getWithdrawableState(application, user)
+      cas1ApplicationService.getWithdrawableState(application, user)
     } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     every {
@@ -308,7 +308,7 @@ Notes: [1 or more placements cannot be withdrawn as they have an arrival recorde
   @Test
   fun `tree for app blocks withdrawal if space booking has arrival in CAS1`() {
     every {
-      applicationService.getWithdrawableState(application, user)
+      cas1ApplicationService.getWithdrawableState(application, user)
     } returns WithdrawableState(withdrawn = false, withdrawable = true, userMayDirectlyWithdraw = true)
 
     val initialPlacementRequest = createPlacementRequest()


### PR DESCRIPTION
Move the two cas1 withdrawal functions from `ApplicationService` into `Cas1ApplicationService`. This is a pre-req for a fix related to application status.

This included a slight change to the `Cas1WithdrawableService` logic, as it’s no longer possible for it to retrieve an application for another CAS, so validation around this was removed