### PR TITLE
APS-2547 - Add `placement_applications.automatic`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -104,7 +104,18 @@ data class PlacementApplicationEntity(
   var placementType: PlacementType?,
 
   /**
-   * It was previously possible to realloacte a PlacementRequest, which would create a copy
+   * If true, this Placement Application was created on assessment of
+   * an application that included a placement date, and represents the
+   * request for placement implicit in that original application
+   *
+   * Automatic applications do not go through the regular placement
+   * applications review process (they're approved on creation),
+   * or appear as completed tasks
+   */
+  val automatic: Boolean,
+
+  /**
+   * It was previously possible to re-allocate a PlacementRequest, which would create a copy
    * of the placement request with the new allocation. This would result in multiple
    * placement requests linked to a single placement application.
    *
@@ -178,6 +189,7 @@ enum class PlacementType {
   ROTL,
   RELEASE_FOLLOWING_DECISION,
   ADDITIONAL_PLACEMENT,
+  AUTOMATIC,
 }
 
 enum class PlacementApplicationDecision(val apiValue: ApiPlacementApplicationDecision) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -106,8 +106,9 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         LEFT JOIN ap_areas area ON area.id = apa.ap_area_id
         LEFT JOIN users u ON u.id = placement_application.allocated_to_user_id
       WHERE
-        'PLACEMENT_APPLICATION' in :taskTypes AND
-        placement_application.submitted_at IS NOT NULL
+        'PLACEMENT_APPLICATION' in :taskTypes 
+        AND placement_application.automatic IS FALSE 
+        AND placement_application.submitted_at IS NOT NULL
         AND placement_application.reallocated_at IS NULL
         AND placement_application.is_withdrawn is FALSE
         AND (

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -50,6 +50,7 @@ class Cas1PlacementApplicationDomainEventService(
       PlacementType.ROTL -> RequestForPlacementType.rotl
       PlacementType.RELEASE_FOLLOWING_DECISION -> RequestForPlacementType.releaseFollowingDecisions
       PlacementType.ADDITIONAL_PLACEMENT -> RequestForPlacementType.additionalPlacement
+      PlacementType.AUTOMATIC -> error("Automatic applications are not submitted")
     }
 
     val staffDetails = when (val staffDetailsResult = apDeliusContextApiClient.getStaffDetail(username)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
@@ -84,6 +84,7 @@ class Cas1PlacementApplicationService(
         decision = null,
         decisionMadeAt = null,
         placementType = null,
+        automatic = false,
         placementRequests = mutableListOf(),
         withdrawalReason = null,
         dueAt = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -107,6 +107,7 @@ class TaskTransformer(
     JpaPlacementType.ROTL -> ApiPlacementType.rotl
     JpaPlacementType.ADDITIONAL_PLACEMENT -> ApiPlacementType.additionalPlacement
     JpaPlacementType.RELEASE_FOLLOWING_DECISION -> ApiPlacementType.releaseFollowingDecision
+    JpaPlacementType.AUTOMATIC -> error("Automatic placement applications should not be returned as tasks")
   }
 
   private fun getPlacementApplicationStatus(entity: PlacementApplicationEntity): TaskStatus = when {

--- a/src/main/resources/db/migration/all/20250721162718__add_placement_applications_automatic.sql
+++ b/src/main/resources/db/migration/all/20250721162718__add_placement_applications_automatic.sql
@@ -1,0 +1,1 @@
+ALTER TABLE placement_applications ADD automatic boolean DEFAULT false NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -27,6 +27,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var decisionMadeAt: Yielded<OffsetDateTime?> = { null }
   private var reallocatedAt: Yielded<OffsetDateTime?> = { null }
   private var placementType: Yielded<PlacementType?> = { null }
+  private var automatic = { false }
   private var withdrawalReason: Yielded<PlacementApplicationWithdrawalReason?> = { null }
   private var dueAt: Yielded<OffsetDateTime?> = { OffsetDateTime.now().randomDateTimeAfter(10) }
   private var submissionGroupId: Yielded<UUID> = { UUID.randomUUID() }
@@ -87,6 +88,10 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     this.placementType = { placementType }
   }
 
+  fun withAutomatic(automatic: Boolean) = apply {
+    this.automatic = { automatic }
+  }
+
   fun withWithdrawalReason(withdrawalReason: PlacementApplicationWithdrawalReason) = apply {
     this.withdrawalReason = { withdrawalReason }
   }
@@ -121,6 +126,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     decision = this.decision(),
     decisionMadeAt = this.decisionMadeAt(),
     placementType = this.placementType(),
+    automatic = this.automatic(),
     placementRequests = mutableListOf(),
     withdrawalReason = this.withdrawalReason(),
     dueAt = this.dueAt(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1TasksTest.kt
@@ -763,7 +763,7 @@ class Cas1TasksTest {
     }
 
     @Nested
-    inner class PaginationAndWithdrawalExclusion : InitialiseDatabasePerClassTestBase() {
+    inner class PaginationAndExclusionOfIrrelevantTasks : InitialiseDatabasePerClassTestBase() {
       private val pageSize = 1
       private lateinit var counts: Map<TaskType, Map<String, Int>>
 
@@ -780,12 +780,10 @@ class Cas1TasksTest {
                 TaskType.assessment to mapOf(
                   "allocated" to 2,
                   "unallocated" to 3,
-                  "withdrawn" to 1,
                 ),
                 TaskType.placementApplication to mapOf(
                   "allocated" to 3,
                   "unallocated" to 2,
-                  "withdrawn" to 1,
                 ),
               )
 
@@ -810,14 +808,13 @@ class Cas1TasksTest {
                 )
               }
 
-              repeat(counts[TaskType.assessment]!!["withdrawn"]!!) {
-                givenAnAssessmentForApprovedPremises(
-                  null,
-                  createdByUser = otherUser,
-                  crn = offenderDetails.otherIds.crn,
-                  isWithdrawn = true,
-                )
-              }
+              // withdrawn, ignored
+              givenAnAssessmentForApprovedPremises(
+                null,
+                createdByUser = otherUser,
+                crn = offenderDetails.otherIds.crn,
+                isWithdrawn = true,
+              )
 
               repeat(counts[TaskType.placementApplication]!!["allocated"]!!) {
                 givenAPlacementApplication(
@@ -840,16 +837,25 @@ class Cas1TasksTest {
                 )
               }
 
-              repeat(counts[TaskType.placementApplication]!!["withdrawn"]!!) {
-                givenAPlacementApplication(
-                  createdByUser = user,
-                  crn = offenderDetails.otherIds.crn,
-                  submittedAt = OffsetDateTime.now(),
-                  isWithdrawn = true,
-                  expectedArrival = LocalDate.now(),
-                  duration = 1,
-                )
-              }
+              // withdrawn, ignored
+              givenAPlacementApplication(
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+                isWithdrawn = true,
+                expectedArrival = LocalDate.now(),
+                duration = 1,
+              )
+
+              // automatic, ignored
+              givenAPlacementApplication(
+                createdByUser = user,
+                crn = offenderDetails.otherIds.crn,
+                submittedAt = OffsetDateTime.now(),
+                expectedArrival = LocalDate.now(),
+                duration = 1,
+                automatic = true,
+              )
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementApplication.kt
@@ -39,6 +39,7 @@ fun IntegrationTestBase.givenAPlacementApplication(
   apType: ApprovedPremisesType? = null,
   expectedArrival: LocalDate? = null,
   duration: Int? = null,
+  automatic: Boolean = false,
 ): PlacementApplicationEntity {
   val userApArea = givenAnApArea()
 
@@ -84,6 +85,7 @@ fun IntegrationTestBase.givenAPlacementApplication(
     withIsWithdrawn(isWithdrawn)
     withExpectedArrival(expectedArrival)
     withDuration(duration)
+    withAutomatic(automatic)
   }
 
   return placementApplication
@@ -102,6 +104,7 @@ fun IntegrationTestBase.givenAPlacementApplication(
   application: ApprovedPremisesApplicationEntity? = null,
   expectedArrival: LocalDate? = null,
   duration: Int? = null,
+  automatic: Boolean = false,
   block: (placementApplicationEntity: PlacementApplicationEntity) -> Unit = { },
 ): PlacementApplicationEntity {
   val placementApplication = givenAPlacementApplication(
@@ -118,6 +121,7 @@ fun IntegrationTestBase.givenAPlacementApplication(
     isWithdrawn = false,
     expectedArrival = expectedArrival,
     duration = duration,
+    automatic = automatic,
   )
   block(placementApplication)
   return placementApplication

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -318,7 +318,11 @@ class TaskTransformerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = JpaPlacementType::class)
+    @EnumSource(
+      value = JpaPlacementType::class,
+      mode = EnumSource.Mode.EXCLUDE,
+      names = [ "AUTOMATIC" ],
+    )
     fun `Placement types are transformed correctly`(placementType: JpaPlacementType) {
       val placementApplication = placementApplicationFactory
         .withPlacementType(placementType)


### PR DESCRIPTION
This will default to false, as all existing placement applications are not automatic.

This commit updates the queries used to return tasks to exclude any placement applications where automatic=true, because these will be created and approved automatically on application assessment.

Currently nothing is creating automatic placement applications, so the request for placement report does not need changing. This will follow in subsequent commits.