### PR TITLE
APS-2477 Change prefix from ap area to cru management area in occupancy reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1OccupancyReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1OccupancyReportRepository.kt
@@ -65,7 +65,7 @@ class Cas1OccupancyReportRepository(
     		select 
     			premises_and_days.day as day,
     			p.id as premises_id,
-    			concat(area.name,' - ',p.name) as premises_name,
+    			concat(cma.name,' - ',p.name) as premises_name,
     			(
     				select count(*) from beds 
     				inner join rooms on beds.room_id = rooms.id
@@ -87,7 +87,8 @@ class Cas1OccupancyReportRepository(
     		from premises_and_days
     		inner join premises p on p.id = premises_and_days.premises_id
         inner join probation_regions region ON region.id = p.probation_region_id
-        inner join ap_areas area ON area.id = region.ap_area_id 
+        inner join approved_premises ap ON ap.premises_id = p.id
+        inner join cas1_cru_management_areas cma on cma.id = ap.cas1_cru_management_area_id   
     	),
     	premises_day_state_summary as (
     		select 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -1352,12 +1352,18 @@ class Cas1PremisesTest : IntegrationTestBase() {
         region = givenAProbationRegion(
           apArea = givenAnApArea(name = "Region 1"),
         ),
+        cruManagementArea = givenACas1CruManagementArea(
+          name = "Management Area 1",
+        ),
       )
       val premises2 = givenAnApprovedPremises(
         name = "Premises 2",
         supportsSpaceBookings = true,
         region = givenAProbationRegion(
           apArea = givenAnApArea(name = "Region 2"),
+        ),
+        cruManagementArea = givenACas1CruManagementArea(
+          name = "Management Area 2",
         ),
       )
       givenAnApprovedPremises(name = "Premises 3 Ignored", supportsSpaceBookings = false)
@@ -1476,7 +1482,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
 
           assertThat(actual.size).isEqualTo(31)
 
-          assertThat(actual["row_name"]).isEqualTo(listOf("Region 1 - Premises 1", "Region 2 - Premises 2"))
+          assertThat(actual["row_name"]).isEqualTo(listOf("Management Area 1 - Premises 1", "Management Area 2 - Premises 2"))
 
           fun getDateToOccupancyMap(index: Int) = actual.keys
             .filter { it != "row_name" }.associateWith { date -> (actual[date]!![index] as Int) }


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2477

The report provided by `Cas1OccupancyReportRepository` currently prefixes the premises name with the `ap_area.name`. It should instead prefix it with the `cas1_cru_management_area.name`. Otherwise, premises in the 'Women’s APs' management area will not be easy to find.

The cru management area for a premises is available on `approved_premises.cas1_cru_management_area_id`
