### PR TITLE
Stop startup if auto seeding fails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedOnStartupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedOnStartupService.kt
@@ -75,7 +75,7 @@ class SeedOnStartupService(
             csv.file.path
           }
 
-          seedService.seedData(seedFileType, seedFileType.value) { filePath }
+          seedService.seedDataThrowErrors(seedFileType, seedFileType.value) { filePath }
         }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/cas1/Cas1StartupScript.kt
@@ -71,7 +71,7 @@ class Cas1StartupScript(
         state = state,
       )
     } catch (e: Exception) {
-      seedLogger.error("Creating application with crn $crn failed", e)
+      throw RuntimeException("Creating application with crn $crn failed", e)
     }
   }
 
@@ -84,7 +84,7 @@ class Cas1StartupScript(
     try {
       cas1ApplicationSeedService.createOfflineApplicationWithBooking(deliusUserName, crn)
     } catch (e: Exception) {
-      seedLogger.error("Creating offline application with crn $crn failed", e)
+      throw RuntimeException("Creating offline application with crn $crn failed", e)
     }
   }
 }


### PR DESCRIPTION
Before this change, failed seed jobs would log errors on startup but not block startup. Often it wasn’t clear that these jobs had failed/been broken which required investigation to determine.

This commit changes the behaviour such that startup will fail if seed jobs fail.

