### PR TITLE
APS-2417 - Remove `placement_application_dates` in reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PlacementMatchingOutcomesV2ReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PlacementMatchingOutcomesV2ReportRepository.kt
@@ -152,7 +152,7 @@ class Cas1PlacementMatchingOutcomesV2ReportRepository(
     return """
       WITH raw_requests_for_placements AS ($cte)
       $CORE_QUERY
-      ORDER BY pr.expected_arrival ASC
+      ORDER BY pr.expected_arrival, pr.id ASC
     """.trimIndent()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PlacementReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PlacementReportRepository.kt
@@ -73,7 +73,7 @@ class Cas1PlacementReportRepository(
                 csb.cancellation_occurred_at >= :startDateTimeInclusive 
                 AND csb.cancellation_occurred_at <= :endDateTimeInclusive
             )
-        ORDER BY csb.expected_arrival_date ASC
+        ORDER BY csb.expected_arrival_date, placement_id ASC
 
       """
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1RequestForPlacementReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1RequestForPlacementReportRepository.kt
@@ -125,7 +125,7 @@ UNION ALL
     pa.submitted_at IS NOT NULL AND
     pa.reallocated_at IS NULL AND
     ($placementApplicationsRangeConstraints)
-    ORDER BY request_for_placement_submitted_date ASC     
+    ORDER BY request_for_placement_submitted_date,request_for_placement_id ASC     
 """
     return s
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -414,7 +414,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
     fun createRequestForPlacement() {
       application = createSubmitAndAssessedApplication(
         crn = "StandardRFPMultipleTransfers",
-        arrivalDateOnApplication = LocalDate.of(REPORT_YEAR, REPORT_MONTH, 4),
+        arrivalDateOnApplication = LocalDate.of(REPORT_YEAR, REPORT_MONTH, 5),
       )
       clock.setNow(LocalDateTime.of(2028, 2, 3, 4, 5, 7))
 
@@ -456,7 +456,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       assertThat(row.request_for_placement_id).matches("placement_request:[a-f0-9-]+")
       assertThat(row.request_for_placement_type).isEqualTo("STANDARD")
-      assertThat(row.requested_arrival_date).isEqualTo("2020-02-04")
+      assertThat(row.requested_arrival_date).isEqualTo("2020-02-05")
       assertThat(row.crn).matches("StandardRFPMultipleTransfers")
 
       assertThat(row.first_match_attempt_date_time).isEqualTo("2028-02-03T04:05:07Z")


### PR DESCRIPTION
This commit removes the usage of `placement_application_dates` in reports, and instead uses the new `placement_application.expected_arrival` and `placement_application.duration` fields.

The integration tests were already populating these fields as they use the actual APIs to create placement applications.

This has allowed us simplify how many ‘internal’ columns are passed between the request for placement and placement matching outcome reports, as we can now just pass a single placement_request ID. This is possible because we can now guarantee that a placement_Application is linked to one and only one active `placement_request`. Before recent changes it could be linked to multiple placement requests if there were multiple dates.

This change has been tested by comparing reports generated using the old and new SQL against a year of placement requests data in pre-prod. Both reports were identical