### PR TITLE
APS-2547 - Rename placement_applications_automatic table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationPlaceholderEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationPlaceholderEntity.kt
@@ -11,20 +11,21 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @Repository
-interface PlacementApplicationAutomaticRepository : JpaRepository<PlacementApplicationAutomaticEntity, UUID>
+interface PlacementApplicationPlaceholderRepository : JpaRepository<PlacementApplicationPlaceholderEntity, UUID>
 
 /**
  * Used to capture requests for placements implicit in the original applications
  * i.e. where an arrival date is defined in the original application
  *
  * This is a stop-gap solution to support reporting until we fix the
- * bifurcated request for placement model
+ * bifurcated request for placement model, at which point these will
+ * be represented by [PlacementApplicationEntity] instead
  *
  * See [PlacementRequestEntity.isForApplicationsArrivalDate] for more information
  */
 @Entity
-@Table(name = "placement_applications_automatic")
-data class PlacementApplicationAutomaticEntity(
+@Table(name = "placement_applications_placeholder")
+data class PlacementApplicationPlaceholderEntity(
   @Id
   val id: UUID,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -315,7 +315,7 @@ data class PlacementRequestEntity(
    * Unfortunately, it's non-trivial to amend the data model and workflow implementation
    * to allow us to use [PlacementApplicationEntity] for this purpose.
    *
-   * Note that we do populated [PlacementApplicationAutomaticEntity] to support reporting on
+   * Note that we do populated [PlacementApplicationPlaceholderEntity] to support reporting on
    * such requests. This could maybe be used as a starting point to fix the data model.
    *
    * For Withdrawal functionality we have a use-case for the user to be able to withdraw the original

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1RequestForPlacementReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1RequestForPlacementReportRepository.kt
@@ -13,7 +13,7 @@ class Cas1RequestForPlacementReportRepository(
   /**
    Because of the bifurcated placement request model, this query is a union from two sources:
 
-   1. placement_applications_automatic
+   1. placement_applications_placeholder
 
    Represents requests for placements implicit in the original application (where dates are defined)
 
@@ -53,7 +53,7 @@ class Cas1RequestForPlacementReportRepository(
     END AS request_for_placement_withdrawal_reason,
     raw_applications_report.*
     
-  FROM placement_applications_automatic paa
+  FROM placement_applications_placeholder paa
   
     INNER JOIN approved_premises_applications apa ON apa.id = paa.application_id 
     INNER JOIN raw_applications_report ON raw_applications_report.application_id = paa.application_id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
@@ -22,8 +22,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationPlaceholderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationPlaceholderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
@@ -60,7 +60,7 @@ class Cas1ApplicationCreationService(
   private val cas1ApplicationDomainEventService: Cas1ApplicationDomainEventService,
   private val cas1ApplicationUserDetailsRepository: Cas1ApplicationUserDetailsRepository,
   private val cas1ApplicationEmailService: Cas1ApplicationEmailService,
-  private val placementApplicationAutomaticRepository: PlacementApplicationAutomaticRepository,
+  private val placementApplicationPlaceholderRepository: PlacementApplicationPlaceholderRepository,
   private val cas1ApplicationStatusService: Cas1ApplicationStatusService,
   private val clock: Clock,
   private val lockableApplicationRepository: LockableApplicationRepository,
@@ -282,8 +282,8 @@ class Cas1ApplicationCreationService(
     cas1ApplicationEmailService.applicationSubmitted(application)
 
     if (application.arrivalDate != null) {
-      placementApplicationAutomaticRepository.save(
-        PlacementApplicationAutomaticEntity(
+      placementApplicationPlaceholderRepository.save(
+        PlacementApplicationPlaceholderEntity(
           id = UUID.randomUUID(),
           application = application,
           submittedAt = application.submittedAt!!,

--- a/src/main/resources/db/migration/all/20250722161242__placement_applications_automatic.sql
+++ b/src/main/resources/db/migration/all/20250722161242__placement_applications_automatic.sql
@@ -1,0 +1,1 @@
+ALTER TABLE placement_applications_automatic RENAME TO placement_applications_placeholder;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
@@ -45,8 +45,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationAutomaticRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationPlaceholderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationPlaceholderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
@@ -86,7 +86,7 @@ class Cas1ApplicationCreationServiceTest {
   private val mockCas1ApplicationDomainEventService = mockk<Cas1ApplicationDomainEventService>()
   private val mockCas1ApplicationUserDetailsRepository = mockk<Cas1ApplicationUserDetailsRepository>()
   private val mockCas1ApplicationEmailService = mockk<Cas1ApplicationEmailService>()
-  private val mockPlacementApplicationAutomaticRepository = mockk<PlacementApplicationAutomaticRepository>()
+  private val mockPlacementApplicationPlaceholderRepository = mockk<PlacementApplicationPlaceholderRepository>()
   private val mockCas1ApplicationStatusService = mockk<Cas1ApplicationStatusService>()
   private val mockLockableApplicationRepository = mockk<LockableApplicationRepository>()
   private val mockCas1CruManagementAreaRepository = mockk<Cas1CruManagementAreaRepository>()
@@ -105,7 +105,7 @@ class Cas1ApplicationCreationServiceTest {
     mockCas1ApplicationDomainEventService,
     mockCas1ApplicationUserDetailsRepository,
     mockCas1ApplicationEmailService,
-    mockPlacementApplicationAutomaticRepository,
+    mockPlacementApplicationPlaceholderRepository,
     mockCas1ApplicationStatusService,
     Clock.systemDefaultZone(),
     mockLockableApplicationRepository,
@@ -705,7 +705,7 @@ class Cas1ApplicationCreationServiceTest {
       }
 
       verify(exactly = 1) { mockCas1ApplicationEmailService.applicationSubmitted(application) }
-      verify(exactly = 0) { mockPlacementApplicationAutomaticRepository.save(any()) }
+      verify(exactly = 0) { mockPlacementApplicationPlaceholderRepository.save(any()) }
     }
 
     @ParameterizedTest
@@ -787,7 +787,7 @@ class Cas1ApplicationCreationServiceTest {
       }
 
       verify(exactly = 1) { mockCas1ApplicationEmailService.applicationSubmitted(application) }
-      verify(exactly = 1) { mockPlacementApplicationAutomaticRepository.save(any()) }
+      verify(exactly = 1) { mockPlacementApplicationPlaceholderRepository.save(any()) }
     }
 
     @ParameterizedTest
@@ -1023,8 +1023,8 @@ class Cas1ApplicationCreationServiceTest {
 
       every { mockCas1ApplicationEmailService.applicationSubmitted(any()) } just Runs
       every {
-        mockPlacementApplicationAutomaticRepository.save(any())
-      } answers { it.invocation.args[0] as PlacementApplicationAutomaticEntity }
+        mockPlacementApplicationPlaceholderRepository.save(any())
+      } answers { it.invocation.args[0] as PlacementApplicationPlaceholderEntity }
     }
   }
 


### PR DESCRIPTION
We now have the concept of an entry in `placement_applications` being automatic (via the ‘automatic’ boolean value)

To avoid confusion, this commit renames the `placement_applications_automatic` table to `placement_applications_placeholder`, as it really represents a limited set of information about a request for placement that will be ‘promoted’ to an entry in the `placement_applications` table once the corresponding application is approved. we need this placeholder to enable reporting on these values before the application has been approved.

In time, `placement_applications_placeholder` will be fully replaced by `placement_applications`.

Typically we’d avoid renaming tables ‘in place’ because it can lead to errors whilst rolling out the correspodning code change. As this table does not have any relationships in JPA and only used in two places in code, renaming in place is deemed acceptable.

