### PR TITLE
Feature/cas 1573 get void bedspaces

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3VoidBedspace.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3VoidBedspace.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonValue
+import java.time.LocalDate
+import java.util.UUID
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Cas3VoidBedspace(
+  val id: UUID,
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+  val bedspaceId: UUID,
+  val bedspaceName: String,
+  val reason: Cas3VoidBedspaceReason,
+  val status: Cas3VoidBedspaceStatus,
+  val referenceNumber: String?,
+  val notes: String?,
+  val cancellationDate: LocalDate?,
+  val cancellationNotes: String?,
+)
+
+data class Cas3VoidBedspaceReason(
+  val id: UUID,
+  val name: String,
+  val isActive: Boolean,
+)
+
+enum class Cas3VoidBedspaceStatus(@JsonValue val value: String) {
+  ACTIVE("active"),
+  CANCELLED("cancelled"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3v2VoidBedspaceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3v2VoidBedspaceService.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspacesRepository
+import java.util.UUID
+
+@Service
+class Cas3v2VoidBedspaceService(
+  private val cas3VoidBedspacesRepository: Cas3VoidBedspacesRepository,
+) {
+  fun findVoidBedspaces(premisesId: UUID): List<Cas3VoidBedspaceEntity> = cas3VoidBedspacesRepository.findActiveVoidBedspacesByPremisesId(premisesId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas3/Cas3VoidBedspaceEntity.kt
@@ -66,6 +66,12 @@ interface Cas3VoidBedspacesRepository : JpaRepository<Cas3VoidBedspaceEntity, UU
 
   @Query("SELECT lb FROM Cas3VoidBedspaceEntity lb LEFT JOIN lb.cancellation c WHERE lb.premises.id = :premisesId AND c is NULL")
   fun findAllActiveForPremisesId(premisesId: UUID): List<Cas3VoidBedspaceEntity>
+
+  @Query(
+    "select vb from Cas3VoidBedspaceEntity vb where vb.bedspace.premises.id = :premisesId " +
+      "and vb.cancellationDate is null",
+  )
+  fun findActiveVoidBedspacesByPremisesId(premisesId: UUID): List<Cas3VoidBedspaceEntity>
 }
 
 @SuppressWarnings("LongParameterList")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -102,8 +102,10 @@ class UserAccessService(
     else -> false
   }
 
+  @Deprecated("Use CAS3UserAccessService.canViewVoidBedspaces")
   fun currentUserCanManagePremisesVoidBedspaces(premises: PremisesEntity) = userCanManagePremisesVoidBedspaces(userService.getUserForRequest(), premises)
 
+  @Deprecated("Use CAS3UserAccessService.canViewVoidBedspaces")
   fun userCanManagePremisesVoidBedspaces(user: UserEntity, premises: PremisesEntity) = when (premises) {
     is TemporaryAccommodationPremisesEntity -> userCanAccessRegion(user, ServiceName.temporaryAccommodation, premises.probationRegion.id) && user.hasRole(UserRole.CAS3_ASSESSOR)
     else -> false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3UserAccessService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import java.util.UUID
+
+@Service
+class Cas3UserAccessService(
+  private val userService: UserService,
+) {
+  fun canViewVoidBedspaces(probationRegionId: UUID): Boolean {
+    val user = userService.getUserForRequest()
+    return user.hasRole(UserRole.CAS3_ASSESSOR) && userCanAccessRegion(user, probationRegionId)
+  }
+
+  fun userCanAccessRegion(user: UserEntity, probationRegionId: UUID) = (user.probationRegion.id == probationRegionId || user.hasRole(UserRole.CAS3_REPORTER))
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3VoidBedspaceReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3VoidBedspaceReasonTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3VoidBedspaceReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceReasonEntity
 
 @Component
@@ -12,5 +13,11 @@ class Cas3VoidBedspaceReasonTransformer {
     name = jpa.name,
     isActive = jpa.isActive,
     serviceScope = ServiceName.temporaryAccommodation.value,
+  )
+
+  fun toCas3VoidBedspaceReason(entity: Cas3VoidBedspaceReasonEntity) = Cas3VoidBedspaceReason(
+    id = entity.id,
+    name = entity.name,
+    isActive = entity.isActive,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3VoidBedspacesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas3/Cas3VoidBedspacesTransformer.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LostBedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3VoidBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3VoidBedspaceStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
 
 @Component
@@ -28,4 +30,18 @@ class Cas3VoidBedspacesTransformer(
     jpa.cancellation != null -> LostBedStatus.cancelled
     else -> LostBedStatus.active
   }
+
+  fun toCas3VoidBedspace(entity: Cas3VoidBedspaceEntity): Cas3VoidBedspace = Cas3VoidBedspace(
+    id = entity.id,
+    startDate = entity.startDate,
+    endDate = entity.endDate,
+    reason = cas3VoidBedspaceReasonTransformer.toCas3VoidBedspaceReason(entity.reason),
+    referenceNumber = entity.referenceNumber,
+    notes = entity.notes,
+    bedspaceId = entity.bedspace!!.id,
+    bedspaceName = entity.bedspace!!.reference,
+    cancellationDate = entity.cancellationDate?.toLocalDate(),
+    cancellationNotes = entity.cancellationNotes,
+    status = if (entity.cancellationDate == null) Cas3VoidBedspaceStatus.ACTIVE else Cas3VoidBedspaceStatus.CANCELLED,
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationDeliveryUnitEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ProbationDeliveryUnitEntityFactory.kt
@@ -11,7 +11,7 @@ class ProbationDeliveryUnitEntityFactory : Factory<ProbationDeliveryUnitEntity> 
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var deliusCode: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
-  private var probationRegion: Yielded<ProbationRegionEntity>? = null
+  private var probationRegion: Yielded<ProbationRegionEntity> = { ProbationRegionEntityFactory().produce() }
 
   fun withDefaults() = apply {
     this.probationRegion = { ProbationRegionEntityFactory().withDefaults().produce() }
@@ -41,6 +41,6 @@ class ProbationDeliveryUnitEntityFactory : Factory<ProbationDeliveryUnitEntity> 
     id = this.id(),
     name = this.name(),
     deliusCode = this.deliusCode(),
-    probationRegion = this.probationRegion?.invoke() ?: throw RuntimeException("Must provide a Probation Region"),
+    probationRegion = this.probationRegion.invoke(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3BedspaceEntityFactory.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var premises: Yielded<Cas3PremisesEntity>? = null
+  private var premises: Yielded<Cas3PremisesEntity> = { Cas3PremisesEntityFactory().produce() }
   private var characteristics: Yielded<MutableList<Cas3BedspaceCharacteristicEntity>> = { mutableListOf() }
   private var reference: Yielded<String> = { randomStringUpperCase(6) }
   private var notes: Yielded<String?> = { null }
@@ -54,7 +54,7 @@ class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
   @SuppressWarnings("TooGenericExceptionThrown")
   override fun produce(): Cas3BedspacesEntity = Cas3BedspacesEntity(
     id = this.id(),
-    premises = this.premises?.invoke() ?: throw RuntimeException("Must provide a Premises"),
+    premises = this.premises.invoke(),
     characteristics = this.characteristics(),
     reference = this.reference(),
     notes = this.notes(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3PremisesEntityFactory.kt
@@ -17,8 +17,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCa
 import java.util.UUID
 
 class Cas3PremisesEntityFactory : Factory<Cas3PremisesEntity> {
-  private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity>? = null
-  private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>? = null
+  private var localAuthorityArea: Yielded<LocalAuthorityAreaEntity> = { LocalAuthorityEntityFactory().produce() }
+  private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity>? =
+    { ProbationDeliveryUnitEntityFactory().produce() }
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var postcode: Yielded<String> = { randomPostCode() }
@@ -92,13 +93,11 @@ class Cas3PremisesEntityFactory : Factory<Cas3PremisesEntity> {
     this.status = { status }
   }
 
-  @SuppressWarnings("TooGenericExceptionThrown")
   override fun produce(): Cas3PremisesEntity = Cas3PremisesEntity(
     id = this.id(),
     name = this.name(),
     postcode = this.postcode(),
-    localAuthorityArea = this.localAuthorityArea?.invoke()
-      ?: throw RuntimeException("Must provide a local authority area"),
+    localAuthorityArea = this.localAuthorityArea.invoke(),
     bookings = mutableListOf(),
     addressLine1 = this.addressLine1(),
     addressLine2 = this.addressLine2(),
@@ -106,8 +105,7 @@ class Cas3PremisesEntityFactory : Factory<Cas3PremisesEntity> {
     notes = this.notes(),
     characteristics = this.characteristics(),
     status = this.status(),
-    probationDeliveryUnit = this.probationDeliveryUnit?.invoke()
-      ?: throw RuntimeException("Must provide a probation delivery unit"),
+    probationDeliveryUnit = this.probationDeliveryUnit!!.invoke(),
     bedspaces = this.bedspaces(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/cas3/Cas3VoidBedspaceEntityFactory.kt
@@ -61,14 +61,6 @@ class Cas3VoidBedspaceEntityFactory : Factory<Cas3VoidBedspaceEntity> {
     this.premises = { premises }
   }
 
-  fun withYieldedVoidBedspaceCancellation(voidBedspaceCancellation: Yielded<Cas3VoidBedspaceCancellationEntity>) = apply {
-    this.voidBedspaceCancellation = voidBedspaceCancellation
-  }
-
-  fun withVoidBedspaceCancellation(voidBedspaceCancellation: Cas3VoidBedspaceCancellationEntity) = apply {
-    this.voidBedspaceCancellation = { voidBedspaceCancellation }
-  }
-
   fun withBed(bed: BedEntity) = apply {
     this.bed = { bed }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/v2/Cas3v2VoidBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/v2/Cas3v2VoidBedspaceTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas3.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3VoidBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.Cas3IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas3Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3VoidBedspaceEntity
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3v2VoidBedspaceTest : Cas3IntegrationTestBase() {
+
+  @Nested
+  inner class GetVoidBedspaces {
+
+    @Test
+    fun `user without CAS_ASSESSOR role is forbidden`() {
+      givenAUser(roles = listOf(UserRole.CAS3_REFERRER)) { user, jwt ->
+        val premises = givenACas3Premises(user.probationRegion)
+        doGetRequest(jwt, premises.id)
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @Test
+    fun `get void bedspaces returns successfully`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = givenACas3Premises(user.probationRegion)
+        val voidBedspaces = createVoidBedspaces(premises)
+        val cancelledVoidBedspaces = createCancelledVoidBedspaces(premises)
+
+        val result = doGetRequest(jwt, premises.id)
+          .expectStatus()
+          .isOk
+          .expectBodyList(Cas3VoidBedspace::class.java)
+          .returnResult()
+          .responseBody!!
+
+        assertAll({
+          assertThat(result).hasSize(3)
+          assertThat(result.map { it.id }).containsExactlyInAnyOrderElementsOf(voidBedspaces.map { it.id })
+          assertThat(result.map { it.id }).doesNotContainAnyElementsOf(cancelledVoidBedspaces.map { it.id })
+        })
+      }
+    }
+
+    fun doGetRequest(jwt: String, premisesId: UUID) = webTestClient.get()
+      .uri("/cas3/v2/premises/$premisesId/void-bedspaces")
+      .header("Authorization", "Bearer $jwt")
+      .header("X-Service-Name", "temporary-accommodation")
+      .exchange()
+
+    fun createVoidBedspaces(premises: Cas3PremisesEntity): List<Cas3VoidBedspaceEntity> {
+      val bedspaces = cas3BedspaceEntityFactory.produceAndPersistMultiple(5) {
+        withPremises(premises)
+      }
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
+      val voidBedspace1 = cas3VoidBedspaceEntityFactory.produceAndPersist {
+        withBedspace(bedspaces.get(0))
+        withYieldedReason { reason }
+      }
+      val voidBedspace2 = cas3VoidBedspaceEntityFactory.produceAndPersist {
+        withBedspace(bedspaces.get(3))
+        withYieldedReason { reason }
+      }
+      val voidBedspace3 = cas3VoidBedspaceEntityFactory.produceAndPersist {
+        withBedspace(bedspaces.get(4))
+        withYieldedReason { reason }
+      }
+
+      return listOf(voidBedspace1, voidBedspace2, voidBedspace3)
+    }
+
+    fun createCancelledVoidBedspaces(premises: Cas3PremisesEntity): List<Cas3VoidBedspaceEntity> {
+      val bedspaces = cas3BedspaceEntityFactory.produceAndPersistMultiple(2) {
+        withPremises(premises)
+      }
+
+      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
+      val voidBedspace1 = cas3VoidBedspaceEntityFactory.produceAndPersist {
+        withBedspace(bedspaces.get(0))
+        withYieldedReason { reason }
+        withCancellationDate(OffsetDateTime.now())
+      }
+
+      val voidBedspace2 = cas3VoidBedspaceEntityFactory.produceAndPersist {
+        withBedspace(bedspaces.get(1))
+        withYieldedReason { reason }
+        withCancellationDate(OffsetDateTime.now())
+        withCancellationNotes("Cancelled")
+      }
+
+      return listOf(voidBedspace1, voidBedspace2)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas3Premises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas3Premises.kt
@@ -4,12 +4,19 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesCharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas3.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.util.UUID
+
+fun IntegrationTestBase.givenACas3Premises(probationRegion: ProbationRegionEntity) = givenACas3Premises(
+  probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+    withProbationRegion(probationRegion)
+  },
+)
 
 fun IntegrationTestBase.givenACas3Premises(
   name: String = randomStringMultiCaseWithNumbers(8),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -35,6 +35,10 @@ fun IntegrationTestBase.givenAUser(
   }
   val apArea = resolvedProbationRegion.apArea!!
 
+  val pdu = probationDeliveryUnitFactory.produceAndPersist {
+    withProbationRegion(resolvedProbationRegion)
+  }
+
   val user = userEntityFactory.produceAndPersist {
     withId(id)
     withDeliusUsername(staffDetail.username)
@@ -47,6 +51,7 @@ fun IntegrationTestBase.givenAUser(
     withYieldedApArea { apArea }
     withCruManagementArea(cruManagementArea ?: apArea.defaultCruManagementArea)
     withCruManagementAreaOverride(cruManagementAreaOverride)
+    withProbationDeliveryUnit { pdu }
   }
 
   roles.forEach { role ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3UserAccessServiceTest.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas3
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3.Cas3UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.addRoleForUnitTest
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas3UserAccessServiceTest {
+
+  @MockK
+  lateinit var userService: UserService
+
+  @InjectMockKs
+  lateinit var cas3UserAccessService: Cas3UserAccessService
+
+  @BeforeEach
+  fun setup() {
+    user = UserEntityFactory()
+      .withProbationRegion(probationRegion)
+      .withRoleEnums(mutableListOf())
+      .produce()
+
+    every { userService.getUserForRequest() } returns user
+  }
+
+  private val probationRegionId = UUID.randomUUID()
+  private val probationRegion = ProbationRegionEntityFactory()
+    .withId(probationRegionId)
+    .withApArea(ApAreaEntityFactory().produce())
+    .produce()
+
+  lateinit var user: UserEntity
+
+  @Nested
+  inner class UserCanViewVoidBedspaces {
+    @Test
+    fun `User can view Void Bedspaces when in probation region and has CAS3_ASSESSOR role`() {
+      user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+      assertThat(cas3UserAccessService.canViewVoidBedspaces(probationRegionId = probationRegionId)).isTrue
+    }
+
+    @Test
+    fun `User cannot view Void Bedspaces when not in correct probation region`() {
+      user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+      assertThat(cas3UserAccessService.canViewVoidBedspaces(probationRegionId = UUID.randomUUID())).isFalse
+    }
+
+    @Test
+    fun `User can view void bedspaces if not in same region but has CAS3_REPORTER and CAS3_ASSESSOR roles`() {
+      user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+      user.addRoleForUnitTest(UserRole.CAS3_REPORTER)
+      assertThat(cas3UserAccessService.canViewVoidBedspaces(probationRegionId = UUID.randomUUID())).isTrue
+    }
+
+    @Test
+    fun `User cannot view Void Bedspaces without CAS3_ASSESSOR role`() {
+      assertThat(cas3UserAccessService.canViewVoidBedspaces(probationRegionId = probationRegionId)).isFalse
+    }
+  }
+
+  @Nested
+  inner class UserCanAccessRegion {
+    @Test
+    fun `User can access reqion when in same region`() {
+      assertThat(cas3UserAccessService.userCanAccessRegion(user, probationRegionId)).isTrue
+    }
+
+    @Test
+    fun `User can access reqion when they have CAS3_REPORTER role`() {
+      user.addRoleForUnitTest(UserRole.CAS3_REPORTER)
+      assertThat(cas3UserAccessService.userCanAccessRegion(user, UUID.randomUUID())).isTrue
+    }
+
+    @Test
+    fun `User cannot access reqion when they do not have CAS3_REPORTER or in different region`() {
+      assertThat(cas3UserAccessService.userCanAccessRegion(user, UUID.randomUUID())).isFalse
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3VoidBedspacesReasonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas3/Cas3VoidBedspacesReasonTransformerTest.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas3
+
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas3.Cas3VoidBedspaceReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas3.Cas3VoidBedspaceReasonTransformer
+
+@ExtendWith(MockKExtension::class)
+class Cas3VoidBedspacesReasonTransformerTest {
+
+  private val cas3VoidBedspacesReasonTransformer: Cas3VoidBedspaceReasonTransformer =
+    Cas3VoidBedspaceReasonTransformer()
+
+  @Test
+  fun `void bedspace reason is correctly transformed`() {
+    val voidBedspaceReason =
+      Cas3VoidBedspaceReasonEntityFactory()
+        .withName("test name")
+        .withIsActive(true)
+        .produce()
+
+    val transformed = cas3VoidBedspacesReasonTransformer.toCas3VoidBedspaceReason(voidBedspaceReason)
+    assertAll(
+      {
+        assertThat(transformed.id).isEqualTo(voidBedspaceReason.id)
+        assertThat(transformed.name).isEqualTo("test name")
+        assertThat(transformed.isActive).isTrue
+      },
+    )
+  }
+}


### PR DESCRIPTION
PR to add the v2 void bedspaces endpoint `cas3/v2/{premisesId}/void-bedspaces`. Functionality was based on the existing `premises/${premises.id}/lost-beds")` endpoint.

It also adds a cas3 user access controller and begins moving cas3 specific functions out.

[https://dsdmoj.atlassian.net/browse/CAS-1573](url)
