### PR TITLE
Don’t check user access if offender not LAO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/UserAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/UserAccess.kt
@@ -8,6 +8,6 @@ data class CaseAccess(
   val crn: String,
   val userExcluded: Boolean,
   val userRestricted: Boolean,
-  val exclusionMessage: String?,
-  val restrictionMessage: String?,
+  val exclusionMessage: String? = null,
+  val restrictionMessage: String? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3BedspaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3BedspaceSearchTest.kt
@@ -404,9 +404,6 @@ class Cas3BedspaceSearchTest : IntegrationTestBase() {
           apDeliusContextAddResponseToUserAccessCall(
             listOf(
               CaseAccessFactory()
-                .withCrn(fullPersonCaseSummary.crn)
-                .produce(),
-              CaseAccessFactory()
                 .withCrn(userExcludedCaseSummary.crn)
                 .withUserExcluded(true)
                 .produce(),


### PR DESCRIPTION
Before this commit when calling `OffenderService.getPersonSummaryInfoResults` we would call the ‘user access’ endpoint to determine if the user could access the offender, even if we already knew there were no restrictions or exclusions on the offender for _any_ users.

This commit changes that logic to only make upstream calls for CRNs where we know there is either a restriction or exclusion in place.