### PR TITLE
APS-2417 Fix Placement Date Migration Job Fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJob.kt
@@ -43,7 +43,7 @@ class Cas1FixDatesLinkedToReallocatedPlacementRequestsJob(
 
     migrationLogger.info("Fixing placement dates for placement app $placementAppId with ${placementDates.size} dates")
 
-    val unassignedPlacementRequests = placementApp.placementRequests.toMutableList()
+    val unassignedPlacementRequests = placementApp.placementRequests.filter { !it.isReallocated() }.toMutableList()
 
     placementDates.forEach { date ->
       val toAssign = unassignedPlacementRequests
@@ -51,10 +51,6 @@ class Cas1FixDatesLinkedToReallocatedPlacementRequestsJob(
 
       if (toAssign == null) {
         error("Couldn't find a placement request for placement date ${date.expectedArrival} with duration ${date.duration} linked to placement app $placementAppId")
-      }
-
-      if (toAssign.isReallocated()) {
-        error("Placement request ${toAssign.id} is unexpectedly reallocated")
       }
 
       migrationLogger.info("Reassigning placement date ${date.id} from reallocated PR ${date.placementRequest?.id} to ${toAssign.id}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest.kt
@@ -40,21 +40,27 @@ class Cas1FixDatesLinkedToReallocatedPlacementRequestsJobTest : MigrationJobTest
       expectedArrival = LocalDate.of(2024, 6, 1),
       duration = 1,
     ).first
-    val placementRequest1Reallocated = placementRequestRepository.save(placementRequest1.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now(), placementApplication = null))
+    val placementRequest1Reallocated = placementRequestRepository.save(
+      placementRequest1.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now()),
+    )
 
     val placementRequest2 = givenAPlacementRequest(
       placementApplication = placementAppWithMultipleDates,
       expectedArrival = LocalDate.of(2024, 7, 1),
       duration = 2,
     ).first
-    val placementRequest2Reallocated = placementRequestRepository.save(placementRequest2.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now(), placementApplication = null))
+    val placementRequest2Reallocated = placementRequestRepository.save(
+      placementRequest2.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now()),
+    )
 
     val placementRequest3 = givenAPlacementRequest(
       placementApplication = placementAppWithMultipleDates,
       expectedArrival = LocalDate.of(2024, 8, 1),
       duration = 3,
     ).first
-    val placementRequest3Reallocated = placementRequestRepository.save(placementRequest3.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now(), placementApplication = null))
+    val placementRequest3Reallocated = placementRequestRepository.save(
+      placementRequest3.copy(id = UUID.randomUUID(), reallocatedAt = OffsetDateTime.now()),
+    )
 
     val placementDate1 = placementAppWithMultipleDates.placementDates.first { it.duration == 1 }
     val placementDate2 = placementAppWithMultipleDates.placementDates.first { it.duration == 2 }


### PR DESCRIPTION
The job previously tried to allocate any placement request linked to the placement application, including those that were realloacted. This was wrong and these should be ignored.

