### PR TITLE
Upstream /users/access always returns requested CRNs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApDeliusContextApiClient.kt
@@ -47,6 +47,19 @@ class ApDeliusContextApiClient(
     body = crnsOrNomsNumbers
   }
 
+  /**
+   * This endpoint will _always_ return a value for the CRN, even if the CRN isn't found.
+   *
+   * If the CRN isn't found it will return the following:
+   *
+   * <pre>
+   * {
+   *   "crn": "...",
+   *   "userExcluded": false,
+   *   "userRestricted": false
+   * }
+   * </pre>
+   */
   fun getUserAccessForCrns(deliusUsername: String, crns: List<String>) = getRequest<UserAccess> {
     path = "/users/access?username=$deliusUsername"
     body = crns

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -89,7 +88,6 @@ class Cas1OasysController(
         laoStrategy = userService.getUserForRequest().cas1CreateApplicationLaoStrategy(),
       )
     ) {
-      null -> throw NotFoundProblem(crn, "Offender")
       false -> throw ForbiddenProblem()
       else -> Unit
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PlacementApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PlacementApplicationsController.kt
@@ -61,7 +61,7 @@ class Cas1PlacementApplicationsController(
     val result = cas1PlacementApplicationService.getApplication(id)
     val placementApplication = extractEntityFromCasResult(result)
 
-    if (offenderService.canAccessOffender(placementApplication.application.crn, user.cas1LaoStrategy()) != true) {
+    if (!offenderService.canAccessOffender(placementApplication.application.crn, user.cas1LaoStrategy())) {
       throw ForbiddenProblem()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3PeopleController.kt
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -58,7 +57,6 @@ class Cas3PeopleController(
         laoStrategy = userService.getUserForRequest().cas3LaoStrategy(),
       )
     ) {
-      null -> throw NotFoundProblem(crn, "Offender")
       false -> throw ForbiddenProblem()
       else -> Unit
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -91,7 +91,7 @@ class ApplicationService(
       ?: throw RuntimeException("Could not get user")
 
     if (userEntity.hasPermission(UserPermission.CAS1_OFFLINE_APPLICATION_VIEW) &&
-      offenderService.canAccessOffender(deliusUsername, applicationEntity.crn) == true
+      offenderService.canAccessOffender(deliusUsername, applicationEntity.crn)
     ) {
       return CasResult.Success(applicationEntity)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -329,9 +329,9 @@ class OffenderService(
     )
   }
 
-  fun canAccessOffender(username: String, crn: String) = canAccessOffenders(username, listOf(crn))[crn]
+  fun canAccessOffender(username: String, crn: String) = canAccessOffenders(username, listOf(crn))[crn]!!
 
-  fun canAccessOffenders(username: String, crns: List<String>): Map<String, Boolean?> {
+  fun canAccessOffenders(username: String, crns: List<String>): Map<String, Boolean> {
     if (crns.isEmpty()) return emptyMap()
 
     if (crns.size > MAX_OFFENDER_REQUEST_COUNT) {
@@ -346,12 +346,8 @@ class OffenderService(
         )
 
         crns.associateBy(
-          keySelector = { it },
-          valueTransform = { crn ->
-            val access = crnToAccessResult[crn]
-
-            access?.hasNotLimitedAccess()
-          },
+          keySelector = { crn -> crn },
+          valueTransform = { crn -> crnToAccessResult[crn]!!.hasNotLimitedAccess() },
         )
       }
       is ClientResult.Failure -> clientResult.throwException()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -118,7 +118,7 @@ class UserAccessService(
     }
 
     return when (application) {
-      is ApprovedPremisesApplicationEntity -> userCanViewApprovedPremisesApplicationCreatedBySomeoneElse(user, application) == true
+      is ApprovedPremisesApplicationEntity -> userCanViewApprovedPremisesApplicationCreatedBySomeoneElse(user, application)
       is TemporaryAccommodationApplicationEntity -> userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse(user, application)
       else -> false
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementRequestService.kt
@@ -132,7 +132,7 @@ class Cas1PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return CasResult.NotFound("PlacementRequest", id.toString())
 
-    if (offenderService.canAccessOffender(placementRequest.application.crn, user.cas1LaoStrategy()) != true) {
+    if (!offenderService.canAccessOffender(placementRequest.application.crn, user.cas1LaoStrategy())) {
       return CasResult.Unauthorised()
     }
 
@@ -147,7 +147,7 @@ class Cas1PlacementRequestService(
     val placementRequest = placementRequestRepository.findByIdOrNull(id)
       ?: return CasResult.NotFound("PlacementRequest", id.toString())
 
-    if (offenderService.canAccessOffender(placementRequest.application.crn, user.cas1LaoStrategy()) != true) {
+    if (!offenderService.canAccessOffender(placementRequest.application.crn, user.cas1LaoStrategy())) {
       return CasResult.Unauthorised()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockNeedsDetails404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockOffenceDetails404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockRiskManagementPlan404Call
@@ -54,20 +53,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
         .exchange()
         .expectStatus()
         .isUnauthorized
-    }
-
-    @Test
-    fun `Return 404 if access record can't be found for the CRN  (legacy behaviour)`() {
-      val (_, jwt) = givenAUser()
-
-      apDeliusContextUserAccessEmptyResponse()
-
-      webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/metadata")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isNotFound
     }
 
     @Test
@@ -155,20 +140,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
         .exchange()
         .expectStatus()
         .isUnauthorized
-    }
-
-    @Test
-    fun `Return 404 if access record can't be found for the CRN`() {
-      val (_, jwt) = givenAUser()
-
-      apDeliusContextUserAccessEmptyResponse()
-
-      webTestClient.get()
-        .uri("/cas1/people/$CRN/oasys/answers?group=riskManagementPlan")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isNotFound
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3PeopleTest.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1OAsysTest.Companion.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockNeedsDetails404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockOffenceDetails404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulOffenceDetailsCall
@@ -31,20 +30,6 @@ class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
         .exchange()
         .expectStatus()
         .isUnauthorized
-    }
-
-    @Test
-    fun `Return 404 if access record can't be found for the CRN  (legacy behaviour)`() {
-      val (_, jwt) = givenAUser()
-
-      apDeliusContextUserAccessEmptyResponse()
-
-      webTestClient.get()
-        .uri("/cas3/people/$CRN/oasys/riskManagement")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isNotFound
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/ApplicationServiceTest.kt
@@ -111,9 +111,6 @@ class ApplicationServiceTest {
     every { mockUserRepository.findByDeliusUsername(deliusUsername) } returns userEntity
     every { mockApplicationRepository.findNonWithdrawnApprovedPremisesSummariesForUser(userId) } returns applicationSummaries
 
-    val crns = applicationSummaries.map { it.getCrn() }.distinct()
-    every { mockOffenderService.canAccessOffenders(deliusUsername, crns) } returns mapOf(crns.first() to true)
-
     assertThat(
       applicationService.getAllApplicationsForUsername(
         userEntity = userEntity,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -300,21 +300,6 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `return null when no access result returned for crn, ReturnRestrictedIfLimitedAccess strategy`() {
-      val crn = randomNumberChars(8)
-
-      every {
-        mockApDeliusContextApiClient.getUserAccessForCrns(
-          "distinguished.name",
-          listOf(crn),
-        )
-      } returns ClientResult.Success(HttpStatus.OK, UserAccess(emptyList()))
-
-      val result = offenderService.canAccessOffender(crn, CheckUserAccess("distinguished.name"))
-      assertThat(result).isNull()
-    }
-
-    @Test
     fun `return true when crn is not user restricted or excluded from viewing, ReturnRestrictedIfLimitedAccess strategy`() {
       val crn = randomNumberChars(8)
       val caseAccess = CaseAccessFactory()
@@ -401,21 +386,6 @@ class OffenderServiceTest {
     }
 
     @Test
-    fun `return null when no access result returned for crn`() {
-      val crn = randomNumberChars(8)
-
-      every {
-        mockApDeliusContextApiClient.getUserAccessForCrns(
-          "distinguished.name",
-          listOf(crn),
-        )
-      } returns ClientResult.Success(HttpStatus.OK, UserAccess(emptyList()))
-
-      val result = offenderService.canAccessOffenders("distinguished.name", listOf(crn))
-      assertThat(result[crn]).isNull()
-    }
-
-    @Test
     fun `return true when crn is not user restricted or excluded from viewing`() {
       val crn = randomNumberChars(8)
       val caseAccess = CaseAccessFactory()
@@ -437,29 +407,28 @@ class OffenderServiceTest {
 
     @Test
     fun `return expected results when multiple crns`() {
-      val crns = mutableListOf<String>()
-      repeat(5) { crns += randomStringMultiCaseWithNumbers(8) }
+      val crns = listOf("CRN1", "CRN2", "CRN3", "CRN4")
 
       val caseAccess1 = CaseAccessFactory()
-        .withCrn(crns[0])
+        .withCrn("CRN1")
         .withUserRestricted(false)
         .withUserExcluded(false)
         .produce()
 
       val caseAccess2 = CaseAccessFactory()
-        .withCrn(crns[1])
+        .withCrn("CRN2")
         .withUserRestricted(false)
         .withUserExcluded(true)
         .produce()
 
       val caseAccess3 = CaseAccessFactory()
-        .withCrn(crns[2])
+        .withCrn("CRN3")
         .withUserRestricted(true)
         .withUserExcluded(false)
         .produce()
 
       val caseAccess4 = CaseAccessFactory()
-        .withCrn(crns[3])
+        .withCrn("CRN4")
         .withUserRestricted(true)
         .withUserExcluded(false)
         .produce()
@@ -475,11 +444,10 @@ class OffenderServiceTest {
 
       val result = offenderService.canAccessOffenders("distinguished.name", crns)
 
-      assertThat(result[crns[0]]).isTrue()
-      assertThat(result[crns[1]]).isFalse()
-      assertThat(result[crns[2]]).isFalse()
-      assertThat(result[crns[3]]).isFalse()
-      assertThat(result[crns[4]]).isNull()
+      assertThat(result["CRN1"]).isTrue()
+      assertThat(result["CRN2"]).isFalse()
+      assertThat(result["CRN3"]).isFalse()
+      assertThat(result["CRN4"]).isFalse()
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Before this commit the code assumed that calls to `/users/access` would not return an entry for a requested CRN if the CRN does not exist. This is not the case, and an entry for the CRN will always be returned.

This commit notes this on the client for this endpoint and updates the code to remove any code related to the CRN not existing

