### PR TITLE
APS-2586 - Add 'reallocate booking not mades' migration job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
@@ -29,6 +29,7 @@ enum class MigrationJobType(@get:JsonValue val value: kotlin.String) {
   updateCas1ArsonSuitableToArsonOffences("update_cas1_arson_suitable_to_arson_offences"),
   updateCas1BackfillArsonSuitable("update_cas1_backfill_arson_suitable"),
   updateCas1ApprovedPremisesAssessmentReportProperties("update_cas1_approved_premises_assessment_report_properties"),
+  cas1BookingNotMadeReallocation("cas1_booking_not_made_reallocation"),
   cas1UpdateRoomCodes("cas1_update_room_codes"),
   updateCas1ApplicationsWithOffender("update_cas1_applications_with_offender"),
   updateCas3BedspaceModelData("update_cas3_bedspace_model_data"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingNotMade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingNotMade.kt
@@ -20,7 +20,7 @@ data class BookingNotMadeEntity(
   val id: UUID,
   @ManyToOne
   @JoinColumn(name = "placement_request_id")
-  val placementRequest: PlacementRequestEntity,
+  var placementRequest: PlacementRequestEntity,
   val createdAt: OffsetDateTime,
   val notes: String?,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -132,6 +132,9 @@ interface PlacementRequestRepository : JpaRepository<PlacementRequestEntity, UUI
   @Query("UPDATE PlacementRequestEntity p SET p.dueAt = :dueAt WHERE p.id = :id")
   fun updateDueAt(id: UUID, dueAt: OffsetDateTime?)
 
+  @Query("SELECT p from PlacementRequestEntity p WHERE p.reallocatedAt IS NOT NULL AND p.bookingNotMades IS NOT EMPTY")
+  fun reallocatedAtWithBookingNotMade(): List<PlacementRequestEntity>
+
   @Query(
     """
     WITH UNFILTERED AS (

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2Statu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1ArsonSuitableToArsonOffencesJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillOfflineApplicationName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BackfillUserApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1BookingNotMadeReallocationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1CapacityPerformanceTestJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1IsArsonSuitableBackfillJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1.Cas1TaskDueMigrationJob
@@ -62,6 +63,7 @@ class MigrationJobService(
         MigrationJobType.updateCas1ArsonSuitableToArsonOffences -> getBean(Cas1ArsonSuitableToArsonOffencesJob::class)
         MigrationJobType.updateCas1BackfillArsonSuitable -> getBean(Cas1IsArsonSuitableBackfillJob::class)
         MigrationJobType.updateCas1ApprovedPremisesAssessmentReportProperties -> getBean(Cas1UpdateAssessmentReportPropertiesJob::class)
+        MigrationJobType.cas1BookingNotMadeReallocation -> getBean(Cas1BookingNotMadeReallocationJob::class)
         MigrationJobType.cas1UpdateRoomCodes -> getBean(Cas1UpdateRoomCodesJob::class)
         MigrationJobType.updateCas1ApplicationsWithOffender -> getBean(Cas1UpdateApprovedPremisesApplicationWithOffenderJob::class)
         MigrationJobType.updateCas3BedspaceModelData -> getBean(Cas3MigrateNewBedspaceModelDataJob::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1BookingNotMadeReallocationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/cas1/Cas1BookingNotMadeReallocationJob.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.cas1
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+
+@Component
+class Cas1BookingNotMadeReallocationJob(
+  val placementRequestRepository: PlacementRequestRepository,
+  val bookingNotMadeRepository: BookingNotMadeRepository,
+) : MigrationJob() {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  override val shouldRunInTransaction = true
+  override fun process(pageSize: Int) {
+    val toUpdate = placementRequestRepository.reallocatedAtWithBookingNotMade()
+
+    log.info("Have found ${toUpdate.size} reallocated placement requests with one or more booking not made records")
+
+    toUpdate.forEach { moveBookingNotMades(it) }
+
+    log.info("Placement requests updated")
+  }
+
+  private fun moveBookingNotMades(placementRequest: PlacementRequestEntity) {
+    val id = placementRequest.id
+    val expectedArrival = placementRequest.expectedArrival
+    val duration = placementRequest.duration
+
+    log.info(
+      "Looking to move ${placementRequest.bookingNotMades.size} booking not mades for " +
+        "placement request $id with arrival date $expectedArrival and duration $duration",
+    )
+
+    val allPlacementRequests = placementRequest.application.placementRequests
+
+    val nonReallocatedEquivalents = allPlacementRequests
+      .filter { it.reallocatedAt == null }
+      .filter { it.expectedArrival == expectedArrival && it.duration == duration }
+
+    if (nonReallocatedEquivalents.isEmpty()) {
+      error("Could not find an equivalent non-reallocated placement request for $id. This should not happen")
+    }
+
+    if (nonReallocatedEquivalents.size > 1) {
+      error("Found multiple non-reallocated placement request for $id. Not sure what to do")
+    }
+
+    val nonReallocatedEquivalent = nonReallocatedEquivalents.first()
+
+    placementRequest.bookingNotMades.forEach {
+      log.info("Moving booking not made ${it.id} from placement request $id to ${nonReallocatedEquivalent.id}")
+      it.placementRequest = nonReallocatedEquivalent
+      bookingNotMadeRepository.save(it)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABookingNotMade.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenABookingNotMade.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+
+fun IntegrationTestBase.givenABookingNotMade(
+  placementRequest: PlacementRequestEntity,
+): BookingNotMadeEntity = bookingNotMadeFactory.produceAndPersist {
+  withPlacementRequest(placementRequest)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1BookingNotMadeReallocationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/cas1/Cas1BookingNotMadeReallocationJobTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenABookingNotMade
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+import java.time.LocalDate
+
+class Cas1BookingNotMadeReallocationJobTest : MigrationJobTestBase() {
+
+  @Test
+  fun success() {
+    val application = givenACas1Application()
+
+    val reallocated1 = givenAPlacementRequest(
+      application = application,
+      reallocated = true,
+      expectedArrival = LocalDate.now().minusDays(1),
+      duration = 5,
+    ).first
+    val bnmToMove1 = givenABookingNotMade(reallocated1)
+    val bnmToMove2 = givenABookingNotMade(reallocated1)
+
+    val reallocated2 = givenAPlacementRequest(
+      application = application,
+      reallocated = true,
+      expectedArrival = LocalDate.now().minusDays(1),
+      duration = 5,
+    ).first
+    val bnmToMove3 = givenABookingNotMade(reallocated2)
+
+    val nonReallocatedSlightlyDifferentDate = givenAPlacementRequest(
+      application = application,
+      reallocated = false,
+      expectedArrival = LocalDate.now().minusDays(2),
+      duration = 5,
+    ).first
+    val unaffectedBnm1 = givenABookingNotMade(nonReallocatedSlightlyDifferentDate)
+
+    val nonReallocatedSlightlyDifferentDuration = givenAPlacementRequest(
+      application = application,
+      reallocated = false,
+      expectedArrival = LocalDate.now().minusDays(1),
+      duration = 6,
+    ).first
+    val unaffectedBnm2 = givenABookingNotMade(nonReallocatedSlightlyDifferentDuration)
+
+    val notReallocatedMatching = givenAPlacementRequest(
+      application = application,
+      reallocated = false,
+      expectedArrival = LocalDate.now().minusDays(1),
+      duration = 5,
+    ).first
+
+    givenAPlacementRequest(
+      application = application,
+      reallocated = true,
+      expectedArrival = LocalDate.now().minusDays(1),
+      duration = 5,
+    )
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1BookingNotMadeReallocation)
+
+    assertThat(placementRequestRepository.findByIdOrNull(reallocated1.id)!!.bookingNotMades).isEmpty()
+    assertThat(placementRequestRepository.findByIdOrNull(reallocated2.id)!!.bookingNotMades).isEmpty()
+    assertThat(placementRequestRepository.findByIdOrNull(notReallocatedMatching.id)!!.bookingNotMades.map { it.id })
+      .containsExactlyInAnyOrder(bnmToMove1.id, bnmToMove2.id, bnmToMove3.id)
+
+    assertThat(bookingNotMadeRepository.findByIdOrNull(unaffectedBnm1.id)!!.placementRequest.id).isEqualTo(nonReallocatedSlightlyDifferentDate.id)
+    assertThat(bookingNotMadeRepository.findByIdOrNull(unaffectedBnm2.id)!!.placementRequest.id).isEqualTo(nonReallocatedSlightlyDifferentDuration.id)
+  }
+}


### PR DESCRIPTION
This migration job moves booking not made records from reallocated placement requests to their non reallocated equivalents.

This will affect a small number of placement requests as the ‘placement request allocation’ functionality has not been used for over 18 months.

This is a pre-requisite for deleting reallocated placement requests from the database, which is a pre-requisite to making the placement-request to placement-application relationships one-to-one.

