### PR TITLE
APS-2463 Add endpoint to get all premises' capacities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -131,6 +131,31 @@ class Cas1PremisesController(
       },
     )
 
+  /*
+  This is a spike endpoint to test performance
+  against a prod-like dataset. It will need refining
+  once requirements are fully understood
+   */
+  override fun getCapacities(
+    startDate: LocalDate,
+    endDate: LocalDate,
+  ): ResponseEntity<List<Cas1PremiseCapacity>> {
+    userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_PREMISES_VIEW)
+
+    val capacities = extractEntityFromCasResult(
+      cas1PremisesService.getPremisesCapacities(
+        premisesIds = cas1PremisesService.getAllPremisesIds(),
+        startDate = startDate,
+        endDate = endDate,
+        excludeSpaceBookingId = null,
+      ),
+    )
+
+    return ResponseEntity.ok().body(
+      capacities.map { cas1PremiseCapacityTransformer.toCas1PremiseCapacitySummary(it) },
+    )
+  }
+
   override fun getCapacity(
     premisesId: UUID,
     startDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedEntity.kt
@@ -80,8 +80,8 @@ interface Cas1OutOfServiceBedRepository : JpaRepository<Cas1OutOfServiceBedEntit
     pageable: Pageable?,
   ): Page<String>
 
-  @Query("SELECT oosb FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE oosb.premises.id = :premisesId AND c is NULL")
-  fun findAllActiveForPremisesId(premisesId: UUID): List<Cas1OutOfServiceBedEntity>
+  @Query("SELECT oosb FROM Cas1OutOfServiceBedEntity oosb LEFT JOIN oosb.cancellation c WHERE oosb.premises.id IN (:premisesIds) AND c is NULL")
+  fun findAllActiveForPremisesIds(premisesIds: List<UUID>): List<Cas1OutOfServiceBedEntity>
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -324,14 +324,14 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
     """
     SELECT b FROM Cas1SpaceBookingEntity b
     LEFT JOIN FETCH b.criteria
-    WHERE b.premises.id = :premisesId
+    WHERE b.premises.id IN (:premisesIds)
     AND b.cancellationOccurredAt IS NULL 
     AND b.canonicalArrivalDate <= :rangeEndInclusive
     AND b.canonicalDepartureDate >= :rangeStartInclusive 
   """,
   )
   fun findNonCancelledBookingsInRange(
-    premisesId: UUID,
+    premisesIds: List<UUID>,
     rangeStartInclusive: LocalDate,
     rangeEndInclusive: LocalDate,
   ): List<Cas1SpaceBookingEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -138,6 +138,9 @@ interface ApprovedPremisesRepository : JpaRepository<ApprovedPremisesEntity, UUI
   fun findForSummaries(gender: ApprovedPremisesGender?, apAreaId: UUID?, cruManagementAreaId: UUID?): List<ApprovedPremisesBasicSummary>
 
   fun findByQCode(qcode: String): ApprovedPremisesEntity?
+
+  @Query("SELECT id FROM ApprovedPremisesEntity")
+  fun findAllIds(): List<UUID>
 }
 
 @SuppressWarnings("LongParameterList")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
@@ -316,7 +316,9 @@ class Cas1OutOfServiceBedService(
     pageCriteria = pageCriteria,
   )
 
-  fun getActiveOutOfServiceBedsForPremisesId(premisesId: UUID) = outOfServiceBedRepository.findAllActiveForPremisesId(premisesId)
+  fun getActiveOutOfServiceBedsForPremisesId(premisesId: UUID) = outOfServiceBedRepository.findAllActiveForPremisesIds(listOf(premisesId))
+
+  fun getActiveOutOfServiceBedsForPremisesIds(premisesIds: List<UUID>) = outOfServiceBedRepository.findAllActiveForPremisesIds(premisesIds)
 
   fun getCurrentOutOfServiceBedsCountForPremisesId(premisesId: UUID): Int = outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
     premisesId = premisesId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.planning.SpacePlanningService.PremiseCapacitySummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.DateRange
 import java.io.OutputStream
 import java.time.Clock
@@ -102,14 +103,18 @@ class Cas1PremisesService(
 
   fun premiseExistsById(id: UUID) = premisesRepository.existsById(id)
 
-  fun getPremiseCapacity(
-    premisesId: UUID,
+  fun getPremisesCapacities(
+    premisesIds: List<UUID>,
     startDate: LocalDate,
     endDate: LocalDate,
     excludeSpaceBookingId: UUID?,
-  ): CasResult<SpacePlanningService.PremiseCapacitySummary> {
-    val premises = premisesRepository.findByIdOrNull(premisesId)
-      ?: return CasResult.NotFound("premises", premisesId.toString())
+  ): CasResult<List<PremiseCapacitySummary>> {
+    val premises = premisesRepository.findAllById(premisesIds)
+
+    if (premises.size != premisesIds.size) {
+      val missingIds = premisesIds - premises.map { it.id }
+      return CasResult.GeneralValidationError("Could not resolve all premises IDs. Missing IDs are $missingIds")
+    }
 
     if (startDate.isAfter(endDate)) {
       return CasResult.GeneralValidationError("Start Date $startDate should be before End Date $endDate")
@@ -118,7 +123,7 @@ class Cas1PremisesService(
     val dateRange = if (ChronoUnit.YEARS.between(startDate, endDate) > 1) {
       log.warn(
         """Capacity requested for more than 2 years, will only return the first few years. 
-        |Arrival Date: $startDate, Departure Date: $endDate, Premises: ${premises.name}
+        |Arrival Date: $startDate, Departure Date: $endDate
         """.trimMargin(),
       )
       DateRange(startDate, startDate.plusYears(2).minusDays(1))
@@ -128,7 +133,7 @@ class Cas1PremisesService(
 
     return CasResult.Success(
       spacePlanningService.capacity(
-        premises = premises,
+        forPremises = premises,
         rangeInclusive = dateRange,
         excludeSpaceBookingId = excludeSpaceBookingId,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -135,7 +135,7 @@ class Cas1PremisesService(
     )
   }
 
-  fun getBeds(premisesId: UUID) = cas1BedsRepository.bedSummary(premisesId)
+  fun getBeds(premisesId: UUID) = cas1BedsRepository.bedSummary(listOf(premisesId))
 
   data class Cas1PremisesInfo(
     val entity: ApprovedPremisesEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -99,6 +99,8 @@ class Cas1PremisesService(
 
   fun getPremises(gender: ApprovedPremisesGender?, apAreaId: UUID?, cruManagementAreaId: UUID?) = premisesRepository.findForSummaries(gender, apAreaId, cruManagementAreaId)
 
+  fun getAllPremisesIds() = premisesRepository.findAllIds()
+
   fun findPremiseById(id: UUID) = premisesRepository.findByIdOrNull(id)
 
   fun premiseExistsById(id: UUID) = premisesRepository.existsById(id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
@@ -66,16 +66,24 @@ class SpacePlanningService(
     premises: ApprovedPremisesEntity,
     rangeInclusive: DateRange,
     excludeSpaceBookingId: UUID?,
-  ): PremiseCapacitySummary {
-    val dayBedStates = bedStatesForEachDay(listOf(premises), rangeInclusive)
-    val dayBookings = spaceBookingsForEachDay(listOf(premises), rangeInclusive, excludeSpaceBookingId)
+  ) = capacity(listOf(premises), rangeInclusive, excludeSpaceBookingId)[0]
 
-    return premisesCapacity(
-      premises,
-      rangeInclusive,
-      dayBedStates.forPremises(premises),
-      dayBookings.forPremises(premises),
-    )
+  fun capacity(
+    forPremises: List<ApprovedPremisesEntity>,
+    rangeInclusive: DateRange,
+    excludeSpaceBookingId: UUID?,
+  ): List<PremiseCapacitySummary> {
+    val dayBedStates = bedStatesForEachDay(forPremises, rangeInclusive)
+    val dayBookings = spaceBookingsForEachDay(forPremises, rangeInclusive, excludeSpaceBookingId)
+
+    return forPremises.map { premises ->
+      premisesCapacity(
+        premises,
+        rangeInclusive,
+        dayBedStates.forPremises(premises),
+        dayBookings.forPremises(premises),
+      )
+    }
   }
 
   private fun premisesCapacity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
@@ -121,14 +121,14 @@ class SpacePlanningService(
   )
 
   private fun bedStatesForEachDay(
-    allPremises: List<ApprovedPremisesEntity>,
+    forPremises: List<ApprovedPremisesEntity>,
     range: DateRange,
   ): List<PremisesDayBedStates> {
-    val allPremisesIds = allPremises.map { it.id }
+    val allPremisesIds = forPremises.map { it.id }
     val outOfServiceBedRecordsToConsider = outOfServiceBedService.getActiveOutOfServiceBedsForPremisesIds(allPremisesIds)
     val beds = cas1BedsRepository.bedSummary(allPremisesIds)
 
-    return allPremises.map { premises ->
+    return forPremises.map { premises ->
       PremisesDayBedStates(
         premises = premises,
         bedStates = range.orderedDatesInRange()
@@ -148,17 +148,17 @@ class SpacePlanningService(
   }
 
   private fun spaceBookingsForEachDay(
-    allPremises: List<ApprovedPremisesEntity>,
+    forPremises: List<ApprovedPremisesEntity>,
     range: DateRange,
     excludeSpaceBookingId: UUID? = null,
   ): List<PremisesDayBookings> {
     val nonCancelledBookingsInRange = spaceBookingRepository.findNonCancelledBookingsInRange(
-      premisesIds = allPremises.map { it.id },
+      premisesIds = forPremises.map { it.id },
       rangeStartInclusive = range.fromInclusive,
       rangeEndInclusive = range.toInclusive,
     ).filter { it.id != excludeSpaceBookingId }
 
-    return allPremises.map { premises ->
+    return forPremises.map { premises ->
       PremisesDayBookings(
         premises = premises,
         dayBookings = range.orderedDatesInRange()

--- a/src/main/resources/static/cas1-api.yml
+++ b/src/main/resources/static/cas1-api.yml
@@ -575,6 +575,51 @@ paths:
       x-codegen-request-body-name: body
 
 
+  /premises/capacity:
+    get:
+      tags:
+        - premises
+      operationId: "getCapacities"
+      summary: Provides capacity information for a given date range for all premises
+      parameters:
+        - name: startDate
+          in: query
+          description: Start date, inclusive
+          required: true
+          schema:
+            type: string
+            format: date
+        - name: endDate
+          in: query
+          description: End date, inclusive. Should be within 2 years of the startDate. If it exceeds this threshold, capacity information will only be provided for 2 years.
+          required: true
+          schema:
+            type: string
+            format: date
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: 'cas1-schemas.yml#/components/schemas/Cas1PremiseCapacity'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        404:
+          description: one or more invalid premises IDs
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Problem'
+      x-codegen-request-body-name: body
+
+
   /premises/occupancy-report:
     get:
       tags:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -577,6 +577,51 @@ paths:
       x-codegen-request-body-name: body
 
 
+  /premises/capacity:
+    get:
+      tags:
+        - premises
+      operationId: "getCapacities"
+      summary: Provides capacity information for a given date range for all premises
+      parameters:
+        - name: startDate
+          in: query
+          description: Start date, inclusive
+          required: true
+          schema:
+            type: string
+            format: date
+        - name: endDate
+          in: query
+          description: End date, inclusive. Should be within 2 years of the startDate. If it exceeds this threshold, capacity information will only be provided for 2 years.
+          required: true
+          schema:
+            type: string
+            format: date
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cas1PremiseCapacity'
+        400:
+          description: invalid params
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        404:
+          description: one or more invalid premises IDs
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Problem'
+      x-codegen-request-body-name: body
+
+
   /premises/occupancy-report:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1PlanningBedSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1PlanningBedSummaryFactory.kt
@@ -1,19 +1,19 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
-import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1PlanningBedSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.LocalDate
 import java.util.UUID
 
 class Cas1PlanningBedSummaryFactory : Factory<Cas1PlanningBedSummary> {
-  private var bedId: Yielded<UUID> = { UUID.randomUUID() }
-  private var bedName: Yielded<String> = { randomStringUpperCase(10) }
-  private var bedEndDate: Yielded<LocalDate> = { LocalDate.now() }
-  private var roomId: Yielded<UUID> = { UUID.randomUUID() }
-  private var roomName: Yielded<String> = { randomStringUpperCase(10) }
-  private var characteristicsPropertyNames: Yielded<List<String>> = { emptyList() }
+  private var bedId = { UUID.randomUUID() }
+  private var bedName = { randomStringUpperCase(10) }
+  private var bedEndDate = { LocalDate.now() }
+  private var roomId = { UUID.randomUUID() }
+  private var roomName = { randomStringUpperCase(10) }
+  private var characteristicsPropertyNames = { emptyList<String>() }
+  private var premisesId = { UUID.randomUUID() }
 
   fun withBedId(id: UUID) = apply {
     this.bedId = { id }
@@ -46,5 +46,6 @@ class Cas1PlanningBedSummaryFactory : Factory<Cas1PlanningBedSummary> {
     this.roomId(),
     this.roomName(),
     this.characteristicsPropertyNames(),
+    this.premisesId(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -445,7 +445,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class GetCapacity : InitialiseDatabasePerClassTestBase() {
+  inner class GetPremisesCapacity : InitialiseDatabasePerClassTestBase() {
     lateinit var premises: ApprovedPremisesEntity
 
     @BeforeAll
@@ -490,6 +490,54 @@ class Cas1PremisesTest : IntegrationTestBase() {
 
       assertThat(result.capacity[0].date).isEqualTo(LocalDate.of(2020, 1, 1))
       assertThat(result.capacity[1].date).isEqualTo(LocalDate.of(2020, 1, 2))
+    }
+  }
+
+  @Nested
+  inner class GetAllPremisesCapacities : InitialiseDatabasePerClassTestBase() {
+    @BeforeAll
+    fun setupTestData() {
+      repeat(10) {
+        givenAnApprovedPremises()
+      }
+    }
+
+    @Test
+    fun `Returns 403 Forbidden if user does not have correct role`() {
+      val (_, jwt) = givenAUser(roles = listOf(CAS1_ASSESSOR))
+
+      webTestClient.get()
+        .uri("/cas1/premises/capacity?startDate=2020-01-01&endDate=2020-01-02")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun success() {
+      val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
+
+      val result = webTestClient.get()
+        .uri("/cas1/premises/capacity?startDate=2020-01-01&endDate=2020-01-07")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsListOfObjects<Cas1PremiseCapacity>()
+
+      assertThat(result).hasSize(10)
+
+      result.forEach {
+        assertThat(it.capacity).hasSize(7)
+        assertThat(it.capacity[0].date).isEqualTo(LocalDate.of(2020, 1, 1))
+        assertThat(it.capacity[1].date).isEqualTo(LocalDate.of(2020, 1, 2))
+        assertThat(it.capacity[2].date).isEqualTo(LocalDate.of(2020, 1, 3))
+        assertThat(it.capacity[3].date).isEqualTo(LocalDate.of(2020, 1, 4))
+        assertThat(it.capacity[4].date).isEqualTo(LocalDate.of(2020, 1, 5))
+        assertThat(it.capacity[5].date).isEqualTo(LocalDate.of(2020, 1, 6))
+        assertThat(it.capacity[6].date).isEqualTo(LocalDate.of(2020, 1, 7))
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/planning/SpacePlanningServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/planning/SpacePlanningServiceTest.kt
@@ -211,16 +211,35 @@ class SpacePlanningServiceTest : IntegrationTestBase() {
         beds = listOf(
           RequiredBed("Premises 1 - Room 3 - Bed 1"),
           RequiredBed("Premises 1 - Room 3 - Bed 2"),
-          RequiredBed("Premises 1 - Room 3 - Bed 3"),
-          RequiredBed("Premises 1 - Room 3 - Bed 4", endDate = date(2020, 5, 8)),
+          RequiredBed("Premises 1 - Room 3 - Bed 3 - OOSB"),
+          RequiredBed("Premises 1 - Room 3 - Bed 4 - Ended", endDate = date(2020, 5, 8)),
         ),
       )
 
       givenAnOutOfServiceBed(
-        bed = premises1Room3.beds.first { it.name == "Premises 1 - Room 3 - Bed 3" },
+        bed = premises1Room3.beds.first { it.name == "Premises 1 - Room 3 - Bed 3 - OOSB" },
         startDate = date(2020, 5, 7),
         endDate = date(2020, 5, 8),
         reason = "refurb",
+      )
+
+      createRoom(
+        premises = premises2,
+        characteristicPropertyNames = listOf(CAS1_PROPERTY_NAME_ARSON_SUITABLE, CAS1_PROPERTY_NAME_ENSUITE, CAS1_PROPERTY_NAME_SINGLE_ROOM),
+        beds = listOf(RequiredBed("Premises 2 - Room 1 - Bed 1")),
+      )
+
+      val premises2Room2 = createRoom(
+        premises = premises2,
+        characteristicPropertyNames = listOf(CAS1_PROPERTY_NAME_ARSON_SUITABLE, CAS1_PROPERTY_NAME_ENSUITE, CAS1_PROPERTY_NAME_SINGLE_ROOM),
+        beds = listOf(RequiredBed("Premises 2 - Room 1 - Bed 2 - OOSB")),
+      )
+
+      givenAnOutOfServiceBed(
+        bed = premises2Room2.beds.first { it.name == "Premises 2 - Room 1 - Bed 2 - OOSB" },
+        startDate = date(2020, 5, 7),
+        endDate = date(2020, 5, 8),
+        reason = "painting",
       )
 
       premises1BookingCrn1 = createSpaceBooking(crn = "PREMISES1-CRN1") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/planning/SpacePlanningServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/planning/SpacePlanningServiceTest.kt
@@ -184,12 +184,14 @@ class SpacePlanningServiceTest : IntegrationTestBase() {
   inner class Capacity {
 
     lateinit var premises1: ApprovedPremisesEntity
+    lateinit var premises2: ApprovedPremisesEntity
 
     private lateinit var premises1BookingCrn1: Cas1SpaceBookingEntity
 
     @BeforeEach
     fun setupTestData() {
       premises1 = givenAnApprovedPremises(name = "Premises 1")
+      premises2 = givenAnApprovedPremises(name = "Premises 2")
 
       createRoom(
         premises = premises1,
@@ -278,6 +280,25 @@ class SpacePlanningServiceTest : IntegrationTestBase() {
         withPremises(premises1)
         withCanonicalArrivalDate(date(2020, 5, 11))
         withCanonicalDepartureDate(date(2020, 5, 12))
+        withCriteria(
+          findCharacteristic(CAS1_PROPERTY_NAME_ENSUITE),
+          findCharacteristic(CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED),
+        )
+      }
+
+      createSpaceBooking(crn = "PREMISES2-CRN10") {
+        withPremises(premises2)
+        withCanonicalArrivalDate(date(2020, 4, 1))
+        withCanonicalDepartureDate(date(2020, 6, 29))
+        withCriteria(
+          findCharacteristic(CAS1_PROPERTY_NAME_SINGLE_ROOM),
+        )
+      }
+
+      createSpaceBooking(crn = "PREMISES2-CRN11") {
+        withPremises(premises2)
+        withCanonicalArrivalDate(date(2020, 5, 1))
+        withCanonicalDepartureDate(date(2020, 5, 9))
         withCriteria(
           findCharacteristic(CAS1_PROPERTY_NAME_ENSUITE),
           findCharacteristic(CAS1_PROPERTY_NAME_WHEELCHAIR_DESIGNATED),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
@@ -892,14 +892,14 @@ class Cas1OutOfServiceBedServiceTest {
     @Test
     fun `Delegates to repository method`() {
       val expectedList = mockk<List<Cas1OutOfServiceBedEntity>>()
-      every { outOfServiceBedRepository.findAllActiveForPremisesId(any()) } returns expectedList
+      every { outOfServiceBedRepository.findAllActiveForPremisesIds(any()) } returns expectedList
 
       val premisesId = UUID.randomUUID()
 
       val result = outOfServiceBedService.getActiveOutOfServiceBedsForPremisesId(premisesId)
 
       assertThat(result).isEqualTo(expectedList)
-      verify(exactly = 1) { outOfServiceBedRepository.findAllActiveForPremisesId(premisesId) }
+      verify(exactly = 1) { outOfServiceBedRepository.findAllActiveForPremisesIds(listOf(premisesId)) }
     }
   }
 


### PR DESCRIPTION
**Background**

This endpoint has been added as part of a spike to test performance when retrieving capacity for multiple premises. The endpoint will be further refined once user requirements are better understood.

Note that much like the existing capacity endpoint, the endpoint integration testing is limited as there is already detailed integration testing in the integration test for the `SpacePlanningService`

**Design Notes**

When determining capacity for a premises, we run 3 queries to retrieve data that is then crunched in-memory:

1. Get all space bookings in the requested time period
2. Get all beds in the premises, including characteristics
3. Get all out of service bed records applicable to the requested time period

To limit how much SQL we're running when determining capacity for multiple premises, we use the same 3 queries, but retrieve the data for all premises of interest which should keep the SQL part of this operation reasonably fast. This then requires some code in the `SpacePlanningService` to put that data into 'premise-specific' buckets which are then used for capacity calculation. That's the majority of the change in this PR (plus adding an endpoint for the spike)