### PR TITLE
APS-2499 - CAS1 Space Booking Backfill should be idempotent

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -374,6 +374,9 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
     nativeQuery = true,
   )
   fun hasNonCancelledTransfer(spaceBookingId: UUID): Boolean
+
+  @Query
+  fun existsByDeliusId(deliusId: String): Boolean
 }
 
 interface Cas1SpaceBookingDaySummarySearchResult {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BackfillActiveSpaceBookingsCreatedInDelius.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1BackfillActiveSpaceBookingsCreatedInDelius.kt
@@ -126,6 +126,11 @@ class Cas1BackfillActiveSpaceBookingsCreatedInDelius(
       return
     }
 
+    if (spaceBookingRepository.existsByDeliusId(deliusReferral.approvedPremisesReferralId)) {
+      log.warn("We already have a space booking for delius id $deliusReferral.approvedPremisesReferralId, will not backfill this booking.")
+      return
+    }
+
     val offlineApplication = offlineApplicationRepository.save(
       OfflineApplicationEntity(
         id = UUID.randomUUID(),


### PR DESCRIPTION
Update the seed job that backfills referrals created directly in Delius to ensure if it’s ran multiple times multiple duplicate space bookings aren’t created

