### PR TITLE
CAS-1775: BE Create a void after bedspace end date update logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
@@ -399,6 +399,7 @@ class Cas3PremisesService(
     return success(updatedRoom.beds.first())
   }
 
+  @Suppress("ComplexCondition")
   fun createVoidBedspaces(
     premises: PremisesEntity,
     startDate: LocalDate,
@@ -415,7 +416,7 @@ class Cas3PremisesService(
     val bed = premises.rooms.flatMap { it.beds }.firstOrNull { it.id == bedId }
     if (bed == null) {
       "$.bedId" hasValidationError "doesNotExist"
-    } else if (bed.endDate != null && startDate.isAfter(bed.endDate)) {
+    } else if (bed.endDate != null && startDate >= bed.endDate) {
       "$.startDate" hasValidationError "voidStartDateAfterBedspaceEndDate"
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3PremisesServiceTest.kt
@@ -737,6 +737,46 @@ class Cas3PremisesServiceTest {
         entry("$.startDate", "voidStartDateAfterBedspaceEndDate"),
       )
     }
+
+    @Test
+    fun `createVoidBedspaces returns validation error message when void start date is the same as bedspace end date`() {
+      val premisesEntity = temporaryAccommodationPremisesFactory.produce()
+
+      val room = RoomEntityFactory()
+        .withPremises(premisesEntity)
+        .produce()
+
+      val bed = BedEntityFactory()
+        .withYieldedRoom { room }
+        .withStartDate(LocalDate.parse("2022-08-20"))
+        .withEndDate(LocalDate.parse("2022-08-24"))
+        .produce()
+
+      premisesEntity.rooms += room
+      room.beds += bed
+
+      val voidBedspaceReason = Cas3VoidBedspaceReasonEntityFactory()
+        .produce()
+
+      every { cas3VoidBedspaceReasonRepositoryMock.findByIdOrNull(voidBedspaceReason.id) } returns voidBedspaceReason
+
+      every { cas3VoidBedspacesRepositoryMock.save(any()) } answers { it.invocation.args[0] as Cas3VoidBedspaceEntity }
+
+      val result = premisesService.createVoidBedspaces(
+        premises = premisesEntity,
+        startDate = LocalDate.parse("2022-08-24"),
+        endDate = LocalDate.parse("2022-08-28"),
+        reasonId = voidBedspaceReason.id,
+        referenceNumber = "12345",
+        notes = "notes",
+        bedId = bed.id,
+      )
+
+      assertThat(result).isInstanceOf(ValidatableActionResult.FieldValidationError::class.java)
+      assertThat((result as ValidatableActionResult.FieldValidationError).validationMessages).contains(
+        entry("$.startDate", "voidStartDateAfterBedspaceEndDate"),
+      )
+    }
   }
 
   @Nested


### PR DESCRIPTION
This Pull Request modifies the logic in the Cas3PremisesService to handle additional validation for bedspaces and provides accompanying new unit tests.

Main Changes

- Updated the createVoidBedspaces function in Cas3PremisesService:
  - Added a more complex condition to validate when void start dates match the bed start date.
  - Suppressed the "ComplexCondition" warning for readability.

- Extended unit tests in Cas3PremisesServiceTest:
  - Added a new test case to ensure errors are returned when the void start date is the same as the bed start date.
  - Verified error messages for specific validation scenarios.