### PR TITLE
APS-2493 - Make placement app to placement req 1-to-1

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.LockModeType
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.persistence.Version
 import org.hibernate.annotations.Immutable
@@ -114,16 +114,8 @@ data class PlacementApplicationEntity(
    */
   val automatic: Boolean,
 
-  /**
-   * It was previously possible to re-allocate a PlacementRequest, which would create a copy
-   * of the placement request with the new allocation. This would result in multiple
-   * placement requests linked to a single placement application.
-   *
-   * If those reallocated placement requests were removed (or the FK nulled), this could
-   * be converted into a one to one relationship
-   */
-  @OneToMany(mappedBy = "placementApplication", fetch = FetchType.LAZY)
-  var placementRequests: MutableList<PlacementRequestEntity>,
+  @OneToOne(mappedBy = "placementApplication", fetch = FetchType.LAZY)
+  var placementRequest: PlacementRequestEntity?,
 
   @Enumerated(value = EnumType.STRING)
   var withdrawalReason: PlacementApplicationWithdrawalReason?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
@@ -85,7 +85,7 @@ class Cas1PlacementApplicationService(
         decisionMadeAt = null,
         placementType = null,
         automatic = false,
-        placementRequests = mutableListOf(),
+        placementRequest = null,
         withdrawalReason = null,
         dueAt = null,
         submissionGroupId = UUID.randomUUID(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1WithdrawableTreeBuilder.kt
@@ -54,7 +54,7 @@ class Cas1WithdrawableTreeBuilder(
   }
 
   fun treeForPlacementApp(placementApplication: PlacementApplicationEntity, user: UserEntity): WithdrawableTree {
-    val children = placementApplication.placementRequests.map { treeForPlacementReq(it, user).rootNode }
+    val children = listOfNotNull(placementApplication.placementRequest?.let { treeForPlacementReq(it, user).rootNode })
 
     return WithdrawableTree(
       WithdrawableTreeNode(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -76,7 +76,7 @@ class RequestForPlacementTransformer(
 
   private fun PlacementApplicationEntity.deriveStatus(): RequestForPlacementStatus = when {
     this.isWithdrawn -> RequestForPlacementStatus.requestWithdrawn
-    this.placementRequests.any { pr -> pr.hasActiveBooking() } -> RequestForPlacementStatus.placementBooked
+    this.placementRequest?.hasActiveBooking() == true -> RequestForPlacementStatus.placementBooked
     this.decision == PlacementApplicationDecision.REJECTED -> RequestForPlacementStatus.requestRejected
     this.decision == PlacementApplicationDecision.ACCEPTED -> RequestForPlacementStatus.awaitingMatch
     this.isSubmitted() -> RequestForPlacementStatus.requestSubmitted

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -127,7 +127,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     decisionMadeAt = this.decisionMadeAt(),
     placementType = this.placementType(),
     automatic = this.automatic(),
-    placementRequests = mutableListOf(),
+    placementRequest = null,
     withdrawalReason = this.withdrawalReason(),
     dueAt = this.dueAt(),
     submissionGroupId = this.submissionGroupId(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -375,9 +375,8 @@ class WithdrawalTest : IntegrationTestBase() {
      * | -> Placement Application 1        | YES          |
      * | ---> Placement request 1          | -            |
      * | -----> Booking 1 arrival pending  | YES          |
-     * | ---> Placement request 2          | -            |
      * | -> Placement Application 2        | YES          |
-     * | -> Placement request 3            | BLOCKED      |
+     * | -> Placement request 2            | BLOCKED      |
      * | ---> Space Booking 2 non arrival  | BLOCKING     |
      * ```
      */
@@ -399,22 +398,20 @@ class WithdrawalTest : IntegrationTestBase() {
                 nonArrivalConfirmedAt = null,
               )
 
-              createPlacementRequest(application, placementApplication = placementApplication1)
-
               val placementApplication2 = createPlacementApplication(
                 application,
                 DateSpan(now(), duration = 2),
                 allocatedTo = requestForPlacementAssessor,
               )
 
-              val placementRequest3 = createPlacementRequest(application)
+              val placementRequest2 = createPlacementRequest(application)
               // spaceBooking2HasNonArrival
               givenACas1SpaceBooking(
                 crn = application.crn,
                 expectedArrivalDate = LocalDate.now(),
                 expectedDepartureDate = nowPlusDays(1),
                 nonArrivalConfirmedAt = Instant.now(),
-                placementRequest = placementRequest3,
+                placementRequest = placementRequest2,
               )
 
               givenACas1SpaceBooking(application = otherApplication)
@@ -452,7 +449,6 @@ class WithdrawalTest : IntegrationTestBase() {
      * | -> Placement application 1           | YES          |
      * | ---> Placement request 1             | -            |
      * | -----> Booking arrival pending       | YES          |
-     * | ---> Placement request 2             | -            |
      * | -> Placement application 2           | YES          |
      * | -> Placement request 3               | BLOCKED      |
      * | ---> Booking has arrival             | BLOCKING     |
@@ -477,18 +473,16 @@ class WithdrawalTest : IntegrationTestBase() {
                 placementRequest = placementRequest1,
               )
 
-              createPlacementRequest(application, placementApplication = placementApplication1)
-
               val placementApplication2 = createPlacementApplication(
                 application,
                 DateSpan(now(), duration = 2),
                 allocatedTo = requestForPlacementAssessor,
               )
 
-              val placementRequest3 = createPlacementRequest(application)
+              val placementRequest2 = createPlacementRequest(application)
               givenACas1SpaceBooking(
                 application = application,
-                placementRequest = placementRequest3,
+                placementRequest = placementRequest2,
                 actualArrivalDate = LocalDate.now(),
                 nonArrivalConfirmedAt = null,
               )
@@ -528,9 +522,8 @@ class WithdrawalTest : IntegrationTestBase() {
      * | -> Placement Application 1           | BLOCKED      |
      * | ---> Placement request 1             | -            |
      * | -----> Booking 1 has arrival         | BLOCKING     |
-     * | ---> Placement request 2             | -            |
      * | -> Placement Application 2           | YES          |
-     * | -> Placement request 3               | BLOCKED      |
+     * | -> Placement request 2               | BLOCKED      |
      * | ---> Booking 2 has arrival           | BLOCKING     |
      * ```
      */
@@ -552,18 +545,16 @@ class WithdrawalTest : IntegrationTestBase() {
                 nonArrivalConfirmedAt = null,
               )
 
-              createPlacementRequest(application, placementApplication = placementApplication1)
-
               val placementApplication2 = createPlacementApplication(
                 application,
                 DateSpan(now(), duration = 2),
                 allocatedTo = requestForPlacementAssessor,
               )
 
-              val placementRequest3 = createPlacementRequest(application)
+              val placementRequest2 = createPlacementRequest(application)
               givenACas1SpaceBooking(
                 application = application,
-                placementRequest = placementRequest3,
+                placementRequest = placementRequest2,
                 actualArrivalDate = LocalDate.now(),
                 nonArrivalConfirmedAt = null,
               )
@@ -603,11 +594,10 @@ class WithdrawalTest : IntegrationTestBase() {
      * | -> Placement Application 1       | YES          |
      * | ---> Placement request 1         | -            |
      * | -----> Booking 1 arrival pending | -            |
-     * | ---> Placement request 2         | -            |
      * | -> Placement Application 2       | YES          |
      * | -> Placement request 3           | BLOCKED      |
      * | ---> Booking 2 has arrival       | -            |
-     * | -> Placement request 4           | BLOCKED      |
+     * | -> Placement request 3           | BLOCKED      |
      * | ---> Space Booking has arrival   | BLOCKED      |
      * ```
      */
@@ -627,29 +617,27 @@ class WithdrawalTest : IntegrationTestBase() {
               nonArrivalConfirmedAt = null,
             )
 
-            createPlacementRequest(application, placementApplication = placementApplication1)
-
             val placementApplication2 = createPlacementApplication(
               application,
               DateSpan(now(), duration = 2),
               allocatedTo = requestForPlacementAssessor,
             )
 
-            val placementRequest3 = createPlacementRequest(application)
+            val placementRequest2 = createPlacementRequest(application)
             givenACas1SpaceBooking(
               application = application,
-              placementRequest = placementRequest3,
+              placementRequest = placementRequest2,
               actualArrivalDate = LocalDate.now(),
               nonArrivalConfirmedAt = null,
             )
 
-            val placementRequest4 = createPlacementRequest(application)
+            val placementRequest3 = createPlacementRequest(application)
             createSpaceBooking(
               application = application,
               startDate = LocalDate.now(),
               endDate = nowPlusDays(1),
               arrivalDate = LocalDateTime.now(),
-              placementRequest = placementRequest4,
+              placementRequest = placementRequest3,
             )
 
             val expected = Withdrawables(
@@ -940,11 +928,9 @@ class WithdrawalTest : IntegrationTestBase() {
      * | -> Placement application 1       | YES       | YES      | -        | -         | -              |
      * | ---> Placement request 1         | YES       | -        | -        | -         | -              |
      * | -----> Booking 1 arrival pending | YES       | YES      | YES      | YES       | -              |
-     * | ---> Placement request 2         | YES       | -        | -        | -         | -              |
-     * | -----> Booking 2 arrival pending | YES       | YES      | YES      | YES       | -              |
      * | -> Placement application 2       | -         | -        | -        | -         | -              |
-     * | ---> Placement request 3         | -         | -        | -        | -         | -              |
-     * | -----> Booking 3 arrival pending | -         | YES      | -        | -         | -              |
+     * | ---> Placement request 2         | -         | -        | -        | -         | -              |
+     * | -----> Booking 2 arrival pending | -         | YES      | -        | -         | -              |
      * ```
      */
     @Test
@@ -963,19 +949,11 @@ class WithdrawalTest : IntegrationTestBase() {
               nonArrivalConfirmedAt = null,
             )
 
-            val placementRequest2 = createPlacementRequest(application, placementApplication = placementApplication1)
+            val placementApplication2 = createPlacementApplication(application, DateSpan(now(), duration = 2))
+            val placementRequest2 = createPlacementRequest(application, placementApplication = placementApplication2)
             val booking2PendingArrival = givenACas1SpaceBooking(
               application = application,
               placementRequest = placementRequest2,
-              actualArrivalDate = null,
-              nonArrivalConfirmedAt = null,
-            )
-
-            val placementApplication2 = createPlacementApplication(application, DateSpan(now(), duration = 2))
-            val placementRequest3 = createPlacementRequest(application, placementApplication = placementApplication2)
-            val booking3PendingArrival = givenACas1SpaceBooking(
-              application = application,
-              placementRequest = placementRequest3,
               actualArrivalDate = null,
               nonArrivalConfirmedAt = null,
             )
@@ -1000,21 +978,15 @@ class WithdrawalTest : IntegrationTestBase() {
             )
             assertSpaceBookingWithdrawn(booking1PendingArrival, "Related request for placement withdrawn")
 
-            assertPlacementRequestWithdrawn(
-              placementRequest2,
-              PlacementRequestWithdrawalReason.RELATED_PLACEMENT_APPLICATION_WITHDRAWN,
-            )
-            assertSpaceBookingWithdrawn(booking2PendingArrival, "Related request for placement withdrawn")
-
             assertPlacementApplicationNotWithdrawn(placementApplication2)
-            assertPlacementRequestNotWithdrawn(placementRequest3)
-            assertSpaceBookingNotWithdrawn(booking3PendingArrival)
+            assertPlacementRequestNotWithdrawn(placementRequest2)
+            assertSpaceBookingNotWithdrawn(booking2PendingArrival)
 
             val applicantEmail = applicant.email!!
             val placementAppCreatorEmail = placementAppCreator.email!!
             val cruEmail = application.cruManagementArea!!.emailAddress!!
 
-            emailAsserter.assertEmailsRequestedCount(10)
+            emailAsserter.assertEmailsRequestedCount(6)
             assertPlacementRequestWithdrawnEmail(applicantEmail, placementRequest1)
             assertPlacementRequestWithdrawnEmail(placementAppCreatorEmail, placementRequest1)
 
@@ -1022,11 +994,6 @@ class WithdrawalTest : IntegrationTestBase() {
             assertSpaceBookingWithdrawnEmail(placementAppCreatorEmail, booking1PendingArrival)
             assertSpaceBookingWithdrawnEmail(booking1PendingArrival.premises.emailAddress!!, booking1PendingArrival)
             assertSpaceBookingWithdrawnEmail(cruEmail, booking1PendingArrival)
-
-            assertSpaceBookingWithdrawnEmail(applicantEmail, booking2PendingArrival)
-            assertSpaceBookingWithdrawnEmail(placementAppCreatorEmail, booking2PendingArrival)
-            assertSpaceBookingWithdrawnEmail(booking2PendingArrival.premises.emailAddress!!, booking2PendingArrival)
-            assertSpaceBookingWithdrawnEmail(cruEmail, booking2PendingArrival)
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/seed/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -68,18 +68,20 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
       givenAnOffender { offenderDetails, _ ->
         val (application, _) = createApplicationAndAssessment(applicant, applicant, offenderDetails)
 
-        val placementApplication = createPlacementApplication(application)
+        val placementApplication1 = createPlacementApplication(application)
         val placementRequest1 = createPlacementRequest(application) {
           withExpectedArrival(LocalDate.of(2023, 1, 1))
-          withPlacementApplication(placementApplication)
+          withPlacementApplication(placementApplication1)
         }
+        val placementApplication2 = createPlacementApplication(application)
         val placementRequest2 = createPlacementRequest(application) {
           withExpectedArrival(LocalDate.of(2023, 1, 10))
-          withPlacementApplication(placementApplication)
+          withPlacementApplication(placementApplication2)
         }
+        val placementApplication3 = createPlacementApplication(application)
         val placementRequest3 = createPlacementRequest(application) {
           withExpectedArrival(LocalDate.of(2023, 1, 20))
-          withPlacementApplication(placementApplication)
+          withPlacementApplication(placementApplication3)
         }
 
         seed(
@@ -98,7 +100,9 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
           ),
         )
 
-        assertPlacementApplicationNotWithdrawn(placementApplication)
+        assertPlacementApplicationNotWithdrawn(placementApplication1)
+        assertPlacementApplicationNotWithdrawn(placementApplication2)
+        assertPlacementApplicationNotWithdrawn(placementApplication3)
 
         assertPlacementRequestWithdrawn(placementRequest1, PlacementRequestWithdrawalReason.DUPLICATE_PLACEMENT_REQUEST)
         assertPlacementRequestNotWithdrawn(placementRequest2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1WithdrawableTreeBuilderTest.kt
@@ -92,7 +92,7 @@ class Cas1WithdrawableTreeBuilderTest {
     val placementApp1 = createPlacementApplication()
     setupWithdrawableState(placementApp1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1 = createPlacementRequest()
-    placementApp1.placementRequests.add(placementApp1PlacementRequest1)
+    placementApp1.placementRequest = placementApp1PlacementRequest1
     setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawn = true, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1SpaceBooking1 = createSpaceBooking()
     placementApp1PlacementRequest1.spaceBookings.add(placementApp1PlacementRequest1SpaceBooking1)
@@ -149,7 +149,7 @@ Notes: []
     val placementApp1 = createPlacementApplication()
     setupWithdrawableState(placementApp1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1 = createPlacementRequest()
-    placementApp1.placementRequests.add(placementApp1PlacementRequest1)
+    placementApp1.placementRequest = placementApp1PlacementRequest1
     setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1Booking = createSpaceBooking()
     placementApp1PlacementRequest1.spaceBookings = mutableListOf(placementApp1PlacementRequest1Booking)
@@ -158,7 +158,7 @@ Notes: []
     val placementApp2 = createPlacementApplication(automatic = true)
     setupWithdrawableState(placementApp2, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp2PlacementRequest1 = createPlacementRequest()
-    placementApp2.placementRequests.add(placementApp2PlacementRequest1)
+    placementApp2.placementRequest = placementApp2PlacementRequest1
     setupWithdrawableState(placementApp2PlacementRequest1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp2PlacementRequest1Booking = createSpaceBooking()
     placementApp2PlacementRequest1.spaceBookings = mutableListOf(placementApp2PlacementRequest1Booking)
@@ -210,7 +210,7 @@ Notes: [1 or more placements cannot be withdrawn as they have an arrival]
     val placementApp1 = createPlacementApplication()
     setupWithdrawableState(placementApp1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1 = createPlacementRequest()
-    placementApp1.placementRequests.add(placementApp1PlacementRequest1)
+    placementApp1.placementRequest = placementApp1PlacementRequest1
     setupWithdrawableState(placementApp1PlacementRequest1, WithdrawableState(withdrawn = false, withdrawable = false, userMayDirectlyWithdraw = false))
     val placementApp1PlacementRequest1SpaceBooking = createSpaceBooking()
     placementApp1PlacementRequest1.spaceBookings.add(placementApp1PlacementRequest1SpaceBooking)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
@@ -137,7 +137,7 @@ class RequestForPlacementTransformerTest {
         .withPlacementRequirements(placementRequirements)
         .produce()
         .apply {
-          placementApplication.placementRequests = mutableListOf(this)
+          placementApplication.placementRequest = this
         }
 
       val premises = ApprovedPremisesEntityFactory()


### PR DESCRIPTION
As we have removed ‘reallocated’ placement requests via 49fb37d8a1ba562baf1ef031a54222f38d475912, we can now update the relationship from `PlacementApplicationEntity` to `PlacementRequestEntity` to be `OneToOne` instead of `OneToMany`

Note that the inverse relationship from `PlacementRequestEntity` to `PlacementApplication` was (incorrectly) configured as `OneToOne` already, so no change is required to that side of the relationship.

