### PR TITLE
APS-2417 Backfill missing placement application dates

### DIFF
--- a/src/main/resources/db/migration/all/20250702142438__backfill_missing_placement_application_dates.sql
+++ b/src/main/resources/db/migration/all/20250702142438__backfill_missing_placement_application_dates.sql
@@ -1,0 +1,9 @@
+UPDATE placement_applications
+SET
+    expected_arrival=placement_app_date.expected_arrival,
+    duration=placement_app_date.duration
+FROM (SELECT placement_application_id, expected_arrival, duration FROM placement_application_dates) AS placement_app_date
+WHERE
+    placement_applications.id = placement_app_date.placement_application_id AND
+    placement_applications.submitted_at IS NOT NULL AND
+    placement_applications.expected_arrival IS NULL;


### PR DESCRIPTION
When the prior backfill was ran, there was a single placement application that was submitted after the previous backfill job had run, but before the container running the new code was fully started. This meant the submission used the old code which didn’t populate the two new fields on placement application.

This commit adds an additional backfill job targetted at that placement application.

