### PR TITLE
CAS3 V2 Booking Search API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BookingSearchResults.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BookingSearchResults.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class Cas3BookingSearchResults(
+  val resultsCount: Int,
+  val results: List<Cas3BookingSearchResult>,
+)
+
+data class Cas3BookingSearchResult(
+  val person: Cas3BookingSearchResultPersonSummary,
+  val booking: Cas3BookingSearchResultBookingSummary,
+  val premises: Cas3BookingSearchResultPremisesSummary,
+  val bedspace: Cas3BookingSearchResultBedspaceSummary,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Cas3BookingSearchResultPersonSummary(
+  val crn: String,
+  val name: String? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Cas3BookingSearchResultBookingSummary(
+  val id: UUID,
+  val status: Cas3BookingStatus,
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+  val createdAt: Instant,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Cas3BookingSearchResultPremisesSummary(
+  val id: UUID,
+  val name: String,
+  val addressLine1: String,
+  val postcode: String,
+  val addressLine2: String? = null,
+  val town: String? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Cas3BookingSearchResultBedspaceSummary(
+  val id: UUID,
+  val reference: String,
+)
+
+data class Cas3BookingSearchResultDto(
+  var personName: String?,
+  val personCrn: String,
+  val bookingId: UUID,
+  val bookingStatus: String,
+  val bookingStartDate: LocalDate,
+  val bookingEndDate: LocalDate,
+  val bookingCreatedAt: OffsetDateTime,
+  val premisesId: UUID,
+  val premisesName: String,
+  val premisesAddressLine1: String,
+  val premisesAddressLine2: String?,
+  val premisesTown: String?,
+  val premisesPostcode: String,
+  val bedspaceId: UUID,
+  val bedspaceReference: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BookingSearchSortField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BookingSearchSortField.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+enum class Cas3BookingSearchSortField(val value: String) {
+  PERSON_NAME("name"),
+  PERSON_CRN("crn"),
+  BOOKING_START_DATE("startDate"),
+  BOOKING_END_DATE("endDate"),
+  BOOKING_CREATED_AT("createdAt"),
+  ;
+
+  companion object {
+    @JvmStatic
+    @JsonCreator
+    fun forValue(value: String): Cas3BookingSearchSortField = entries.first { it.value == value }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3v2BookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas3/Cas3v2BookingController.kt
@@ -4,8 +4,16 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Booking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.v2.Cas3v2BookingSearchService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.v2.Cas3v2BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger.PaginationHeaders
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BookingSearchResultTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.util.UUID
@@ -14,7 +22,9 @@ import java.util.UUID
 @RequestMapping("/cas3/v2", headers = ["X-Service-Name=temporary-accommodation"])
 class Cas3v2BookingController(
   private val bookingService: Cas3v2BookingService,
+  private val bookingSearchService: Cas3v2BookingSearchService,
   private val bookingTransformer: Cas3BookingTransformer,
+  private val bookingSearchResultTransformer: Cas3BookingSearchResultTransformer,
 ) {
 
   @GetMapping("/bookings/{bookingId}")
@@ -28,5 +38,28 @@ class Cas3v2BookingController(
     )
 
     return ResponseEntity.ok(apiBooking)
+  }
+
+  @PaginationHeaders
+  @GetMapping("/bookings/search")
+  fun bookingsSearch(
+    @RequestParam status: Cas3BookingStatus?,
+    @RequestParam(defaultValue = "asc") sortDirection: SortDirection,
+    @RequestParam(defaultValue = "createdAt") sortField: Cas3BookingSearchSortField,
+    @RequestParam page: Int?,
+    @RequestParam(required = false) crnOrName: String?,
+  ): ResponseEntity<Cas3BookingSearchResults> {
+    val (results, metadata) = bookingSearchService.findBookings(
+      status,
+      sortDirection,
+      sortField,
+      page,
+      crnOrName,
+    )
+    return ResponseEntity.ok()
+      .headers(metadata?.toHeaders())
+      .body(
+        bookingSearchResultTransformer.transformDomainToApi(results),
+      )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/v2/Cas3v2BookingSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/v2/Cas3v2BookingSearchService.kt
@@ -1,0 +1,125 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.v2
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3v2BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3v2BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PaginationMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadataWithSize
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNameFromPersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+@Service
+class Cas3v2BookingSearchService(
+  private val cas3BookingRepository: Cas3v2BookingRepository,
+  private val offenderService: OffenderService,
+  private val userService: UserService,
+  @Value("\${pagination.cas3.booking-search-page-size}") private val cas3BookingSearchPageSize: Int,
+) {
+
+  fun findBookings(
+    status: Cas3BookingStatus?,
+    sortDirection: SortDirection,
+    sortField: Cas3BookingSearchSortField,
+    page: Int?,
+    crnOrName: String?,
+  ): Pair<List<Cas3BookingSearchResultDto>, PaginationMetadata?> {
+    val user = userService.getUserForRequest()
+    val findBookings = cas3BookingRepository.findBookings(
+      status?.name,
+      user.probationRegion.id,
+      crnOrName,
+      buildPage(sortDirection, sortField, page, cas3BookingSearchPageSize),
+    )
+
+    var results = updateRestrictedAndPersonNameFromOffenderDetail(
+      mapToBookingSearchResults(findBookings),
+      user,
+    )
+
+    if (sortField == Cas3BookingSearchSortField.PERSON_NAME) {
+      results = sortBookingResultByPersonName(results, sortDirection)
+    }
+
+    return Pair(results, getMetadataWithSize(findBookings, page, cas3BookingSearchPageSize))
+  }
+
+  private fun sortBookingResultByPersonName(
+    results: List<Cas3BookingSearchResultDto>,
+    sortDirection: SortDirection,
+  ): List<Cas3BookingSearchResultDto> {
+    val comparator = compareBy<Cas3BookingSearchResultDto> { it.personName }
+    return if (sortDirection == SortDirection.asc) {
+      results.sortedWith(comparator)
+    } else {
+      results.sortedWith(comparator.reversed())
+    }
+  }
+
+  private fun mapToBookingSearchResults(findBookings: Page<Cas3v2BookingSearchResult>) = findBookings.content
+    .mapNotNull { rs ->
+      Cas3BookingSearchResultDto(
+        rs.getPersonName(),
+        rs.getPersonCrn(),
+        rs.getBookingId(),
+        rs.getBookingStatus(),
+        rs.getBookingStartDate(),
+        rs.getBookingEndDate(),
+        OffsetDateTime.ofInstant(rs.getBookingCreatedAt(), ZoneOffset.UTC),
+        rs.getPremisesId(),
+        rs.getPremisesName(),
+        rs.getPremisesAddressLine1(),
+        rs.getPremisesAddressLine2(),
+        rs.getPremisesTown(),
+        rs.getPremisesPostcode(),
+        rs.getBedspaceId(),
+        rs.getBedspaceReference(),
+      )
+    }
+
+  private fun buildPage(
+    sortDirection: SortDirection,
+    sortField: Cas3BookingSearchSortField,
+    page: Int?,
+    pageSize: Int,
+  ): Pageable {
+    val sortingField = convertSortFieldToDBField(sortField)
+    return getPageableOrAllPages(sortingField, sortDirection, page, pageSize)
+  }
+
+  private fun convertSortFieldToDBField(sortField: Cas3BookingSearchSortField) = when (sortField) {
+    Cas3BookingSearchSortField.BOOKING_END_DATE -> listOf("departure_date", "personName")
+    Cas3BookingSearchSortField.BOOKING_START_DATE -> listOf("arrival_date", "personName")
+    Cas3BookingSearchSortField.BOOKING_CREATED_AT -> listOf("created_at")
+    Cas3BookingSearchSortField.PERSON_CRN -> listOf("crn")
+    Cas3BookingSearchSortField.PERSON_NAME -> listOf("personName")
+  }
+
+  private fun updateRestrictedAndPersonNameFromOffenderDetail(
+    bookingSearchResultDtos: List<Cas3BookingSearchResultDto>,
+    user: UserEntity,
+  ): List<Cas3BookingSearchResultDto> {
+    val offenderSummaries = offenderService.getPersonSummaryInfoResults(
+      bookingSearchResultDtos.map { it.personCrn }.toSet(),
+      user.cas3LaoStrategy(),
+    )
+    return bookingSearchResultDtos
+      .map { result -> result to offenderSummaries.first { it.crn == result.personCrn } }
+      .map { (result, offenderSummary) ->
+        result.personName = getNameFromPersonSummaryInfoResult(offenderSummary)
+        result
+      }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/v2/Cas3v2BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/v2/Cas3v2BookingService.kt
@@ -4,9 +4,9 @@ import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingAndPersons
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
@@ -155,7 +155,7 @@ class Cas3v2BookingService(
         createdAt = bookingCreatedAt,
         application = application,
         turnarounds = mutableListOf(),
-        status = BookingStatus.provisional,
+        status = Cas3BookingStatus.provisional,
         offenderName = offenderName,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BookingSearchResultTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3BookingSearchResultTransformer.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultBedspaceSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultPersonSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
+
+@Component
+class Cas3BookingSearchResultTransformer {
+  fun transformDomainToApi(results: List<Cas3BookingSearchResultDto>) = Cas3BookingSearchResults(
+    resultsCount = results.size,
+    results = results.map(::transformResult),
+  )
+
+  private fun transformResult(result: Cas3BookingSearchResultDto) = Cas3BookingSearchResult(
+    person = Cas3BookingSearchResultPersonSummary(
+      name = result.personName,
+      crn = result.personCrn,
+    ),
+    booking = Cas3BookingSearchResultBookingSummary(
+      id = result.bookingId,
+      status = Cas3BookingStatus.entries.find { it.value == result.bookingStatus } ?: throw IllegalArgumentException("Unknown booking status ${result.bookingStatus}"),
+      startDate = result.bookingStartDate,
+      endDate = result.bookingEndDate,
+      createdAt = result.bookingCreatedAt.toInstant(),
+    ),
+    premises = Cas3BookingSearchResultPremisesSummary(
+      id = result.premisesId,
+      name = result.premisesName,
+      addressLine1 = result.premisesAddressLine1,
+      addressLine2 = result.premisesAddressLine2,
+      town = result.premisesTown,
+      postcode = result.premisesPostcode,
+    ),
+    bedspace = Cas3BookingSearchResultBedspaceSummary(
+      id = result.bedspaceId,
+      reference = result.bedspaceReference,
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BookingEntityFactory.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -48,7 +48,7 @@ class Cas3BookingEntityFactory : Factory<Cas3BookingEntity> {
   private var turnarounds: Yielded<MutableList<Cas3v2TurnaroundEntity>>? = null
   private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var placementRequest: Yielded<PlacementRequestEntity?> = { null }
-  private var status: Yielded<BookingStatus?> = { null }
+  private var status: Yielded<Cas3BookingStatus?> = { null }
   private var offenderName: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
@@ -159,7 +159,7 @@ class Cas3BookingEntityFactory : Factory<Cas3BookingEntity> {
     this.placementRequest = { placementRequest }
   }
 
-  fun withStatus(status: BookingStatus) = apply {
+  fun withStatus(status: Cas3BookingStatus) = apply {
     this.status = { status }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/v2/Cas3v2ConfirmationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/v2/Cas3v2ConfirmationEntityFactory.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.v2
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3v2ConfirmationEntityFactory : Factory<Cas3v2ConfirmationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(14) }
+  private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
+  private var booking: Yielded<Cas3BookingEntity>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(14L).randomDateTimeBefore(14) }
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withDateTime(dateTime: OffsetDateTime) = apply {
+    this.dateTime = { dateTime }
+  }
+
+  fun withNotes(notes: String) = apply {
+    this.notes = { notes }
+  }
+
+  fun withBooking(booking: Cas3BookingEntity) = apply {
+    this.booking = { booking }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  @Suppress("TooGenericExceptionThrown")
+  override fun produce() = Cas3v2ConfirmationEntity(
+    id = this.id(),
+    notes = this.notes(),
+    dateTime = this.dateTime(),
+    booking = this.booking?.invoke() ?: throw RuntimeException("Booking must be provided"),
+    createdAt = this.createdAt(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -121,6 +121,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3Turnaro
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceCancellationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.v2.Cas3v2ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.v2.Cas3v2TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.DomainEventAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.EmailNotificationAsserter
@@ -216,6 +217,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3Turn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
@@ -253,6 +255,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3Turnaroun
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspaceReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3VoidBedspacesTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.Cas3v2ConfirmationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DepartureTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.repository.DestinationProviderTestRepository
@@ -370,6 +373,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var confirmationRepository: Cas3ConfirmationTestRepository
+
+  @Autowired
+  lateinit var cas3v2ConfirmationRepository: Cas3v2ConfirmationTestRepository
 
   @Autowired
   lateinit var departureRepository: DepartureTestRepository
@@ -604,6 +610,7 @@ abstract class IntegrationTestBase {
   lateinit var bookingEntityFactory: PersistedFactory<BookingEntity, UUID, BookingEntityFactory>
   lateinit var arrivalEntityFactory: PersistedFactory<ArrivalEntity, UUID, ArrivalEntityFactory>
   lateinit var cas3ConfirmationEntityFactory: PersistedFactory<Cas3ConfirmationEntity, UUID, Cas3ConfirmationEntityFactory>
+  lateinit var cas3v2ConfirmationEntityFactory: PersistedFactory<Cas3v2ConfirmationEntity, UUID, Cas3v2ConfirmationEntityFactory>
   lateinit var departureEntityFactory: PersistedFactory<DepartureEntity, UUID, DepartureEntityFactory>
   lateinit var destinationProviderEntityFactory: PersistedFactory<DestinationProviderEntity, UUID, DestinationProviderEntityFactory>
   lateinit var departureReasonEntityFactory: PersistedFactory<DepartureReasonEntity, UUID, DepartureReasonEntityFactory>
@@ -721,6 +728,7 @@ abstract class IntegrationTestBase {
     bookingEntityFactory = PersistedFactory({ BookingEntityFactory() }, bookingRepository)
     arrivalEntityFactory = PersistedFactory({ ArrivalEntityFactory() }, arrivalRepository)
     cas3ConfirmationEntityFactory = PersistedFactory({ Cas3ConfirmationEntityFactory() }, confirmationRepository)
+    cas3v2ConfirmationEntityFactory = PersistedFactory({ Cas3v2ConfirmationEntityFactory() }, cas3v2ConfirmationRepository)
     departureEntityFactory = PersistedFactory({ DepartureEntityFactory() }, departureRepository)
     destinationProviderEntityFactory = PersistedFactory({ DestinationProviderEntityFactory() }, destinationProviderRepository)
     departureReasonEntityFactory = PersistedFactory({ DepartureReasonEntityFactory() }, departureReasonRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/v2/Cas3v2BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/v2/Cas3v2BookingSearchTest.kt
@@ -1,0 +1,1230 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas3.v2
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultBedspaceSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultBookingSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultPersonSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenSomeOffenders
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3BookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.Name
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+@SuppressWarnings("LargeClass", "LongParameterList")
+class Cas3v2BookingSearchTest : IntegrationTestBase() {
+  @Test
+  fun `Searching for bookings without JWT returns 401`() {
+    webTestClient.get()
+      .uri("/cas3/v2/bookings/search")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Searching for CAS3 bookings returns 200 with correct body`() {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        val allBookings = create15TestCas3Bookings(userEntity, offenderDetails)
+        val expectedResponse = getExpectedResponse(allBookings, offenderDetails)
+
+        callApiAndAssertResponse("/cas3/v2/bookings/search", jwt, expectedResponse, true)
+      }
+    }
+  }
+
+  @Test
+  fun `Searching for CAS3 bookings correctly filtered single booking for a specific crn`() {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        val crn = "S121978"
+        create15TestCas3Bookings(userEntity, offenderDetails)
+        val expectedBookingSearchResult = createTestCas3Bookings(
+          userEntity.probationRegion,
+          numberOfPremises = 1,
+          numberOfBedsInEachPremises = 1,
+          crn,
+          offenderName = "${offenderDetails.firstName} ${offenderDetails.surname}",
+        )
+        val expectedResponse = getExpectedResponse(expectedBookingSearchResult, crn, personName = "Unknown")
+
+        apDeliusContextAddListCaseSummaryToBulkResponse(casesSummary = emptyList(), crns = listOf("S121978"))
+        apDeliusContextAddResponseToUserAccessCall(casesAccess = emptyList(), username = userEntity.deliusUsername)
+
+        // when CRN is upper case
+        callApiAndAssertResponse("/cas3/v2/bookings/search?crnOrName=$crn", jwt, expectedResponse, true)
+
+        // when CRN is lower case
+        callApiAndAssertResponse("/cas3/v2/bookings/search?crnOrName=${crn.lowercase()}", jwt, expectedResponse, true)
+      }
+    }
+  }
+
+  @Test
+  fun `Searching for CAS3 single booking for a specific crn where the offender is LAO`() {
+    givenAUser(qualifications = listOf(UserQualification.LAO)) { userEntity, jwt ->
+      val crn = "S121978"
+      givenAnOffender(
+        offenderDetailsConfigBlock = {
+          withCrn(crn)
+          withCurrentRestriction(true)
+        },
+      ) { offenderDetails, _ ->
+        val expectedBookingSearchResult =
+          createTestCas3Bookings(userEntity.probationRegion, 1, 1, crn, "Limited Access Offender")
+        val expectedResponse = getExpectedResponse(expectedBookingSearchResult, crn, "Limited Access Offender")
+
+        val userExcludedCaseSummary = CaseSummaryFactory()
+          .fromOffenderDetails(offenderDetails)
+          .withPnc(offenderDetails.otherIds.pncNumber)
+          .withCrn(offenderDetails.otherIds.crn)
+          .withCurrentExclusion(true)
+          .produce()
+
+        apDeliusContextAddListCaseSummaryToBulkResponse(listOf(userExcludedCaseSummary))
+
+        apDeliusContextAddResponseToUserAccessCall(
+          listOf(
+            CaseAccessFactory()
+              .withCrn(userExcludedCaseSummary.crn)
+              .withUserExcluded(true)
+              .produce(),
+          ),
+          username = userEntity.deliusUsername,
+        )
+
+        // when CRN is upper case
+        callApiAndAssertResponse("/cas3/v2/bookings/search?crnOrName=$crn", jwt, expectedResponse, true)
+
+        // when CRN is lower case
+        callApiAndAssertResponse("/cas3/v2/bookings/search?crnOrName=${crn.lowercase()}", jwt, expectedResponse, true)
+      }
+    }
+  }
+
+  @Test
+  fun `Searching for CAS3 bookings correctly filtered multiple booking for a specific crn`() {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        val crn = "S121978"
+        val expectedBookingInSearchResult =
+          create15TestCas3Bookings(userEntity, offenderDetails)
+        createTestCas3Bookings(userEntity.probationRegion, numberOfPremises = 1, numberOfBedsInEachPremises = 1, crn, offenderName = "${offenderDetails.firstName} ${offenderDetails.surname}")
+        val expectedResponse = getExpectedResponse(expectedBookingInSearchResult, offenderDetails)
+
+        // when CRN is upper case
+        callApiAndAssertResponse("/cas3/v2/bookings/search?crnOrName=${offenderDetails.otherIds.crn}", jwt, expectedResponse, true)
+
+        // when CRN is lower case
+        callApiAndAssertResponse("/cas3/v2/bookings/search?crnOrName=${offenderDetails.otherIds.crn.lowercase()}", jwt, expectedResponse, true)
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource("S121978", "PersonName")
+  fun `Searching for CAS3 bookings with crn or name not exists in the database return empty response`(queryParameterValue: String) {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        create15TestCas3Bookings(userEntity, offenderDetails)
+        val expectedBookingSearchResults = Cas3BookingSearchResults(resultsCount = 0, results = emptyList())
+
+        callApiAndAssertResponse("/cas3/v2/bookings/search?crnOrName=$queryParameterValue", jwt, expectedBookingSearchResults, true)
+      }
+    }
+  }
+
+  @Test
+  fun `Searching for CAS3 bookings correctly filtered multiple booking when name is used in crnOrName query parameter`() {
+    val firstname = "Someuniquename"
+    val surname = "Someotheruniqueuniquesurname"
+    givenAUser { userEntity, jwt ->
+      givenSomeOffenders { offenderSequence ->
+        givenAnOffender(
+          offenderDetailsConfigBlock = {
+            withFirstName(firstname)
+            withLastName(surname)
+          },
+        ) { offenderWithFixedName, _ ->
+
+          val offendersDetailSummary =
+            offenderSequence.take(10).map { (offenderDetailSummary, _) -> offenderDetailSummary }.toList()
+          val allBookings = mutableListOf<Cas3BookingEntity>()
+          val temporaryAccommodationApplications = mutableListOf<TemporaryAccommodationApplicationEntity>()
+
+          offendersDetailSummary.forEach {
+            setupApplicationData(it, userEntity, temporaryAccommodationApplications, allBookings)
+          }
+
+          setupApplicationData(
+            offenderWithFixedName,
+            userEntity,
+            temporaryAccommodationApplications,
+            allBookings,
+          )
+
+          // full name match
+          var expectedOffender = offendersDetailSummary.drop(2).first()
+          var expectedBookings = allBookings.filter { b -> b.crn == expectedOffender.otherIds.crn }
+          var expectedResponse = getExpectedResponse(expectedBookings, expectedOffender)
+
+          callApiAndAssertResponse(
+            "/cas3/v2/bookings/search?crnOrName=${expectedOffender.firstName} ${expectedOffender.surname}",
+            jwt,
+            expectedResponse,
+            true,
+          )
+
+          // first name match
+          expectedOffender = offendersDetailSummary.drop(4).first()
+          expectedBookings = allBookings.filter { b -> b.crn == expectedOffender.otherIds.crn }
+          expectedResponse = getExpectedResponse(expectedBookings, expectedOffender)
+
+          callApiAndAssertResponse(
+            "/cas3/v2/bookings/search?crnOrName=${expectedOffender.firstName}",
+            jwt,
+            expectedResponse,
+            true,
+          )
+
+          // surname match
+          expectedOffender = offendersDetailSummary.drop(7).first()
+          expectedBookings = allBookings.filter { b -> b.crn == expectedOffender.otherIds.crn }
+          expectedResponse = getExpectedResponse(expectedBookings, expectedOffender)
+
+          callApiAndAssertResponse(
+            "/cas3/v2/bookings/search?crnOrName=${expectedOffender.surname}",
+            jwt,
+            expectedResponse,
+            true,
+          )
+
+          // partial match
+          expectedOffender = offenderWithFixedName
+          expectedBookings = allBookings.filter { b -> b.crn == expectedOffender.otherIds.crn }
+          expectedResponse = getExpectedResponse(expectedBookings, expectedOffender)
+
+          callApiAndAssertResponse(
+            "/cas3/v2/bookings/search?crnOrName=uniquename Someother",
+            jwt,
+            expectedResponse,
+            true,
+          )
+        }
+      }
+    }
+  }
+
+  private fun setupApplicationData(
+    it: OffenderDetailSummary,
+    userEntity: UserEntity,
+    temporaryAccommodationApplications: MutableList<TemporaryAccommodationApplicationEntity>,
+    allBookings: MutableList<Cas3BookingEntity>,
+  ) {
+    val offenderName = "${it.firstName} ${it.surname}"
+    val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+      withName(offenderName)
+      withCrn(it.otherIds.crn)
+      withProbationRegion(userEntity.probationRegion)
+      withCreatedByUser(userEntity)
+    }
+    temporaryAccommodationApplications += application
+
+    val booking = createTestCas3Bookings(userEntity.probationRegion, 1, 1, it.otherIds.crn, offenderName)
+    allBookings += booking
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "PERSON_NAME,asc,departed",
+      "PERSON_NAME,desc,departed",
+    ],
+  )
+  fun `Results for departed offenders are sorted correctly for both ascending and descending order`(
+    bookingSearchSort: Cas3BookingSearchSortField,
+    sortDirection: SortDirection,
+    bookingStatus: Cas3BookingStatus,
+  ) {
+    givenAUser { userEntity, jwt ->
+      givenSomeOffenders { offenderSequence ->
+        val totalResults = 15
+        val pageSize = 10
+
+        val allPremises = cas3PremisesEntityFactory.produceAndPersistMultiple(5) {
+          withProbationDeliveryUnit(
+            probationDeliveryUnitFactory.produceAndPersist {
+              withProbationRegion(userEntity.probationRegion)
+            },
+          )
+          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        }
+
+        allPremises.forEach { premises ->
+          cas3BedspaceEntityFactory.produceAndPersistMultiple(3) {
+            withPremises(premises)
+          }
+        }
+
+        val offenders = offenderSequence.take(totalResults).toList()
+        val temporaryAccommodationApplications = mutableListOf<TemporaryAccommodationApplicationEntity>()
+        val allBookings: List<Cas3BookingEntity> = offenders.map {
+          val offenderName = "${it.first.firstName} ${it.first.surname}"
+          val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+            withName(offenderName)
+            withCrn(it.first.otherIds.crn)
+            withProbationRegion(userEntity.probationRegion)
+            withCreatedByUser(userEntity)
+          }
+
+          temporaryAccommodationApplications += application
+
+          val booking = createBooking(
+            bedspace = createTestCas3Bedspace(userEntity.probationRegion),
+            crn = it.first.otherIds.crn,
+            arrivalDate = LocalDate.now().minusDays(randomInt(5, 20).toLong()),
+            departureDate = LocalDate.now().plusDays(3),
+            createdAt = LocalDate.now().minusDays(randomInt(10, 20).toLong()).toLocalDateTime(),
+            bookingStatus,
+            offenderName,
+          )
+          val departure = cas3DepartureEntityFactory.produceAndPersist {
+            withBooking(booking)
+            withYieldedReason {
+              departureReasonEntityFactory.produceAndPersist()
+            }
+            withYieldedMoveOnCategory {
+              moveOnCategoryEntityFactory.produceAndPersist()
+            }
+          }
+          booking.departures.add(departure)
+
+          booking
+        }
+
+        var offendersSorted: List<Pair<OffenderDetailSummary, InmateDetail>> = mutableListOf()
+        var responseSorted: Cas3BookingSearchResults? = null
+
+        when (sortDirection) {
+          SortDirection.asc -> {
+            offendersSorted = offenders.sortedBy { it.first.firstName }
+            responseSorted = Cas3BookingSearchResults(
+              offenders.size,
+              getExpectedResponseList(allBookings, offenders.map { it.first }).results.sortedBy { it.person.name },
+            )
+          }
+
+          SortDirection.desc -> {
+            offendersSorted = offenders.sortedByDescending { it.first.firstName }
+            responseSorted = Cas3BookingSearchResults(
+              offenders.size,
+              getExpectedResponseList(allBookings, offenders.map { it.first }).results.sortedByDescending { it.person.name },
+            )
+          }
+        }
+
+        val totalPages = 2
+        for (page in 0..<totalPages) {
+          val currentPageSize = if (page == totalPages - 1) totalResults % pageSize else pageSize
+
+          apDeliusContextAddListCaseSummaryToBulkResponse(
+            casesSummary = offendersSorted.drop(page * pageSize)
+              .take(pageSize)
+              .map { it.first.asCaseSummary() },
+          )
+
+          val expectedPageResponse = Cas3BookingSearchResults(currentPageSize, responseSorted.results.subList(page * pageSize, page * pageSize + currentPageSize))
+          val apiUri = "/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=${bookingSearchSort.value}&status=departed&page=${page + 1}"
+          webTestClient.get()
+            .uri(apiUri)
+            .header("Authorization", "Bearer $jwt")
+            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectHeader().valueEquals("X-Pagination-CurrentPage", page + 1.toLong())
+            .expectHeader().valueEquals("X-Pagination-TotalPages", totalPages.toLong())
+            .expectHeader().valueEquals("X-Pagination-TotalResults", totalResults.toLong())
+            .expectHeader().valueEquals("X-Pagination-PageSize", pageSize.toLong())
+            .expectBody()
+            .json(objectMapper.writeValueAsString(expectedPageResponse), true)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `Results are filtered by booking status when query parameter is supplied`() {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+
+        val allPremises = cas3PremisesEntityFactory.produceAndPersistMultiple(5) {
+          withProbationDeliveryUnit(
+            probationDeliveryUnitFactory.produceAndPersist {
+              withProbationRegion(userEntity.probationRegion)
+            },
+          )
+          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        }
+
+        val allBedspaces = allPremises.map { premises ->
+          cas3BedspaceEntityFactory.produceAndPersistMultiple(3) {
+            withPremises(premises)
+          }
+        }.flatten()
+
+        val allBookings = allBedspaces.mapIndexed { index, bedspace ->
+          when (index % 5) {
+            // Provisional
+            0 -> {
+              cas3BookingEntityFactory.produceAndPersist {
+                withPremises(bedspace.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBedspace(bedspace)
+                withStatus(Cas3BookingStatus.provisional)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
+            }
+            // Confirmed
+            1 -> {
+              val booking = cas3BookingEntityFactory.produceAndPersist {
+                withPremises(bedspace.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBedspace(bedspace)
+                withStatus(Cas3BookingStatus.confirmed)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
+              val confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+                withBooking(booking)
+              }
+              booking.confirmation = confirmation
+              booking
+            }
+            // Active
+            2 -> {
+              val booking = cas3BookingEntityFactory.produceAndPersist {
+                withPremises(bedspace.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBedspace(bedspace)
+                withStatus(Cas3BookingStatus.arrived)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
+              val arrival = cas3ArrivalEntityFactory.produceAndPersist {
+                withBooking(booking)
+              }
+              booking.arrivals.add(arrival)
+              booking
+            }
+            // Closed
+            3 -> {
+              val booking = cas3BookingEntityFactory.produceAndPersist {
+                withPremises(bedspace.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBedspace(bedspace)
+                withStatus(Cas3BookingStatus.closed)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
+              val departure = cas3DepartureEntityFactory.produceAndPersist {
+                withBooking(booking)
+                withYieldedReason {
+                  departureReasonEntityFactory.produceAndPersist()
+                }
+                withYieldedMoveOnCategory {
+                  moveOnCategoryEntityFactory.produceAndPersist()
+                }
+              }
+              booking.departures.add(departure)
+              booking
+            }
+            // Cancelled
+            4 -> {
+              val booking = cas3BookingEntityFactory.produceAndPersist {
+                withPremises(bedspace.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBedspace(bedspace)
+                withStatus(Cas3BookingStatus.cancelled)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
+              val cancellation = cas3CancellationEntityFactory.produceAndPersist {
+                withBooking(booking)
+                withYieldedReason {
+                  cancellationReasonEntityFactory.produceAndPersist()
+                }
+              }
+              booking.cancellations.add(cancellation)
+              booking
+            }
+            else -> {
+              cas3BookingEntityFactory.produceAndPersist {
+                withPremises(bedspace.premises)
+                withCrn(offenderDetails.otherIds.crn)
+                withBedspace(bedspace)
+                withStatus(Cas3BookingStatus.provisional)
+                withServiceName(ServiceName.temporaryAccommodation)
+              }
+            }
+          }
+        }
+
+        val expectedBookings = allBookings.filter { it.cancellation != null }
+
+        val expectedResponse = getExpectedResponse(expectedBookings, offenderDetails)
+
+        callApiAndAssertResponse("/cas3/v2/bookings/search?status=cancelled", jwt, expectedResponse, false)
+      }
+    }
+  }
+
+  @Test
+  fun `Results are only returned for the user's probation region for Temporary Accommodation`() {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        val expectedPremises = cas3PremisesEntityFactory.produceAndPersistMultiple(5) {
+          withProbationDeliveryUnit(
+            probationDeliveryUnitFactory.produceAndPersist {
+              withProbationRegion(userEntity.probationRegion)
+            },
+          )
+          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        }
+
+        val unexpectedPremises = cas3PremisesEntityFactory.produceAndPersistMultiple(5) {
+          withProbationDeliveryUnit(
+            probationDeliveryUnitFactory.produceAndPersist {
+              withProbationRegion(probationRegionEntityFactory.produceAndPersist())
+            },
+          )
+          withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+        }
+
+        val allPremises = expectedPremises + unexpectedPremises
+
+        val allBedspaces = allPremises.map { premises ->
+          cas3BedspaceEntityFactory.produceAndPersistMultiple(3) {
+            withPremises(premises)
+          }
+        }.flatten()
+
+        val allBookings = allBedspaces.map {
+          cas3BookingEntityFactory.produceAndPersist {
+            withPremises(it.premises)
+            withCrn(offenderDetails.otherIds.crn)
+            withBedspace(it)
+            withServiceName(ServiceName.temporaryAccommodation)
+          }
+        }
+
+        val expectedPremisesIds = expectedPremises.map { it.id }
+        val expectedBookings = allBookings.filter { expectedPremisesIds.contains(it.premises.id) }
+        val expectedResponse = getExpectedResponse(expectedBookings, offenderDetails)
+        callApiAndAssertResponse("/cas3/v2/bookings/search", jwt, expectedResponse, false)
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "PERSON_CRN,asc",
+      "BOOKING_START_DATE,asc",
+      "BOOKING_END_DATE,asc",
+      "BOOKING_CREATED_AT,asc",
+      "PERSON_CRN,desc",
+      "BOOKING_START_DATE,desc",
+      "BOOKING_END_DATE,desc",
+      "BOOKING_CREATED_AT,desc",
+    ],
+  )
+  fun `Searching for Temporary Accommodation bookings with pagination returns 200 with correct subset of results`(
+    bookingSearchSort: Cas3BookingSearchSortField,
+    sortDirection: SortDirection,
+  ) {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        val allBookings = create15TestCas3Bookings(userEntity, offenderDetails).toMutableList()
+        getSortedBooking(allBookings, bookingSearchSort, sortDirection)
+        val firstPage = allBookings.subList(0, 10)
+        val secondPage = allBookings.subList(10, allBookings.size)
+        val expectedFirstPageResponse = getExpectedResponse(firstPage, offenderDetails)
+        val expectedSecondPageResponse = getExpectedResponse(secondPage, offenderDetails)
+
+        webTestClient.get()
+          .uri("/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=${bookingSearchSort.value}&page=1")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectHeader().valueEquals("X-Pagination-CurrentPage", 1)
+          .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+          .expectHeader().valueEquals("X-Pagination-TotalResults", 15)
+          .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+          .expectBody()
+          .json(objectMapper.writeValueAsString(expectedFirstPageResponse))
+
+        webTestClient.get()
+          .uri("/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=${bookingSearchSort.value}&page=2")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+          .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+          .expectHeader().valueEquals("X-Pagination-TotalResults", 15)
+          .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+          .expectBody()
+          .json(objectMapper.writeValueAsString(expectedSecondPageResponse))
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = SortDirection::class)
+  fun `Results are ordered by the start date when multiple booking have the same arrival date when the query parameters are supplied with Pagination`(
+    sortDirection: SortDirection,
+  ) {
+    givenAUser { userEntity, jwt ->
+      val crns = mutableListOf<String>()
+      repeat(15) { crns += randomStringMultiCaseWithNumbers(8) }
+
+      val temporaryAccommodationApplications = mutableListOf<TemporaryAccommodationApplicationEntity>()
+      val offendersCrnAndName = crns.associateBy(
+        keySelector = { it },
+        valueTransform = { NameFactory().produce() },
+      )
+
+      val allBookings = crns.map {
+        val offenderName = "${offendersCrnAndName[it]?.forename} ${offendersCrnAndName[it]?.surname}"
+        val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withName(offenderName)
+          withCrn(it)
+          withProbationRegion(userEntity.probationRegion)
+          withCreatedByUser(userEntity)
+        }
+        temporaryAccommodationApplications += application
+
+        val bed = createTestCas3Bedspace(userEntity.probationRegion)
+        createBooking(
+          bed,
+          it,
+          LocalDate.now().minusDays(5),
+          LocalDate.now().plusDays(randomInt(1, 10).toLong()),
+          LocalDate.now().minusDays(randomInt(10, 20).toLong()).toLocalDateTime(),
+          offenderName = offenderName,
+        )
+      }
+
+      // Assert bookings page 1
+      mockApDeliusContextCasesSummary(temporaryAccommodationApplications, offendersCrnAndName, userEntity.deliusUsername, sortDirection, 10, 0)
+
+      var bookingSearchResults = getExpectedResponse(allBookings, temporaryAccommodationApplications)
+      var expectedResponse = Cas3BookingSearchResults(
+        10,
+        if (sortDirection == SortDirection.asc) {
+          bookingSearchResults.results.sortedBy { it.booking.startDate }.sortedBy { it.person.name }.take(10)
+        } else {
+          bookingSearchResults.results.sortedByDescending { it.booking.startDate }.sortedByDescending { it.person.name }.take(10)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=startDate&page=1&status=provisional")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valueEquals("X-Pagination-CurrentPage", 1)
+        .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalResults", 15)
+        .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+        .expectBody()
+        .json(objectMapper.writeValueAsString(expectedResponse), true)
+
+      // Assert bookings page 2
+      mockApDeliusContextCasesSummary(temporaryAccommodationApplications, offendersCrnAndName, userEntity.deliusUsername, sortDirection, 5, 10)
+
+      bookingSearchResults = getExpectedResponse(allBookings, temporaryAccommodationApplications)
+      expectedResponse = Cas3BookingSearchResults(
+        5,
+        if (sortDirection == SortDirection.asc) {
+          bookingSearchResults.results.sortedBy { it.booking.startDate }.sortedBy { it.person.name }.drop(10)
+        } else {
+          bookingSearchResults.results.sortedByDescending { it.booking.startDate }.sortedByDescending { it.person.name }.drop(10)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=startDate&page=2&status=provisional")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalResults", 15)
+        .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+        .expectBody()
+        .json(objectMapper.writeValueAsString(expectedResponse), true)
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = SortDirection::class)
+  fun `Results are ordered by the end date when multiple booking have the same arrival date when the query parameters are supplied with Pagination`(
+    sortDirection: SortDirection,
+  ) {
+    givenAUser { userEntity, jwt ->
+      val crns = mutableListOf<String>()
+      repeat(15) { crns += randomStringMultiCaseWithNumbers(8) }
+
+      val temporaryAccommodationApplications = mutableListOf<TemporaryAccommodationApplicationEntity>()
+      val offendersCrnAndName = crns.associateBy(
+        keySelector = { it },
+        valueTransform = { NameFactory().produce() },
+      )
+
+      val allBookings = crns.map {
+        val offenderName = "${offendersCrnAndName[it]?.forename} ${offendersCrnAndName[it]?.surname}"
+        val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withName(offenderName)
+          withCrn(it)
+          withProbationRegion(userEntity.probationRegion)
+          withCreatedByUser(userEntity)
+        }
+        temporaryAccommodationApplications += application
+
+        val booking = createBooking(
+          bedspace = createTestCas3Bedspace(userEntity.probationRegion),
+          crn = it,
+          arrivalDate = LocalDate.now().minusDays(randomInt(5, 20).toLong()),
+          departureDate = LocalDate.now().plusDays(3),
+          createdAt = LocalDate.now().minusDays(randomInt(10, 20).toLong()).toLocalDateTime(),
+          offenderName = offenderName,
+        )
+        booking
+      }
+
+      // Assert bookings page 1
+      mockApDeliusContextCasesSummary(temporaryAccommodationApplications, offendersCrnAndName, userEntity.deliusUsername, sortDirection, 10, 0)
+
+      var bookingSearchResults = getExpectedResponse(allBookings, temporaryAccommodationApplications)
+      var expectedResponse = Cas3BookingSearchResults(
+        10,
+        if (sortDirection == SortDirection.asc) {
+          bookingSearchResults.results.sortedBy { it.booking.endDate }.sortedBy { it.person.name }.take(10)
+        } else {
+          bookingSearchResults.results.sortedByDescending { it.booking.endDate }.sortedByDescending { it.person.name }.take(10)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=endDate&page=1&status=provisional")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valueEquals("X-Pagination-CurrentPage", 1)
+        .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalResults", 15)
+        .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+        .expectBody()
+        .json(objectMapper.writeValueAsString(expectedResponse), true)
+
+      // Assert bookings page 2
+      mockApDeliusContextCasesSummary(temporaryAccommodationApplications, offendersCrnAndName, userEntity.deliusUsername, sortDirection, 5, 10)
+
+      bookingSearchResults = getExpectedResponse(allBookings, temporaryAccommodationApplications)
+      expectedResponse = Cas3BookingSearchResults(
+        5,
+        if (sortDirection == SortDirection.asc) {
+          bookingSearchResults.results.sortedBy { it.booking.endDate }.sortedBy { it.person.name }.drop(10)
+        } else {
+          bookingSearchResults.results.sortedByDescending { it.booking.endDate }.sortedByDescending { it.person.name }.drop(10)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=endDate&page=2&status=provisional")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalResults", 15)
+        .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+        .expectBody()
+        .json(objectMapper.writeValueAsString(expectedResponse), true)
+    }
+  }
+
+  @Test
+  fun `Results are ordered by the person crn and sorted descending order when the query parameters are supplied with Pagination`() {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        val allBookings = create10TestCas3Bookings(userEntity, offenderDetails)
+        val sortedByDescending = allBookings.sortedByDescending { it.crn }
+        val expectedResponse = getExpectedResponse(sortedByDescending, offenderDetails)
+
+        webTestClient.get()
+          .uri("/cas3/v2/bookings/search?sortDirection=descending&sortField=crn&page=1&status=provisional")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectHeader().valueEquals("X-Pagination-CurrentPage", 1)
+          .expectHeader().valueEquals("X-Pagination-TotalPages", 1)
+          .expectHeader().valueEquals("X-Pagination-TotalResults", 10)
+          .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+          .expectBody()
+          .json(objectMapper.writeValueAsString(expectedResponse), true)
+      }
+    }
+  }
+
+  @Test
+  fun `Get all results ordered by the person crn in descending order when the query parameters supplied without Pagination`() {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        val allBookings = create15TestCas3Bookings(userEntity, offenderDetails)
+        val sortedByDescending = allBookings.sortedByDescending { it.crn }
+        val expectedResponse = getExpectedResponse(sortedByDescending, offenderDetails)
+
+        callApiAndAssertResponse("/cas3/v2/bookings/search?sortDirection=descending&sortField=crn&status=provisional", jwt, expectedResponse, true)
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = SortDirection::class)
+  fun `Results are ordered by the person name when the query parameters are supplied with Pagination`(
+    sortDirection: SortDirection,
+  ) {
+    givenAUser { userEntity, jwt ->
+      val crns = mutableListOf<String>()
+      repeat(15) { crns += randomStringMultiCaseWithNumbers(8) }
+
+      val temporaryAccommodationApplications = mutableListOf<TemporaryAccommodationApplicationEntity>()
+      val offendersCrnAndName = crns.associateBy(
+        keySelector = { it },
+        valueTransform = { NameFactory().produce() },
+      )
+
+      val allBookings = crns.map {
+        val offenderName = "${offendersCrnAndName[it]?.forename} ${offendersCrnAndName[it]?.surname}"
+        val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+          withName(offenderName)
+          withCrn(it)
+          withProbationRegion(userEntity.probationRegion)
+          withCreatedByUser(userEntity)
+        }
+        temporaryAccommodationApplications += application
+        createTestCas3Bookings(userEntity.probationRegion, 1, 1, it, offenderName)
+      }.flatten()
+
+      // Assert bookings page 1
+      mockApDeliusContextCasesSummary(temporaryAccommodationApplications, offendersCrnAndName, userEntity.deliusUsername, sortDirection, 10, 0)
+
+      var bookingSearchResults = getExpectedResponse(allBookings, temporaryAccommodationApplications)
+      var expectedResponse = Cas3BookingSearchResults(
+        10,
+        if (sortDirection == SortDirection.asc) {
+          bookingSearchResults.results.sortedBy { it.person.name }.take(10)
+        } else {
+          bookingSearchResults.results.sortedByDescending { it.person.name }.take(10)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=name&page=1&status=provisional")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valueEquals("X-Pagination-CurrentPage", 1)
+        .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalResults", 15)
+        .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+        .expectBody()
+        .json(objectMapper.writeValueAsString(expectedResponse), true)
+
+      // Assert bookings page 2
+      mockApDeliusContextCasesSummary(temporaryAccommodationApplications, offendersCrnAndName, userEntity.deliusUsername, sortDirection, 5, 10)
+
+      bookingSearchResults = getExpectedResponse(allBookings, temporaryAccommodationApplications)
+      expectedResponse = Cas3BookingSearchResults(
+        5,
+        if (sortDirection == SortDirection.asc) {
+          bookingSearchResults.results.sortedBy { it.person.name }.drop(10)
+        } else {
+          bookingSearchResults.results.sortedByDescending { it.person.name }.drop(10)
+        },
+      )
+
+      webTestClient.get()
+        .uri("/cas3/v2/bookings/search?sortDirection=$sortDirection&sortField=name&page=2&status=provisional")
+        .header("Authorization", "Bearer $jwt")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().valueEquals("X-Pagination-CurrentPage", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalPages", 2)
+        .expectHeader().valueEquals("X-Pagination-TotalResults", 15)
+        .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+        .expectBody()
+        .json(objectMapper.writeValueAsString(expectedResponse), true)
+    }
+  }
+
+  @Test
+  fun `No Results returned when searching for cancelled booking status and all existing bookings are confirmed`() {
+    givenAUser { userEntity, jwt ->
+      givenAnOffender { offenderDetails, _ ->
+        create10TestCas3Bookings(userEntity, offenderDetails)
+        val expectedResponse = getExpectedResponse(emptyList(), offenderDetails)
+
+        webTestClient.get()
+          .uri("/cas3/v2/bookings/search?sortDirection=descending&sortField=crn&page=1&status=cancelled")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectHeader().valueEquals("X-Pagination-CurrentPage", 1)
+          .expectHeader().valueEquals("X-Pagination-TotalPages", 0)
+          .expectHeader().valueEquals("X-Pagination-TotalResults", 0)
+          .expectHeader().valueEquals("X-Pagination-PageSize", 10)
+          .expectBody()
+          .json(objectMapper.writeValueAsString(expectedResponse), true)
+      }
+    }
+  }
+
+  private fun getExpectedResponseList(
+    expectedBookings: List<Cas3BookingEntity>,
+    offenderDetails: List<OffenderDetailSummary>,
+  ) = Cas3BookingSearchResults(
+    resultsCount = expectedBookings.size,
+    results = expectedBookings.map { booking -> bookingSearchMapping(offenderDetails.first { it.otherIds.crn == booking.crn }, booking) },
+  )
+
+  private fun getExpectedResponse(
+    expectedBookings: List<Cas3BookingEntity>,
+    offenderDetails: OffenderDetailSummary,
+  ) = Cas3BookingSearchResults(
+    resultsCount = expectedBookings.size,
+    results = expectedBookings.map { booking ->
+      bookingSearchMapping(offenderDetails, booking)
+    },
+  )
+
+  private fun bookingSearchMapping(
+    offenderDetails: OffenderDetailSummary,
+    booking: Cas3BookingEntity,
+  ) = Cas3BookingSearchResult(
+    person = Cas3BookingSearchResultPersonSummary(
+      name = "${offenderDetails.firstName} ${offenderDetails.surname}",
+      crn = offenderDetails.otherIds.crn,
+    ),
+    booking = Cas3BookingSearchResultBookingSummary(
+      id = booking.id,
+      status = when {
+        booking.cancellation != null -> Cas3BookingStatus.cancelled
+        booking.departure != null -> Cas3BookingStatus.departed
+        booking.arrival != null -> Cas3BookingStatus.arrived
+        booking.nonArrival != null -> Cas3BookingStatus.notMinusArrived
+        booking.confirmation != null -> Cas3BookingStatus.confirmed
+        else -> Cas3BookingStatus.provisional
+      },
+      startDate = booking.arrivalDate,
+      endDate = booking.departureDate,
+      createdAt = booking.createdAt.toInstant(),
+    ),
+    premises = Cas3BookingSearchResultPremisesSummary(
+      id = booking.premises.id,
+      name = booking.premises.name,
+      addressLine1 = booking.premises.addressLine1,
+      addressLine2 = booking.premises.addressLine2,
+      town = booking.premises.town,
+      postcode = booking.premises.postcode,
+    ),
+    bedspace = Cas3BookingSearchResultBedspaceSummary(
+      id = booking.bedspace.id,
+      reference = booking.bedspace.reference,
+    ),
+  )
+
+  private fun getExpectedResponse(
+    expectedBookings: List<Cas3BookingEntity>,
+    temporaryAccommodationApplications: List<TemporaryAccommodationApplicationEntity>,
+  ) = Cas3BookingSearchResults(
+    resultsCount = expectedBookings.size,
+    results = expectedBookings.map { booking ->
+      val userApplication = temporaryAccommodationApplications.firstOrNull { a -> a.crn == booking.crn }
+      Cas3BookingSearchResult(
+        person = Cas3BookingSearchResultPersonSummary(
+          name = userApplication?.name,
+          crn = booking.crn,
+        ),
+        booking = Cas3BookingSearchResultBookingSummary(
+          id = booking.id,
+          status = when {
+            booking.cancellation != null -> Cas3BookingStatus.cancelled
+            booking.departure != null -> Cas3BookingStatus.departed
+            booking.arrival != null -> Cas3BookingStatus.arrived
+            booking.nonArrival != null -> Cas3BookingStatus.notMinusArrived
+            booking.confirmation != null -> Cas3BookingStatus.confirmed
+            else -> Cas3BookingStatus.provisional
+          },
+          startDate = booking.arrivalDate,
+          endDate = booking.departureDate,
+          createdAt = booking.createdAt.toInstant(),
+        ),
+        premises = Cas3BookingSearchResultPremisesSummary(
+          id = booking.premises.id,
+          name = booking.premises.name,
+          addressLine1 = booking.premises.addressLine1,
+          addressLine2 = booking.premises.addressLine2,
+          town = booking.premises.town,
+          postcode = booking.premises.postcode,
+        ),
+        bedspace = Cas3BookingSearchResultBedspaceSummary(
+          id = booking.bedspace.id,
+          reference = booking.bedspace.reference,
+        ),
+      )
+    },
+  )
+
+  private fun getExpectedResponse(
+    expectedBookings: List<Cas3BookingEntity>,
+    crn: String,
+    personName: String,
+  ) = Cas3BookingSearchResults(
+    resultsCount = expectedBookings.size,
+    results = expectedBookings.map { booking ->
+      Cas3BookingSearchResult(
+        person = Cas3BookingSearchResultPersonSummary(
+          name = personName,
+          crn = crn,
+        ),
+        booking = Cas3BookingSearchResultBookingSummary(
+          id = booking.id,
+          status = when {
+            booking.cancellation != null -> Cas3BookingStatus.cancelled
+            booking.departure != null -> Cas3BookingStatus.departed
+            booking.arrival != null -> Cas3BookingStatus.arrived
+            booking.nonArrival != null -> Cas3BookingStatus.notMinusArrived
+            booking.confirmation != null -> Cas3BookingStatus.confirmed
+            else -> Cas3BookingStatus.provisional
+          },
+          startDate = booking.arrivalDate,
+          endDate = booking.departureDate,
+          createdAt = booking.createdAt.toInstant(),
+        ),
+        premises = Cas3BookingSearchResultPremisesSummary(
+          id = booking.premises.id,
+          name = booking.premises.name,
+          addressLine1 = booking.premises.addressLine1,
+          addressLine2 = booking.premises.addressLine2,
+          town = booking.premises.town,
+          postcode = booking.premises.postcode,
+        ),
+        bedspace = Cas3BookingSearchResultBedspaceSummary(
+          id = booking.bedspace.id,
+          reference = booking.bedspace.reference,
+        ),
+      )
+    },
+  )
+
+  private fun create10TestCas3Bookings(
+    userEntity: UserEntity,
+    offenderDetails: OffenderDetailSummary,
+  ): List<Cas3BookingEntity> = createTestCas3Bookings(
+    probationRegion = userEntity.probationRegion,
+    numberOfPremises = 5,
+    numberOfBedsInEachPremises = 2,
+    crn = offenderDetails.otherIds.crn,
+    offenderName = "${offenderDetails.firstName} ${offenderDetails.surname}",
+  )
+
+  private fun create15TestCas3Bookings(
+    userEntity: UserEntity,
+    offenderDetails: OffenderDetailSummary,
+  ): List<Cas3BookingEntity> = createTestCas3Bookings(
+    probationRegion = userEntity.probationRegion,
+    numberOfPremises = 3,
+    numberOfBedsInEachPremises = 5,
+    crn = offenderDetails.otherIds.crn,
+    offenderName = "${offenderDetails.firstName} ${offenderDetails.surname}",
+  )
+
+  private fun createTestCas3Bookings(
+    probationRegion: ProbationRegionEntity,
+    numberOfPremises: Int,
+    numberOfBedsInEachPremises: Int,
+    crn: String,
+    offenderName: String,
+  ): List<Cas3BookingEntity> {
+    val allPremises = cas3PremisesEntityFactory.produceAndPersistMultiple(numberOfPremises) {
+      withProbationDeliveryUnit(
+        probationDeliveryUnitFactory.produceAndPersist {
+          withProbationRegion(probationRegion)
+        },
+      )
+      withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+    }
+
+    val allBedspaces = allPremises.map { premises ->
+      cas3BedspaceEntityFactory.produceAndPersistMultiple(numberOfBedsInEachPremises) {
+        withPremises(premises)
+      }
+    }.flatten()
+
+    return allBedspaces.mapIndexed { index, bed ->
+      createBooking(
+        bed,
+        crn,
+        LocalDate.now().minusDays((60 - index).toLong()),
+        LocalDate.now().minusDays((30 - index).toLong()),
+        LocalDate.now().minusDays((30 - index).toLong()).toLocalDateTime(),
+        offenderName = offenderName,
+      )
+    }
+  }
+
+  private fun createTestCas3Bedspace(probationRegion: ProbationRegionEntity): Cas3BedspacesEntity {
+    val premises = cas3PremisesEntityFactory.produceAndPersist {
+      withProbationDeliveryUnit(
+        probationDeliveryUnitFactory.produceAndPersist {
+          withProbationRegion(probationRegion)
+        },
+      )
+      withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+    }
+
+    return cas3BedspaceEntityFactory.produceAndPersist {
+      withPremises(premises)
+    }
+  }
+
+  @Suppress("LongParameterList")
+  private fun createBooking(
+    bedspace: Cas3BedspacesEntity,
+    crn: String,
+    arrivalDate: LocalDate,
+    departureDate: LocalDate,
+    createdAt: OffsetDateTime,
+    bookingStatus: Cas3BookingStatus = Cas3BookingStatus.provisional,
+    offenderName: String,
+  ): Cas3BookingEntity = cas3BookingEntityFactory.produceAndPersist {
+    withCrn(crn)
+    withPremises(bedspace.premises)
+    withBedspace(bedspace)
+    withStatus(bookingStatus)
+    withServiceName(ServiceName.temporaryAccommodation)
+    withArrivalDate(arrivalDate)
+    withDepartureDate(departureDate)
+    withCreatedAt(createdAt)
+    withOffenderName(offenderName)
+  }
+
+  private fun callApiAndAssertResponse(
+    uri: String,
+    jwt: String,
+    expectedResponse: Cas3BookingSearchResults,
+    jsonStrictMatch: Boolean,
+  ) {
+    webTestClient.get()
+      .uri(uri)
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(objectMapper.writeValueAsString(expectedResponse), jsonStrictMatch)
+  }
+
+  private fun mockApDeliusContextCasesSummary(
+    applications: MutableList<TemporaryAccommodationApplicationEntity>,
+    offendersCrnAndName: Map<String, Name>,
+    username: String,
+    sortDirection: SortDirection,
+    take: Int,
+    skip: Int,
+  ) {
+    val cases = if (sortDirection == SortDirection.asc) {
+      applications.sortedBy { it.name }.drop(skip).take(take).map {
+        CaseSummaryFactory()
+          .withCrn(it.crn)
+          .withName(offendersCrnAndName[it.crn]!!)
+          .produce()
+      }
+    } else {
+      applications.sortedByDescending { it.name }.drop(skip).take(take).map {
+        CaseSummaryFactory()
+          .withCrn(it.crn)
+          .withName(offendersCrnAndName[it.crn]!!)
+          .produce()
+      }
+    }
+
+    apDeliusContextAddListCaseSummaryToBulkResponse(cases)
+    apDeliusContextAddResponseToUserAccessCall(
+      casesAccess = cases.map { CaseAccessFactory().withCrn(it.crn).withAccess().produce() },
+      username = username,
+    )
+  }
+
+  private fun getSortedBooking(bookings: MutableList<Cas3BookingEntity>, sortBy: Cas3BookingSearchSortField, sortDirection: SortDirection) = when (sortBy) {
+    Cas3BookingSearchSortField.BOOKING_END_DATE -> sortBookings(Cas3BookingEntity::departureDate, bookings, sortDirection)
+    Cas3BookingSearchSortField.BOOKING_START_DATE -> sortBookings(Cas3BookingEntity::arrivalDate, bookings, sortDirection)
+    Cas3BookingSearchSortField.PERSON_CRN -> sortBookings(Cas3BookingEntity::crn, bookings, sortDirection)
+    else -> sortBookings(Cas3BookingEntity::createdAt, bookings, sortDirection)
+  }
+
+  fun <T : Comparable<T>> sortBookings(fn: Cas3BookingEntity.() -> T, bookings: MutableList<Cas3BookingEntity>, sortDirection: SortDirection) = when (sortDirection) {
+    SortDirection.asc -> bookings.sortBy { it.fn() }
+    else -> bookings.sortByDescending { it.fn() }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3v2ConfirmationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/Cas3v2ConfirmationTestRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.v2.Cas3v2ConfirmationEntity
+import java.util.UUID
+
+@Repository
+interface Cas3v2ConfirmationTestRepository : JpaRepository<Cas3v2ConfirmationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestCas3BookingSearchResult.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/TestCas3BookingSearchResult.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3v2BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class TestCas3BookingSearchResult : Cas3v2BookingSearchResult {
+  private var personName: String? = null
+  private var personCrn: String = randomStringMultiCaseWithNumbers(6)
+  private var bookingId: UUID = UUID.randomUUID()
+  private var bookingStatus: String =
+    randomOf(
+      listOf(
+        "arrived",
+        "awaiting-arrival",
+        "not-arrived",
+        "departed",
+        "cancelled",
+        "provisional",
+        "confirmed",
+      ),
+    )
+
+  private var bookingStartDate: LocalDate = LocalDate.now().randomDateBefore(14)
+  private var bookingEndDate: LocalDate = LocalDate.now().randomDateAfter(14)
+  private var bookingCreatedAt: OffsetDateTime = OffsetDateTime.now().minusDays(30).randomDateTimeBefore(14)
+  private var premisesId: UUID = UUID.randomUUID()
+  private var premisesName: String = randomStringMultiCaseWithNumbers(6)
+  private var premisesAddressLine1: String = randomStringMultiCaseWithNumbers(6)
+  private var premisesAddressLine2: String? = null
+  private var premisesTown: String? = null
+  private var premisesPostcode: String = randomStringMultiCaseWithNumbers(6)
+  private var bedspaceId: UUID = UUID.randomUUID()
+  private var bedspaceReference: String = randomStringMultiCaseWithNumbers(6)
+
+  fun withPersonName(personName: String) = apply {
+    this.personName = personName
+  }
+
+  fun withPersonCrn(personCrn: String) = apply {
+    this.personCrn = personCrn
+  }
+
+  fun withBookingStatus(bookingStatus: Cas3BookingStatus) = apply {
+    this.bookingStatus = bookingStatus.value
+  }
+
+  fun withBookingCreatedAt(bookingCreatedAt: OffsetDateTime) = apply {
+    this.bookingCreatedAt = bookingCreatedAt
+  }
+
+  override fun getPersonName(): String? = this.personName
+
+  override fun getPersonCrn(): String = this.personCrn
+
+  override fun getBookingStatus(): String = this.bookingStatus
+
+  override fun getBookingId(): UUID = this.bookingId
+
+  override fun getBookingStartDate(): LocalDate = this.bookingStartDate
+
+  override fun getBookingEndDate(): LocalDate = this.bookingEndDate
+
+  override fun getBookingCreatedAt(): Instant = this.bookingCreatedAt.toInstant()
+
+  override fun getPremisesId(): UUID = this.premisesId
+
+  override fun getPremisesName(): String = this.premisesName
+
+  override fun getPremisesAddressLine1(): String = this.premisesAddressLine1
+
+  override fun getPremisesAddressLine2(): String? = this.premisesAddressLine2
+
+  override fun getPremisesTown(): String? = this.premisesTown
+
+  override fun getPremisesPostcode(): String = this.premisesPostcode
+
+  override fun getBedspaceId(): UUID = this.bedspaceId
+
+  override fun getBedspaceReference(): String = this.bedspaceReference
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/v2/Cas3v2BookingSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/v2/Cas3v2BookingSearchServiceTest.kt
@@ -1,0 +1,433 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas3.v2
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.dao.DataRetrievalFailureException
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchSortField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3v2BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.v2.Cas3v2BookingSearchService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.TestCas3BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
+import java.time.OffsetDateTime
+
+class Cas3v2BookingSearchServiceTest {
+  private val mockCas3v2BookingRepository = mockk<Cas3v2BookingRepository>()
+  private val mockOffenderService = mockk<OffenderService>()
+  private val mockUserService = mockk<UserService>()
+  private val cas3BookingSearchPageSize = 50
+
+  private val cas3BookingSearchService = Cas3v2BookingSearchService(
+    mockCas3v2BookingRepository,
+    mockOffenderService,
+    mockUserService,
+    cas3BookingSearchPageSize,
+  )
+
+  @BeforeEach
+  fun before() {
+    PaginationConfig(defaultPageSize = 10).postInit()
+  }
+
+  @Test
+  fun `findBookings returns results from repository when offender details are found for all bookings`() {
+    val crns = setOf("crn1", "crn2", "crn3")
+
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(
+      crns.map { TestCas3BookingSearchResult().withPersonCrn(it) },
+    )
+
+    every { mockOffenderService.getPersonSummaryInfoResults(crns, any()) } returns
+      crns.map { PersonSummaryInfoResult.Success.Full(it, CaseSummaryFactory().produce()) }
+
+    val (results, metaData) = cas3BookingSearchService.findBookings(
+      null,
+      SortDirection.asc,
+      Cas3BookingSearchSortField.BOOKING_CREATED_AT,
+      1,
+      null,
+    )
+
+    assertThat(results).hasSize(3)
+    assertThat(results).allMatch {
+      it.personName != null
+    }
+    assertThat(metaData).isNotNull()
+  }
+
+  @Test
+  fun `findBookings finds out bookings where the user is not authorised to get offender details for a particular CRN and gives them the name Limited Access Offender`() {
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(
+      listOf(
+        TestCas3BookingSearchResult()
+          .withPersonCrn("crn1")
+          .withBookingCreatedAt(OffsetDateTime.now().minusDays(3)),
+        TestCas3BookingSearchResult()
+          .withPersonCrn("crn2")
+          .withBookingCreatedAt(OffsetDateTime.now().minusDays(2)),
+        TestCas3BookingSearchResult()
+          .withPersonCrn("crn3")
+          .withBookingCreatedAt(OffsetDateTime.now().minusDays(1)),
+      ),
+    )
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
+      listOf(
+        PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().withName(NameFactory().withForename("Gregor").withSurname("Samsa").produce()).produce()),
+        PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().withName(NameFactory().withForename("Franz").withSurname("Kafka").produce()).produce()),
+        PersonSummaryInfoResult.Success.Restricted("crn3", "crn3noms"),
+      )
+
+    val (results, metadata) = cas3BookingSearchService.findBookings(
+      null,
+      SortDirection.asc,
+      Cas3BookingSearchSortField.BOOKING_CREATED_AT,
+      1,
+      null,
+    )
+    assertThat(results).hasSize(3)
+    assertThat(results).matches { result ->
+      result.map { it.personName }.toSet() == setOf("Gregor Samsa", "Franz Kafka", "Limited Access Offender")
+    }
+    assertThat(metadata).isNotNull()
+    verify(exactly = 1) {
+      mockCas3v2BookingRepository.findBookings(any(), any(), any(), any())
+    }
+  }
+
+  @Test
+  fun `findBookings provides Unknown for a person's name when offender details for a particular CRN could not be found`() {
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(
+      listOf(
+        TestCas3BookingSearchResult()
+          .withPersonCrn("crn1")
+          .withBookingCreatedAt(OffsetDateTime.now().minusDays(3)),
+        TestCas3BookingSearchResult()
+          .withPersonCrn("crn2")
+          .withBookingCreatedAt(OffsetDateTime.now().minusDays(2)),
+        TestCas3BookingSearchResult()
+          .withPersonCrn("crn3")
+          .withBookingCreatedAt(OffsetDateTime.now().minusDays(1)),
+      ),
+    )
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
+      listOf(
+        PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
+        PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
+        PersonSummaryInfoResult.NotFound("crn3"),
+      )
+
+    every { mockOffenderService.getOffenderByCrn(any(), any()) } returnsMany listOf(
+      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
+      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
+      AuthorisableActionResult.NotFound(),
+    )
+
+    val (results, metaData) = cas3BookingSearchService.findBookings(
+      null,
+      SortDirection.asc,
+      Cas3BookingSearchSortField.BOOKING_CREATED_AT,
+      1,
+      null,
+    )
+
+    assertThat(results).hasSize(3)
+    assertThat(results).allSatisfy {
+      assertThat(it.personName).isNotNull()
+    }
+    assertThat(results.last().personName).isEqualTo("Unknown")
+    assertThat(metaData).isNotNull()
+    verify(exactly = 1) {
+      mockCas3v2BookingRepository.findBookings(any(), any(), any(), any())
+    }
+  }
+
+  @EnumSource(value = SortDirection::class)
+  @ParameterizedTest
+  fun `findBookings returns sorted results by person name and database default sort when page number is given`(sortDirection: SortDirection) {
+    val pageSort = when (sortDirection) {
+      SortDirection.asc -> Sort.by("personName").ascending()
+      SortDirection.desc -> Sort.by("personName").descending()
+    }
+    val pageable = PageRequest.of(0, cas3BookingSearchPageSize, pageSort)
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), pageable) } returns PageImpl(
+      listOf(
+        TestCas3BookingSearchResult().withPersonCrn("crn1"),
+        TestCas3BookingSearchResult().withPersonCrn("crn2"),
+        TestCas3BookingSearchResult().withPersonCrn("crn3"),
+      ),
+    )
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
+      listOf(
+        PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
+        PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
+        PersonSummaryInfoResult.Success.Full("crn3", CaseSummaryFactory().produce()),
+      )
+
+    val (results, metaData) = cas3BookingSearchService.findBookings(
+      null,
+      sortDirection,
+      Cas3BookingSearchSortField.PERSON_NAME,
+      1,
+      null,
+    )
+
+    assertThat(results).hasSize(3)
+    assertThat(results.map { it.personName }).isSortedAccordingTo { a, b ->
+      when (sortDirection) {
+        SortDirection.asc -> compareValues(a, b)
+        SortDirection.desc -> compareValues(b, a)
+      }
+    }
+    assertThat(metaData).isNotNull()
+    verify(exactly = 1) {
+      mockCas3v2BookingRepository.findBookings(any(), any(), any(), pageable)
+    }
+  }
+
+  @EnumSource(value = SortDirection::class)
+  @ParameterizedTest
+  fun `findBookings returns sorted results by person name and database default sort when page number is not given`(sortDirection: SortDirection) {
+    val pageSort = when (sortDirection) {
+      SortDirection.asc -> Sort.by("personName").ascending()
+      SortDirection.desc -> Sort.by("personName").descending()
+    }
+    val pageable = PageRequest.of(0, Int.MAX_VALUE, pageSort)
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), pageable) } returns PageImpl(
+      listOf(
+        TestCas3BookingSearchResult().withPersonCrn("crn1"),
+        TestCas3BookingSearchResult().withPersonCrn("crn2"),
+        TestCas3BookingSearchResult().withPersonCrn("crn3"),
+      ),
+    )
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
+      listOf(
+        PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
+        PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
+        PersonSummaryInfoResult.Success.Full("crn3", CaseSummaryFactory().produce()),
+      )
+
+    val (results, metaData) = cas3BookingSearchService.findBookings(
+      null,
+      sortDirection,
+      Cas3BookingSearchSortField.PERSON_NAME,
+      null,
+      null,
+    )
+
+    assertThat(results).hasSize(3)
+    assertThat(results.map { it.personName }).isSortedAccordingTo { a, b ->
+      when (sortDirection) {
+        SortDirection.asc -> compareValues(a, b)
+        SortDirection.desc -> compareValues(b, a)
+      }
+    }
+    assertThat(metaData).isNull()
+    verify(exactly = 1) {
+      mockCas3v2BookingRepository.findBookings(any(), any(), any(), pageable)
+    }
+  }
+
+  @EnumSource(value = SortDirection::class)
+  @ParameterizedTest
+  fun `findBookings returns results and database sorted by crn when page number is given`(sortDirection: SortDirection) {
+    val pageSort = when (sortDirection) {
+      SortDirection.asc -> Sort.by("crn").ascending()
+      SortDirection.desc -> Sort.by("crn").descending()
+    }
+    val pageable = PageRequest.of(1, cas3BookingSearchPageSize, pageSort)
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), pageable) } returns PageImpl(
+      listOf(
+        TestCas3BookingSearchResult().withPersonCrn("crn1"),
+        TestCas3BookingSearchResult().withPersonCrn("crn2"),
+        TestCas3BookingSearchResult().withPersonCrn("crn3"),
+      ),
+    )
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf("crn1", "crn2", "crn3"), any()) } returns
+      listOf(
+        PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce()),
+        PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
+        PersonSummaryInfoResult.Success.Full("crn3", CaseSummaryFactory().produce()),
+      )
+
+    val (results, metaData) = cas3BookingSearchService.findBookings(
+      null,
+      sortDirection,
+      Cas3BookingSearchSortField.PERSON_CRN,
+      2,
+      null,
+    )
+
+    assertThat(results).hasSize(3)
+    assertThat(metaData).isNotNull()
+    verify(exactly = 1) {
+      mockCas3v2BookingRepository.findBookings(any(), any(), any(), pageable)
+    }
+  }
+
+  @Test
+  fun `findBookings returns empty results from repository when page number is given`() {
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(emptyList())
+    every { mockOffenderService.getPersonSummaryInfoResults(emptySet(), any()) } returns emptyList()
+
+    val (results, metaData) = cas3BookingSearchService.findBookings(
+      null,
+      SortDirection.asc,
+      Cas3BookingSearchSortField.BOOKING_CREATED_AT,
+      1,
+      null,
+    )
+
+    assertThat(results).hasSize(0)
+    assertThat(metaData).isNotNull()
+    verify(exactly = 1) {
+      mockCas3v2BookingRepository.findBookings(any(), any(), any(), any())
+    }
+  }
+
+  @Test
+  fun `findBookings returns empty results from repository when page number is not given`() {
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), any()) } returns PageImpl(emptyList())
+    every { mockOffenderService.getPersonSummaryInfoResults(emptySet(), any()) } returns emptyList()
+
+    val (results, metaData) = cas3BookingSearchService.findBookings(
+      null,
+      SortDirection.asc,
+      Cas3BookingSearchSortField.BOOKING_CREATED_AT,
+      null,
+      "S448160",
+    )
+
+    assertThat(results).hasSize(0)
+    assertThat(metaData).isNull()
+    verify(exactly = 1) {
+      mockCas3v2BookingRepository.findBookings(any(), any(), any(), any())
+    }
+  }
+
+  @Test
+  fun `throw exception when DB exception happened`() {
+    every { mockUserService.getUserForRequest() } returns UserEntityFactory()
+      .withYieldedProbationRegion {
+        ProbationRegionEntityFactory()
+          .withYieldedApArea {
+            ApAreaEntityFactory().produce()
+          }
+          .produce()
+      }
+      .produce()
+    every { mockCas3v2BookingRepository.findBookings(any(), any(), any(), any()) }.throws(
+      DataRetrievalFailureException(
+        "some-exception",
+      ),
+    )
+
+    Assertions.assertThrows(DataRetrievalFailureException::class.java) {
+      cas3BookingSearchService.findBookings(
+        null,
+        SortDirection.asc,
+        Cas3BookingSearchSortField.BOOKING_CREATED_AT,
+        1,
+        null,
+      )
+    }
+    verify(exactly = 1) {
+      mockCas3v2BookingRepository.findBookings(any(), any(), any(), any())
+    }
+    verify(exactly = 0) {
+      mockOffenderService.getOffenderByCrn(any(), any())
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/v2/Cas3v2BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/v2/Cas3v2BookingServiceTest.kt
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingAndPersons
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
@@ -479,7 +479,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == assessment.application &&
-              it.status == BookingStatus.provisional
+              it.status == Cas3BookingStatus.provisional
           },
         )
       }
@@ -553,7 +553,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == null &&
-              it.status == BookingStatus.provisional
+              it.status == Cas3BookingStatus.provisional
           },
         )
       }
@@ -619,7 +619,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == assessment.application &&
-              it.status == BookingStatus.provisional
+              it.status == Cas3BookingStatus.provisional
           },
         )
       }
@@ -690,7 +690,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == assessment.application &&
-              it.status == BookingStatus.provisional
+              it.status == Cas3BookingStatus.provisional
           },
         )
       }
@@ -763,7 +763,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == assessment.application &&
-              it.status == BookingStatus.provisional &&
+              it.status == Cas3BookingStatus.provisional &&
               it.offenderName == "John Smith"
           },
         )
@@ -838,7 +838,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == assessment.application &&
-              it.status == BookingStatus.provisional
+              it.status == Cas3BookingStatus.provisional
           },
         )
       }
@@ -912,7 +912,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == assessment.application &&
-              it.status == BookingStatus.provisional
+              it.status == Cas3BookingStatus.provisional
           },
         )
       }
@@ -1032,7 +1032,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == assessment.application &&
-              it.status == BookingStatus.provisional
+              it.status == Cas3BookingStatus.provisional
           },
         )
       }
@@ -1108,7 +1108,7 @@ class Cas3v2BookingServiceTest {
               it.arrivalDate == arrivalDate &&
               it.departureDate == departureDate &&
               it.application == assessment.application &&
-              it.status == BookingStatus.provisional
+              it.status == Cas3BookingStatus.provisional
           },
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3BookingSearchTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3BookingSearchTransformerTest.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BookingSearchResultDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3BookingSearchResultTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.TestCas3BookingSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class Cas3BookingSearchTransformerTest {
+  private val bookingSearchResultTransformer = Cas3BookingSearchResultTransformer()
+
+  @Test
+  fun `transformDomainToApi transforms correctly`() {
+    val (domainResults, bookingSearchResultDtos) = buildBookingSearchData()
+    val result = bookingSearchResultTransformer.transformDomainToApi(bookingSearchResultDtos)
+
+    assertThat(result.resultsCount).isEqualTo(6)
+
+    result.results.forEachIndexed { index: Int, transformedResult: Cas3BookingSearchResult ->
+      val domainResult = domainResults[index]
+
+      assertThat(transformedResult.person.name).isEqualTo(domainResult.getPersonName())
+      assertThat(transformedResult.person.crn).isEqualTo(domainResult.getPersonCrn())
+      assertThat(transformedResult.booking.id).isEqualTo(domainResult.getBookingId())
+      assertThat(transformedResult.booking.status.value).isEqualTo(domainResult.getBookingStatus())
+      assertThat(transformedResult.booking.startDate).isEqualTo(domainResult.getBookingStartDate())
+      assertThat(transformedResult.booking.endDate).isEqualTo(domainResult.getBookingEndDate())
+      assertThat(transformedResult.booking.createdAt).isEqualTo(domainResult.getBookingCreatedAt())
+      assertThat(transformedResult.premises.id).isEqualTo(domainResult.getPremisesId())
+      assertThat(transformedResult.premises.name).isEqualTo(domainResult.getPremisesName())
+      assertThat(transformedResult.premises.addressLine1).isEqualTo(domainResult.getPremisesAddressLine1())
+      assertThat(transformedResult.premises.addressLine2).isEqualTo(domainResult.getPremisesAddressLine2())
+      assertThat(transformedResult.premises.town).isEqualTo(domainResult.getPremisesTown())
+      assertThat(transformedResult.premises.postcode).isEqualTo(domainResult.getPremisesPostcode())
+      assertThat(transformedResult.bedspace.id).isEqualTo(domainResult.getBedspaceId())
+      assertThat(transformedResult.bedspace.reference).isEqualTo(domainResult.getBedspaceReference())
+    }
+  }
+
+  private fun buildBookingSearchData(): Pair<List<TestCas3BookingSearchResult>, List<Cas3BookingSearchResultDto>> {
+    val domainResults = listOf(
+      TestCas3BookingSearchResult()
+        .withPersonName(randomStringMultiCaseWithNumbers(6))
+        .withBookingStatus(Cas3BookingStatus.provisional),
+      TestCas3BookingSearchResult()
+        .withPersonName(randomStringMultiCaseWithNumbers(6))
+        .withBookingStatus(Cas3BookingStatus.confirmed),
+      TestCas3BookingSearchResult()
+        .withBookingStatus(Cas3BookingStatus.notMinusArrived),
+      TestCas3BookingSearchResult()
+        .withPersonName(randomStringMultiCaseWithNumbers(6))
+        .withBookingStatus(Cas3BookingStatus.arrived),
+      TestCas3BookingSearchResult()
+        .withBookingStatus(Cas3BookingStatus.departed),
+      TestCas3BookingSearchResult()
+        .withPersonName(randomStringMultiCaseWithNumbers(6))
+        .withBookingStatus(Cas3BookingStatus.cancelled),
+    )
+    val bookingSearchResultDtos = domainResults.map { rs ->
+      Cas3BookingSearchResultDto(
+        rs.getPersonName(),
+        rs.getPersonCrn(),
+        rs.getBookingId(),
+        rs.getBookingStatus(),
+        rs.getBookingStartDate(),
+        rs.getBookingEndDate(),
+        OffsetDateTime.ofInstant(rs.getBookingCreatedAt(), ZoneOffset.UTC),
+        rs.getPremisesId(),
+        rs.getPremisesName(),
+        rs.getPremisesAddressLine1(),
+        rs.getPremisesAddressLine2(),
+        rs.getPremisesTown(),
+        rs.getPremisesPostcode(),
+        rs.getBedspaceId(),
+        rs.getBedspaceReference(),
+      )
+    }
+    return Pair(domainResults, bookingSearchResultDtos)
+  }
+}


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" height="1152" alt="Screenshot 2025-07-18 at 16 09 22 (2)" src="https://github.com/user-attachments/assets/c481791a-7112-40d8-a9ed-165ec5fa0e6c" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `GET /cas3/v2/bookings/search`.
2. This endpoint was modelled on the `GET /bookings/search` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models.
