### PR TITLE
CAS3 V2 reinstate cas3_void_bedspaces foreign-keys

### DIFF
--- a/src/main/resources/db/migration/all/20250707192500__cas3_void_bedspaces_add_premises_and_beds_foreign_keys.sql
+++ b/src/main/resources/db/migration/all/20250707192500__cas3_void_bedspaces_add_premises_and_beds_foreign_keys.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cas3_void_bedspaces ADD FOREIGN KEY (bed_id) REFERENCES beds(id);
+ALTER TABLE cas3_void_bedspaces ADD FOREIGN KEY (premises_id) REFERENCES premises(id);


### PR DESCRIPTION
**Background**
In previous PR, I commented about the need to drop a couple of foreign keys: 
https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3823/files#r2185362168

I realised that this is actually not necessary, we can keep the foreign keys. The only thing we needed to keep in that flyway script was dropping the not null:
```
ALTER TABLE cas3_void_bedspaces
    ALTER COLUMN premises_id drop not null;
```

We previously dropped a foreign key in `bookings` table that we discussed in `Dev checkin` because we were sharing a column - this was at the forefront of my mind when decided to drop the foreign keys above but dropping these latest foreign keys is not needed and a mistake.

**Solution**
* this PR adds back in the foreign keys I dropped unnecessarily.

**IMPORTANT**
* The removal of these foreign key constraints actually resulted in an issue with `CAS3 e2es` in the pipeline so very keen to get these constraints back (to avoid similar data issues in higher environments)

* Somehow dev was creating data in the DB in the `cas3_void_bedspaces.bed_id` column that did not link to `beds`
<img width="2048" alt="01_dev" src="https://github.com/user-attachments/assets/6c932adb-e9e4-4ca1-827f-615ed650331d" />

* I can see in `preprod` we do NOT have the same issue:
<img width="2048" alt="02_preprod" src="https://github.com/user-attachments/assets/570f2782-621d-4579-90c1-bd085f8e0040" />

* We saw this related Sentry event when the `CAS3 e2es` triggered the related `Cas3VoidBedspacesTransformer` to transform a null value at runtime: https://ministryofjustice.sentry.io/issues/6731455526

* **Fix** - Ran this sql scripts to cleanup the data on dev:

```
delete
from cas3_void_bedspace_cancellations
where cas3_void_bedspace_id in (
    select id
    from cas3_void_bedspaces
    where bed_id not in (select id from beds)
);
delete
from cas3_void_bedspaces
where bed_id not in (select id from beds)
```

* After running the above data cleanup SQL script against dev, and re-running the `CAS e2es` -> the pipeline was fixed and passed 🎉 