### PR TITLE
APS-2605 - Add OOSB reason reference type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1OutOfServiceBedReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1OutOfServiceBedReason.kt
@@ -1,22 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import io.swagger.v3.oas.annotations.media.Schema
+import com.fasterxml.jackson.annotation.JsonValue
+import java.util.UUID
 
-/**
- *
- * @param id
- * @param name
- * @param isActive
- */
 data class Cas1OutOfServiceBedReason(
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
-
-  @Schema(example = "Double Room with Single Occupancy - Other (Non-FM)", required = true, description = "")
-  @get:JsonProperty("name", required = true) val name: kotlin.String,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("isActive", required = true) val isActive: kotlin.Boolean,
+  val id: UUID,
+  val name: String,
+  val isActive: Boolean,
+  val referenceType: Cas1OutOfServiceBedReasonReferenceType,
 )
+
+enum class Cas1OutOfServiceBedReasonReferenceType(@get:JsonValue val value: String) {
+  CRN("crn"),
+  WORK_ORDER("workOrder"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedReasonEntity.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
@@ -27,4 +29,11 @@ data class Cas1OutOfServiceBedReasonEntity(
   val createdAt: OffsetDateTime,
   val name: String,
   val isActive: Boolean,
+  @Enumerated(EnumType.STRING)
+  val referenceType: Cas1OutOfServiceBedReasonEntityReferenceType,
 )
+
+enum class Cas1OutOfServiceBedReasonEntityReferenceType {
+  CRN,
+  WORK_ORDER,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedRevisionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1OutOfServiceBedRevisionEntity.kt
@@ -34,6 +34,9 @@ data class Cas1OutOfServiceBedRevisionEntity(
    * This date is inclusive. The bed will be unavailable for the whole of the day
    */
   var endDate: LocalDate,
+  /**
+   * The type of value in here is determined by Cas1OutOfServiceBedReasonEntity.referenceType
+   */
   var referenceNumber: String?,
   var notes: String?,
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedReasonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OutOfServiceBedReasonTransformer.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReasonReferenceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntityReferenceType
 
 @Component
 class Cas1OutOfServiceBedReasonTransformer {
@@ -10,5 +12,9 @@ class Cas1OutOfServiceBedReasonTransformer {
     id = jpa.id,
     name = jpa.name,
     isActive = jpa.isActive,
+    referenceType = when (jpa.referenceType) {
+      Cas1OutOfServiceBedReasonEntityReferenceType.CRN -> Cas1OutOfServiceBedReasonReferenceType.CRN
+      Cas1OutOfServiceBedReasonEntityReferenceType.WORK_ORDER -> Cas1OutOfServiceBedReasonReferenceType.WORK_ORDER
+    },
   )
 }

--- a/src/main/resources/db/migration/all/20250730142358__add_oosb_reason_reference_type.sql
+++ b/src/main/resources/db/migration/all/20250730142358__add_oosb_reason_reference_type.sql
@@ -1,0 +1,7 @@
+ALTER TABLE cas1_out_of_service_bed_reasons ADD reference_type varchar DEFAULT 'WORK_ORDER' NOT NULL;
+
+UPDATE cas1_out_of_service_bed_reasons SET reference_type = 'CRN' WHERE name IN (
+ 'Double room with single occupancy – other (Non-FM)',
+ 'Double room with single occupancy – risk (Non-FM)',
+ 'Bed on hold'
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1OutOfServiceBedReasonEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntityReferenceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -12,6 +13,7 @@ class Cas1OutOfServiceBedReasonEntityFactory : Factory<Cas1OutOfServiceBedReason
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
   private var isActive: Yielded<Boolean> = { true }
+  private var referenceType = { Cas1OutOfServiceBedReasonEntityReferenceType.WORK_ORDER }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -29,10 +31,15 @@ class Cas1OutOfServiceBedReasonEntityFactory : Factory<Cas1OutOfServiceBedReason
     this.isActive = { isActive }
   }
 
+  fun withReferenceType(referenceType: Cas1OutOfServiceBedReasonEntityReferenceType) = apply {
+    this.referenceType = { referenceType }
+  }
+
   override fun produce(): Cas1OutOfServiceBedReasonEntity = Cas1OutOfServiceBedReasonEntity(
     id = this.id(),
     createdAt = this.createdAt(),
     name = this.name(),
     isActive = this.isActive(),
+    referenceType = this.referenceType(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedReasonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedReasonTransformerTest.kt
@@ -1,22 +1,36 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReasonReferenceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntityReferenceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OutOfServiceBedReasonTransformer
 
 class Cas1OutOfServiceBedReasonTransformerTest {
   private val transformer = Cas1OutOfServiceBedReasonTransformer()
 
-  @Test
-  fun `transformJpaToApi transforms correctly`() {
+  @ParameterizedTest
+  @CsvSource(
+    "CRN, CRN",
+    "WORK_ORDER, WORK_ORDER",
+  )
+  fun `transformJpaToApi transforms correctly`(
+    jpaReferenceType: Cas1OutOfServiceBedReasonEntityReferenceType,
+    apiReferenceType: Cas1OutOfServiceBedReasonReferenceType,
+  ) {
     val reason = Cas1OutOfServiceBedReasonEntityFactory()
+      .withName("the reason name")
+      .withIsActive(true)
+      .withReferenceType(jpaReferenceType)
       .produce()
 
     val result = transformer.transformJpaToApi(reason)
 
     assertThat(result.id).isEqualTo(reason.id)
-    assertThat(result.name).isEqualTo(reason.name)
-    assertThat(result.isActive).isEqualTo(reason.isActive)
+    assertThat(result.name).isEqualTo("the reason name")
+    assertThat(result.isActive).isEqualTo(true)
+    assertThat(result.referenceType).isEqualTo(apiReferenceType)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedRevisionTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedRevisionTransformerTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReasonReferenceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.ApprovedPremisesUserFactory
@@ -44,6 +45,7 @@ class Cas1OutOfServiceBedRevisionTransformerTest {
     id = UUID.randomUUID(),
     name = "Some Reason",
     isActive = true,
+    referenceType = Cas1OutOfServiceBedReasonReferenceType.CRN,
   )
 
   private val expectedUser = ApprovedPremisesUserFactory().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedSummaryTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedSummaryTransformerTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReasonReferenceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
@@ -55,6 +56,7 @@ class Cas1OutOfServiceBedSummaryTransformerTest {
       id = outOfServiceReason.id,
       name = outOfServiceReason.name,
       isActive = true,
+      referenceType = Cas1OutOfServiceBedReasonReferenceType.WORK_ORDER,
     )
 
     val outOfServiceBed = Cas1OutOfServiceBedEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OutOfServiceBedTransformerTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReasonReferenceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedRevisionType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedStatus
@@ -84,6 +85,7 @@ class Cas1OutOfServiceBedTransformerTest {
       id = UUID.randomUUID(),
       name = randomStringLowerCase(12),
       isActive = true,
+      referenceType = Cas1OutOfServiceBedReasonReferenceType.WORK_ORDER,
     )
 
     val historyItem = Cas1OutOfServiceBedRevision(
@@ -151,6 +153,7 @@ class Cas1OutOfServiceBedTransformerTest {
       id = UUID.randomUUID(),
       name = randomStringLowerCase(12),
       isActive = true,
+      referenceType = Cas1OutOfServiceBedReasonReferenceType.CRN,
     )
 
     val cancellation = Cas1OutOfServiceBedCancellation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PremisesDayTransformerTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedReasonReferenceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OutOfServiceBedSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceCharacteristic
@@ -62,7 +63,12 @@ class Cas1PremisesDayTransformerTest {
         bedId = UUID.randomUUID(),
         startDate = LocalDate.now().minusDays(5),
         endDate = LocalDate.now().plusDays(5),
-        reason = Cas1OutOfServiceBedReason(UUID.randomUUID(), "reason", true),
+        reason = Cas1OutOfServiceBedReason(
+          UUID.randomUUID(),
+          "reason",
+          true,
+          Cas1OutOfServiceBedReasonReferenceType.WORK_ORDER,
+        ),
         characteristics = listOf(Cas1SpaceCharacteristic.isSingle),
       ),
     )


### PR DESCRIPTION
The reference type is used by the UI to determine the type of value that should be populated in the optional ‘referenceNumber’ field

