### PR TITLE
Add characteristics to `Cas1Premises`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1Premises.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1Premises.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1PremisesLocalRestrictionSummary
 
@@ -21,45 +20,44 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1Prem
  */
 data class Cas1Premises(
 
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
+  val id: java.util.UUID,
 
-  @Schema(example = "Hope House", required = true, description = "")
-  @get:JsonProperty("name", required = true) val name: kotlin.String,
+  @Schema(example = "Hope House")
+  val name: kotlin.String,
 
-  @Schema(example = "NEHOPE1", required = true, description = "")
-  @get:JsonProperty("apCode", required = true) val apCode: kotlin.String,
+  @Schema(example = "NEHOPE1")
+  val apCode: kotlin.String,
 
-  @Schema(example = "null", required = true, description = "Full address, excluding postcode")
-  @get:JsonProperty("fullAddress", required = true) val fullAddress: kotlin.String,
+  @Schema(description = "Full address, excluding postcode")
+  val fullAddress: kotlin.String,
 
-  @Schema(example = "LS1 3AD", required = true, description = "")
-  @get:JsonProperty("postcode", required = true) val postcode: kotlin.String,
+  @Schema(example = "LS1 3AD")
+  val postcode: kotlin.String,
 
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("apArea", required = true) val apArea: ApArea,
+  val apArea: ApArea,
 
-  @Schema(example = "22", required = true, description = "The total number of beds in this premises")
-  @get:JsonProperty("bedCount", required = true) val bedCount: kotlin.Int,
+  @Schema(example = "22", description = "The total number of beds in this premises")
+  val bedCount: kotlin.Int,
 
-  @Schema(example = "20", required = true, description = "The total number of beds available at this moment in time")
-  @get:JsonProperty("availableBeds", required = true) val availableBeds: kotlin.Int,
+  @Schema(example = "20", description = "The total number of beds available at this moment in time")
+  val availableBeds: kotlin.Int,
 
-  @Schema(example = "2", required = true, description = "The total number of out of service beds at this moment in time")
-  @get:JsonProperty("outOfServiceBeds", required = true) val outOfServiceBeds: kotlin.Int,
+  @Schema(example = "2", description = "The total number of out of service beds at this moment in time")
+  val outOfServiceBeds: kotlin.Int,
 
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("supportsSpaceBookings", required = true) val supportsSpaceBookings: kotlin.Boolean,
+  val supportsSpaceBookings: kotlin.Boolean,
 
-  @Schema(example = "null", required = true, description = "over-bookings for the next 12 weeks")
-  @get:JsonProperty("overbookingSummary", required = true) val overbookingSummary: kotlin.collections.List<Cas1OverbookingRange>,
+  @Schema(description = "over-bookings for the next 12 weeks")
+  val overbookingSummary: kotlin.collections.List<Cas1OverbookingRange>,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("managerDetails") val managerDetails: kotlin.String? = null,
+  val managerDetails: kotlin.String? = null,
 
   @Schema(
     example = "No hate based offences",
     description = "A list of restrictions that apply specifically to this approved premises.",
   )
   val localRestrictions: List<Cas1PremisesLocalRestrictionSummary>? = emptyList(),
+
+  @Schema(description = "Room and premise characteristics")
+  val characteristics: List<Cas1SpaceCharacteristic>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PremisesService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Overbookin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1PremisesLocalRestrictionSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesGender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesJdbcRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1BedsRepository
@@ -31,6 +32,7 @@ import java.util.UUID
 @Service
 class Cas1PremisesService(
   val premisesRepository: ApprovedPremisesRepository,
+  val premisesJdbcRepository: ApprovedPremisesJdbcRepository,
   val bedRepository: BedRepository,
   val premisesService: PremisesService,
   val outOfServiceBedService: Cas1OutOfServiceBedService,
@@ -78,6 +80,7 @@ class Cas1PremisesService(
           createdAt = restriction.createdAt.toLocalDate(),
         )
       }
+    val characteristicPropertyNames = premisesJdbcRepository.findAllCharacteristicPropertyNames(premisesId)
 
     val overbookingSummary = if (!featureFlagService.getBooleanFlag("cas1-disable-overbooking-summary")) {
       premise.takeIf { it.supportsSpaceBookings }?.let { buildOverBookingSummary(it) } ?: emptyList()
@@ -93,6 +96,7 @@ class Cas1PremisesService(
         outOfServiceBeds = outOfServiceBedsCount,
         overbookingSummary = overbookingSummary,
         localRestrictions = localRestrictions,
+        characteristicPropertyNames = characteristicPropertyNames,
       ),
     )
   }
@@ -213,5 +217,6 @@ class Cas1PremisesService(
     val outOfServiceBeds: Int,
     val overbookingSummary: List<Cas1OverbookingRange>,
     val localRestrictions: List<Cas1PremisesLocalRestrictionSummary> = emptyList(),
+    val characteristicPropertyNames: List<String>,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PremisesTransformer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PremisesBasicSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesBasicSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
@@ -29,6 +30,7 @@ class Cas1PremisesTransformer(
       managerDetails = entity.managerDetails,
       overbookingSummary = premisesSummaryInfo.overbookingSummary,
       localRestrictions = premisesSummaryInfo.localRestrictions,
+      characteristics = premisesSummaryInfo.characteristicPropertyNames.map { Cas1SpaceCharacteristic.valueOf(it) },
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesEntityFactory.kt
@@ -126,8 +126,8 @@ class ApprovedPremisesEntityFactory : Factory<ApprovedPremisesEntity> {
     this.qCode = { qCode }
   }
 
-  fun withCharacteristics(characteristics: MutableList<CharacteristicEntity>) = apply {
-    this.characteristics = { characteristics }
+  fun withCharacteristics(characteristics: List<CharacteristicEntity>) = apply {
+    this.characteristics = { characteristics.toMutableList() }
   }
 
   fun withCharacteristicsList(characteristics: List<CharacteristicEntity>) = withCharacteristics(characteristics.toMutableList())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
@@ -48,8 +48,8 @@ class RoomEntityFactory : Factory<RoomEntity> {
     this.premises = premises
   }
 
-  fun withCharacteristics(characteristics: MutableList<CharacteristicEntity>) = apply {
-    this.characteristics = { characteristics }
+  fun withCharacteristics(characteristics: List<CharacteristicEntity>) = apply {
+    this.characteristics = { characteristics.toMutableList() }
   }
 
   fun withCharacteristics(vararg characteristics: CharacteristicEntity) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -43,6 +43,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremisesBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremisesRoom
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOutOfServiceBed
@@ -82,7 +83,7 @@ import java.util.UUID
 class Cas1PremisesTest : IntegrationTestBase() {
 
   @Nested
-  inner class GetPremisesSummary : InitialiseDatabasePerClassTestBase() {
+  inner class GetPremises : InitialiseDatabasePerClassTestBase() {
 
     lateinit var premises: ApprovedPremisesEntity
     lateinit var offender: CaseSummary
@@ -104,6 +105,17 @@ class Cas1PremisesTest : IntegrationTestBase() {
           apArea = givenAnApArea(name = "The ap area name"),
         ),
         managerDetails = "manager details",
+        characteristics = listOf(characteristicRepository.findCas1ByPropertyName("isSuitableForVulnerable")!!),
+      )
+
+      givenAnApprovedPremisesRoom(
+        premises,
+        characteristics = listOf(characteristicRepository.findCas1ByPropertyName("hasEnSuite")!!),
+      )
+
+      givenAnApprovedPremisesRoom(
+        premises,
+        characteristics = listOf(characteristicRepository.findCas1ByPropertyName("isArsonSuitable")!!),
       )
     }
 
@@ -133,7 +145,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
 
     @SuppressWarnings("UnusedPrivateProperty")
     @Test
-    fun `Returns premises summary`() {
+    fun `Returns premises`() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
 
       repeat((1..10).count()) {
@@ -230,6 +242,11 @@ class Cas1PremisesTest : IntegrationTestBase() {
       assertThat(summary.localRestrictions).containsExactly(
         Cas1PremisesLocalRestrictionSummary(restriction2.id, restriction2.description, restriction2.createdAt.toLocalDate()),
         Cas1PremisesLocalRestrictionSummary(restriction1.id, restriction1.description, restriction1.createdAt.toLocalDate()),
+      )
+      assertThat(summary.characteristics).containsExactlyInAnyOrder(
+        Cas1SpaceCharacteristic.isArsonSuitable,
+        Cas1SpaceCharacteristic.hasEnSuite,
+        Cas1SpaceCharacteristic.isSuitableForVulnerable,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenARoom.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenARoom.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 
@@ -10,6 +11,7 @@ fun IntegrationTestBase.givenAnApprovedPremisesRoom(
   code: String = randomStringMultiCaseWithNumbers(6),
   name: String = randomStringMultiCaseWithNumbers(8),
   bedCount: Int = 0,
+  characteristics: List<CharacteristicEntity> = emptyList(),
 ): RoomEntity {
   val resolvedPremises = premises ?: approvedPremisesEntityFactory.produceAndPersist {
     withProbationRegion(givenAProbationRegion())
@@ -20,6 +22,7 @@ fun IntegrationTestBase.givenAnApprovedPremisesRoom(
     withPremises(resolvedPremises)
     withCode(code)
     withName(name)
+    withCharacteristics(characteristics)
   }
 
   repeat(bedCount) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PremisesServiceTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Overbookin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1PremisesLocalRestrictionSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesJdbcRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1BedsRepository
@@ -76,6 +77,9 @@ class Cas1PremisesServiceTest {
 
   @MockK
   lateinit var clock: Clock
+
+  @MockK
+  lateinit var premisesJdbcRepository: ApprovedPremisesJdbcRepository
 
   @InjectMockKs
   lateinit var service: Cas1PremisesService
@@ -139,6 +143,7 @@ class Cas1PremisesServiceTest {
       every { spacePlanningService.capacity(PREMISES_ID, any(), null) } returns premisesCapacitySummary
       every { spaceBookingRepository.countActiveSpaceBookings(PREMISES_ID) } returns 4
       every { cas1PremisesLocalRestrictionRepository.findAllByApprovedPremisesIdAndArchivedFalseOrderByCreatedAtDesc(PREMISES_ID) } returns listOf(restriction1, restriction2)
+      every { premisesJdbcRepository.findAllCharacteristicPropertyNames(PREMISES_ID) } returns listOf("char1", "char2")
 
       val result = service.getPremisesInfo(PREMISES_ID)
 
@@ -155,6 +160,7 @@ class Cas1PremisesServiceTest {
             Cas1PremisesLocalRestrictionSummary(restriction2.id, restriction2.description, restriction2.createdAt.toLocalDate()),
           ),
         )
+        assertThat(premisesSummaryInfo.characteristicPropertyNames).containsExactly("char1", "char2")
       }
     }
 
@@ -184,6 +190,7 @@ class Cas1PremisesServiceTest {
       every { spacePlanningService.capacity(PREMISES_ID, any(), null) } returns premisesCapacitySummary
       every { spaceBookingRepository.countActiveSpaceBookings(PREMISES_ID) } returns 5
       every { cas1PremisesLocalRestrictionRepository.findAllByApprovedPremisesIdAndArchivedFalseOrderByCreatedAtDesc(PREMISES_ID) } returns emptyList()
+      every { premisesJdbcRepository.findAllCharacteristicPropertyNames(PREMISES_ID) } returns emptyList()
 
       val result = service.getPremisesInfo(PREMISES_ID)
 
@@ -227,6 +234,7 @@ class Cas1PremisesServiceTest {
       every { premisesService.getBedCount(premises) } returns 56
       every { outOfServiceBedService.getCurrentOutOfServiceBedsCountForPremisesId(PREMISES_ID) } returns 4
       every { cas1PremisesLocalRestrictionRepository.findAllByApprovedPremisesIdAndArchivedFalseOrderByCreatedAtDesc(PREMISES_ID) } returns emptyList()
+      every { premisesJdbcRepository.findAllCharacteristicPropertyNames(PREMISES_ID) } returns emptyList()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesTransformerTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1PremisesLocalRestrictionSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
@@ -71,6 +72,7 @@ class Cas1PremisesTransformerTest {
           outOfServiceBeds = 2,
           availableBeds = 8,
           overbookingSummary = emptyList(),
+          characteristicPropertyNames = listOf("hasBrailleSignage", "hasCrib7Bedding"),
           localRestrictions = listOf(
             restriction2,
             restriction1,
@@ -90,7 +92,8 @@ class Cas1PremisesTransformerTest {
       assertThat(result.supportsSpaceBookings).isTrue()
       assertThat(result.managerDetails).isEqualTo("manager details")
       assertThat(result.overbookingSummary).isEmpty()
-      assertThat(result.localRestrictions).isEqualTo(listOf(restriction2, restriction1))
+      assertThat(result.localRestrictions).containsExactly(restriction2, restriction1)
+      assertThat(result.characteristics).containsExactlyInAnyOrder(Cas1SpaceCharacteristic.hasBrailleSignage, Cas1SpaceCharacteristic.hasCrib7Bedding)
     }
   }
 


### PR DESCRIPTION
We have quite a few queries/lazy loading being ran to populate `Cas1Premises`. We should monitor performance and consider flattening some of it down into a single query (similar to queries used for premises search)