### PR TITLE
Use /cas1/assessments endpoints in reports tests and improve coverage

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationDomainEventService.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DomainEventTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.Clock
 import java.time.Instant
 import java.util.UUID
 
@@ -33,6 +34,7 @@ class Cas1PlacementApplicationDomainEventService(
   private val domainEventTransformer: DomainEventTransformer,
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
   @Value("\${url-templates.frontend.application}") private val applicationUrlTemplate: UrlTemplate,
+  val clock: Clock,
 ) {
 
   fun placementApplicationSubmitted(
@@ -96,7 +98,7 @@ class Cas1PlacementApplicationDomainEventService(
     val user = withdrawalContext.withdrawalTriggeredBy.user
 
     val domainEventId = UUID.randomUUID()
-    val eventOccurredAt = Instant.now()
+    val eventOccurredAt = Instant.now(clock)
     val application = placementApplication.application
 
     val eventDetails = PlacementApplicationWithdrawn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitPlacemen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatePlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
@@ -217,6 +218,22 @@ class Cas1SimpleApiClient {
     integrationTestBase.webTestClient.put()
       .uri("/cas1/placement-applications/$placementApplicationId")
       .header("Authorization", "Bearer $creatorJwt")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  fun placementApplicationWithdraw(
+    integrationTestBase: IntegrationTestBase,
+    placementApplicationId: UUID,
+    body: WithdrawPlacementApplication,
+  ) {
+    val managerJwt = integrationTestBase.givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER)).second
+
+    integrationTestBase.webTestClient.post()
+      .uri("/cas1/placement-applications/$placementApplicationId/withdraw")
+      .header("Authorization", "Bearer $managerJwt")
       .bodyValue(body)
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
@@ -88,7 +88,7 @@ class Cas1SimpleApiClient {
     body: UpdateAssessment,
   ) {
     integrationTestBase.webTestClient.put()
-      .uri("/assessments/$assessmentId")
+      .uri("/cas1/assessments/$assessmentId")
       .header("Authorization", "Bearer $assessorJwt")
       .bodyValue(body)
       .exchange()
@@ -103,7 +103,7 @@ class Cas1SimpleApiClient {
     body: AssessmentAcceptance,
   ) {
     integrationTestBase.webTestClient.post()
-      .uri("/assessments/$assessmentId/acceptance")
+      .uri("/cas1/assessments/$assessmentId/acceptance")
       .header("Authorization", "Bearer $assessorJwt")
       .bodyValue(body)
       .exchange()
@@ -118,7 +118,7 @@ class Cas1SimpleApiClient {
     body: AssessmentRejection,
   ) {
     integrationTestBase.webTestClient.post()
-      .uri("/assessments/$assessmentId/rejection")
+      .uri("/cas1/assessments/$assessmentId/rejection")
       .header("Authorization", "Bearer $assessorJwt")
       .bodyValue(body)
       .exchange()
@@ -153,7 +153,7 @@ class Cas1SimpleApiClient {
     assessorJwt: String,
     body: NewClarificationNote,
   ): ClarificationNote = integrationTestBase.webTestClient.post()
-    .uri("/assessments/$assessmentId/notes")
+    .uri("/cas1/assessments/$assessmentId/notes")
     .header("Authorization", "Bearer $assessorJwt")
     .bodyValue(body)
     .exchange()
@@ -171,7 +171,7 @@ class Cas1SimpleApiClient {
     body: UpdatedClarificationNote,
   ) {
     integrationTestBase.webTestClient.put()
-      .uri("/assessments/$assessmentId/notes/$noteId")
+      .uri("/cas1/assessments/$assessmentId/notes/$noteId")
       .header("Authorization", "Bearer $assessorJwt")
       .bodyValue(body)
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationCas1DomainEventServiceTest.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1Pl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1PlacementApplicationCas1DomainEventServiceTest.TestConstants.USERNAME
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
+import java.time.Clock
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecision as ApiDecision
@@ -58,6 +59,7 @@ class Cas1PlacementApplicationCas1DomainEventServiceTest {
     domainEventTransformer,
     apDeliusContextApiClient,
     applicationUrlTemplate = UrlTemplate("http://frontend/applications/#id"),
+    Clock.systemDefaultZone(),
   )
 
   val user = UserEntityFactory()


### PR DESCRIPTION
/assessments is deprecated for CAS1, and the /cas1 versions should be used instead

This also adds some additional coverage to the reports tests

