### PR TITLE
Remove ‘assign default region’ logic

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -33,7 +33,6 @@ generic-service:
     SERVICES_PRISONER-SEARCH_BASE-URL: https://prisoner-search-dev.prison.service.justice.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/dev+test,classpath:db/migration/dev-truncate,classpath:db/migration/dev,classpath:db/migration/all-except-integration
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
-    ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: dev
     SENTRY_TRACES-SAMPLE-RATE: 0.01
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -34,7 +34,6 @@ generic-service:
     SERVICES_PRISONER-SEARCH_BASE-URL: https://prisoner-search-dev.prison.service.justice.gov.uk
     SPRING_FLYWAY_LOCATIONS: classpath:db/migration/all,classpath:db/migration/dev+test,classpath:db/migration/test,classpath:db/migration/all-except-integration
     LOG-CLIENT-CREDENTIALS-JWT-INFO: true
-    ASSIGN-DEFAULT-REGION-TO-USERS-WITH-UNKNOWN-REGION: true
     SENTRY_ENVIRONMENT: test
     CACHES_STAFFMEMBERS_EXPIRY-SECONDS: 20
     DOMAIN-EVENTS_CAS1_EMIT-ENABLED: false

--- a/src/main/resources/application-localdev.yml
+++ b/src/main/resources/application-localdev.yml
@@ -58,8 +58,6 @@ user-allocations:
     esap-assessments:
       allocate-to-user: JIMSNOWLDAP
 
-assign-default-region-to-users-with-unknown-region: true
-
 # Logging
 
 log-client-credentials-jwt-info: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -246,8 +246,6 @@ caches:
 seed:
   file-prefix: "/tmp/seed"
 
-assign-default-region-to-users-with-unknown-region: false
-
 url-templates:
   api:
     cas1:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserServiceTest.kt
@@ -34,7 +34,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruMana
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationAreaProbationRegionMappingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
@@ -56,7 +55,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.RequestContextService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService.GetUserResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserServiceConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApAreaMappingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -65,14 +63,12 @@ import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification as APIUserQualification
 
 class UserServiceTest {
-  private val mockUserServiceConfig = mockk<UserServiceConfig>()
   private val mockRequestContextService = mockk<RequestContextService>()
   private val mockHttpAuthService = mockk<HttpAuthService>()
   private val mockOffenderService = mockk<OffenderService>()
   private val mockUserRepository = mockk<UserRepository>()
   private val mockUserRoleAssignmentRepository = mockk<UserRoleAssignmentRepository>()
   private val mockUserQualificationAssignmentRepository = mockk<UserQualificationAssignmentRepository>()
-  private val mockProbationRegionRepository = mockk<ProbationRegionRepository>()
   private val mockProbationAreaProbationRegionMappingRepository = mockk<ProbationAreaProbationRegionMappingRepository>()
   private val mockProbationDeliveryUnitRepository = mockk<ProbationDeliveryUnitRepository>()
   private val mockCas1ApAreaMappingService = mockk<Cas1ApAreaMappingService>()
@@ -81,14 +77,12 @@ class UserServiceTest {
   private val mockEnvironmentService = mockk<EnvironmentService>()
 
   private val userService = UserService(
-    mockUserServiceConfig,
     mockRequestContextService,
     mockHttpAuthService,
     mockOffenderService,
     mockUserRepository,
     mockUserRoleAssignmentRepository,
     mockUserQualificationAssignmentRepository,
-    mockProbationRegionRepository,
     mockProbationAreaProbationRegionMappingRepository,
     mockCas1ApAreaMappingService,
     mockProbationDeliveryUnitRepository,
@@ -96,11 +90,6 @@ class UserServiceTest {
     mockCas1CruManagementAreaRepository,
     mockEnvironmentService,
   )
-
-  @BeforeEach
-  fun setup() {
-    every { mockUserServiceConfig.assignDefaultRegionToUsersWithUnknownRegion } returns false
-  }
 
   @Nested
   inner class GetExistingUserOrCreate {


### PR DESCRIPTION
The `assign-default-region-to-users-with-unknown-region` configuration option was only enabled in dev and test environments and only required when a test user is not configured with a known region.

After disabling this option locally I can login using all CAS1 & CAS3 test users, suggesting this option isn’t required.

