### PR TITLE
CAS-1708: C3 BE migration start date premises fix start date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/RoomEntity.kt
@@ -24,6 +24,8 @@ interface RoomRepository : JpaRepository<RoomEntity, UUID> {
   @Modifying
   @Query("UPDATE RoomEntity r SET r.code = :code WHERE r.id = :id")
   fun updateCode(id: UUID, code: String)
+
+  fun findAllByPremisesId(premisesId: UUID): List<RoomEntity>
 }
 
 @Entity


### PR DESCRIPTION
This Pull Request adds the ability to determine the startDate of a premises based on the earliest startDate of its associated beds when no alternative data exists. It also updates the relevant unit tests to cover this new behavior.

Main Changes:

- RoomEntity.kt:
  - Introduced a new method findAllByPremisesId in RoomRepository to fetch rooms by premises ID.

- Cas3UpdatePremisesStartDateJob.kt:
  - Modified existing logic to incorporate bed start dates when determining a premises' startDate.
  - Added fallback logic to check rooms and beds if no booking data exists for a premises.

- Cas3UpdatePremisesStartDateJobTest.kt:
  - Updated test cases to validate the new logic for determining the premises startDate.
  - Added and adjusted test setup for generating rooms and beds with specific start dates.