### PR TITLE
APS-1056 Set trigger type to SYSTEM

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestDomainEventService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Re
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementCreatedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.Clock
@@ -68,6 +69,7 @@ class Cas1PlacementRequestDomainEventService(
         crn = application.crn,
         nomsNumber = application.nomsNumber,
         occurredAt = eventOccurredAt,
+        triggerSource = TriggerSourceType.SYSTEM,
         data = RequestForPlacementCreatedEnvelope(
           id = domainEventId,
           timestamp = eventOccurredAt,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementRequestCas1DomainEventServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequire
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.WithdrawnByFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TriggerSourceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.PlacementRequestSource
@@ -118,6 +119,7 @@ class Cas1PlacementRequestCas1DomainEventServiceTest {
             assertThat(it.crn).isEqualTo(CRN)
             assertThat(it.nomsNumber).isEqualTo(application.nomsNumber)
             assertThat(it.occurredAt).isWithinTheLastMinute()
+            assertThat(it.triggerSource).isEqualTo(TriggerSourceType.SYSTEM)
 
             val eventDetails = it.data.eventDetails
             assertThat(eventDetails.applicationId).isEqualTo(application.id)


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-1056

Set trigger source to `TriggerSourceType.SYSTEM` when `PlacementRequestSource` is `ASSESSMENT_OF_APPLICATION`.

**Before:**

Submitted, reallocated and assessed the existing application locally for X320741, having logged in as AP_USER_TEST_1 and see this on the timeline:

![image](https://github.com/user-attachments/assets/402da118-5d2f-4cda-a9b4-3563ec30cd8b)

This incorrectly (or rather misleadingly) shows the placement requested by AP_USER_TEST_1.

**After:**

After changing the trigger source to ‘SYSTEM’ and repeating the process, the user has changed from AP_USER_TEST_1 to System in the timeline as expected:

![image](https://github.com/user-attachments/assets/4f5f4edf-62c5-4935-be99-3a511bf25466)

Tested locally.