### PR TITLE
APS-2463 - Add migration job to support testing capacity calc

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2Statu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1ArsonSuitableToArsonOffencesJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillOfflineApplicationName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillUserApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1CapacityPerformanceTestJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1IsArsonSuitableBackfillJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1TaskDueMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1UpdateApplicationLicenceExpiryDateJob
@@ -65,6 +66,7 @@ class MigrationJobService(
         MigrationJobType.updateCas1ApplicationsWithOffender -> getBean(Cas1UpdateApprovedPremisesApplicationWithOffenderJob::class)
         MigrationJobType.updateCas3BedspaceModelData -> getBean(Cas3MigrateNewBedspaceModelDataJob::class)
         MigrationJobType.updateCas3VoidBedspaceCancellationData -> getBean(Cas3VoidBedspaceCancellationJob::class)
+        MigrationJobType.cas1CapacityPerformanceTest -> getBean(Cas1CapacityPerformanceTestJob::class)
       }
 
       if (job.shouldRunInTransaction) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1CapacityPerformanceTestJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1CapacityPerformanceTestJob.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PremiseCapacitySummaryTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+@SuppressWarnings("MagicNumber")
+@Service
+class Cas1CapacityPerformanceTestJob(
+  private val cas1PremisesService: Cas1PremisesService,
+  private val cas1PremiseCapacitySummaryTransformer: Cas1PremiseCapacitySummaryTransformer,
+  private val objectMapper: ObjectMapper,
+) : MigrationJob() {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override val shouldRunInTransaction = false
+
+  override fun process(pageSize: Int) {
+    log.info("Calculating capacity")
+    val start = LocalDateTime.now()
+
+    val capacities = extractEntityFromCasResult(
+      cas1PremisesService.getPremisesCapacities(
+        premisesIds = cas1PremisesService.getAllPremisesIds(),
+        startDate = LocalDate.of(2025, 1, 1),
+        endDate = LocalDate.of(2025, 1, 7),
+        excludeSpaceBookingId = null,
+      ),
+    )
+
+    val description = objectMapper.writeValueAsString(capacities.map { cas1PremiseCapacitySummaryTransformer.toCas1PremiseCapacitySummary(it) })
+
+    log.info("Capacities are $description")
+
+    val timeTaken = ChronoUnit.MILLIS.between(start, LocalDateTime.now())
+
+    log.info("job took $timeTaken millis")
+  }
+}

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3335,6 +3335,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - cas1_capacity_performance_test
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6491,6 +6491,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - cas1_capacity_performance_test
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -5993,6 +5993,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - cas1_capacity_performance_test
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3849,6 +3849,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - cas1_capacity_performance_test
     PlacementDates:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3870,6 +3870,7 @@ components:
         - update_cas1_applications_with_offender
         - update_cas3_bedspace_model_data
         - update_cas3_void_bedspace_cancellation_data
+        - cas1_capacity_performance_test
     PlacementDates:
       type: object
       properties:


### PR DESCRIPTION
This provides a simple way to test performance of the capacity calculation algorithm against _all_ premises

