### PR TITLE
APS-886 Remove CAS1 Application ‘Submitted’ status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesApplicationStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/ApprovedPremisesApplicationStatus.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremis
 
 enum class ApprovedPremisesApplicationStatus(val apiValue: ApiApprovedPremisesApplicationStatus) {
   STARTED(ApiApprovedPremisesApplicationStatus.started),
-  SUBMITTED(ApiApprovedPremisesApplicationStatus.submitted),
   REJECTED(ApiApprovedPremisesApplicationStatus.rejected),
   AWAITING_ASSESSMENT(ApiApprovedPremisesApplicationStatus.awaitingAssesment),
   UNALLOCATED_ASSESSMENT(ApiApprovedPremisesApplicationStatus.unallocatedAssesment),
@@ -46,7 +45,6 @@ enum class ApprovedPremisesApplicationStatus(val apiValue: ApiApprovedPremisesAp
   fun toCas1Status(): Cas1ApplicationStatus = when (this) {
     EXPIRED -> Cas1ApplicationStatus.expired
     STARTED -> Cas1ApplicationStatus.started
-    SUBMITTED -> Cas1ApplicationStatus.submitted
     REJECTED -> Cas1ApplicationStatus.rejected
     AWAITING_ASSESSMENT -> Cas1ApplicationStatus.awaitingAssesment
     UNALLOCATED_ASSESSMENT -> Cas1ApplicationStatus.unallocatedAssesment

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -1835,7 +1835,6 @@ components:
       type: string
       enum:
         - started
-        - submitted
         - rejected
         - awaitingAssesment
         - unallocatedAssesment

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -4987,7 +4987,6 @@ components:
       type: string
       enum:
         - started
-        - submitted
         - rejected
         - awaitingAssesment
         - unallocatedAssesment

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -4239,7 +4239,6 @@ components:
       type: string
       enum:
         - started
-        - submitted
         - rejected
         - awaitingAssesment
         - unallocatedAssesment

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2349,7 +2349,6 @@ components:
       type: string
       enum:
         - started
-        - submitted
         - rejected
         - awaitingAssesment
         - unallocatedAssesment

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -2370,7 +2370,6 @@ components:
       type: string
       enum:
         - started
-        - submitted
         - rejected
         - awaitingAssesment
         - unallocatedAssesment

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2398,7 +2398,6 @@ components:
       type: string
       enum:
         - started
-        - submitted
         - rejected
         - awaitingAssesment
         - unallocatedAssesment

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -73,7 +73,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withIsWomensApplication(false)
             withReleaseType("rotl")
             withSubmittedAt(OffsetDateTime.parse("2023-04-19T09:34:00+01:00"))
-            withStatus(ApprovedPremisesApplicationStatus.SUBMITTED)
+            withStatus(ApprovedPremisesApplicationStatus.AWAITING_ASSESSMENT)
           }
 
           val results = realApplicationRepository.findNonWithdrawnApprovedPremisesSummariesForUser(user.id)
@@ -95,7 +95,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             assertThat(it.getCreatedByUserId()).isEqualTo(submittedApplication.createdByUser.id)
             assertThat(it.getCreatedAt()).isEqualTo(submittedApplication.createdAt.toInstant())
             assertThat(it.getSubmittedAt()).isEqualTo(submittedApplication.submittedAt?.toInstant())
-            assertThat(it.getStatus()).isEqualTo("SUBMITTED")
+            assertThat(it.getStatus()).isEqualTo("AWAITING_ASSESSMENT")
           }
 
           assertThat(results).noneMatch {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ExpireUnsubmittedApplicationsScheduledJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ExpireUnsubmittedApplicationsScheduledJobTest.kt
@@ -47,7 +47,7 @@ class Cas1ExpireUnsubmittedApplicationsScheduledJobTest : IntegrationTestBase() 
         val unsubmittedApplicationsNewerThan6Months = createApplicationsWithCreatedAtDate(user, ApprovedPremisesApplicationStatus.STARTED, 5) {
           OffsetDateTime.now().randomDateTimeBeyond(0, 179)
         }
-        val applicationsWithOtherStatus = createApplicationsWithCreatedAtDate(user, ApprovedPremisesApplicationStatus.SUBMITTED, 2) {
+        val applicationsWithOtherStatus = createApplicationsWithCreatedAtDate(user, ApprovedPremisesApplicationStatus.AWAITING_ASSESSMENT, 2) {
           OffsetDateTime.now().randomDateTimeBeyond(180, 365)
         }
         applicationsWithOtherStatus.addAll(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/ApprovedPremisesApplicationStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/ApprovedPremisesApplicationStatusTest.kt
@@ -11,7 +11,6 @@ class ApprovedPremisesApplicationStatusTest {
   @CsvSource(
     value = [
       "started,STARTED",
-      "submitted,SUBMITTED",
       "rejected,REJECTED",
       "awaitingAssesment,AWAITING_ASSESSMENT",
       "unallocatedAssesment,UNALLOCATED_ASSESSMENT",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformersTest.kt
@@ -450,7 +450,7 @@ class ApplicationsTransformersTest {
       override fun getCreatedAt() = Instant.parse("2023-04-19T13:25:00+01:00")
       override fun getSubmittedAt() = Instant.parse("2023-04-19T13:25:00+01:00")
       override fun getTier(): String? = null
-      override fun getStatus(): String = ApprovedPremisesApplicationStatus.SUBMITTED.toString()
+      override fun getStatus(): String = ApprovedPremisesApplicationStatus.AWAITING_ASSESSMENT.toString()
       override fun getIsWithdrawn(): Boolean = true
       override fun getReleaseType(): String? = releaseTypeOption?.let { releaseTypeOption.toString() }
       override fun getHasRequestsForPlacement(): Boolean = true
@@ -650,7 +650,7 @@ class ApplicationsTransformersTest {
       override fun getCreatedAt() = Instant.parse("2023-04-19T13:25:00+01:00")
       override fun getSubmittedAt() = Instant.parse("2023-04-19T13:25:00+01:00")
       override fun getTier(): String? = null
-      override fun getStatus(): String = ApprovedPremisesApplicationStatus.SUBMITTED.toString()
+      override fun getStatus(): String = ApprovedPremisesApplicationStatus.AWAITING_ASSESSMENT.toString()
       override fun getIsWithdrawn(): Boolean = true
       override fun getReleaseType(): String? = releaseTypeOption?.let { releaseTypeOption.toString() }
       override fun getHasRequestsForPlacement(): Boolean = true
@@ -671,7 +671,6 @@ class ApplicationsTransformersTest {
     fun applicationStatusArgs() = listOf(
       ApiApprovedPremisesApplicationStatus.assesmentInProgress to ApprovedPremisesApplicationStatus.ASSESSMENT_IN_PROGRESS,
       ApiApprovedPremisesApplicationStatus.started to ApprovedPremisesApplicationStatus.STARTED,
-      ApiApprovedPremisesApplicationStatus.submitted to ApprovedPremisesApplicationStatus.SUBMITTED,
       ApiApprovedPremisesApplicationStatus.rejected to ApprovedPremisesApplicationStatus.REJECTED,
       ApiApprovedPremisesApplicationStatus.awaitingAssesment to ApprovedPremisesApplicationStatus.AWAITING_ASSESSMENT,
       ApiApprovedPremisesApplicationStatus.unallocatedAssesment to ApprovedPremisesApplicationStatus.UNALLOCATED_ASSESSMENT,


### PR DESCRIPTION
On submission an application will transition directly to the ‘UNALLOCATED_ASSESSMENT’  or `AWAITING_ASSESSMENT`, so it will never have the the ‘Submitted’ status.

There are no applications in prod with this status

