### PR TITLE
CAS-1730: C3 BE Unarchive Premise Domain Event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesUnarchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesUnarchiveEvent.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.CAS3Event
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.EventType
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class CAS3PremisesUnarchiveEvent(
+  val eventDetails: CAS3PremisesUnarchiveEventDetails,
+
+  override val id: UUID,
+
+  override val timestamp: Instant,
+
+  override val eventType: EventType,
+) : CAS3Event
+
+data class CAS3PremisesUnarchiveEventDetails(
+
+  val premisesId: UUID,
+
+  val userId: UUID,
+
+  val currentStartDate: LocalDate,
+
+  val newStartDate: LocalDate,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/generated/events/EventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/generated/events/EventType.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 @Suppress("ktlint:standard:enum-entry-name-case", "EnumNaming")
 enum class EventType(@get:JsonValue val value: String) {
 
+  premisesUnarchived("accommodation.cas3.premises.unarchived"),
   bedspaceArchived("accommodation.cas3.bedspace.archived"),
   bedspaceUnarchived("accommodation.cas3.bedspace.unarchived"),
   bookingCancelled("accommodation.cas3.booking.cancelled"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3BedspaceA
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3BedspaceArchiveEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3BedspaceUnarchiveEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3BedspaceUnarchiveEventDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3PremisesUnarchiveEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3PremisesUnarchiveEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.CAS3AssessmentUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.CAS3AssessmentUpdatedField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.CAS3BookingCancelledEvent
@@ -37,8 +39,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import java.net.URI
@@ -285,6 +289,30 @@ class Cas3DomainEventBuilder(
     )
   }
 
+  fun getPremisesUnarchiveEvent(
+    premises: TemporaryAccommodationPremisesEntity,
+    currentStartDate: LocalDate,
+    newStartDate: LocalDate,
+    user: UserEntity,
+  ): DomainEvent<CAS3PremisesUnarchiveEvent> {
+    val domainEventId = UUID.randomUUID()
+
+    return DomainEvent(
+      id = domainEventId,
+      applicationId = null,
+      bookingId = null,
+      crn = null,
+      nomsNumber = null,
+      occurredAt = Instant.now(),
+      data = CAS3PremisesUnarchiveEvent(
+        id = domainEventId,
+        timestamp = Instant.now(),
+        eventType = EventType.premisesUnarchived,
+        eventDetails = buildCAS3PremisesUnarchiveEventDetails(premises, currentStartDate, newStartDate, user),
+      ),
+    )
+  }
+
   fun getBedspaceUnarchiveEvent(
     bedspace: BedEntity,
     currentStartDate: LocalDate,
@@ -505,6 +533,18 @@ class Cas3DomainEventBuilder(
     applicationUrl = application.toUrl(),
     reasonDetail = null,
     recordedBy = user?.let { populateStaffMember(it) },
+  )
+
+  private fun buildCAS3PremisesUnarchiveEventDetails(
+    premises: PremisesEntity,
+    currentStartDate: LocalDate,
+    newStartDate: LocalDate,
+    user: UserEntity,
+  ) = CAS3PremisesUnarchiveEventDetails(
+    premisesId = premises.id,
+    userId = user.id,
+    currentStartDate = currentStartDate,
+    newStartDate = newStartDate,
   )
 
   private fun buildCAS3BedspaceArchiveEventDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -920,6 +920,8 @@ class Cas3PremisesService(
       return@validatedCasResult errors()
     }
 
+    val originalStartDate = premises.startDate
+
     premises.startDate = restartDate
     premises.endDate = null
     premises.status = PropertyStatus.active
@@ -931,6 +933,8 @@ class Cas3PremisesService(
         return result.reviseType()
       }
     }
+
+    cas3DomainEventService.savePremisesUnarchiveEvent(premises, originalStartDate, restartDate)
 
     success(updatedPremises)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -524,6 +524,11 @@ enum class DomainEventType(
     Cas3EventType.draftReferralDeleted.value,
     "A draft referral has been deleted",
   ),
+  CAS3_PREMISES_UNARCHIVED(
+    DomainEventCas.CAS3,
+    Cas3EventType.premisesUnarchived.value,
+    "A premises for a Transitional Accommodation has been unarchived",
+  ),
 }
 
 data class Cas1DomainEventTypeInfo(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
@@ -2040,6 +2040,7 @@ class Cas3PremisesServiceTest {
       every { premisesRepositoryMock.save(any()) } returns updatedPremises
       every { bedRepositoryMock.save(any()) } returns updatedBedspace
       every { mockCas3DomainEventService.saveBedspaceUnarchiveEvent(any(), any(), any()) } returns Unit
+      every { mockCas3DomainEventService.savePremisesUnarchiveEvent(any(), any(), any()) } returns Unit
 
       val result = premisesService.unarchivePremises(archivedPremises, restartDate)
 
@@ -2069,6 +2070,24 @@ class Cas3PremisesServiceTest {
           match<BedEntity> {
             it.id == archivedBedspace.id
           },
+        )
+      }
+
+      verify(exactly = 1) {
+        mockCas3DomainEventService.savePremisesUnarchiveEvent(
+          match<TemporaryAccommodationPremisesEntity> {
+            it.id == archivedPremises.id
+          },
+          any(),
+          any(),
+        )
+      }
+
+      verify(exactly = 1) {
+        mockCas3DomainEventService.saveBedspaceUnarchiveEvent(
+          any(),
+          any(),
+          any(),
         )
       }
     }
@@ -2161,10 +2180,25 @@ class Cas3PremisesServiceTest {
 
       every { premisesRepositoryMock.findByIdOrNull(archivedPremises.id) } returns archivedPremises
       every { premisesRepositoryMock.save(any()) } returns updatedPremises
+      every { mockCas3DomainEventService.savePremisesUnarchiveEvent(any(), any(), any()) } returns Unit
 
       val result = premisesService.unarchivePremises(archivedPremises, restartDate)
 
       assertThatCasResult(result).isSuccess()
+
+      verify(exactly = 1) {
+        mockCas3DomainEventService.savePremisesUnarchiveEvent(
+          match<TemporaryAccommodationPremisesEntity> {
+            it.id == archivedPremises.id
+          },
+          any(),
+          any(),
+        )
+      }
+
+      verify(exactly = 1) {
+        premisesRepositoryMock.save(any())
+      }
     }
 
     @Test
@@ -2185,10 +2219,25 @@ class Cas3PremisesServiceTest {
 
       every { premisesRepositoryMock.findByIdOrNull(archivedPremises.id) } returns archivedPremises
       every { premisesRepositoryMock.save(any()) } returns updatedPremises
+      every { mockCas3DomainEventService.savePremisesUnarchiveEvent(any(), any(), any()) } returns Unit
 
       val result = premisesService.unarchivePremises(archivedPremises, restartDate)
 
       assertThatCasResult(result).isSuccess()
+
+      verify(exactly = 1) {
+        mockCas3DomainEventService.savePremisesUnarchiveEvent(
+          match<TemporaryAccommodationPremisesEntity> {
+            it.id == archivedPremises.id
+          },
+          any(),
+          any(),
+        )
+      }
+
+      verify(exactly = 1) {
+        premisesRepositoryMock.save(any())
+      }
     }
   }
 
@@ -2243,6 +2292,16 @@ class Cas3PremisesServiceTest {
           match<BedEntity> {
             it.startDate == restartDate && it.endDate == null
           },
+        )
+      }
+
+      verify(exactly = 1) {
+        mockCas3DomainEventService.saveBedspaceUnarchiveEvent(
+          match<BedEntity> {
+            it.id == updatedBedspace.id
+          },
+          currentStartDate,
+          currentEndDate,
         )
       }
     }


### PR DESCRIPTION
This Pull Request adds functionality for handling "premises unarchived" events within the CAS3 domain, including updates to event models, builders, services, and tests.

Main Changes:

- Event Type Extension: Added a new event type premisesUnarchived in the EventType enum.
- New Domain Model: Introduced CAS3PremisesUnarchiveEvent and its details to represent "premises unarchived" events.
- Entity Update: Extended DomainEventEntity with support for the new CAS3PremisesUnarchiveEvent.

- Service Logic:
  - Added methods to build, save, and emit "premises unarchived" events in Cas3DomainEventBuilder and Cas3DomainEventService.
  - Updated Cas3PremisesService to trigger "premises unarchived" events upon unarchiving premises.

- Test Enhancements: Updated Cas3PremisesServiceTest to include mock expectations and validations for "premises unarchived" event handling.