### PR TITLE
APS-2463 - Use custom SQL to get OOSB for capacity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1OutOfServiceBedService.kt
@@ -316,9 +316,9 @@ class Cas1OutOfServiceBedService(
     pageCriteria = pageCriteria,
   )
 
-  fun getActiveOutOfServiceBedsForPremisesId(premisesId: UUID) = outOfServiceBedRepository.findAllActiveForPremisesIds(listOf(premisesId))
+  fun getActiveOutOfServiceBedsForPremisesId(premisesId: UUID) = outOfServiceBedRepository.findAllActiveForPremisesId(premisesId)
 
-  fun getActiveOutOfServiceBedsForPremisesIds(premisesIds: List<UUID>) = outOfServiceBedRepository.findAllActiveForPremisesIds(premisesIds)
+  fun getActiveOutOfServiceBedsForPremisesIds(premisesIds: List<UUID>) = outOfServiceBedRepository.findSummariesForAllActiveForPremisesIds(premisesIds)
 
   fun getCurrentOutOfServiceBedsCountForPremisesId(premisesId: UUID): Int = outOfServiceBedRepository.findOutOfServiceBedIdsForDate(
     premisesId = premisesId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/planning/SpacePlanningService.kt
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1BedsRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository.OutOfServiceBedSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1PlanningBedSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
@@ -204,5 +204,5 @@ class SpacePlanningService(
 
   private fun List<Cas1SpaceBookingEntity>.bookingsForPremises(premises: ApprovedPremisesEntity) = filter { it.premises.id == premises.id }
   private fun List<Cas1PlanningBedSummary>.bedsForPremises(premises: ApprovedPremisesEntity) = filter { it.premisesId == premises.id }
-  private fun List<Cas1OutOfServiceBedEntity>.oosbForPremises(premises: ApprovedPremisesEntity) = filter { it.premises.id == premises.id }
+  private fun List<OutOfServiceBedSummary>.oosbForPremises(premises: ApprovedPremisesEntity) = filter { it.getPremisesId() == premises.id }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/OutOfServiceBedSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/OutOfServiceBedSummaryFactory.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1
+
+import io.github.bluegroundltd.kfactory.Factory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+class OutOfServiceBedSummaryFactory : Factory<Cas1OutOfServiceBedRepository.OutOfServiceBedSummary> {
+  private var id = { UUID.randomUUID() }
+  private var bedId = { UUID.randomUUID() }
+  private var premisesId = { UUID.randomUUID() }
+  private var startDate = { LocalDate.now() }
+  private var endDate = { LocalDate.now() }
+  private var reasonName = { randomStringMultiCaseWithNumbers(4) }
+
+  fun withBedId(bedId: UUID) = apply {
+    this.bedId = { bedId }
+  }
+
+  fun withPremisesId(premisesId: UUID) = apply {
+    this.premisesId = { premisesId }
+  }
+
+  fun withStartDate(startDate: LocalDate) = apply {
+    this.startDate = { startDate }
+  }
+
+  fun withEndDate(endDate: LocalDate) = apply {
+    this.endDate = { endDate }
+  }
+
+  fun withReasonName(reasonName: String) = apply {
+    this.reasonName = { reasonName }
+  }
+
+  override fun produce(): Cas1OutOfServiceBedRepository.OutOfServiceBedSummary = OutOfServiceBedSummaryImpl(
+    id(),
+    bedId(),
+    premisesId(),
+    startDate(),
+    endDate(),
+    reasonName(),
+  )
+}
+
+data class OutOfServiceBedSummaryImpl(
+  private val id: UUID,
+  private val bedId: UUID,
+  private val premisesId: UUID,
+  private val startDate: LocalDate,
+  private val endDate: LocalDate,
+  private val reasonName: String,
+) : Cas1OutOfServiceBedRepository.OutOfServiceBedSummary {
+  override fun getId() = id
+  override fun getBedId() = bedId
+  override fun getPremisesId() = premisesId
+  override fun getStartDate() = startDate
+  override fun getEndDate() = endDate
+  override fun getReasonName() = reasonName
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOutOfServiceBed.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOutOfServiceBed.kt
@@ -7,6 +7,33 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCa
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
+fun IntegrationTestBase.givenAnOutOfServiceBedWithMultipleRevisions(
+  bed: BedEntity,
+  revisions: List<OutOfServiceBedRevision>,
+): Cas1OutOfServiceBedEntity {
+  val outOfServiceBed = cas1OutOfServiceBedEntityFactory.produceAndPersist {
+    withCreatedAt(OffsetDateTime.now())
+    withBed(bed)
+  }
+
+  revisions.forEach { rev ->
+    outOfServiceBed.revisionHistory += cas1OutOfServiceBedRevisionEntityFactory.produceAndPersist {
+      withCreatedAt(rev.createdAt)
+      withCreatedBy(givenAUser().first)
+      withOutOfServiceBed(outOfServiceBed)
+      withStartDate(rev.startDate)
+      withEndDate(rev.endDate)
+      withReason(
+        cas1OutOfServiceBedReasonEntityFactory.produceAndPersist {
+          withName(rev.reason)
+        },
+      )
+    }
+  }
+
+  return outOfServiceBed
+}
+
 fun IntegrationTestBase.givenAnOutOfServiceBed(
   bed: BedEntity,
   startDate: LocalDate = LocalDate.now(),
@@ -43,3 +70,10 @@ fun IntegrationTestBase.givenAnOutOfServiceBed(
 
   return outOfServiceBed
 }
+
+data class OutOfServiceBedRevision(
+  val createdAt: OffsetDateTime,
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+  val reason: String = randomStringMultiCaseWithNumbers(6),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1OutOfServiceBedServiceTest.kt
@@ -891,15 +891,14 @@ class Cas1OutOfServiceBedServiceTest {
   inner class GetActiveOutOfServiceBedsForPremisesId {
     @Test
     fun `Delegates to repository method`() {
-      val expectedList = mockk<List<Cas1OutOfServiceBedEntity>>()
-      every { outOfServiceBedRepository.findAllActiveForPremisesIds(any()) } returns expectedList
-
       val premisesId = UUID.randomUUID()
+
+      val expectedList = mockk<List<Cas1OutOfServiceBedEntity>>()
+      every { outOfServiceBedRepository.findAllActiveForPremisesId(premisesId) } returns expectedList
 
       val result = outOfServiceBedService.getActiveOutOfServiceBedsForPremisesId(premisesId)
 
       assertThat(result).isEqualTo(expectedList)
-      verify(exactly = 1) { outOfServiceBedRepository.findAllActiveForPremisesIds(listOf(premisesId)) }
     }
   }
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-2471

Before this commit we were retrieving `OutOfServiceBedEntity` when determining if there were out of service beds when calculating capacity.

Whilst this query was constrained to a given date range and premises, lazy loading was still required to find the latest out of service bed revision. This would make retreiving capacity for all premises very inefficient.

This commit changes the code to use custom SQL that only returns what is required, including information on the latest out of service bed revision.

The tests in `SpacePlanningServiceTest` have been improved to test various out of service bed scenarios to ensure the query is returning the expected values (e.g. not returning older out of service bed revision information)

