### PR TITLE
APS-2583 Remove bookings from WithdrawalTest

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -327,9 +327,6 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
   )
   fun hasNonCancelledTransfer(spaceBookingId: UUID): Boolean
 
-  @Query
-  fun existsByDeliusId(deliusId: String): Boolean
-
   /*
   Checking cancellationRecordedAt shouldn't be required, because an arrived
   booking can't be cancelled. Unfortunately, there are some historical bookings
@@ -420,7 +417,12 @@ data class Cas1SpaceBookingEntity(
   @JoinColumn(name = "offline_application_id")
   val offlineApplication: OfflineApplicationEntity?,
   /**
-   * Placement request will only be null for migrated [BookingEntity]s, where adhoc = true
+   * Placement request can be null for the following:
+   *
+   * 1. A booking linked to an offlineApplication (these are legacy and shouldn't be created anymore)
+   * 2. A booking created from a migrated booking, where adhoc was originally true (these are legacy and shouldn't be created anymore)
+   * 3. A booking created from a migrated cancelled booking. In this case the legacy data model didn't track placement
+   *    request ids for cancelled (and subsequently rebooked) bookings
    */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "placement_request_id")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/EmailNotificationAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/asserter/EmailNotificationAsserter.kt
@@ -59,6 +59,6 @@ class EmailNotificationAsserter {
   fun formatRequestedEmails() = "\n" + requestedEmails.map { "\n $it" }
 
   fun assertEmailsRequestedCount(expectedCount: Int) {
-    assertThat(requestedEmails.size).withFailMessage("Emails are $requestedEmails").isEqualTo(expectedCount)
+    assertThat(requestedEmails).hasSize(expectedCount).withFailMessage("Expected count $expectedCount was ${requestedEmails.size}. Emails are $requestedEmails")
   }
 }


### PR DESCRIPTION
This commit updates the WithdrawalTest to remove all usages of bookings and replace them with space bookings

It also updates terminology to use `placement applicaitons` and `placement requests` consistently.

This also removes testing of withdrawing adoc bookings linked to an application (something we haven’t implemented for space bookings). This is because there are no withdrawable adhoc space bookings with a departure date after 2024, so these would not appear on any upcoming list regardless so no need for them to be withdrawn (all corresponding applications will also be expired)

This was verified with the following query (it produces 11 bookings)

```
select
created_At,
approved_premises_application_id,
expected_arrival_date,
expected_departure_date
from cas1_space_bookings
where
approved_premises_application_id IS NOT NULL and
placement_request_id IS NULL and
cancellation_occurred_at IS NULL and
non_arrival_confirmed_at IS NULL and
actual_arrival_date IS NULL
order by created_at desc;
```

