### PR TITLE
APS-2547 - Exclude auto placement apps from workload stats

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/TaskEntity.kt
@@ -232,7 +232,8 @@ interface TaskRepository : JpaRepository<Task, UUID> {
         (
           SELECT COUNT(1)
             FROM placement_applications pa
-            WHERE pa.allocated_to_user_id = u.id
+            WHERE pa.allocated_to_user_id = u.id AND
+            pa.automatic IS FALSE
             AND 
               (
                 pa.submitted_at IS NULL
@@ -296,6 +297,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
           placement_applications placement_application
         where
           placement_application.allocated_to_user_id = u.id
+          and placement_application.automatic is false
           and placement_application.reallocated_at is null
           and placement_application.is_withdrawn != true
           and placement_application.decision_made_at is null
@@ -307,6 +309,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
           placement_applications placement_application
         where
           placement_application.allocated_to_user_id = u.id
+          and placement_application.automatic is false
           and placement_application.reallocated_at is null
           and placement_application.decision_made_at > current_date - interval '7' day
       ) as completedPlacementApplicationsInTheLastSevenDays,
@@ -317,6 +320,7 @@ interface TaskRepository : JpaRepository<Task, UUID> {
           placement_applications placement_application
         where
           placement_application.allocated_to_user_id = u.id
+          and placement_application.automatic is false
           and placement_application.reallocated_at is null
           and placement_application.decision_made_at > current_date - interval '30' day
       ) as completedPlacementApplicationsInTheLastThirtyDays

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1TasksTest.kt
@@ -2033,6 +2033,8 @@ class Cas1TasksTest {
       }
       // withdrawn, ignored
       createPlacementApplication(assessedAt = null, allocatableUser, creatingUser, crn, isWithdrawn = true)
+      // automatic, ignored
+      createPlacementApplication(assessedAt = null, allocatableUser, creatingUser, crn, automatic = true)
 
       val numAppAssessCompletedBetween1And7DaysAgo = 4
       repeat(numAppAssessCompletedBetween1And7DaysAgo) {
@@ -2045,6 +2047,8 @@ class Cas1TasksTest {
         val days = kotlin.random.Random.nextInt(1, 7).toLong()
         createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, creatingUser, crn)
       }
+      // automatic, ignored
+      createPlacementApplication(OffsetDateTime.now().minusDays(1), allocatableUser, creatingUser, crn, automatic = true)
 
       val numAppAssessCompletedBetween8And30DaysAgo = 4
       repeat(numAppAssessCompletedBetween8And30DaysAgo) {
@@ -2057,6 +2061,8 @@ class Cas1TasksTest {
         val days = kotlin.random.Random.nextInt(8, 30).toLong()
         createPlacementApplication(OffsetDateTime.now().minusDays(days), allocatableUser, creatingUser, crn)
       }
+      // automatic, ignored
+      createPlacementApplication(OffsetDateTime.now().minusDays(10), allocatableUser, creatingUser, crn, automatic = true)
 
       // completed after 30 days ago, ignored
       repeat(10) {
@@ -2113,12 +2119,14 @@ class Cas1TasksTest {
       )
     }
 
+    @SuppressWarnings("LongParameterList")
     private fun createPlacementApplication(
       assessedAt: OffsetDateTime?,
       allocatedUser: UserEntity,
       createdByUser: UserEntity,
       crn: String,
       isWithdrawn: Boolean = false,
+      automatic: Boolean = false,
     ) {
       givenAPlacementApplication(
         createdByUser = createdByUser,
@@ -2127,6 +2135,7 @@ class Cas1TasksTest {
         decisionMadeAt = assessedAt,
         crn = crn,
         isWithdrawn = isWithdrawn,
+        automatic = automatic,
       )
     }
   }


### PR DESCRIPTION
This commit excludes placement applications created automatically on applciation submission (i.e. automatic placement applications) from historical workload stats from users. Without this change we would be double counting application assessments in these stats.

Note that we have an open question about removing population of the ‘allocated_to_user_id’ and ‘allocated_at’ fields on automatic placement applications. As we won’t have an answer to this until at least next week and we currently need to populate these fields to ensure the ‘request for placement report’ is consistent, this commit is needed (see APS-2593).

