### PR TITLE
CAS3 V2 Get Premises Bookings By Booking ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BookingAndPersons.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BookingAndPersons.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+
+data class Cas3BookingAndPersons(
+  val booking: Cas3BookingEntity,
+  val personInfo: PersonInfoResult,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3BedspacesEntity.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 @Entity
 @Table(name = "cas3_bedspaces")
 @Inheritance(strategy = InheritanceType.JOINED)
-class Cas3BedspacesEntity(
+data class Cas3BedspacesEntity(
   @Id
   val id: UUID,
 


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" alt="swags" src="https://github.com/user-attachments/assets/9ada2084-4bb1-42bf-9092-f7a3b43088ad" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `GET /cas3/v2/premises/{premiseId}/bookings/{bookingId}`.
2. This endpoint was modelled on the `GET /premises/{premiseId}/bookings/{bookingId}` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data model.
