### PR TITLE
APS-2547 Simplify PlacementRequirements creation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -332,14 +332,7 @@ class AssessmentService(
     }
 
     if (assessment is ApprovedPremisesAssessmentEntity) {
-      val placementRequirementsResult =
-        when (
-          val result =
-            cas1PlacementRequirementsService.createPlacementRequirements(assessment, placementRequirements!!)
-        ) {
-          is CasResult.Success -> result.value
-          is CasResult.Error -> return result.reviseType()
-        }
+      val placementRequirementsResult = cas1PlacementRequirementsService.createPlacementRequirements(assessment, placementRequirements!!)
 
       if (createPlacementRequest) {
         placementRequestService.createPlacementRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentService.kt
@@ -247,14 +247,13 @@ class Cas1AssessmentService(
     preUpdateAssessment(assessment)
     val savedAssessment = approvedPremisesAssessmentRepository.save(assessment)
 
-    val placementRequirementsResult =
-      when (
-        val result =
-          cas1PlacementRequirementsService.createPlacementRequirements(assessment, placementRequirements)
-      ) {
-        is CasResult.Success -> result.value
-        is CasResult.Error -> return result.reviseType()
-      }
+    /*
+    Note - these placement requirements are required for all subsequent placement applications linked
+    to the application, so they're created here even if a placement request isn't required
+
+    Ideally a placement requirements would be created for each individual placement application instead
+     */
+    val placementRequirementsResult = cas1PlacementRequirementsService.createPlacementRequirements(assessment, placementRequirements)
 
     if (createPlacementRequest) {
       placementRequestService.createPlacementRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/AssessmentTest.kt
@@ -2087,66 +2087,6 @@ class AssessmentTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Accept assessment returns an error if the postcode cannot be found`() {
-      givenAUser(
-        staffDetail = StaffDetailFactory.staffDetail(
-          probationArea = ProbationArea(
-            code = "N21",
-            description = randomStringMultiCaseWithNumbers(10),
-          ),
-        ),
-      ) { userEntity, jwt ->
-        givenAnOffender { offenderDetails, _ ->
-
-          val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
-            withCrn(offenderDetails.otherIds.crn)
-            withCreatedByUser(userEntity)
-          }
-
-          val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
-            withAllocatedToUser(userEntity)
-            withApplication(application)
-          }
-
-          val essentialCriteria = listOf(PlacementCriteria.isArsonSuitable, PlacementCriteria.isESAP)
-          val desirableCriteria =
-            listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
-
-          val placementDates = PlacementDates(
-            expectedArrival = LocalDate.now(),
-            duration = 12,
-          )
-
-          val placementRequirements = PlacementRequirements(
-            type = ApType.normal,
-            location = "SW1",
-            radius = 50,
-            essentialCriteria = essentialCriteria,
-            desirableCriteria = desirableCriteria,
-          )
-
-          webTestClient.post()
-            .uri("/assessments/${assessment.id}/acceptance")
-            .header("Authorization", "Bearer $jwt")
-            .bodyValue(
-              AssessmentAcceptance(
-                document = mapOf("document" to "value"),
-                requirements = placementRequirements,
-                placementDates = placementDates,
-              ),
-            )
-            .exchange()
-            .expectStatus()
-            .is4xxClientError
-            .expectBody()
-            .jsonPath("title").isEqualTo("Bad Request")
-            .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
-            .jsonPath("invalid-params[0].propertyName").isEqualTo("\$.postcodeDistrict")
-        }
-      }
-    }
-
-    @Test
     fun `Accept assessment with an outstanding clarification note sets the application status correctly`() {
       givenAUser(
         staffDetail = StaffDetailFactory.staffDetail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AssessmentTest.kt
@@ -1353,66 +1353,6 @@ class Cas1AssessmentTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Accept assessment returns an error if the postcode cannot be found`() {
-      givenAUser(
-        staffDetail = StaffDetailFactory.staffDetail(
-          probationArea = ProbationArea(
-            code = "N21",
-            description = randomStringMultiCaseWithNumbers(10),
-          ),
-        ),
-      ) { userEntity, jwt ->
-        givenAnOffender { offenderDetails, inmateDetails ->
-
-          val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
-            withCrn(offenderDetails.otherIds.crn)
-            withCreatedByUser(userEntity)
-          }
-
-          val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
-            withAllocatedToUser(userEntity)
-            withApplication(application)
-          }
-
-          val essentialCriteria = listOf(PlacementCriteria.isArsonSuitable, PlacementCriteria.isESAP)
-          val desirableCriteria =
-            listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
-
-          val placementDates = PlacementDates(
-            expectedArrival = LocalDate.now(),
-            duration = 12,
-          )
-
-          val placementRequirements = PlacementRequirements(
-            type = ApType.normal,
-            location = "SW1",
-            radius = 50,
-            essentialCriteria = essentialCriteria,
-            desirableCriteria = desirableCriteria,
-          )
-
-          webTestClient.post()
-            .uri("/cas1/assessments/${assessment.id}/acceptance")
-            .header("Authorization", "Bearer $jwt")
-            .bodyValue(
-              Cas1AssessmentAcceptance(
-                document = mapOf("document" to "value"),
-                requirements = placementRequirements,
-                placementDates = placementDates,
-              ),
-            )
-            .exchange()
-            .expectStatus()
-            .is4xxClientError
-            .expectBody()
-            .jsonPath("title").isEqualTo("Bad Request")
-            .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
-            .jsonPath("invalid-params[0].propertyName").isEqualTo("\$.postcodeDistrict")
-        }
-      }
-    }
-
-    @Test
     fun `Accept assessment with an outstanding clarification note sets the application status correctly`() {
       givenAUser(
         staffDetail = StaffDetailFactory.staffDetail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/AssessmentServiceTest.kt
@@ -2819,7 +2819,7 @@ class AssessmentServiceTest {
           assessment,
           placementRequirements,
         )
-      } returns CasResult.Success(placementRequirementEntity)
+      } returns placementRequirementEntity
 
       every { cas1AssessmentDomainEventService.assessmentAccepted(any(), any(), any(), any(), any(), any()) } just Runs
 
@@ -2883,7 +2883,7 @@ class AssessmentServiceTest {
           assessment,
           placementRequirements,
         )
-      } returns CasResult.Success(placementRequirementEntity)
+      } returns placementRequirementEntity
 
       every {
         placementRequestServiceMock.createPlacementRequest(
@@ -2963,49 +2963,6 @@ class AssessmentServiceTest {
         verify(exactly = 1) {
           cas1PlacementRequestEmailService.placementRequestSubmitted(assessment.application as ApprovedPremisesApplicationEntity)
         }
-      }
-    }
-
-    @Test
-    fun `CAS1 does not emit Domain Event when failing to create Placement Requirements`() {
-      val assessment = assessmentFactory.produce()
-
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
-
-      every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
-
-      every { assessmentListener.preUpdate(any()) } returns Unit
-      every { assessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as AssessmentEntity }
-
-      every {
-        cas1PlacementRequirementsServiceMock.createPlacementRequirements(
-          assessment,
-          placementRequirements,
-        )
-      } returns CasResult.GeneralValidationError("Couldn't create Placement Requirements")
-
-      every {
-        offenderServiceMock.getPersonSummaryInfoResult(
-          assessment.application.crn,
-          user.cas1LaoStrategy(),
-        )
-      } returns
-        PersonSummaryInfoResult.Success.Full("crn1", CaseSummaryFactory().produce())
-
-      val result = assessmentService.acceptAssessment(
-        user,
-        assessmentId,
-        "{\"test\": \"data\"}",
-        placementRequirements,
-        null,
-        null,
-        null,
-      )
-
-      assertThatCasResult(result).isGeneralValidationError("Couldn't create Placement Requirements")
-
-      verify(exactly = 1) {
-        cas1PlacementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements)
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentServiceTest.kt
@@ -949,7 +949,7 @@ class Cas1AssessmentServiceTest {
           assessment,
           placementRequirements,
         )
-      } returns CasResult.Success(placementRequirementEntity)
+      } returns placementRequirementEntity
 
       every { cas1AssessmentDomainEventService.assessmentAccepted(any(), any(), any(), any(), any(), any()) } just Runs
 
@@ -1013,7 +1013,7 @@ class Cas1AssessmentServiceTest {
           assessment,
           placementRequirements,
         )
-      } returns CasResult.Success(placementRequirementEntity)
+      } returns placementRequirementEntity
 
       every {
         placementRequestServiceMock.createPlacementRequest(
@@ -1103,52 +1103,6 @@ class Cas1AssessmentServiceTest {
         verify(exactly = 1) {
           cas1PlacementRequestEmailService.placementRequestSubmitted(assessment.application as ApprovedPremisesApplicationEntity)
         }
-      }
-    }
-
-    @Test
-    fun `CAS1 does not emit Domain Event when failing to create Placement Requirements`() {
-      val assessment = assessmentFactory.produce()
-
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
-
-      every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
-
-      every { assessmentListener.preUpdate(any()) } returns Unit
-      every { approvedPremisesAssessmentRepositoryMock.save(any()) } answers { it.invocation.args[0] as ApprovedPremisesAssessmentEntity }
-
-      every {
-        cas1PlacementRequirementsServiceMock.createPlacementRequirements(
-          assessment,
-          placementRequirements,
-        )
-      } returns CasResult.GeneralValidationError("Couldn't create Placement Requirements")
-
-      every {
-        offenderServiceMock.getPersonSummaryInfoResult(
-          assessment.application.crn,
-          user.cas1LaoStrategy(),
-        )
-      } returns
-        PersonSummaryInfoResult.Success.Full(
-          "crn1",
-          CaseSummaryFactory().withName(NameFactory().withForename("Gregor").withSurname("Samsa").produce()).produce(),
-        )
-
-      val result = cas1AssessmentService.acceptAssessment(
-        user,
-        assessmentId,
-        "{\"test\": \"data\"}",
-        placementRequirements,
-        null,
-        null,
-        null,
-      )
-
-      assertThatCasResult(result).isGeneralValidationError("Couldn't create Placement Requirements")
-
-      verify(exactly = 1) {
-        cas1PlacementRequirementsServiceMock.createPlacementRequirements(assessment, placementRequirements)
       }
     }
   }


### PR DESCRIPTION
Before this commit the `createPlacementRequirements` function would return a `CasResult`, allowing for an error to be returned if the postcode isn’t recognised.

Given that this postcode is verified earlier in the process during creation of the original application, and cannot be modified after this, it’s fine to return an exception in this case (i.e. this should never happen). Futhermore, there’s nothing the user can do in response to this error because the postcode is locked in. They’d have to contact support anyway.

 This allows us to simplify the response type from `createPlacementRequirements`