### PR TITLE
APS-2586 - Remove reallocated_placement_requests

### DIFF
--- a/src/main/resources/db/migration/all/20250724162522__remove_reallocated_placement_requests.sql
+++ b/src/main/resources/db/migration/all/20250724162522__remove_reallocated_placement_requests.sql
@@ -1,0 +1,9 @@
+DELETE from booking_not_mades where id IN (
+    select
+        bnm.id
+    from booking_not_mades bnm
+    inner join placement_requests pr on pr.id = bnm.placement_request_id
+    where pr.reallocated_at is not null
+);
+
+DELETE from placement_requests where reallocated_at is not null;


### PR DESCRIPTION
Clsoing this. Agreed with Dan that we'll create a migration job to redirect the booking not mades to the final placement request, then no need to remove the reallocated at placement requests

For a short period of time placement_requests were assigned to users to complete, much like assessments. Whenever a `placement_requests` entry was reallocated a complete copy of the row was taking, setting the existing row’s `reallocated_at` value to the current timestamp which is effectively a soft delete.

This functionality has not been used for over 18 months, leaving our data model polluted with unused columns and rows that are soft deleted and never retrieved by the code. This makes it difficult when trying to ‘fix’ cardinality (e.g. making placement applications to placement requests a one to one relationship instead of the current one to many)

There are 450 reallocated placements_requests that are effectively soft deleted/archived:

```
select count(*) from placement_requests where reallocated_at is not null;
-- success --
count
-----
  450
```

This commit removes all of these reallocated entries, leaving only entries in placement_requests where realloacted_at is null

This also requires us to remove some linked `booking_not_made` entries, of which there are 33

```
select count(*)
from placement_requests pr
left outer join booking_not_mades b on b.placement_request_id = pr.id
where
reallocated_at is not null AND
b.id IS NOT NULL;
-- success --
count
-----
   31
```

