### PR TITLE
CAS-1682: C3 BE Make bestpace start date not nullable - script fixes

### DIFF
--- a/src/main/resources/db/migration/dev/R__4_create_rooms_and_beds.sql
+++ b/src/main/resources/db/migration/dev/R__4_create_rooms_and_beds.sql
@@ -16,12 +16,13 @@ values
     ) ON CONFLICT (id) DO NOTHING;
 
 insert into
-    beds ("id", "name", "room_id")
+    beds ("id", "name", "room_id", "start_date")
 values
     (
         'e8887df9-b31b-4e9c-931a-e063d778ab0d',
         'BED1',
-        '14c0911e-6296-4b3f-ad00-5a2cf6f23a08'
+        '14c0911e-6296-4b3f-ad00-5a2cf6f23a08',
+     '01/06/2024'
     ) ON CONFLICT (id) DO NOTHING;
 
 insert into
@@ -34,12 +35,13 @@ values
         'd6447105-4bfe-4f1e-add7-4668e1ca28b0'
     ) ON CONFLICT (id) DO NOTHING;
 insert into
-    beds ("id", "name", "room_id")
+    beds ("id", "name", "room_id", "start_date")
 values
     (
         '135812b4-e6c0-4ccf-9502-4bfea66f3bd3',
         'BED1',
-        'fe86a602-6873-49d3-ac3a-3dfef743ae03'
+        'fe86a602-6873-49d3-ac3a-3dfef743ae03',
+        '01/07/2024'
     ) ON CONFLICT (id) DO NOTHING;
 
 -- Premises 2 (1x room, 1x bed)
@@ -53,12 +55,13 @@ values
         'e2543d2f-33a9-454b-ae15-03ca0475faa3'
     ) ON CONFLICT (id) DO NOTHING;
 insert into
-    beds ("id", "name", "room_id")
+    beds ("id", "name", "room_id", "start_date")
 values
     (
         '6d6d4c56-9989-4fb5-a486-d32f525748e6',
         'BED1',
-        '2d87a9a2-1f94-45ec-9790-eb8732a4ba6f'
+        '2d87a9a2-1f94-45ec-9790-eb8732a4ba6f',
+        '01/08/2024'
     ) ON CONFLICT (id) DO NOTHING;
 
 -- Premises 3 (1x room, 1x bed)
@@ -72,12 +75,13 @@ values
         '0ad5999f-a07c-4605-b875-81d7a17e9f70'
     ) ON CONFLICT (id) DO NOTHING;
 insert into
-    beds ("id", "name", "room_id")
+    beds ("id", "name", "room_id", "start_date")
 values
     (
         '8be1ed0e-dae7-42d2-97e0-95c95fdb4c50',
         'BED1',
-        '135812b4-e6c0-4ccf-9502-4bfea66f3bd3'
+        '135812b4-e6c0-4ccf-9502-4bfea66f3bd3',
+        '01/09/2024'
     ) ON CONFLICT (id) DO NOTHING;
 
 -- CAS3 beds for East of England
@@ -94,12 +98,13 @@ values
     ) ON CONFLICT (id) DO NOTHING;
 
 insert into
-    beds ("id", "name", "room_id")
+    beds ("id", "name", "room_id", "start_date")
 values
     (
         '38e6b775-88c5-4571-8b6e-da3711aeaca6',
         'BED1',
-        '4d27144d-1c3d-4785-9fbd-879d8b0b5b41'
+        '4d27144d-1c3d-4785-9fbd-879d8b0b5b41',
+        '01/10/2024'
     ) ON CONFLICT (id) DO NOTHING;
 
 insert into
@@ -113,12 +118,13 @@ values
     ) ON CONFLICT (id) DO NOTHING;
 
 insert into
-    beds ("id", "name", "room_id")
+    beds ("id", "name", "room_id", "start_date")
 values
     (
         'fd1c7078-43c8-41f5-8e57-a4d59f3c831a',
         'BED1',
-        '94c58e72-d31a-49c3-8569-fc341e46ba6a'
+        '94c58e72-d31a-49c3-8569-fc341e46ba6a',
+        '01/11/2024'
     ) ON CONFLICT (id) DO NOTHING;
 
 -- Premises 2 (1x room, 1x bed)
@@ -132,12 +138,13 @@ values
         '6aa177cb-617f-4abb-be46-056ea7e4a59d'
     ) ON CONFLICT (id) DO NOTHING;
 insert into
-    beds ("id", "name", "room_id")
+    beds ("id", "name", "room_id", "start_date")
 values
     (
         '64fd8f3d-1fb6-4346-a190-65588b998301',
         'BED1',
-        '82ff4d7f-13c2-4827-8957-c38ad4750c53'
+        '82ff4d7f-13c2-4827-8957-c38ad4750c53',
+        '01/12/2024'
     ) ON CONFLICT (id) DO NOTHING;
 
 -- Premises 2 (1x room, 1x bed)
@@ -151,10 +158,11 @@ values
         '773431cd-f560-4be8-9e6f-b582a4ebf204'
     ) ON CONFLICT (id) DO NOTHING;
 insert into
-    beds ("id", "name", "room_id")
+    beds ("id", "name", "room_id", "start_date")
 values
     (
         '8ecef9a5-268c-4595-9fd0-042fed3d4882',
         'BED1',
-        '02e1c7a3-47e7-4845-95f5-98aeed0ef81b'
+        '02e1c7a3-47e7-4845-95f5-98aeed0ef81b',
+        '01/01/2025'
     ) ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
This Pull Request modifies a database migration script to include an additional column, "start_date," for the beds table and provides updated data inserts with corresponding values for this new field.

Main Changes

- Added a new column, start_date, to the beds table insert statements.
- Updated all beds data insert statements to include a value for the start_date column, with data such as dates ranging from 01/06/2024 to 01/01/2025.