### PR TITLE
APS-1127 - Manually install Open Entity in View Interceptor

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ConfigureOpenEntityManagerInView.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ConfigureOpenEntityManagerInView.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class ConfigureOpenEntityManagerInView {
+  @Bean
+  fun openEntityManagerInViewInterceptor(interceptor: CasOpenEntityManagerInViewInterceptor): WebMvcConfigurer = object : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+      registry.addWebRequestInterceptor(interceptor)
+        /**
+         * Ideally all endpoints would be excluded from this interceptor, but
+         * this requires updates to ensure they stop relying on lazy loading
+         * before this can be done
+         */
+        .excludePathPatterns(
+          "/cas1/premises/*/space-bookings",
+        )
+    }
+  }
+}
+
+@Component
+class CasOpenEntityManagerInViewInterceptor : OpenEntityManagerInViewInterceptor()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,8 @@ spring:
     type: redis
 
   jpa:
+    # this is managed via ConfigureOpenEntityManagerInView
+    open-in-view: false
     hibernate:
       ddl-auto: none
     properties:


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-1127

Open Entity (Session) In View (OSIV) is enabled by default in Spring, and whilst simplifying development wrt. lazy loading JPA relationships, it results in a database connection being held open from it’s first usage to completion of the API request. This can lead to exhausted connection pools under load, especially when calls are being made to upstream services in the same thread that holds the connection.

Because removing OSIV can cause subtle issues (especially around object equality), we've decided to selectively disable it for certain paths that are causing particular issues. To support this we manually install the interceptor in the configuration class added by this commit.

This commit initially adds the interceptor to one endpoint as a proof of concept. We’ve confirmed locally that the interceptor is no longer being invoked for this specific endpoint.

Note that before this commit we relied on spring to install this interceptor. The code behind this option is `JpaBaseConfiguration.JpaWebConfiguration`, which installs the interceptor as follows:

```

		@Bean
		public OpenEntityManagerInViewInterceptor openEntityManagerInViewInterceptor() {
			if (this.jpaProperties.getOpenInView() == null) {
				logger.warn("spring.jpa.open-in-view is enabled by default. "
						+ "Therefore, database queries may be performed during view "
						+ "rendering. Explicitly configure spring.jpa.open-in-view to disable this warning");
			}
			return new OpenEntityManagerInViewInterceptor();
		}

		@Bean
		public WebMvcConfigurer openEntityManagerInViewInterceptorConfigurer(
				OpenEntityManagerInViewInterceptor interceptor) {
			return new WebMvcConfigurer() {

				@Override
				public void addInterceptors(InterceptorRegistry registry) {
					registry.addWebRequestInterceptor(interceptor);
				}

			};
		}
```