### PR TITLE
updating the reports controller

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReportsController.kt
@@ -3,18 +3,21 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ReportsService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.generateXlsxStreamingResponse
 
-@Cas2Controller
+@RestController
+@RequestMapping(
+  "\${api.base-path:}/cas2",
+  produces = ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
+)
 class Cas2ReportsController(private val reportService: Cas2ReportsService) {
 
-  @GetMapping(
-    "/reports/{reportName}",
-    produces = ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
-  )
+  @GetMapping("/reports/{reportName}")
   fun reportsReportNameGet(@PathVariable reportName: Cas2ReportName): ResponseEntity<StreamingResponseBody> = when (reportName) {
     Cas2ReportName.submittedMinusApplications -> generateXlsxStreamingResponse { outputStream ->
       reportService.createSubmittedApplicationsReport(outputStream)


### PR DESCRIPTION
A previous change added the service name header to the spec file, which is not sent from the UI, and causes a failure in the contract tests.

