### PR TITLE
APS-2468 - Backfill missing placement app decision made at

### DIFF
--- a/src/main/resources/db/migration/all/20250703084855__backfill_placement_application_decision_made_at.sql
+++ b/src/main/resources/db/migration/all/20250703084855__backfill_placement_application_decision_made_at.sql
@@ -1,0 +1,6 @@
+UPDATE placement_applications
+SET
+    decision_made_at = allocated_at
+WHERE
+    decision IS NOT NULL AND
+    decision_made_at IS NULL;


### PR DESCRIPTION
`decision_made_at` was only added to `placement_applications` in December 2023. There are several placement applications without a decision made at date, which has resulted in incorrect counts appearing for task allocation since the bug fix added by f3fa7e616db4f6bee53c6dc746f3ffc5312975fc

Because there is no concrete data we can use to backfill this (there were not timeline entries for decisions in 2023, and placement_requests weren’t originally linked to placement_applications), we are using the `allocated_at` timestamp to backfill the `decision_made_at` timestamp. This is obviously not correct, but is the closest timestamp we have to when a decision would have been made. Given these figures are only used to calculate stats on workload (Which typically only consider the last 90 days), this is acceptable.

