### PR TITLE
CAS-1620: Create unarchive bedspace api endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/generated/Cas3UnarchiveBedspace.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/generated/Cas3UnarchiveBedspace.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated
+
+import java.time.LocalDate
+
+data class Cas3UnarchiveBedspace(
+  val restartDate: LocalDate,
+)


### PR DESCRIPTION
This Pull Request introduces a new feature for unarchiving bedspaces in a premises and includes all required functionality, validations, and tests.

- New Model Added: Cas3UnarchiveBedspace for handling unarchiving of bedspaces with a required restartDate.
- New Endpoint: Adds a POST endpoint for unarchiving bedspaces in the Cas3PremisesController. Includes permission checks and validation logic.
- Service Layer Changes: Implements unarchiveBedspace in the Cas3PremisesService, adding validations for restart dates and archived bedspace checks.
- Validation Rules Added:
  - restartDate must not be more than 7 days in the past or future.
  - restartDate must be after the last archive's end date.
  - The bedspace must exist and must currently be archived.
- Integration Testing: Comprehensive integration tests validate the new endpoint's behavior for success, validation errors, and permission constraints.
- Unit Testing: Comprehensive unit tests added to the service layer to validate logic for unarchiving scenarios.