### PR TITLE
APS-2586 - Delete reallocated placement requests

### DIFF
--- a/src/main/resources/db/migration/all/20250729103452__delete_reallocated_placement_requests.sql
+++ b/src/main/resources/db/migration/all/20250729103452__delete_reallocated_placement_requests.sql
@@ -1,0 +1,1 @@
+DELETE from placement_requests where reallocated_at is not null;


### PR DESCRIPTION
For a short period of time `placement_requests` were assigned to users to complete, much like assessments. Whenever a `placement_requests` entry was reallocated a complete copy of the row was taking, setting the existing row’s `reallocated_at` value to the current timestamp which is effectively a soft delete.

This functionality has not been used for over 18 months (The last one of these was reallocated almost 18 months ago: 2024-02-27), leaving our data model polluted with unused columns and rows that are soft deleted and never retrieved by the code. This is also a blocker to making the relationship between a placement_application and placement_request one to one (it’s currently one to many, but logically shouldn’t be).

There are 450 reallocated placements_requests that are effectively soft deleted/archived:

```
select count(*) from placement_requests where reallocated_at is not null;
-- success --
count
-----
  450
```

This commit removes all of these reallocated entries, leaving only entries in `placement_requests` where `reallocated_at` is null

None of these have linked `booking_made_entries` as these were migrated to the reallocated versions via the migration job on https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3987/commits/ee8ae5a8cf9463ca0b6649679f81d73ce581197e

