### PR TITLE
APS-2446 - Remove `Cas1PremisesDaySummary.capacity`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1PremisesDaySummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1PremisesDaySummary.kt
@@ -1,35 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import io.swagger.v3.oas.annotations.media.Schema
-
-/**
- *
- * @param forDate
- * @param previousDate
- * @param nextDate
- * @param capacity
- * @param spaceBookings
- * @param spaceBookingSummaries
- * @param outOfServiceBeds
- */
 data class Cas1PremisesDaySummary(
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("forDate", required = true) val forDate: java.time.LocalDate,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("previousDate", required = true) val previousDate: java.time.LocalDate,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("nextDate", required = true) val nextDate: java.time.LocalDate,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("capacity", required = true) val capacity: Cas1PremiseCapacityForDay,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("spaceBookingSummaries", required = true) val spaceBookingSummaries: kotlin.collections.List<Cas1SpaceBookingSummary>,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("outOfServiceBeds", required = true) val outOfServiceBeds: kotlin.collections.List<Cas1OutOfServiceBedSummary>,
+  val forDate: java.time.LocalDate,
+  val previousDate: java.time.LocalDate,
+  val nextDate: java.time.LocalDate,
+  val spaceBookingSummaries: List<Cas1SpaceBookingSummary>,
+  val outOfServiceBeds: List<Cas1OutOfServiceBedSummary>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1PremisesController.kt
@@ -265,16 +265,6 @@ class Cas1PremisesController(
     return ResponseEntity.ok().body(
       cas1PremisesDayTransformer.toCas1PremisesDaySummary(
         date = date,
-        premisesCapacity = cas1PremiseCapacityTransformer.toCas1PremiseCapacitySummary(
-          premiseCapacity = extractEntityFromCasResult(
-            cas1PremisesService.getPremisesCapacities(
-              premisesIds = listOf(premisesId),
-              startDate = date,
-              endDate = date,
-              excludeSpaceBookingId = excludeSpaceBookingId,
-            ),
-          ).results[0],
-        ).capacity.first(),
         outOfServiceBeds = extractEntityFromCasResult(
           cas1OutOfServiceBedSummaryService.getOutOfServiceBedSummaries(
             premisesId = premisesId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesDayTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesDayTransformer.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacityForDay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesDaySummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
 import java.time.LocalDate
@@ -12,14 +11,12 @@ class Cas1PremisesDayTransformer {
 
   fun toCas1PremisesDaySummary(
     date: LocalDate,
-    premisesCapacity: Cas1PremiseCapacityForDay,
     outOfServiceBeds: List<Cas1OutOfServiceBedSummary>,
     spaceBookingSummaries: List<Cas1SpaceBookingSummary>,
   ) = Cas1PremisesDaySummary(
     forDate = date,
     previousDate = date.minusDays(1),
     nextDate = date.plusDays(1),
-    capacity = premisesCapacity,
     outOfServiceBeds = outOfServiceBeds,
     spaceBookingSummaries = spaceBookingSummaries,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -1306,26 +1306,6 @@ class Cas1PremisesTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `return capacity information`() {
-      val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
-
-      val summaries = webTestClient.get()
-        .uri("/cas1/premises/${premises.id}/day-summary/$summaryDate")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isOk
-        .returnResult(Cas1PremisesDaySummary::class.java).responseBody.blockFirst()!!
-
-      val capacity = summaries.capacity
-      assertThat(capacity.date).isEqualTo(summaryDate)
-      assertThat(capacity.totalBedCount).isEqualTo(8)
-      assertThat(capacity.availableBedCount).isEqualTo(5)
-      assertThat(capacity.bookingCount).isEqualTo(3)
-      assertThat(capacity.characteristicAvailability.count()).isEqualTo(6)
-    }
-
-    @Test
     fun `return out of service beds applicable to given date`() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_CRU_MEMBER))
 
@@ -1434,12 +1414,6 @@ class Cas1PremisesTest : IntegrationTestBase() {
       val spaceBookingsAvailableInPremisesSummary = summaries.spaceBookingSummaries
       assertThat(spaceBookingsAvailableInPremisesSummary.size).isEqualTo(2)
       assertThat(spaceBookingsAvailableInPremisesSummary).extracting("id").doesNotContain(excludeSpaceBookingId)
-
-      val capacity = summaries.capacity
-      assertThat(capacity.date).isEqualTo(summaryDate)
-      assertThat(capacity.totalBedCount).isEqualTo(8)
-      assertThat(capacity.availableBedCount).isEqualTo(5)
-      assertThat(capacity.bookingCount).isEqualTo(2)
 
       assertThat(summaries.spaceBookingSummaries.map { it.id }).containsExactly(
         spaceBookingOfflineApplication.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
@@ -7,9 +7,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCapacityForDay
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremiseCharacteristicAvailability
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
@@ -28,18 +25,6 @@ class Cas1PremisesDayTransformerTest {
   @Test
   fun toCas1PremisesDaySummary() {
     val currentSearchDay = LocalDate.now()
-
-    val capacity =
-      Cas1PremiseCapacityForDay(
-        date = currentSearchDay,
-        totalBedCount = 5,
-        availableBedCount = 3,
-        bookingCount = 4,
-        characteristicAvailability = listOf(
-          Cas1PremiseCharacteristicAvailability(Cas1SpaceBookingCharacteristic.IS_SINGLE, 10, 4),
-          Cas1PremiseCharacteristicAvailability(Cas1SpaceBookingCharacteristic.IS_WHEELCHAIR_DESIGNATED, 20, 8),
-        ),
-      )
 
     val spaceBookingSummaries = listOf(
       Cas1SpaceBookingSummary(
@@ -85,7 +70,6 @@ class Cas1PremisesDayTransformerTest {
 
     val result = transformer.toCas1PremisesDaySummary(
       currentSearchDay,
-      capacity,
       outOfServiceBeds,
       spaceBookingSummaries,
     )
@@ -93,7 +77,6 @@ class Cas1PremisesDayTransformerTest {
     assertThat(result.forDate).isEqualTo(currentSearchDay)
     assertThat(result.previousDate).isEqualTo(currentSearchDay.minusDays(1))
     assertThat(result.nextDate).isEqualTo(currentSearchDay.plusDays(1))
-    assertThat(result.capacity).isEqualTo(capacity)
     assertThat(result.outOfServiceBeds).isEqualTo(outOfServiceBeds)
     assertThat(result.spaceBookingSummaries).isEqualTo(spaceBookingSummaries)
   }


### PR DESCRIPTION
This UI makes a separate call to the capacity endpoint to retrieve this information, so it’s no longer required on `Cas1PremisesDaySummary`

