### PR TITLE
CAS-1625 Extend the bad request response to include id and value

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/Cas3ValidationErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/Cas3ValidationErrors.kt
@@ -6,6 +6,7 @@ value class Cas3ValidationErrors(private val errorMap: MutableMap<String, Cas3Va
 }
 
 data class Cas3ValidationMessage(
+  val entityId: String,
   val message: String,
   val value: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
@@ -20,7 +20,8 @@ class BadRequestProblem(
         ParamError(
           propertyName = it.key,
           errorType = it.value.errorType,
-          errorDetail = it.value.errorDetail,
+          entityId = it.value.entityId,
+          value = it.value.value,
         )
       } ?: emptyList()
       ),
@@ -29,11 +30,13 @@ class BadRequestProblem(
 
 data class ParamDetails(
   val errorType: String,
-  val errorDetail: String? = null,
+  val entityId: String? = null,
+  val value: String? = null,
 )
 
 data class ParamError(
   val propertyName: String,
   val errorType: String,
-  val errorDetail: String? = null,
+  val entityId: String? = null,
+  val value: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas3/Cas3PremisesService.kt
@@ -637,6 +637,7 @@ class Cas3PremisesService(
         Cas3ValidationErrors().apply {
           this["$.endDate"] = Cas3ValidationMessage(
             message = "existingVoid",
+            entityId = bedspace.id.toString(),
             value = lastOverlapVoid?.endDate?.plusDays(1).toString(),
           )
         },
@@ -648,6 +649,7 @@ class Cas3PremisesService(
           Cas3ValidationErrors().apply {
             this["$.endDate"] = Cas3ValidationMessage(
               message = "existingBookings",
+              entityId = bedspace.id.toString(),
               value = lastOverlapBooking.departureDate.plusDays(1).toString(),
             )
           },
@@ -657,6 +659,7 @@ class Cas3PremisesService(
           Cas3ValidationErrors().apply {
             this["$.endDate"] = Cas3ValidationMessage(
               message = "existingTurnaround",
+              entityId = bedspace.id.toString(),
               value = lastTurnaroundDate.plusDays(1).toString(),
             )
           },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/EntityUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/EntityUtils.kt
@@ -19,7 +19,7 @@ fun <EntityType> extractEntityFromAuthorisableActionResult(result: AuthorisableA
 @Deprecated("Update calling code to use CasResult", ReplaceWith("extractEntityFromCasResult"))
 fun <EntityType> extractEntityFromValidatableActionResult(result: ValidatableActionResult<EntityType>) = when (result) {
   is ValidatableActionResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = result.message)
-  is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = result.validationMessages.mapValues { ParamDetails(errorType = it.value, errorDetail = null) })
+  is ValidatableActionResult.FieldValidationError -> throw BadRequestProblem(invalidParams = result.validationMessages.mapValues { ParamDetails(errorType = it.value) })
   is ValidatableActionResult.ConflictError -> throw ConflictProblem(id = result.conflictingEntityId, conflictReason = result.message)
   is ValidatableActionResult.Success -> result.entity
 }
@@ -50,11 +50,17 @@ fun <EntityType> extractEntityFromCasResult(result: CasResult<EntityType>) = whe
   is CasResult.Unauthorised -> throw ForbiddenProblem(result.message)
   is CasResult.GeneralValidationError -> throw BadRequestProblem(errorDetail = result.message)
   is CasResult.FieldValidationError -> throw BadRequestProblem(
-    invalidParams = result.validationMessages.mapValues { ParamDetails(errorType = it.value, errorDetail = null) },
+    invalidParams = result.validationMessages.mapValues { ParamDetails(errorType = it.value) },
   )
   is CasResult.ConflictError -> throw ConflictProblem(id = result.conflictingEntityId, conflictReason = result.message)
   is CasResult.Cas3FieldValidationError -> throw BadRequestProblem(
-    invalidParams = result.validationMessages.mapValues { ParamDetails(errorType = it.value.message, errorDetail = it.value.value) },
+    invalidParams = result.validationMessages.mapValues {
+      ParamDetails(
+        errorType = it.value.message,
+        entityId = it.value.entityId,
+        value = it.value.value,
+      )
+    },
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas3/Cas3PremisesTest.kt
@@ -2017,7 +2017,8 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
           .jsonPath("$.title").isEqualTo("Bad Request")
           .jsonPath("$.invalid-params[0].propertyName").isEqualTo("\$.endDate")
           .jsonPath("$.invalid-params[0].errorType").isEqualTo("existingBookings")
-          .jsonPath("$.invalid-params[0].errorDetail").isEqualTo(bookingDepartureDate.plusDays(1).toString())
+          .jsonPath("$.invalid-params[0].entityId").isEqualTo(bedspace.id.toString())
+          .jsonPath("$.invalid-params[0].value").isEqualTo(bookingDepartureDate.plusDays(1).toString())
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas3/Cas3PremisesServiceTest.kt
@@ -1073,7 +1073,7 @@ class Cas3PremisesServiceTest {
 
       val result = premisesService.archiveBedspace(bedspace.id, archiveDate)
 
-      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", "existingVoid", voidBedspace.endDate.plusDays(1).toString())
+      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", bedspace.id.toString(), "existingVoid", voidBedspace.endDate.plusDays(1).toString())
     }
 
     @Test
@@ -1094,7 +1094,7 @@ class Cas3PremisesServiceTest {
 
       val result = premisesService.archiveBedspace(bedspace.id, archiveDate)
 
-      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", "existingBookings", booking.departureDate.plusDays(1).toString())
+      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", bedspace.id.toString(), "existingBookings", booking.departureDate.plusDays(1).toString())
     }
 
     @Test
@@ -1120,7 +1120,7 @@ class Cas3PremisesServiceTest {
 
       val result = premisesService.archiveBedspace(bedspace.id, archiveDate)
 
-      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", "existingTurnaround", booking.departureDate.plusDays(3).toString())
+      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", bedspace.id.toString(), "existingTurnaround", booking.departureDate.plusDays(3).toString())
     }
 
     @Test
@@ -1149,7 +1149,7 @@ class Cas3PremisesServiceTest {
 
       val result = premisesService.archiveBedspace(bedspace.id, archiveDate)
 
-      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", "existingVoid", voidBedspace.endDate.plusDays(1).toString())
+      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", bedspace.id.toString(), "existingVoid", voidBedspace.endDate.plusDays(1).toString())
     }
 
     @Test
@@ -1175,7 +1175,7 @@ class Cas3PremisesServiceTest {
 
       val result = premisesService.archiveBedspace(bedspace.id, archiveDate)
 
-      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", "existingTurnaround", booking.departureDate.plusDays(3).toString())
+      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", bedspace.id.toString(), "existingTurnaround", booking.departureDate.plusDays(3).toString())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
@@ -161,10 +161,10 @@ class CasResultCas3FieldValidationErrorAssertions<T>(actual: CasResult.Cas3Field
     actual,
     CasResultCas3FieldValidationErrorAssertions::class.java,
   ) {
-  fun hasMessage(field: String, expectedMessage: String, expectedValue: String): CasResultCas3FieldValidationErrorAssertions<T> {
+  fun hasMessage(field: String, expectedId: String, expectedMessage: String, expectedValue: String): CasResultCas3FieldValidationErrorAssertions<T> {
     val validationMessages = actual.validationMessages
 
-    assertThat(validationMessages).containsEntry(field, Cas3ValidationMessage(expectedMessage, expectedValue))
+    assertThat(validationMessages).containsEntry(field, Cas3ValidationMessage(expectedId, expectedMessage, expectedValue))
 
     return this
   }


### PR DESCRIPTION
This [PR CAS-1625](https://dsdmoj.atlassian.net/browse/CAS-1625) is to extend the bad request response to include id and value