### PR TITLE
Always generate built-cas1-roles on compile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,7 @@ val buildDir = layout.buildDirectory.asFile.get()
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+    finalizedBy("generateCas1Roles")
     getByName("check") {
       dependsOn(":ktlintCheck", "detekt")
     }
@@ -194,10 +195,6 @@ tasks.register<JavaExec>("generateCas1Roles") {
   classpath = sourceSets["main"].runtimeClasspath
 
   outputs.file(file("built-cas1-roles.json"))
-}
-
-tasks.named("assemble") {
-  finalizedBy("generateCas1Roles")
 }
 
 allOpen {


### PR DESCRIPTION
dbf99b0b05c1b86f43d822a7b66312857812be8e removed open api code generation, moving the `generateCas1Roles` from the compile finalize phase to the `assembly` task finalize phase.

Because devs don’t always run assembly, updates to this file were missed.

This commit moves the `generateCas1Roles` back into the compile finalize phase

