### PR TITLE
Add test reports to PR builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,17 +93,39 @@ jobs:
           java-version: 21
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: run unit tests
+      - name: Run unit tests
         shell: bash
         run: ./gradlew unitTest
-      - name: upload the artifacts
-        if: always()
+      - name: Upload raw test reports on failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: upload kotlin test results
+          name: unit-test-results
           path: |
             build/test-results
             build/reports/tests
+      - name: Publish Test Report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: './build/test-results/unitTest/*.xml'
+          use-suite-name: true
+          integrations-config: |
+            {
+              "junit-to-ctrf": {
+                "enabled": true,
+                "action": "convert",
+                "options": {
+                  "output": "./ctrf-reports/ctrf-report.json",
+                  "toolname": "junit-to-ctrf",
+                  "useSuiteName": true,
+                  "env": {
+                    "appName": "approved-premises-api"
+                  }
+                }
+              }
+            }
+        if: always()
+
 
   integration_test:
     name: Integration Test
@@ -181,13 +203,33 @@ jobs:
           echo "Prepared arguments for Gradle: $SPECS_LIST"
           ./gradlew integrationTest $SPECS_LIST
 
-      - name: upload the artifacts
-        if: always()
+      - name: Upload raw test reports on failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-results-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: |
             build/test-results
             build/reports/tests
-  
 
+      - name: Publish Test Report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: './build/test-results/integrationTest/*.xml'
+          use-suite-name: true
+          integrations-config: |
+            {
+              "junit-to-ctrf": {
+                "enabled": true,
+                "action": "convert",
+                "options": {
+                  "output": "./ctrf-reports/ctrf-report.json",
+                  "toolname": "junit-to-ctrf",
+                  "useSuiteName": true,
+                  "env": {
+                    "appName": "approved-premises-api"
+                  }
+                }
+              }
+            }
+        if: always()


### PR DESCRIPTION
This commit adds test reports to PR builds using https://github.com/ctrf-io/github-test-reporter.

It also change the ‘upload raw test artifact’ steps to only uploads raw artifacts in the event of a test failure, significantly reducing the amount of artifacts we’re retaining.

Example output:

Unit test - https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/15922993979/attempts/1#summary-44913899411
Integration test - https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/15922993979/attempts/1#summary-44913899421

![Screenshot 2025-06-27 at 10 31 10](https://github.com/user-attachments/assets/e9183b41-1674-46e8-b5b2-154b8a793761)