### PR TITLE
Add `Cas1Premises.overbookingSummary` placeholder

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1Premises.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1Premises.kt
@@ -57,4 +57,7 @@ data class Cas1Premises(
 
   @Schema(description = "Room and premise characteristics")
   val characteristics: List<Cas1SpaceCharacteristic>,
+
+  @Schema(description = "This is deprecated and only returns an empty list", deprecated = true)
+  val overbookingSummary: List<Cas1OverbookingRange> = emptyList(),
 )


### PR DESCRIPTION
A previous commit completely removed the field `Cas1Premises.overbookingSummary`. The UI code still depends on this existing and as such errors when viewing a premises.

