### PR TITLE
Create `GET /cas1/documents/{crn}/{documentId}`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/DocumentsApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/DocumentsApi.kt
@@ -26,7 +26,8 @@ interface DocumentsApi {
     tags = ["Application data"],
     summary = "Downloads a document",
     operationId = "documentsCrnDocumentIdGet",
-    description = """""",
+    description = "Deprecated. Use /cas1/documents/{crn}/{documentId}",
+    deprecated = true,
     responses = [
       ApiResponse(responseCode = "200", description = "successful operation", content = [Content(schema = Schema(implementation = org.springframework.core.io.Resource::class))]),
       ApiResponse(responseCode = "404", description = "invalid applicationId or documentId", content = [Content(schema = Schema(implementation = Problem::class))]),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DocumentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/DocumentsController.kt
@@ -1,71 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.DocumentsApiDelegate
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.APDeliusDocument
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DocumentService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
-import java.io.OutputStream
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1DocumentsController
 import java.util.UUID
 
 @Controller
 class DocumentsController(
-  private val userService: UserService,
-  private val offenderService: OffenderService,
-  private val documentService: DocumentService,
+  private val cas1DocumentsController: Cas1DocumentsController,
 ) : DocumentsApiDelegate {
-
-  override fun documentsCrnDocumentIdGet(crn: String, documentId: UUID): ResponseEntity<StreamingResponseBody> {
-    val user = userService.getUserForRequest()
-
-    getOffenderDetails(crn, user)
-
-    val documentsMetaData = getDocuments(crn)
-
-    val documentFilename = getDocumentFileName(documentsMetaData, documentId)
-    return ResponseEntity(
-      StreamingResponseBody { outputStream ->
-        getDocument(crn, documentId, outputStream)
-      },
-      HttpHeaders().apply {
-        put("Content-Disposition", listOf("attachment; filename=\"$documentFilename\""))
-      },
-      HttpStatus.OK,
-    )
-  }
-
-  private fun getOffenderDetails(crn: String, user: UserEntity) {
-    val offenderDetailsResult =
-      offenderService.getOffenderByCrn(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
-
-    when (offenderDetailsResult) {
-      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(crn, "Person")
-      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
-      is AuthorisableActionResult.Success -> Unit
-    }
-  }
-
-  private fun getDocument(crn: String, documentId: UUID, outputStream: OutputStream) {
-    documentService.getDocumentFromDelius(crn, documentId.toString(), outputStream)
-  }
-
-  private fun getDocuments(crn: String): List<APDeliusDocument> = extractEntityFromCasResult(
-    documentService.getDocumentsFromApDeliusApi(crn),
-  )
-
-  private fun getDocumentFileName(documentsMetaData: List<APDeliusDocument>, documentId: UUID): String {
-    val document = documentsMetaData.firstOrNull { it.id == documentId.toString() } ?: throw NotFoundProblem(documentId, "Document")
-    return document.filename
-  }
+  override fun documentsCrnDocumentIdGet(crn: String, documentId: UUID) = cas1DocumentsController.getDocument(crn, documentId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1DocumentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1DocumentsController.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.APDeliusDocument
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DocumentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+import java.io.OutputStream
+import java.util.UUID
+
+@Cas1Controller
+@Tag(name = "CAS1 Documents")
+class Cas1DocumentsController(
+  private val userService: UserService,
+  private val offenderService: OffenderService,
+  private val documentService: DocumentService,
+) {
+
+  @Operation(summary = "Downloads a document")
+  @GetMapping(
+    value = ["/documents/{crn}/{documentId}"],
+    produces = ["application/octet-stream", "application/json"],
+  )
+  fun getDocument(
+    @PathVariable crn: String,
+    @PathVariable documentId: UUID,
+  ): ResponseEntity<StreamingResponseBody> {
+    val user = userService.getUserForRequest()
+
+    getOffenderDetails(crn, user)
+
+    val documentsMetaData = getDocuments(crn)
+
+    val documentFilename = getDocumentFileName(documentsMetaData, documentId)
+    return ResponseEntity(
+      StreamingResponseBody { outputStream ->
+        getDocument(crn, documentId, outputStream)
+      },
+      HttpHeaders().apply {
+        put("Content-Disposition", listOf("attachment; filename=\"$documentFilename\""))
+      },
+      HttpStatus.OK,
+    )
+  }
+
+  private fun getOffenderDetails(crn: String, user: UserEntity) {
+    val offenderDetailsResult =
+      offenderService.getOffenderByCrn(crn, user.deliusUsername, user.hasQualification(UserQualification.LAO))
+
+    when (offenderDetailsResult) {
+      is AuthorisableActionResult.NotFound -> throw NotFoundProblem(crn, "Person")
+      is AuthorisableActionResult.Unauthorised -> throw ForbiddenProblem()
+      is AuthorisableActionResult.Success -> Unit
+    }
+  }
+
+  private fun getDocument(crn: String, documentId: UUID, outputStream: OutputStream) {
+    documentService.getDocumentFromDelius(crn, documentId.toString(), outputStream)
+  }
+
+  private fun getDocuments(crn: String): List<APDeliusDocument> = extractEntityFromCasResult(
+    documentService.getDocumentsFromApDeliusApi(crn),
+  )
+
+  private fun getDocumentFileName(documentsMetaData: List<APDeliusDocument>, documentId: UUID): String {
+    val document = documentsMetaData.firstOrNull { it.id == documentId.toString() } ?: throw NotFoundProblem(documentId, "Document")
+    return document.filename
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/APDeliusDocumentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/APDeliusDocumentFactory.kt
@@ -11,7 +11,7 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
 
-class DocumentFromDeliusApiFactory : Factory<APDeliusDocument> {
+class APDeliusDocumentFactory : Factory<APDeliusDocument> {
   private var id: Yielded<String?> = { UUID.randomUUID().toString() }
   private var description: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
   private var level: Yielded<String> = { randomInt(1, 5).toString() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationDocumentsTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ContentDisposition
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DocumentFromDeliusApiFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.APDeliusDocumentFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulDocumentDownloadCall
@@ -114,7 +114,7 @@ class ApplicationDocumentsTest : InitialiseDatabasePerClassTestBase() {
   }
 
   private fun stubDocumentsFromDelius(convictionLevelDocId: UUID): List<APDeliusDocument> = listOf(
-    DocumentFromDeliusApiFactory()
+    APDeliusDocumentFactory()
       .withId(UUID.randomUUID().toString())
       .withDescription("Offender level doc description")
       .withLevel("LEVEL-1")
@@ -125,7 +125,7 @@ class ApplicationDocumentsTest : InitialiseDatabasePerClassTestBase() {
       .withDateSaved(LocalDateTime.parse("2024-03-18T06:00:00").atZone(ZoneId.systemDefault()))
       .withDateCreated(LocalDateTime.parse("2024-03-02T15:20:00").atZone(ZoneId.systemDefault()))
       .produce(),
-    DocumentFromDeliusApiFactory()
+    APDeliusDocumentFactory()
       .withId(convictionLevelDocId.toString())
       .withDescription("Conviction level doc description")
       .withLevel("LEVEL-2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1DocumentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1DocumentTest.kt
@@ -21,7 +21,7 @@ class Cas1DocumentTest : InitialiseDatabasePerClassTestBase() {
   inner class GetDocument {
 
     @Test
-    fun `Download document - returns 404 when not found in documents meta data`() {
+    fun `Returns 404 when document doesn't exist for CRN`() {
       givenAUser { userEntity, jwt ->
         givenAnOffender { offenderDetails, _ ->
           val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
@@ -47,7 +47,7 @@ class Cas1DocumentTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Download document - returns 200 with correct body and headers`() {
+    fun success() {
       givenAUser { userEntity, jwt ->
         givenAnOffender { offenderDetails, _ ->
           val application = approvedPremisesApplicationEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1DocumentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1DocumentTest.kt
@@ -1,0 +1,106 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.ContentDisposition
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DocumentFromDeliusApiFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulDocumentDownloadCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulDocumentsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.APDeliusDocument
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.UUID
+
+class Cas1DocumentTest : InitialiseDatabasePerClassTestBase() {
+
+  @Nested
+  inner class GetDocument {
+
+    @Test
+    fun `Download document - returns 404 when not found in documents meta data`() {
+      givenAUser { userEntity, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(userEntity)
+            withCrn(offenderDetails.otherIds.crn)
+            withConvictionId(12345)
+          }
+
+          val convictionLevelDocId = UUID.randomUUID()
+          val documents = stubDocumentsFromDelius(convictionLevelDocId)
+
+          apDeliusContextMockSuccessfulDocumentsCall(offenderDetails.otherIds.crn, documents)
+
+          val notFoundDocId = UUID.randomUUID()
+          webTestClient.get()
+            .uri("/cas1/documents/${application.crn}/$notFoundDocId")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isNotFound
+        }
+      }
+    }
+
+    @Test
+    fun `Download document - returns 200 with correct body and headers`() {
+      givenAUser { userEntity, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
+            withCreatedByUser(userEntity)
+            withCrn(offenderDetails.otherIds.crn)
+            withConvictionId(12345)
+          }
+          val convictionLevelDocId = UUID.randomUUID()
+          val documents = stubDocumentsFromDelius(convictionLevelDocId)
+          val docFileContents = this::class.java.classLoader.getResourceAsStream("mock_document.txt").readAllBytes()
+
+          apDeliusContextMockSuccessfulDocumentsCall(offenderDetails.otherIds.crn, documents)
+          apDeliusContextMockSuccessfulDocumentDownloadCall(offenderDetails.otherIds.crn, convictionLevelDocId, docFileContents)
+
+          val result = webTestClient.get()
+            .uri("/cas1/documents/${application.crn}/$convictionLevelDocId")
+            .header("Authorization", "Bearer $jwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectHeader()
+            .contentDisposition(ContentDisposition.parse("attachment; filename=\"conviction_level_doc.pdf\""))
+            .expectBody()
+            .returnResult()
+
+          assertThat(result.responseBody).isEqualTo(docFileContents)
+        }
+      }
+    }
+
+    private fun stubDocumentsFromDelius(convictionLevelDocId: UUID): List<APDeliusDocument> = listOf(
+      DocumentFromDeliusApiFactory()
+        .withId(UUID.randomUUID().toString())
+        .withDescription("Offender level doc description")
+        .withLevel("LEVEL-1")
+        .withEventNumber("2")
+        .withFilename("offender_level_doc.pdf")
+        .withTypeCode("TYPE-1")
+        .withTypeDescription("Type 1 Description")
+        .withDateSaved(LocalDateTime.parse("2024-03-18T06:00:00").atZone(ZoneId.systemDefault()))
+        .withDateCreated(LocalDateTime.parse("2024-03-02T15:20:00").atZone(ZoneId.systemDefault()))
+        .produce(),
+      DocumentFromDeliusApiFactory()
+        .withId(convictionLevelDocId.toString())
+        .withDescription("Conviction level doc description")
+        .withLevel("LEVEL-2")
+        .withEventNumber("1")
+        .withFilename("conviction_level_doc.pdf")
+        .withTypeCode("TYPE-2")
+        .withTypeDescription("Type 2 Description")
+        .withDateSaved(LocalDateTime.parse("2024-10-05T13:12:00").atZone(ZoneId.systemDefault()))
+        .withDateCreated(LocalDateTime.parse("2024-10-02T10:40:00").atZone(ZoneId.systemDefault()))
+        .produce(),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DocumentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/DocumentTransformerTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Document
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.DocumentLevel
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DocumentFromDeliusApiFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.APDeliusDocumentFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.APDeliusDocument
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DocumentTransformer
 import java.time.Instant
@@ -50,7 +50,7 @@ class DocumentTransformerTest {
     val offenderDocId = UUID.randomUUID()
     val convictionDocId = UUID.randomUUID()
     val deliusDocs = stubDocumentsFromDelius(offenderDocId, convictionDocId) + listOf(
-      DocumentFromDeliusApiFactory()
+      APDeliusDocumentFactory()
         .withId(null)
         .withDescription("Null Id description")
         .withLevel(DocumentLevel.offender.value)
@@ -71,7 +71,7 @@ class DocumentTransformerTest {
   }
 
   private fun stubDocumentsFromDelius(offenderDocId: UUID, convictionDocId: UUID): List<APDeliusDocument> = listOf(
-    DocumentFromDeliusApiFactory()
+    APDeliusDocumentFactory()
       .withId(offenderDocId.toString())
       .withDescription("Offender level doc description")
       .withLevel(DocumentLevel.offender.value)
@@ -82,7 +82,7 @@ class DocumentTransformerTest {
       .withDateSaved(LocalDateTime.parse("2024-03-18T06:00:00").atZone(ZoneId.of("UTC")))
       .withDateCreated(LocalDateTime.parse("2024-03-02T15:20:00").atZone(ZoneId.of("UTC")))
       .produce(),
-    DocumentFromDeliusApiFactory()
+    APDeliusDocumentFactory()
       .withId(convictionDocId.toString())
       .withDescription("Conviction level doc description")
       .withLevel(DocumentLevel.conviction.value)


### PR DESCRIPTION
The original get document endpoint is only used by CAS1. This commit creates a CAS1 specific version of this endpoint and deprecates the original endpoint

