### PR TITLE
CAS-1809 Downgrade spring and jpa plugin versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ import java.io.File
 
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0"
-  kotlin("plugin.spring") version "2.2.0"
-  kotlin("plugin.jpa") version "2.2.0"
+  kotlin("plugin.spring") version "2.1.21"
+  kotlin("plugin.jpa") version "2.1.21"
   id("org.openapi.generator") version "7.13.0"
   id("io.gitlab.arturbosch.detekt") version "1.23.8"
   id("org.owasp.dependencycheck") version "12.1.3"


### PR DESCRIPTION
This [PR CAS-1809](https://dsdmoj.atlassian.net/browse/CAS-1809) is to downgrade spring and jpa plugin versions as many developers had issues in Intellij complaining about Unresolved reference