### PR TITLE
APS-2594 Set pending property status to active.

### DIFF
--- a/src/main/resources/db/migration/all/20250804095332__change_pending_property_status_to_active.sql
+++ b/src/main/resources/db/migration/all/20250804095332__change_pending_property_status_to_active.sql
@@ -1,0 +1,1 @@
+UPDATE premises SET status = 'active' WHERE status = 'pending';


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2594

Only one premises has a `pending` status which will be changed to `active` once this migration job has run.