### PR TITLE
CAS-1273: added job to trigger workflow on deploy to dev

### DIFF
--- a/.github/workflows/generate-cas3-ui-types.yml
+++ b/.github/workflows/generate-cas3-ui-types.yml
@@ -1,12 +1,8 @@
 name: Generate CAS3 UI Types
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/main/resources/static/codegen/built-api-spec.yml'
-      - 'src/main/resources/static/codegen/built-cas3-api-spec.yml'
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   generate-ui:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,6 +41,12 @@ jobs:
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 
+  cas3_generate_types:
+    needs: e2e
+    name: Run the generate types job for the CAS3 UI
+    uses: ./.github/workflows/generate-cas3-ui-types.yml@main
+    secrets: inherit
+
   deploy_preprod:
     name: Deploy to pre-production environment
     needs:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3DummyController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3DummyController.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AllocatedFilte
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingSearchSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas3ReportType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 
 @RestController
@@ -39,4 +40,5 @@ data class ClassesToInclude(
   val bookingSearchSortField: BookingSearchSortField,
   val cas3ReportType: Cas3ReportType,
   val assessmentSortField: AssessmentSortField,
+  val oasysSection: OASysSection,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/swagger/SwaggerConfiguration.kt
@@ -46,7 +46,7 @@ class SwaggerConfiguration {
   fun cas1Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS1Shared")
     .displayName("CAS1 & Shared")
-    .pathsToExclude("/**/cas2/**", "/**/cas3/**", "/**/events/**")
+    .pathsToExclude("/**/cas2/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**")
     .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
@@ -63,7 +63,7 @@ class SwaggerConfiguration {
   fun cas2Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS2Shared")
     .displayName("CAS2 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas3/**", "/**/events/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**")
     .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 
@@ -87,7 +87,7 @@ class SwaggerConfiguration {
   fun cas3Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS3Shared")
     .displayName("CAS3 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/events/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas2v2/**", "/**/events/**")
     .addOpenApiCustomizer(errorResponsesCustomizer())
     .build()
 


### PR DESCRIPTION
CAS-1273: This changes how the generate-types job is called in the cas3 api repo - currently it's triggered when branch is merged to main, however this moves it to run after a successful deploy to dev and after the e2e tests have ran. It also adds some filtering in to exclude cas2v2 paths from the generated swagger docs, and also adds a model into the dummy controller that is needed by the UI.