### PR TITLE
APS-2417 - Remove unused SQL

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -51,24 +51,6 @@ interface PlacementApplicationRepository : JpaRepository<PlacementApplicationEnt
   @Modifying
   @Query("UPDATE PlacementApplicationEntity p SET p.dueAt = :dueAt WHERE p.id = :id")
   fun updateDueAt(id: UUID, dueAt: OffsetDateTime?)
-
-  @Query(
-    value = """
-    with pa_with_date_count as (
-      select 
-      count(*) as date_count, 
-      pad.placement_application_id
-      from  placement_application_dates pad 
-      group by pad.placement_application_id
-    )
-    select 
-      placement_application_id
-    from pa_with_date_count 
-    where date_count > 1
-    """,
-    nativeQuery = true,
-  )
-  fun findAllWithMultipleDates(): List<UUID>
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementDateEntity.kt
@@ -17,15 +17,6 @@ interface PlacementDateRepository : JpaRepository<PlacementDateEntity, UUID> {
 
   @Query("SELECT p FROM PlacementDateEntity p WHERE p.placementApplication = :placementApplication")
   fun findAllByPlacementApplication(placementApplication: PlacementApplicationEntity): List<PlacementDateEntity>
-
-  @Query(
-    """select pad.placement_application_id 
-       from placement_application_dates pad 
-       inner join placement_requests pr on pr.id = pad.placement_request_id 
-       where pr.reallocated_at is not null""",
-    nativeQuery = true,
-  )
-  fun findPlacementAppIdsWithDatesLinkedToReallocatedPlacementRequest(): List<UUID>
 }
 
 @Deprecated("This is being replaced by date fields on the [PlacementApplicationEntity]")


### PR DESCRIPTION
This was used by seed jobs used to ‘flatten’ placement applications. These have now been removed.

