### PR TITLE
APS-2455 Add logic to set end date if bed no longer exists in site survey data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -32,6 +32,8 @@ interface BedRepository : JpaRepository<BedEntity, UUID> {
   @Query(nativeQuery = true)
   fun findAllBedsForPremises(premisesId: UUID): List<DomainBedSummary>
 
+  fun findByRoomPremisesIdAndEndDateIsNull(premisesId: UUID): List<BedEntity>
+
   @Query(nativeQuery = true)
   fun getDetailById(id: UUID): DomainBedSummary?
 


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2455

Update the site survey import functionality to spot that a bed has been removed in the site survey and set its 'end date' to the date the site survey was imported.

Update `Cas1SeedRoomsFromSiteSurveyXlsxJob.processXlsx` with new functionality that compares the list of beds returned from resolveBeds with the existing beds returned using the bedRepository.  This logic should be based on `bedCode`.

If a bed has been removed call a new `expireBed` function which sets the `endDate` for the existing bed to todays date.

Update `SeedCas1RoomsFromSiteSurveyXlsxTest.kt` and add a new test to check that the end date is updated for a bed that no longer exists in the site survey data. 

Re-load the site survey data (confirm in pre-prod before running in prod).