### PR TITLE
APS-2615 - Add migration job to backfill CAS1 app durations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
@@ -1,15 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 
-/**
-*
-* Values: updateAllUsersFromCommunityApi,updateSentenceTypeAndSituation,updateBookingStatus,updateTaskDueDates,updateUsersPduByApi,updateCas2ApplicationsWithAssessments,updateCas2StatusUpdatesWithAssessments,updateCas2NotesWithAssessments,updateCas1BackfillUserApArea,updateCas3ApplicationOffenderName,updateCas3BookingOffenderName,updateCas3BedspaceStartDate,updateCas3PremisesStartDate,updateCas3DomainEventTypeForPersonDepartedUpdated,updateCas1ApplicationsLicenceExpiryDate,updateCas1BackfillOfflineApplicationName,updateCas1ArsonSuitableToArsonOffences,updateCas1BackfillArsonSuitable,updateCas1ApprovedPremisesAssessmentReportProperties,cas1UpdateRoomCodes,updateCas1ApplicationsWithOffender,updateCas3BedspaceModelData,updateCas3VoidBedspaceCancellationData,cas1CapacityPerformanceTest
-*/
 @Suppress("ktlint:standard:enum-entry-name-case", "EnumNaming")
-enum class MigrationJobType(@get:JsonValue val value: kotlin.String) {
-
+enum class MigrationJobType(@get:JsonValue val value: String) {
   updateAllUsersFromCommunityApi("update_all_users_from_community_api"),
   updateSentenceTypeAndSituation("update_sentence_type_and_situation"),
   updateBookingStatus("update_booking_status"),
@@ -33,12 +27,6 @@ enum class MigrationJobType(@get:JsonValue val value: kotlin.String) {
   updateCas1ApplicationsWithOffender("update_cas1_applications_with_offender"),
   updateCas3BedspaceModelData("update_cas3_bedspace_model_data"),
   updateCas3VoidBedspaceData("update_cas3_void_bedspace_data"),
+  cas1BackfillApplicationDuration("cas1_backfill_application_duration"),
   cas1CapacityPerformanceTest("cas1_capacity_performance_test"),
-  ;
-
-  companion object {
-    @JvmStatic
-    @JsonCreator
-    fun forValue(value: kotlin.String): MigrationJobType = values().first { it -> it.value == value }
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDuration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDuration.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import java.util.UUID
+
+@Component
+class Cas1BackfillApplicationDuration(
+  val repository: Cas1BackfillApplicationDurationRepository,
+  private val migrationLogger: MigrationLogger,
+) : MigrationJob() {
+  override val shouldRunInTransaction = true
+
+  override fun process(pageSize: Int) {
+    repository.updateWhereDurationSetManually().let {
+      migrationLogger.info("Have set duration for $it applications with an overridden duration")
+    }
+
+    repository.updatePipeApplications().let {
+      migrationLogger.info("Have set duration for $it PIPE applications")
+    }
+
+    repository.updateEsapApplications().let {
+      migrationLogger.info("Have set duration for $it ESAP applications")
+    }
+
+    repository.updateRemainingApplications().let {
+      migrationLogger.info("Have set duration for $it remaining applications")
+    }
+  }
+}
+
+@Repository
+interface Cas1BackfillApplicationDurationRepository : JpaRepository<ApprovedPremisesApplicationEntity, UUID> {
+  @Query(
+    value = """
+      with to_update as (
+          select 
+              apa.id as id,
+              (a.data -> 'move-on' -> 'placement-duration' ->> 'duration')::integer as duration
+          from approved_premises_applications apa inner join applications a on a.id = apa.id
+          where 
+          apa.arrival_date IS NOT NULL AND 
+          apa.duration IS NULL AND 
+          a.data -> 'move-on' -> 'placement-duration' ->> 'differentDuration' = 'yes'
+      )
+      UPDATE approved_premises_applications
+      SET duration = to_update.duration
+      FROM to_update
+      WHERE approved_premises_applications.id = to_update.id;
+  """,
+    nativeQuery = true,
+  )
+  @Modifying
+  fun updateWhereDurationSetManually(): Int
+
+  @Query(
+    value = """
+      UPDATE approved_premises_applications
+      SET duration = (26 * 7)
+      WHERE 
+      arrival_date IS NOT NULL AND 
+      duration IS NULL AND 
+      ap_type = 'PIPE'
+  """,
+    nativeQuery = true,
+  )
+  @Modifying
+  fun updatePipeApplications(): Int
+
+  @Query(
+    value = """
+      UPDATE approved_premises_applications
+      SET duration = (52 * 7)
+      WHERE 
+      arrival_date IS NOT NULL AND 
+      duration IS NULL AND 
+      ap_type = 'ESAP'
+  """,
+    nativeQuery = true,
+  )
+  @Modifying
+  fun updateEsapApplications(): Int
+
+  @Query(
+    value = """
+      UPDATE approved_premises_applications
+      SET duration = (12 * 7)
+      WHERE 
+      arrival_date IS NOT NULL AND 
+      duration IS NULL
+  """,
+    nativeQuery = true,
+  )
+  @Modifying
+  fun updateRemainingApplications(): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration.Cas1ArsonSuitableToArsonOffencesJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration.Cas1BackfillApplicationDuration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration.Cas1BackfillOfflineApplicationName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration.Cas1BackfillUserApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration.Cas1CapacityPerformanceTestJob
@@ -68,6 +69,7 @@ class MigrationJobService(
         MigrationJobType.updateCas1ApplicationsWithOffender -> getBean(Cas1UpdateApprovedPremisesApplicationWithOffenderJob::class)
         MigrationJobType.updateCas3BedspaceModelData -> getBean(Cas3MigrateNewBedspaceModelDataJob::class)
         MigrationJobType.updateCas3VoidBedspaceData -> getBean(Cas3VoidBedspaceJob::class)
+        MigrationJobType.cas1BackfillApplicationDuration -> getBean(Cas1BackfillApplicationDuration::class)
         MigrationJobType.cas1CapacityPerformanceTest -> getBean(Cas1CapacityPerformanceTestJob::class)
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDurationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDurationJobTest.kt
@@ -1,0 +1,112 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.integration.migration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJobService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
+import java.time.OffsetDateTime
+
+class Cas1BackfillApplicationDurationJobTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var migrationJobService: MigrationJobService
+
+  @Test
+  fun `backfill applications correctly`() {
+    val application1NoArrivalDate = givenACas1Application(
+      arrivalDate = null,
+    )
+
+    val application2ArrivalDate = OffsetDateTime.now().minusDays(2).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application2OverriddenDuration = givenACas1Application(
+      arrivalDate = application2ArrivalDate,
+      apType = ApprovedPremisesType.PIPE,
+      data = """{
+                "move-on": {
+                    "placement-duration": {
+                        "differentDuration": "yes",
+                        "duration": "25",
+                        "durationDays": "1",
+                        "durationWeeks": "1",
+                        "reason": "asd"
+                    }
+                }
+            }""",
+    )
+
+    val application3ArrivalDate = OffsetDateTime.now().minusDays(3).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application3ApTypeStandard = givenACas1Application(
+      arrivalDate = application3ArrivalDate,
+      apType = ApprovedPremisesType.NORMAL,
+    )
+
+    val application4ArrivalDate = OffsetDateTime.now().minusDays(4).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application4ApTypeMhapStJosephs = givenACas1Application(
+      arrivalDate = application4ArrivalDate,
+      apType = ApprovedPremisesType.MHAP_ST_JOSEPHS,
+    )
+
+    val application5ArrivalDate = OffsetDateTime.now().minusDays(5).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application5ApTypeMhapStElliots = givenACas1Application(
+      arrivalDate = application5ArrivalDate,
+      apType = ApprovedPremisesType.MHAP_ELLIOTT_HOUSE,
+    )
+
+    val application6ArrivalDate = OffsetDateTime.now().minusDays(6).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application6ApTypeRfap = givenACas1Application(
+      arrivalDate = application6ArrivalDate,
+      apType = ApprovedPremisesType.RFAP,
+    )
+
+    val application7ArrivalDate = OffsetDateTime.now().minusDays(7).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application7ApTypePipe = givenACas1Application(
+      arrivalDate = application7ArrivalDate,
+      apType = ApprovedPremisesType.PIPE,
+    )
+
+    val application8ArrivalDate = OffsetDateTime.now().minusDays(8).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application8ApTypePipe = givenACas1Application(
+      arrivalDate = application8ArrivalDate,
+      apType = ApprovedPremisesType.ESAP,
+    )
+
+    migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillApplicationDuration)
+
+    val updatedApplication1 = approvedPremisesApplicationRepository.findByIdOrNull(application1NoArrivalDate.id)!!
+    assertThat(updatedApplication1.arrivalDate).isNull()
+    assertThat(updatedApplication1.duration).isNull()
+
+    val updatedApplication2 = approvedPremisesApplicationRepository.findByIdOrNull(application2OverriddenDuration.id)!!
+    assertThat(updatedApplication2.arrivalDate).isEqualTo(application2ArrivalDate)
+    assertThat(updatedApplication2.duration).isEqualTo(25)
+
+    val updatedApplication3 = approvedPremisesApplicationRepository.findByIdOrNull(application3ApTypeStandard.id)!!
+    assertThat(updatedApplication3.arrivalDate).isEqualTo(application3ArrivalDate)
+    assertThat(updatedApplication3.duration).isEqualTo(12 * 7)
+
+    val updatedApplication4 = approvedPremisesApplicationRepository.findByIdOrNull(application4ApTypeMhapStJosephs.id)!!
+    assertThat(updatedApplication4.arrivalDate).isEqualTo(application4ArrivalDate)
+    assertThat(updatedApplication4.duration).isEqualTo(12 * 7)
+
+    val updatedApplication5 = approvedPremisesApplicationRepository.findByIdOrNull(application5ApTypeMhapStElliots.id)!!
+    assertThat(updatedApplication5.arrivalDate).isEqualTo(application5ArrivalDate)
+    assertThat(updatedApplication5.duration).isEqualTo(12 * 7)
+
+    val updatedApplication6 = approvedPremisesApplicationRepository.findByIdOrNull(application6ApTypeRfap.id)!!
+    assertThat(updatedApplication6.arrivalDate).isEqualTo(application6ArrivalDate)
+    assertThat(updatedApplication6.duration).isEqualTo(12 * 7)
+
+    val updatedApplication7 = approvedPremisesApplicationRepository.findByIdOrNull(application7ApTypePipe.id)!!
+    assertThat(updatedApplication7.arrivalDate).isEqualTo(application7ArrivalDate)
+    assertThat(updatedApplication7.duration).isEqualTo(26 * 7)
+
+    val updatedApplication8 = approvedPremisesApplicationRepository.findByIdOrNull(application8ApTypePipe.id)!!
+    assertThat(updatedApplication8.arrivalDate).isEqualTo(application8ArrivalDate)
+    assertThat(updatedApplication8.duration).isEqualTo(52 * 7)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.CaseSummary
@@ -44,6 +45,9 @@ fun IntegrationTestBase.givenACas1Application(
   tier: String? = null,
   caseManager: Cas1ApplicationUserDetailsEntity? = null,
   applicant: Cas1ApplicationUserDetailsEntity? = null,
+  arrivalDate: OffsetDateTime? = null,
+  data: String? = "{}",
+  apType: ApprovedPremisesType = ApprovedPremisesType.NORMAL,
   block: (application: ApplicationEntity) -> Unit = {},
 ) = givenAnApplication(
   createdByUser,
@@ -56,6 +60,9 @@ fun IntegrationTestBase.givenACas1Application(
   tier,
   caseManager,
   applicant,
+  arrivalDate,
+  data,
+  apType,
   block,
 )
 
@@ -71,6 +78,9 @@ fun IntegrationTestBase.givenAnApplication(
   tier: String? = null,
   caseManager: Cas1ApplicationUserDetailsEntity? = null,
   applicant: Cas1ApplicationUserDetailsEntity? = null,
+  arrivalDate: OffsetDateTime? = null,
+  data: String? = "{}",
+  apType: ApprovedPremisesType = ApprovedPremisesType.NORMAL,
   block: (application: ApplicationEntity) -> Unit = {},
 ): ApprovedPremisesApplicationEntity {
   val riskRatings = tier?.let {
@@ -89,6 +99,9 @@ fun IntegrationTestBase.givenAnApplication(
     withCaseManagerUserDetails(caseManager)
     withCaseManagerIsNotApplicant(caseManager != null)
     withApplicantUserDetails(applicant)
+    withArrivalDate(arrivalDate)
+    withData(data)
+    withApType(apType)
   }
 
   block(application)


### PR DESCRIPTION
This commit adds a backfill job that backfills the duration field for an application’s original request for placement using the following logic:

* If the duration was overridden by the user, use the overridden duration (this is defined in the application JSON data
* if apType is PIPE, duration is 26 weeks
* if apType is ESAP, duration is 52 weeks
* otherwise, duration is 12 weeks

This logic has been taken from the corresponding UI code: https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/ab1e43c11ac3def69fceb6eacebd526fcd150388/server/utils/applications/getDefaultPlacementDurationInDays.ts#L6.

All new durations will be provided by the UI to the API using the API field added by **INSERT COMMIT HERE (and in the commit message)**