### PR TITLE
APS-2503 national occupancy sorting improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1PremisesSearchResultSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1PremisesSearchResultSummary.kt
@@ -1,38 +1,18 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-/**
- *
- * @param id
- * @param apType
- * @param name
- * @param fullAddress Full address, excluding postcode
- * @param apArea
- * @param characteristics Room and premise characteristics
- * @param postcode
- */
 data class Cas1PremisesSearchResultSummary(
 
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("apType", required = true) val apType: ApType,
-
-  @Schema(example = "Hope House", required = true, description = "")
-  @get:JsonProperty("name", required = true) val name: kotlin.String,
-
-  @Schema(example = "null", required = true, description = "Full address, excluding postcode")
-  @get:JsonProperty("fullAddress", required = true) val fullAddress: kotlin.String,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("apArea", required = true) val apArea: NamedId,
-
-  @Schema(example = "null", required = true, description = "Room and premise characteristics")
-  @get:JsonProperty("characteristics", required = true) val characteristics: kotlin.collections.List<Cas1SpaceCharacteristic>,
-
-  @Schema(example = "LS1 3AD", description = "")
-  @get:JsonProperty("postcode") val postcode: kotlin.String? = null,
+  val id: java.util.UUID,
+  val apType: ApType,
+  @Schema(example = "Hope House")
+  val name: String,
+  @Schema(description = "Full address, excluding postcode")
+  val fullAddress: String,
+  val apArea: NamedId,
+  @Schema(description = "Room and premise characteristics")
+  val characteristics: List<Cas1SpaceCharacteristic>,
+  @Schema(example = "LS1 3AD")
+  val postcode: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/NamedId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/NamedId.kt
@@ -1,18 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
 
-/**
- * A generic stub for an object with a name and an ID.
- * @param id
- * @param name
- */
 data class NamedId(
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("name", required = true) val name: kotlin.String,
+  val id: UUID,
+  val name: String,
+  val code: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
@@ -78,7 +78,16 @@ AND
     WHERE r.premises_id = result.premises_id AND rc.characteristic_id IN (:roomCharacteristics)
   )
 )
-ORDER BY result.distance_in_miles
+ORDER BY 
+    CASE 
+        WHEN :outcode = 'ANY' THEN ap_area_identifier
+        ELSE ''
+    END,
+    CASE 
+        WHEN :outcode != 'ANY' THEN distance_in_miles
+        ELSE 0
+    END,
+    name
 """
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
@@ -41,6 +41,7 @@ FROM
     p.postcode AS postcode,
     aa.id AS ap_area_id,
     aa.name AS ap_area_name,
+    aa.identifier AS ap_area_identifier,
     ARRAY_REMOVE(ARRAY_AGG (DISTINCT premises_chars_resolved.property_name), null) as premises_characteristics,
     ARRAY_REMOVE(ARRAY_AGG (DISTINCT room_chars_resolved.property_name), null) as room_characteristics
   FROM approved_premises ap
@@ -109,14 +110,15 @@ class Cas1SpaceSearchRepository(
         rs.getUUID("premises_id"),
         if (targetPostcodeDistrict == null) null else rs.getFloat("distance_in_miles"),
         apType,
-        rs.getString("name"),
-        rs.getString("full_address"),
-        rs.getString("address_line1"),
-        rs.getString("address_line2"),
-        rs.getString("town"),
-        rs.getString("postcode"),
-        rs.getUUID("ap_area_id"),
-        rs.getString("ap_area_name"),
+        name = rs.getString("name"),
+        fullAddress = rs.getString("full_address"),
+        addressLine1 = rs.getString("address_line1"),
+        addressLine2 = rs.getString("address_line2"),
+        town = rs.getString("town"),
+        postcode = rs.getString("postcode"),
+        apAreaId = rs.getUUID("ap_area_id"),
+        apAreaName = rs.getString("ap_area_name"),
+        apAreaIdentifier = rs.getString("ap_area_identifier"),
         characteristics = (
           SqlUtil.toStringList(rs.getArray("premises_characteristics")) +
             SqlUtil.toStringList(rs.getArray("room_characteristics"))
@@ -138,5 +140,6 @@ data class CandidatePremises(
   val postcode: String,
   val apAreaId: UUID,
   val apAreaName: String,
+  val apAreaIdentifier: String,
   val characteristics: List<String>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceSearchResultsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceSearchResultsTransformer.kt
@@ -33,6 +33,7 @@ class Cas1SpaceSearchResultsTransformer {
     apArea = NamedId(
       id = premises.apAreaId,
       name = premises.apAreaName,
+      code = premises.apAreaIdentifier,
     ),
     characteristics = premises.characteristics.map {
       Cas1SpaceCharacteristic.valueOf(it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/CandidatePremisesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas1/CandidatePremisesFactory.kt
@@ -24,6 +24,7 @@ class CandidatePremisesFactory : Factory<CandidatePremises> {
     "TB1 2AB",
     UUID.randomUUID(),
     "Some AP Area",
+    "Area Code",
     characteristics = emptyList(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApArea.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApArea.kt
@@ -9,10 +9,14 @@ fun IntegrationTestBase.givenAnApArea(
   id: UUID = UUID.randomUUID(),
   name: String? = null,
   defaultCruManagementArea: Cas1CruManagementAreaEntity? = null,
+  identifier: String? = null,
 ): ApAreaEntity = apAreaEntityFactory.produceAndPersist {
   withId(id)
   if (name != null) {
     withName(name)
+  }
+  if (identifier != null) {
+    withIdentifier(identifier)
   }
   withDefaultCruManagementArea(defaultCruManagementArea ?: givenACas1CruManagementArea())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesSearchServiceTest.kt
@@ -54,6 +54,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area1",
       characteristics = emptyList(),
     )
 
@@ -69,6 +70,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area2",
       characteristics = emptyList(),
     )
 
@@ -84,6 +86,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area3",
       characteristics = emptyList(),
     )
 
@@ -153,6 +156,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area1",
       characteristics = emptyList(),
     )
 
@@ -168,6 +172,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area2",
       characteristics = emptyList(),
     )
 
@@ -183,6 +188,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area3",
       characteristics = emptyList(),
     )
 
@@ -241,6 +247,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area1",
       characteristics = emptyList(),
     )
 
@@ -256,6 +263,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area2",
       characteristics = emptyList(),
     )
 
@@ -271,6 +279,7 @@ class Cas1PremisesSearchServiceTest {
       "TB1 2AB",
       UUID.randomUUID(),
       "Some AP Area",
+      "Area3",
       characteristics = emptyList(),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceSearchResultsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceSearchResultsTransformerTest.kt
@@ -33,6 +33,7 @@ class Cas1SpaceSearchResultsTransformerTest {
         postcode = "TB1 2AB",
         apAreaId = apAreaId1,
         apAreaName = "Some AP Area 1",
+        apAreaIdentifier = "Area1",
         characteristics = emptyList(),
       ),
       CandidatePremises(
@@ -47,6 +48,7 @@ class Cas1SpaceSearchResultsTransformerTest {
         postcode = "TB1 2AC",
         apAreaId = apAreaId2,
         apAreaName = "Some AP Area 2",
+        apAreaIdentifier = "Area2",
         characteristics = emptyList(),
       ),
     )
@@ -62,6 +64,7 @@ class Cas1SpaceSearchResultsTransformerTest {
     assertThat(premises1.postcode).isEqualTo("TB1 2AB")
     assertThat(premises1.apArea.id).isEqualTo(apAreaId1)
     assertThat(premises1.apArea.name).isEqualTo("Some AP Area 1")
+    assertThat(premises1.apArea.code).isEqualTo("Area1")
     assertThat(premises1.characteristics).isEmpty()
     assertThat(actual.results[0].distanceInMiles).isEqualTo(BigDecimal.valueOf(1.0))
 
@@ -73,6 +76,7 @@ class Cas1SpaceSearchResultsTransformerTest {
     assertThat(premises2.postcode).isEqualTo("TB1 2AC")
     assertThat(premises2.apArea.id).isEqualTo(apAreaId2)
     assertThat(premises2.apArea.name).isEqualTo("Some AP Area 2")
+    assertThat(premises2.apArea.code).isEqualTo("Area2")
     assertThat(premises2.characteristics).isEmpty()
     assertThat(actual.results[1].distanceInMiles).isEqualTo(BigDecimal.valueOf(2.0))
   }


### PR DESCRIPTION
National occupancy sorting improvements

Sort on ap area identifier if no postcode is provided.

The ORDER BY construct in the SQL is slightly awkward because the type returned for each order by ‘position’ must be the same

e.g.

order by position 1 - varchar (area identifier or ‘’)
order by position 2 - numeric (distance in miles or 0)
order by position 3 - varchar (always premises name)