### PR TITLE
Remove gradle incremental build config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,5 @@
 # Set sensible defaults for memory usage
 org.gradle.jvmargs=-Xms256M -Xmx4g -XX:MaxMetaspaceSize=1g -Dkotlin.daemon.jvmargs=-Xmx2g
-# Enable Kotlin incremental builds
-kotlin.incremental.useClasspathSnapshot=true
 # Enable Gradle Daemon
 org.gradle.daemon=true
 # Enable Configure on demand


### PR DESCRIPTION
Gradle is reporting the following:

```
⚠️ Deprecated Gradle Property 'kotlin.incremental.useClasspathSnapshot' Used
The `kotlin.incremental.useClasspathSnapshot` deprecated property is used in your build.
Solutions:
 • It is unsupported, please stop using it.
 • History based incremental compilation approach for JVM platform is removed. Kotlin Gradle plugin is now using a more efficient approach based on ABI snapshots.
```

This commit removes that config

