### PR TITLE
tidied up cas2application model.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/model/Cas2Application.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/model/Cas2Application.kt
@@ -1,101 +1,32 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2User
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-/**
- *
- * @param createdBy
- * @param schemaVersion
- * @param outdatedSchema
- * @param status
- * @param isTransferredApplication
- * @param cas2CreatedBy
- * @param &#x60;data&#x60; Any object
- * @param document Any object
- * @param submittedAt
- * @param telephoneNumber
- * @param assessment
- * @param timelineEvents
- * @param allocatedPomName
- * @param currentPrisonName
- * @param allocatedPomEmailAddress
- * @param omuEmailAddress
- * @param assignmentDate
- * @param applicationOrigin
- * @param bailHearingDate
- */
 data class Cas2Application(
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("createdBy", required = true) val createdBy: NomisUser,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("status", required = true) val status: ApplicationStatus,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("isTransferredApplication", required = true) val isTransferredApplication: Boolean,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("type", required = true) override val type: String,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("id", required = true) override val id: UUID,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("person", required = true) override val person: Person,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("createdAt", required = true) override val createdAt: Instant,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("cas2CreatedBy") val cas2CreatedBy: Cas2User? = null,
-
-  @Schema(example = "null", description = "Any object")
-  @get:JsonProperty("data") val `data`: Any? = null,
-
-  @Schema(example = "null", description = "Any object")
-  @get:JsonProperty("document") val document: Any? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("submittedAt") val submittedAt: Instant? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("telephoneNumber") val telephoneNumber: String? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("assessment") val assessment: Cas2Assessment? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("timelineEvents") val timelineEvents: List<Cas2TimelineEvent>? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("allocatedPomName") val allocatedPomName: String? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("currentPrisonName") val currentPrisonName: String? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("allocatedPomEmailAddress") val allocatedPomEmailAddress: String? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("omuEmailAddress") val omuEmailAddress: String? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("assignmentDate") val assignmentDate: LocalDate? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("applicationOrigin") val applicationOrigin: ApplicationOrigin? = ApplicationOrigin.homeDetentionCurfew,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("bailHearingDate") val bailHearingDate: LocalDate? = null,
-) : Application
+  val createdBy: NomisUser,
+  val status: ApplicationStatus,
+  val isTransferredApplication: Boolean,
+  val type: String,
+  val id: UUID,
+  val person: Person,
+  val createdAt: Instant,
+  val data: Any? = null,
+  val document: Any? = null,
+  val submittedAt: Instant? = null,
+  val telephoneNumber: String? = null,
+  val assessment: Cas2Assessment? = null,
+  val timelineEvents: List<Cas2TimelineEvent>? = null,
+  val allocatedPomName: String? = null,
+  val currentPrisonName: String? = null,
+  val allocatedPomEmailAddress: String? = null,
+  val omuEmailAddress: String? = null,
+  val assignmentDate: LocalDate? = null,
+  val applicationOrigin: ApplicationOrigin? = ApplicationOrigin.homeDetentionCurfew,
+  val bailHearingDate: LocalDate? = null,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationTest.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.test.web.reactive.server.returnResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssignmentType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
@@ -1776,7 +1775,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               .responseBody
               .blockFirst()
 
-            val result = objectMapper.readValue(resultBody, Application::class.java)
+            val result = objectMapper.readValue(resultBody, Cas2Application::class.java)
 
             assertThat(result.person.crn).isEqualTo(offenderDetails.otherIds.crn)
           }
@@ -1814,7 +1813,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               .responseBody
               .blockFirst()
 
-            val result = objectMapper.readValue(resultBody, Application::class.java)
+            val result = objectMapper.readValue(resultBody, Cas2Application::class.java)
 
             assertThat(result.person.crn).isEqualTo(offenderDetails.otherIds.crn)
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2ApplicationsTransformerTest.kt
@@ -125,7 +125,6 @@ class Cas2ApplicationsTransformerTest {
         "omuEmailAddress",
         "applicationOrigin",
         "bailHearingDate",
-        "cas2CreatedBy",
       )
 
       assertThat(result.id).isEqualTo(application.id)
@@ -294,7 +293,6 @@ class Cas2ApplicationsTransformerTest {
         "omuEmailAddress",
         "applicationOrigin",
         "bailHearingDate",
-        "cas2CreatedBy",
       )
 
       assertThat(result.id).isEqualTo(application.id)


### PR DESCRIPTION
this removes the auto-generated annotations, and also removes Cas2User field, which doesn't appear to be used anywhere in code. This also referenced entities, which was bringing in all of the nested entities into the UI. If needed in the future, there should be a model created instead.

