### PR TITLE
Add validation to Nomis User

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserService.kt
@@ -84,6 +84,10 @@ class Cas2UserService(
       is ClientResult.Failure -> nomisUserDetailResponse.throwException()
     }
 
+    if (nomisUserDetails.primaryEmail == null) {
+      error("User $username does not have a primary email set in NOMIS")
+    }
+
     val normalisedUsername = username.uppercase()
     val existingUser = nomisUserRepository.findByNomisUsername(normalisedUsername)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NomisUserDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NomisUserDetailFactory.kt
@@ -44,7 +44,7 @@ class NomisUserDetailFactory : Factory<NomisUserDetail> {
     this.accountType = { accountType }
   }
 
-  fun withEmail(email: String) = apply {
+  fun withEmail(email: String?) = apply {
     this.primaryEmail = { email }
   }
 


### PR DESCRIPTION
This adds a null check on the primary email address field from the nomis user roles api call. This is a required field for sending emails within cas2, and raises errors in domain event processing, meaning messages go to the DLQ. This will prevent that from happening by ensuring the account always has an email address attached when the user logs in.

