### PR TITLE
CAS3 V2 Get Booking By Booking ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3v2BookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3v2BookingController.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas3
+
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.v2.Cas3v2BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BookingTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+import java.util.UUID
+
+@RestController
+@RequestMapping(
+  "\${api.base-path:}/cas3/v2",
+  headers = ["X-Service-Name=temporary-accommodation"],
+  produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE],
+)
+class Cas3v2BookingController(
+  private val bookingService: Cas3v2BookingService,
+  private val bookingTransformer: Cas3BookingTransformer,
+) {
+
+  @GetMapping(value = ["/bookings/{bookingId}"])
+  fun bookingsBookingIdGet(@PathVariable bookingId: UUID): ResponseEntity<Cas3Booking> {
+    val bookingAndPersonsResult = bookingService.getBooking(bookingId, premisesId = null)
+    val bookingAndPersons = extractEntityFromCasResult(bookingAndPersonsResult)
+
+    val apiBooking = bookingTransformer.transformJpaToApi(
+      bookingAndPersons.booking,
+      bookingAndPersons.personInfo,
+    )
+
+    return ResponseEntity.ok(apiBooking)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/v2/Cas3v2BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/v2/Cas3v2BookingService.kt
@@ -45,14 +45,14 @@ class Cas3v2BookingService(
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun getBooking(bookingId: UUID, premisesId: UUID): CasResult<Cas3BookingAndPersons> {
+  fun getBooking(bookingId: UUID, premisesId: UUID?): CasResult<Cas3BookingAndPersons> {
     val booking = cas3BookingRepository.findByIdOrNull(bookingId)
       ?: return CasResult.NotFound("Booking", bookingId.toString())
 
     val user = userService.getUserForRequest()
     if (!userAccessService.userCanManagePremisesBookings(user, booking.premises)) {
       return CasResult.Unauthorised()
-    } else if (premisesId != booking.premises.id) {
+    } else if (premisesId != null && premisesId != booking.premises.id) {
       return CasResult.GeneralValidationError("The supplied premisesId does not match the booking's premises")
     }
 


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" alt="Screenshot 2025-07-09 at 15 38 03 (2)" src="https://github.com/user-attachments/assets/3a996ed7-3dcc-4352-9af7-34a3c400f94b" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `GET /cas3/v2/bookings/{bookingId}`.
2. This endpoint was modelled on the `GET /bookings/{bookingId}` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data model.
