### PR TITLE
APS-2555 - Use space booking URL in booking made emails

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -37,7 +37,7 @@ generic-service:
     ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: test
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
-    DOMAIN-EVENTS_CAS1_EMIT-ENABLED: true
+    DOMAIN-EVENTS_CAS1_EMIT-ENABLED: false
     DOMAIN-EVENTS_CAS2_EMIT-ENABLED: false
     DOMAIN-EVENTS_CAS3_EMIT-ENABLED: referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingEmailService.kt
@@ -18,7 +18,7 @@ class Cas1BookingEmailService(
   private val emailNotifier: Cas1EmailNotifier,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
   @Value("\${url-templates.frontend.application-timeline}") private val applicationTimelineUrlTemplate: UrlTemplate,
-  @Value("\${url-templates.frontend.booking}") private val bookingUrlTemplate: UrlTemplate,
+  @Value("\${url-templates.frontend.cas1.space-booking}") private val spaceBookingUrlTemplate: UrlTemplate,
 ) {
 
   fun spaceBookingMade(
@@ -163,7 +163,7 @@ class Cas1BookingEmailService(
       "apName" to values.premisesName,
       "applicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
       "applicationTimelineUrl" to applicationTimelineUrlTemplate.resolve("applicationId", application.id.toString()),
-      "bookingUrl" to bookingUrlTemplate.resolve(
+      "bookingUrl" to spaceBookingUrlTemplate.resolve(
         mapOf(
           "premisesId" to emailBookingInfo.premises.id.toString(),
           "bookingId" to emailBookingInfo.bookingId.toString(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingEmailServiceTest.kt
@@ -58,7 +58,7 @@ class Cas1BookingEmailServiceTest {
     mockEmailNotificationService,
     applicationUrlTemplate = UrlTemplate("http://frontend/applications/#id"),
     applicationTimelineUrlTemplate = UrlTemplate("http://frontend/applications/#applicationId?tab=timeline"),
-    bookingUrlTemplate = UrlTemplate("http://frontend/premises/#premisesId/bookings/#bookingId"),
+    spaceBookingUrlTemplate = UrlTemplate("http://frontend/manage/premises/#premisesId/placements/#bookingId"),
   )
 
   private val withdrawingUser = UserEntityFactory()
@@ -108,7 +108,7 @@ class Cas1BookingEmailServiceTest {
         mapOf(
           "apName" to PREMISES_NAME,
           "applicationUrl" to "http://frontend/applications/${application.id}",
-          "bookingUrl" to "http://frontend/premises/${premises.id}/bookings/${booking.id}",
+          "bookingUrl" to "http://frontend/manage/premises/${premises.id}/placements/${booking.id}",
           "crn" to CRN,
           "startDate" to "2023-02-01",
           "endDate" to "2023-02-14",
@@ -146,7 +146,7 @@ class Cas1BookingEmailServiceTest {
       val personalisation = mapOf(
         "apName" to PREMISES_NAME,
         "applicationUrl" to "http://frontend/applications/${application.id}",
-        "bookingUrl" to "http://frontend/premises/${premises.id}/bookings/${booking.id}",
+        "bookingUrl" to "http://frontend/manage/premises/${premises.id}/placements/${booking.id}",
         "crn" to CRN,
         "startDate" to "2023-02-01",
         "endDate" to "2023-02-14",
@@ -258,7 +258,7 @@ class Cas1BookingEmailServiceTest {
       val personalisation = mapOf(
         "apName" to PREMISES_NAME,
         "applicationUrl" to "http://frontend/applications/${application.id}",
-        "bookingUrl" to "http://frontend/premises/${premises.id}/bookings/${booking.id}",
+        "bookingUrl" to "http://frontend/manage/premises/${premises.id}/placements/${booking.id}",
         "crn" to CRN,
         "startDate" to "2023-02-01",
         "endDate" to "2023-02-14",


### PR DESCRIPTION
Previously we used a legacy ‘booking’ url (which will be redirected to this new URL by the UI)

This PR also disables domain events in test to unblock testing this functionality. This was enabled last week but ultimately wasn't required

<img width="610" height="182" alt="Screenshot 2025-07-21 at 12 59 32" src="https://github.com/user-attachments/assets/235abcfc-c199-4d3d-9879-7d5ffe6e3d5e" />