### PR TITLE
update generate types job

### DIFF
--- a/.github/workflows/generate-cas1-ui-types.yml
+++ b/.github/workflows/generate-cas1-ui-types.yml
@@ -1,13 +1,8 @@
 name: Generate CAS1 UI Types
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/main/resources/static/codegen/built-api-spec.yml'
-      - 'src/main/resources/static/codegen/built-cas1-api-spec.yml'
-      - 'src/main/resources/static/codegen/built-cas1-roles.json'
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   generate-ui:

--- a/.github/workflows/generate-cas2-ui-types.yml
+++ b/.github/workflows/generate-cas2-ui-types.yml
@@ -1,11 +1,8 @@
 name: Generate CAS2 UI Types
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/main/resources/static/codegen/built-cas2-api-spec.yml'
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   generate-ui:

--- a/.github/workflows/generate-cas2v2-ui-types.yml
+++ b/.github/workflows/generate-cas2v2-ui-types.yml
@@ -1,11 +1,8 @@
 name: Generate CAS2 Bail UI Types
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/main/resources/static/codegen/built-cas2v2-api-spec.yml'
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   generate-ui:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,6 +41,24 @@ jobs:
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 
+  cas1_generate_types:
+    needs: e2e
+    name: Run the generate types job for the CAS1 UI
+    uses: ./.github/workflows/generate-cas1-ui-types.yml
+    secrets: inherit
+
+  cas2_generate_types:
+    needs: e2e
+    name: Run the generate types job for the CAS2 UI
+    uses: ./.github/workflows/generate-cas2-ui-types.yml
+    secrets: inherit
+
+  cas2v2_generate_types:
+    needs: e2e
+    name: Run the generate types job for the CAS2v2 UI
+    uses: ./.github/workflows/generate-cas2v2-ui-types.yml
+    secrets: inherit
+
   cas3_generate_types:
     needs: e2e
     name: Run the generate types job for the CAS3 UI


### PR DESCRIPTION
CAS-1807 / CAS-1808
This moves the generate-types jobs to run after successful E2E runs. This is pre-work for switching over to using the open API spec files from the dev environment.

The trade off is that this job runs one each successful completion of the E2Es, rather than only if the build-spec files were changed.

