### PR TITLE
CAS-1708: Migration process to assign start date to premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3Updat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateBedSpaceStartDateJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateBookingOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3UpdatePremisesStartDateJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3.Cas3VoidBedspaceCancellationJob
 import kotlin.reflect.KClass
 
@@ -55,6 +56,7 @@ class MigrationJobService(
         MigrationJobType.updateCas3ApplicationOffenderName -> getBean(Cas3UpdateApplicationOffenderNameJob::class)
         MigrationJobType.updateCas3BookingOffenderName -> getBean(Cas3UpdateBookingOffenderNameJob::class)
         MigrationJobType.updateCas3BedspaceStartDate -> getBean(Cas3UpdateBedSpaceStartDateJob::class)
+        MigrationJobType.updateCas3PremisesStartDate -> getBean(Cas3UpdatePremisesStartDateJob::class)
         MigrationJobType.updateCas3DomainEventTypeForPersonDepartedUpdated -> getBean(Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob::class)
         MigrationJobType.updateCas1ApplicationsLicenceExpiryDate -> getBean(Cas1UpdateApplicationLicenceExpiryDateJob::class)
         MigrationJobType.updateCas1BackfillOfflineApplicationName -> getBean(Cas1BackfillOfflineApplicationName::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3UpdatePremisesStartDateJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas3/Cas3UpdatePremisesStartDateJob.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas3
+
+import jakarta.persistence.EntityManager
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName.temporaryAccommodation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+
+@Component
+class Cas3UpdatePremisesStartDateJob(
+  private val entityManager: EntityManager,
+  private val migrationLogger: MigrationLogger,
+  private val premisesRepository: PremisesRepository,
+) : MigrationJob() {
+  override val shouldRunInTransaction = false
+
+  @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught", "NestedBlockDepth")
+  override fun process(pageSize: Int) {
+    var page = 0
+    var hasNext = true
+    var slice: Slice<TemporaryAccommodationPremisesEntity>
+    var currentSlice = setOf<String>()
+
+    try {
+      while (hasNext) {
+        migrationLogger.info("Getting page $page for max page size $pageSize")
+        slice = premisesRepository.findTemporaryAccommodationPremisesByService(temporaryAccommodation.value, PageRequest.of(page, pageSize))
+
+        currentSlice = slice.map { it.id.toString() }.toSet()
+
+        for (tap in slice.content) {
+          if (tap.startDate == null) {
+            migrationLogger.info("Updating premises start_date for premises id ${tap.id}")
+            if (tap.createdAt != null) {
+              migrationLogger.info("Using created_date as start_date for premises id ${tap.id}")
+              tap.startDate = tap.createdAt!!.toLocalDate()
+              premisesRepository.save(tap)
+            } else {
+              migrationLogger.info("Using oldest booking arrival_date as start_date for premises id ${tap.id}")
+              val oldestBooking = tap.bookings.sortedBy { it.arrivalDate }.take(1).firstOrNull()
+              if (oldestBooking == null) {
+                migrationLogger.info("No bookings found for premises id ${tap.id}")
+              } else {
+                tap.startDate = oldestBooking.arrivalDate
+                premisesRepository.save(tap)
+                migrationLogger.info("Updated start_date for premises id ${tap.id} from booking arrival_date ${oldestBooking?.arrivalDate}")
+              }
+            }
+          } else {
+            migrationLogger.info("Premises start_date already set for premises id ${tap.id}")
+          }
+        }
+        entityManager.clear()
+        hasNext = slice.hasNext()
+        page++
+      }
+    } catch (exception: Exception) {
+      migrationLogger.error("Unable to update premises start_date with id ${currentSlice.joinToString()}", exception)
+    }
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3361,6 +3361,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
         - update_cas3_bedspace_start_date
+        - update_cas3_premises_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6513,6 +6513,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
         - update_cas3_bedspace_start_date
+        - update_cas3_premises_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5765,6 +5765,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
         - update_cas3_bedspace_start_date
+        - update_cas3_premises_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3875,6 +3875,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
         - update_cas3_bedspace_start_date
+        - update_cas3_premises_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3896,6 +3896,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
         - update_cas3_bedspace_start_date
+        - update_cas3_premises_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -3891,6 +3891,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
         - update_cas3_bedspace_start_date
+        - update_cas3_premises_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3v2-api-spec.yml
@@ -3393,6 +3393,7 @@ components:
         - update_cas3_application_offender_name
         - update_cas3_booking_offender_name
         - update_cas3_bedspace_start_date
+        - update_cas3_premises_start_date
         - update_cas3_domain_event_type_for_person_departed_updated
         - update_cas1_applications_licence_expiry_date
         - update_cas1_backfill_offline_application_name

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdatePremisesStartDateJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas3/Cas3UpdatePremisesStartDateJobTest.kt
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName.temporaryAccommodation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+class Cas3UpdatePremisesStartDateJobTest : MigrationJobTestBase() {
+
+  @Test
+  fun `Premises with null startDate are updated using createdAt date`() {
+    givenAUser { user, jwt ->
+
+      val premisesTemporaryAccommodation = temporaryAccommodationPremisesEntityFactory.produceAndPersistMultiple(5) {
+        withProbationRegion(user.probationRegion)
+        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+      }
+
+      premisesTemporaryAccommodation.forEach {
+        it.createdAt = OffsetDateTime.now().randomDateTimeBefore(360)
+        temporaryAccommodationPremisesRepository.save(it)
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3PremisesStartDate, 10)
+
+      val savedTap = temporaryAccommodationPremisesRepository.findAll()
+      assertThat(savedTap).hasSize(5)
+      savedTap.forEach {
+        assertThat(it.startDate).isEqualTo(it.createdAt!!.toLocalDate())
+      }
+    }
+  }
+
+  @Test
+  fun `Premises with null startDate and null createdAt are updated using oldest booking arrival date`() {
+    givenAUser { user, jwt ->
+
+      val premisesTemporaryAccommodation = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withProbationRegion(user.probationRegion)
+        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+      }
+
+      premisesTemporaryAccommodation.createdAt = null
+
+      temporaryAccommodationPremisesRepository.save(premisesTemporaryAccommodation)
+
+      val oldestArrivalDate = LocalDate.now().randomDateBefore(60)
+      val newerArrivalDate = LocalDate.now().randomDateAfter(59)
+
+      bookingEntityFactory.produceAndPersist {
+        withPremises(premisesTemporaryAccommodation)
+        withServiceName(temporaryAccommodation)
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withRoom(
+              roomEntityFactory.produceAndPersist {
+                withPremises(premisesTemporaryAccommodation)
+              },
+            )
+          },
+        )
+        withArrivalDate(oldestArrivalDate)
+        withDepartureDate(oldestArrivalDate.plusDays(7))
+        withServiceName(temporaryAccommodation)
+      }
+
+      bookingEntityFactory.produceAndPersist {
+        withPremises(premisesTemporaryAccommodation)
+        withServiceName(temporaryAccommodation)
+        withBed(
+          bedEntityFactory.produceAndPersist {
+            withRoom(
+              roomEntityFactory.produceAndPersist {
+                withPremises(premisesTemporaryAccommodation)
+              },
+            )
+          },
+        )
+        withArrivalDate(newerArrivalDate)
+        withDepartureDate(newerArrivalDate.plusDays(7))
+        withServiceName(temporaryAccommodation)
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3PremisesStartDate, 10)
+
+      val savedTap = temporaryAccommodationPremisesRepository.findAll()
+      assertThat(savedTap).hasSize(1)
+      savedTap.forEach {
+        assertThat(it.startDate).isEqualTo(oldestArrivalDate)
+      }
+    }
+  }
+
+  @Test
+  fun `Premises with null startDate and no bookings remain unchanged`() {
+    givenAUser { user, jwt ->
+
+      val premisesTemporaryAccommodation = temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+        withProbationRegion(user.probationRegion)
+        withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+      }
+
+      val room = roomEntityFactory.produceAndPersist {
+        withPremises(premisesTemporaryAccommodation)
+        withName("Test Room")
+      }
+
+      val bed = bedEntityFactory.produceAndPersist {
+        withRoom(room)
+        withName("Bed with no bookings")
+        withStartDate(null)
+      }
+
+      setCreatedAt(bed, null)
+
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3PremisesStartDate, 10)
+
+      val savedBed = bedRepository.findById(bed.id).get()
+      assertThat(savedBed.startDate).isNull()
+    }
+  }
+
+  private fun setCreatedAt(bed: BedEntity, createdAt: OffsetDateTime?) {
+    bed.createdAt = createdAt
+    bedRepository.save(bed)
+  }
+}


### PR DESCRIPTION
Summary

This Pull Request introduces functionality to update the startDate for temporary accommodation premises in the system. The update logic uses either the creation timestamp or, when absent, the oldest booking arrival date. Additionally, code is revised to include the corresponding migration job, and tests are added to validate the new functionality.

Main Changes

- Added a new repository method to fetch temporary accommodation premises by service with pagination (findTemporaryAccommodationPremisesByService).
- Introduced the Cas3UpdatePremisesStartDateJob class to implement the migration logic, updating startDate based on createdAt or the earliest booking arrival date.
- Modified the PremisesEntity to include createdAt with a @CreationTimestamp.
- Added the migration job logic to MigrationJobService and registered it in multiple configuration files (_shared.yml and codegen specs).
- Implemented the Cas3UpdatePremisesStartDateJobTest to validate:
  - Updating startDate using createdAt.
  - Using the oldest booking arrival date when createdAt is null.
  - No changes when neither createdAt nor bookings are available.