### PR TITLE
Remove read use of `placement_application_dates`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -112,8 +112,12 @@ data class PlacementApplicationEntity(
   var placementDates: MutableList<PlacementDateEntity>,
 
   /**
-   * Supporting multiple placements requests in a single Placement Application is legacy behaviour. Any new
-   * placement application will have one and only one Placement Request in this collection
+   * It was previously possible to realloacte a PlacementRequest, which would create a copy
+   * of the placement request with the new allocation. This would result in multiple
+   * placement requests linked to a single placement application.
+   *
+   * If those reallocated placement requests were removed (or the FK nulled), this could
+   * be converted into a one to one relationship
    */
   @OneToMany(mappedBy = "placementApplication", fetch = FetchType.LAZY)
   var placementRequests: MutableList<PlacementRequestEntity>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationEmailService.kt
@@ -93,16 +93,16 @@ class Cas1PlacementApplicationEmailService(
 
   private fun getCommonPersonalisation(placementApplication: PlacementApplicationEntity): MutableMap<String, String?> {
     val application = placementApplication.application
-    val dates = placementApplication.placementDates
+    val dates = placementApplication.placementDates()
 
     return mutableMapOf(
       "crn" to application.crn,
       "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
       "applicationTimelineUrl" to applicationTimelineUrlTemplate.resolve("applicationId", application.id.toString()),
       "applicationArea" to application.apArea?.name,
-      "startDate" to dates.getOrNull(0)?.expectedArrival.toString(),
-      "endDate" to dates.getOrNull(0)?.expectedDeparture().toString(),
-      "additionalDatesSet" to if (dates.size > 1) "yes" else "no",
+      "startDate" to dates?.expectedArrival.toString(),
+      "endDate" to dates?.expectedDeparture().toString(),
+      "additionalDatesSet" to "no",
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -69,7 +69,14 @@ class Cas1WithdrawableTreeBuilder(
         entityType = WithdrawableEntityType.PlacementApplication,
         entityId = placementApplication.id,
         status = cas1PlacementApplicationService.getWithdrawableState(placementApplication, user),
-        dates = placementApplication.placementDates.map { WithdrawableDatePeriod(it.expectedArrival, it.expectedDeparture()) },
+        dates = listOfNotNull(
+          placementApplication.placementDates()?.let {
+            WithdrawableDatePeriod(
+              startDate = it.expectedArrival,
+              endDate = it.expectedDeparture(),
+            )
+          },
+        ),
         children = children,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DatePeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawableType
@@ -19,6 +18,7 @@ class PlacementApplicationTransformer(
   fun transformJpaToApi(jpa: PlacementApplicationEntity): PlacementApplication {
     val assessment = jpa.application.getLatestAssessment()!!
     val application = jpa.application
+    val placementDates = jpa.placementDates()?.toApiType()
 
     return PlacementApplication(
       id = jpa.id,
@@ -35,7 +35,8 @@ class PlacementApplicationTransformer(
       isWithdrawn = jpa.isWithdrawn,
       withdrawalReason = getWithdrawalReason(jpa.withdrawalReason),
       type = PlacementApplicationType.additional,
-      placementDates = jpa.placementDates.map { PlacementDates(it.expectedArrival, it.duration) },
+      dates = placementDates,
+      placementDates = listOfNotNull(placementDates),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementApplicationTransformer.kt
@@ -41,11 +41,13 @@ class PlacementApplicationTransformer(
   }
 
   fun transformToWithdrawable(placementApplication: PlacementApplicationEntity): Withdrawable = Withdrawable(
-    placementApplication.id,
-    WithdrawableType.placementApplication,
-    placementApplication.placementDates.map {
-      DatePeriod(it.expectedArrival, it.expectedDeparture())
-    },
+    id = placementApplication.id,
+    type = WithdrawableType.placementApplication,
+    dates = listOfNotNull(
+      placementApplication.placementDates()?.let {
+        DatePeriod(it.expectedArrival, it.expectedDeparture())
+      },
+    ),
   )
 
   fun getWithdrawalReason(withdrawalReason: PlacementApplicationWithdrawalReason?): WithdrawPlacementRequestReason? = when (withdrawalReason) {

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -3411,8 +3411,13 @@ components:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
             type:
               $ref: '#/components/schemas/PlacementApplicationType'
+            dates:
+              description: Only populated once the placement application has been submitted
+              $ref: '#/components/schemas/PlacementDates'
             placementDates:
               type: array
+              deprecated: true
+              description: Deprecated, use dates. Only populated with values after the placement application has been submitted
               items:
                 $ref: '#/components/schemas/PlacementDates'
           required:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6567,8 +6567,13 @@ components:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
             type:
               $ref: '#/components/schemas/PlacementApplicationType'
+            dates:
+              description: Only populated once the placement application has been submitted
+              $ref: '#/components/schemas/PlacementDates'
             placementDates:
               type: array
+              deprecated: true
+              description: Deprecated, use dates. Only populated with values after the placement application has been submitted
               items:
                 $ref: '#/components/schemas/PlacementDates'
           required:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6069,8 +6069,13 @@ components:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
             type:
               $ref: '#/components/schemas/PlacementApplicationType'
+            dates:
+              description: Only populated once the placement application has been submitted
+              $ref: '#/components/schemas/PlacementDates'
             placementDates:
               type: array
+              deprecated: true
+              description: Deprecated, use dates. Only populated with values after the placement application has been submitted
               items:
                 $ref: '#/components/schemas/PlacementDates'
           required:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -3925,8 +3925,13 @@ components:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
             type:
               $ref: '#/components/schemas/PlacementApplicationType'
+            dates:
+              description: Only populated once the placement application has been submitted
+              $ref: '#/components/schemas/PlacementDates'
             placementDates:
               type: array
+              deprecated: true
+              description: Deprecated, use dates. Only populated with values after the placement application has been submitted
               items:
                 $ref: '#/components/schemas/PlacementDates'
           required:

--- a/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2v2-api-spec.yml
@@ -3946,8 +3946,13 @@ components:
               $ref: '#/components/schemas/WithdrawPlacementRequestReason'
             type:
               $ref: '#/components/schemas/PlacementApplicationType'
+            dates:
+              description: Only populated once the placement application has been submitted
+              $ref: '#/components/schemas/PlacementDates'
             placementDates:
               type: array
+              deprecated: true
+              description: Deprecated, use dates. Only populated with values after the placement application has been submitted
               items:
                 $ref: '#/components/schemas/PlacementDates'
           required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -1204,6 +1204,8 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             withYieldedProbationRegion { givenAProbationRegion() }
           },
           submittedAt = OffsetDateTime.now(),
+          expectedArrival = LocalDate.now(),
+          duration = 5,
         ) { placementApplicationEntity ->
 
           webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -68,7 +68,7 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
       givenAnOffender { offenderDetails, _ ->
         val (application, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
-        val placementApplication = createPlacementApplication(application, listOf(LocalDate.now() to 2))
+        val placementApplication = createPlacementApplication(application)
         val placementRequest1 = createPlacementRequest(application) {
           withExpectedArrival(LocalDate.of(2023, 1, 1))
           withPlacementApplication(placementApplication)
@@ -198,31 +198,17 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
 
   private fun createPlacementApplication(
     application: ApprovedPremisesApplicationEntity,
-    placementDates: List<Pair<LocalDate, Int>> = emptyList(),
     isSubmitted: Boolean = true,
     configuration: (PlacementApplicationEntityFactory.() -> Unit)? = null,
-  ): PlacementApplicationEntity {
-    val placementApplication = placementApplicationFactory.produceAndPersist {
-      withCreatedByUser(application.createdByUser)
-      withApplication(application)
-      withSubmittedAt(if (isSubmitted) OffsetDateTime.now() else null)
-      withDecision(if (isSubmitted) PlacementApplicationDecision.ACCEPTED else null)
-      withPlacementType(PlacementType.ADDITIONAL_PLACEMENT)
-      configuration?.invoke(this)
-    }
-
-    if (isSubmitted) {
-      val dates = placementDates.map { (start, duration) ->
-        placementDateFactory.produceAndPersist {
-          withPlacementApplication(placementApplication)
-          withExpectedArrival(start)
-          withDuration(duration)
-        }
-      }
-      placementApplication.placementDates.addAll(dates)
-    }
-
-    return placementApplication
+  ) = placementApplicationFactory.produceAndPersist {
+    withCreatedByUser(application.createdByUser)
+    withApplication(application)
+    withSubmittedAt(if (isSubmitted) OffsetDateTime.now() else null)
+    withDecision(if (isSubmitted) PlacementApplicationDecision.ACCEPTED else null)
+    withPlacementType(PlacementType.ADDITIONAL_PLACEMENT)
+    configuration?.invoke(this)
+    withExpectedArrival(if (isSubmitted) LocalDate.now() else null)
+    withDuration(if (isSubmitted) 2 else null)
   }
 
   private fun createPlacementRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -36,7 +36,6 @@ fun IntegrationTestBase.givenAPlacementApplication(
   requiredQualification: UserQualification? = null,
   noticeType: Cas1ApplicationTimelinessCategory? = null,
   isWithdrawn: Boolean = false,
-  placementDates: List<PlacementDate> = listOf(),
   application: ApprovedPremisesApplicationEntity? = null,
   apType: ApprovedPremisesType? = null,
   expectedArrival: LocalDate? = null,
@@ -88,16 +87,6 @@ fun IntegrationTestBase.givenAPlacementApplication(
     withDuration(duration)
   }
 
-  placementApplication.placementDates = placementDates
-    .map {
-      placementDateFactory.produceAndPersist {
-        withPlacementApplication(placementApplication)
-        withExpectedArrival(it.expectedArrival)
-        withDuration(it.duration)
-        withPlacementRequest(it.placementRequest)
-      }
-    }.toMutableList()
-
   return placementApplication
 }
 
@@ -111,7 +100,6 @@ fun IntegrationTestBase.givenAPlacementApplication(
   decision: PlacementApplicationDecision? = null,
   reallocated: Boolean = false,
   placementType: PlacementType? = PlacementType.ADDITIONAL_PLACEMENT,
-  placementDates: List<PlacementDate> = listOf(),
   application: ApprovedPremisesApplicationEntity? = null,
   expectedArrival: LocalDate? = null,
   duration: Int? = null,
@@ -127,7 +115,6 @@ fun IntegrationTestBase.givenAPlacementApplication(
     reallocated = reallocated,
     placementType = placementType,
     dueAt = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
-    placementDates = placementDates,
     application = application,
     isWithdrawn = false,
     expectedArrival = expectedArrival,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationCas1DomainEventServiceTest.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.StaffMemberFactory
@@ -237,7 +236,7 @@ class Cas1PlacementApplicationCas1DomainEventServiceTest {
         .produce()
 
       val application = ApprovedPremisesApplicationEntityFactory()
-        .withCrn(TestConstants.CRN)
+        .withCrn(CRN)
         .withCreatedByUser(user)
         .withSubmittedAt(OffsetDateTime.now())
         .produce()
@@ -252,19 +251,6 @@ class Cas1PlacementApplicationCas1DomainEventServiceTest {
         .apply {
           allocatedAt = OffsetDateTime.now()
         }
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withPlacementApplication(placementApplication)
-          .withExpectedArrival(LocalDate.of(2024, 5, 3))
-          .withDuration(7)
-          .produce(),
-        PlacementDateEntityFactory()
-          .withPlacementApplication(placementApplication)
-          .withExpectedArrival(LocalDate.of(2025, 2, 2))
-          .withDuration(14)
-          .produce(),
-      )
 
       assertThrows<IllegalArgumentException> { service.placementApplicationAllocated(placementApplication, user) }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationEmailServiceTest.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1ApplicationUserDetailsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationEmailService
@@ -87,15 +86,10 @@ class Cas1PlacementApplicationEmailServiceTest {
         .withApplication(application)
         .withCreatedByUser(creator)
         .withAllocatedToUser(assessor)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationSubmitted(placementApplication)
 
@@ -165,15 +159,10 @@ class Cas1PlacementApplicationEmailServiceTest {
         .withApplication(application)
         .withCreatedByUser(creator)
         .withAllocatedToUser(assessor)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationAllocated(placementApplication)
 
@@ -243,15 +232,10 @@ class Cas1PlacementApplicationEmailServiceTest {
         .withApplication(application)
         .withCreatedByUser(creator)
         .withAllocatedToUser(assessor)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationAccepted(placementApplication)
 
@@ -321,15 +305,10 @@ class Cas1PlacementApplicationEmailServiceTest {
         .withApplication(application)
         .withCreatedByUser(creator)
         .withAllocatedToUser(assessor)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationRejected(placementApplication)
 
@@ -386,15 +365,10 @@ class Cas1PlacementApplicationEmailServiceTest {
       val placementApplication = PlacementApplicationEntityFactory()
         .withApplication(application)
         .withCreatedByUser(creator)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
@@ -432,15 +406,10 @@ class Cas1PlacementApplicationEmailServiceTest {
       val placementApplication = PlacementApplicationEntityFactory()
         .withApplication(application)
         .withCreatedByUser(creator)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
@@ -477,15 +446,10 @@ class Cas1PlacementApplicationEmailServiceTest {
       val placementApplication = PlacementApplicationEntityFactory()
         .withApplication(application)
         .withCreatedByUser(creator)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
@@ -532,15 +496,10 @@ class Cas1PlacementApplicationEmailServiceTest {
         .withApplication(application)
         .withCreatedByUser(creator)
         .withAllocatedToUser(assessor)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,
@@ -570,52 +529,6 @@ class Cas1PlacementApplicationEmailServiceTest {
     }
 
     @Test
-    fun `placementApplicationWithdrawn sends an email with 'additionalDates' if multiple dates defined due to a legacy placement application`() {
-      val creator = createUser(emailAddress = null)
-      val assessor = createUser(emailAddress = ASSESSOR_EMAIL)
-
-      val application = createApplicationForApplicant()
-
-      val placementApplication = PlacementApplicationEntityFactory()
-        .withApplication(application)
-        .withCreatedByUser(creator)
-        .withAllocatedToUser(assessor)
-        .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2021, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
-
-      service.placementApplicationWithdrawn(
-        placementApplication = placementApplication,
-        wasBeingAssessedBy = assessor,
-        withdrawalTriggeredBy = WithdrawalTriggeredByUser(withdrawnByUser),
-      )
-
-      mockEmailNotificationService.assertEmailRequestCount(1)
-
-      val personalisation = mapOf(
-        "additionalDatesSet" to "yes",
-      )
-
-      mockEmailNotificationService.assertEmailRequested(
-        ASSESSOR_EMAIL,
-        Cas1NotifyTemplates.PLACEMENT_REQUEST_WITHDRAWN_V2,
-        personalisation,
-        application,
-      )
-    }
-
-    @Test
     fun `placementApplicationWithdrawn sends an email if triggered by seed job`() {
       val creator = createUser(emailAddress = null)
       val applicant = createUser(emailAddress = APPLICANT_EMAIL)
@@ -624,15 +537,10 @@ class Cas1PlacementApplicationEmailServiceTest {
       val placementApplication = PlacementApplicationEntityFactory()
         .withApplication(application)
         .withCreatedByUser(creator)
+        .withSubmittedAt(OffsetDateTime.now())
+        .withExpectedArrival(LocalDate.of(2020, 3, 12))
+        .withDuration(10)
         .produce()
-
-      placementApplication.placementDates = mutableListOf(
-        PlacementDateEntityFactory()
-          .withExpectedArrival(LocalDate.of(2020, 3, 12))
-          .withDuration(10)
-          .withPlacementApplication(placementApplication)
-          .produce(),
-      )
 
       service.placementApplicationWithdrawn(
         placementApplication = placementApplication,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -174,23 +173,10 @@ class PlacementApplicationTransformerTest {
       .withCreatedByUser(user)
       .withApplication(applicationMock)
       .withDecision(PlacementApplicationDecision.ACCEPTED)
+      .withSubmittedAt(OffsetDateTime.now())
+      .withExpectedArrival(LocalDate.of(2023, 12, 11))
+      .withDuration(30)
       .produce()
-
-    jpa.placementDates.add(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2023, 12, 11))
-        .withDuration(30)
-        .withPlacementApplication(jpa)
-        .produce(),
-    )
-
-    jpa.placementDates.add(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2024, 1, 31))
-        .withDuration(15)
-        .withPlacementApplication(jpa)
-        .produce(),
-    )
 
     val result = placementApplicationTransformer.transformToWithdrawable(jpa)
 
@@ -202,10 +188,6 @@ class PlacementApplicationTransformerTest {
           DatePeriod(
             LocalDate.of(2023, 12, 11),
             LocalDate.of(2024, 1, 10),
-          ),
-          DatePeriod(
-            LocalDate.of(2024, 1, 31),
-            LocalDate.of(2024, 2, 15),
           ),
         ),
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementApplicationTransformerTest.kt
@@ -71,23 +71,10 @@ class PlacementApplicationTransformerTest {
       .withApplication(applicationMock)
       .withData(null)
       .withDocument(null)
+      .withSubmittedAt(OffsetDateTime.now())
+      .withExpectedArrival(LocalDate.of(2023, 12, 11))
+      .withDuration(30)
       .produce()
-
-    placementApplication.placementDates.add(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2023, 12, 11))
-        .withDuration(30)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
-
-    placementApplication.placementDates.add(
-      PlacementDateEntityFactory()
-        .withExpectedArrival(LocalDate.of(2024, 1, 31))
-        .withDuration(15)
-        .withPlacementApplication(placementApplication)
-        .produce(),
-    )
 
     val result = placementApplicationTransformer.transformJpaToApi(placementApplication)
 
@@ -100,17 +87,17 @@ class PlacementApplicationTransformerTest {
     assertThat(result.createdAt).isEqualTo(placementApplication.createdAt.toInstant())
     assertThat(result.data).isNull()
     assertThat(result.document).isNull()
-    assertThat(result.submittedAt).isNull()
-    assertThat(result.canBeWithdrawn).isFalse
+    assertThat(result.submittedAt).isNotNull()
+    assertThat(result.canBeWithdrawn).isTrue
     assertThat(result.isWithdrawn).isFalse
     assertThat(result.withdrawalReason).isNull()
     assertThat(result.type).isEqualTo(PlacementApplicationType.additional)
+    assertThat(result.dates!!.expectedArrival).isEqualTo(LocalDate.of(2023, 12, 11))
+    assertThat(result.dates!!.duration).isEqualTo(30)
 
-    assertThat(result.placementDates).hasSize(2)
+    assertThat(result.placementDates).hasSize(1)
     assertThat(result.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2023, 12, 11))
     assertThat(result.placementDates[0].duration).isEqualTo(30)
-    assertThat(result.placementDates[1].expectedArrival).isEqualTo(LocalDate.of(2024, 1, 31))
-    assertThat(result.placementDates[1].duration).isEqualTo(15)
   }
 
   @Test
@@ -122,6 +109,9 @@ class PlacementApplicationTransformerTest {
       .withApplication(applicationMock)
       .withData(data)
       .withDocument(document)
+      .withSubmittedAt(OffsetDateTime.now())
+      .withExpectedArrival(LocalDate.of(2023, 12, 11))
+      .withDuration(30)
       .produce()
 
     val result = placementApplicationTransformer.transformJpaToApi(placementApplication)
@@ -129,6 +119,32 @@ class PlacementApplicationTransformerTest {
     assertThat(result.id).isEqualTo(placementApplication.id)
     assertThat(result.data).isEqualTo(objectMapper.readTree(data))
     assertThat(result.document).isEqualTo(objectMapper.readTree(document))
+    assertThat(result.dates!!.expectedArrival).isEqualTo(LocalDate.of(2023, 12, 11))
+    assertThat(result.dates!!.duration).isEqualTo(30)
+
+    assertThat(result.placementDates).hasSize(1)
+    assertThat(result.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2023, 12, 11))
+    assertThat(result.placementDates[0].duration).isEqualTo(30)
+  }
+
+  @Test
+  fun `transformJpaToApi converts correctly when not submitted`() {
+    val placementApplication = PlacementApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .withApplication(applicationMock)
+      .withData(null)
+      .withDocument(null)
+      .withSubmittedAt(null)
+      .withExpectedArrival(null)
+      .withDuration(null)
+      .produce()
+
+    val result = placementApplicationTransformer.transformJpaToApi(placementApplication)
+
+    assertThat(result.id).isEqualTo(placementApplication.id)
+    assertThat(result.submittedAt).isNull()
+    assertThat(result.dates).isNull()
+    assertThat(result.placementDates).isEmpty()
   }
 
   @Test


### PR DESCRIPTION
Remove all remaining code that reads values from the `placement_application_dates` table, updating the code to instead use `placement_applications.expected_arrival_date` and `placement_applications.duration`.

Once this is merged the only remaining use of placement dates is code that is populating the values, and the code that converts placement applications into placement requests, both of which can be updated to remove use of this table