### PR TITLE
CAS1 application.duration will always be populated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDuration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDuration.kt
@@ -45,8 +45,7 @@ interface Cas1BackfillApplicationDurationRepository : JpaRepository<ApprovedPrem
               apa.id as id,
               (a.data -> 'move-on' -> 'placement-duration' ->> 'duration')::integer as duration
           from approved_premises_applications apa inner join applications a on a.id = apa.id
-          where 
-          apa.arrival_date IS NOT NULL AND 
+          where  
           apa.duration IS NULL AND 
           a.data -> 'move-on' -> 'placement-duration' ->> 'differentDuration' = 'yes'
       )
@@ -64,10 +63,7 @@ interface Cas1BackfillApplicationDurationRepository : JpaRepository<ApprovedPrem
     value = """
       UPDATE approved_premises_applications
       SET duration = (26 * 7)
-      WHERE 
-      arrival_date IS NOT NULL AND 
-      duration IS NULL AND 
-      ap_type = 'PIPE'
+      WHERE duration IS NULL AND ap_type = 'PIPE'
   """,
     nativeQuery = true,
   )
@@ -78,10 +74,7 @@ interface Cas1BackfillApplicationDurationRepository : JpaRepository<ApprovedPrem
     value = """
       UPDATE approved_premises_applications
       SET duration = (52 * 7)
-      WHERE 
-      arrival_date IS NOT NULL AND 
-      duration IS NULL AND 
-      ap_type = 'ESAP'
+      WHERE duration IS NULL AND ap_type = 'ESAP'
   """,
     nativeQuery = true,
   )
@@ -91,10 +84,8 @@ interface Cas1BackfillApplicationDurationRepository : JpaRepository<ApprovedPrem
   @Query(
     value = """
       UPDATE approved_premises_applications
-      SET duration = (12 * 7)
-      WHERE 
-      arrival_date IS NOT NULL AND 
-      duration IS NULL
+      SET duration = (12 * 7) 
+      WHERE duration IS NULL
   """,
     nativeQuery = true,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -392,8 +392,12 @@ class ApprovedPremisesApplicationEntity(
    */
   var arrivalDate: OffsetDateTime?,
   /**
-   * If a request for placement was made in the original application, this provides
-   * the duration of the stay in days
+   * The duration agreed by the applicant. This is typically the default duration
+   * for the corresponding apType, but the applicant will have the option to
+   * modify this.
+   *
+   * Note that this will be populated even if the applicant didn't make a request
+   * for a placement as part of the original application (i.e. arrivalDate isn't null)
    */
   var duration: Int?,
   /**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDurationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDurationJobTest.kt
@@ -18,13 +18,9 @@ class Cas1BackfillApplicationDurationJobTest : IntegrationTestBase() {
 
   @Test
   fun `backfill applications correctly`() {
-    val application1NoArrivalDate = givenACas1Application(
-      arrivalDate = null,
-    )
-
-    val application2ArrivalDate = OffsetDateTime.now().minusDays(2).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
-    val application2OverriddenDuration = givenACas1Application(
-      arrivalDate = application2ArrivalDate,
+    val application1ArrivalDate = OffsetDateTime.now().minusDays(2).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application1OverriddenDuration = givenACas1Application(
+      arrivalDate = application1ArrivalDate,
       apType = ApprovedPremisesType.PIPE,
       data = """{
                 "move-on": {
@@ -39,74 +35,70 @@ class Cas1BackfillApplicationDurationJobTest : IntegrationTestBase() {
             }""",
     )
 
-    val application3ArrivalDate = OffsetDateTime.now().minusDays(3).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
-    val application3ApTypeStandard = givenACas1Application(
-      arrivalDate = application3ArrivalDate,
+    val application2ArrivalDate = OffsetDateTime.now().minusDays(3).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application2ApTypeStandard = givenACas1Application(
+      arrivalDate = application2ArrivalDate,
       apType = ApprovedPremisesType.NORMAL,
     )
 
-    val application4ArrivalDate = OffsetDateTime.now().minusDays(4).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
-    val application4ApTypeMhapStJosephs = givenACas1Application(
-      arrivalDate = application4ArrivalDate,
+    val application3ArrivalDate = OffsetDateTime.now().minusDays(4).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application3ApTypeMhapStJosephs = givenACas1Application(
+      arrivalDate = application3ArrivalDate,
       apType = ApprovedPremisesType.MHAP_ST_JOSEPHS,
     )
 
-    val application5ArrivalDate = OffsetDateTime.now().minusDays(5).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
-    val application5ApTypeMhapStElliots = givenACas1Application(
-      arrivalDate = application5ArrivalDate,
+    val application4ArrivalDate = OffsetDateTime.now().minusDays(5).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application4ApTypeMhapStElliots = givenACas1Application(
+      arrivalDate = application4ArrivalDate,
       apType = ApprovedPremisesType.MHAP_ELLIOTT_HOUSE,
     )
 
-    val application6ArrivalDate = OffsetDateTime.now().minusDays(6).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
-    val application6ApTypeRfap = givenACas1Application(
-      arrivalDate = application6ArrivalDate,
+    val application5ArrivalDate = OffsetDateTime.now().minusDays(6).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application5ApTypeRfap = givenACas1Application(
+      arrivalDate = application5ArrivalDate,
       apType = ApprovedPremisesType.RFAP,
     )
 
-    val application7ArrivalDate = OffsetDateTime.now().minusDays(7).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
-    val application7ApTypePipe = givenACas1Application(
-      arrivalDate = application7ArrivalDate,
+    val application6ArrivalDate = OffsetDateTime.now().minusDays(7).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application6ApTypePipe = givenACas1Application(
+      arrivalDate = application6ArrivalDate,
       apType = ApprovedPremisesType.PIPE,
     )
 
-    val application8ArrivalDate = OffsetDateTime.now().minusDays(8).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
-    val application8ApTypePipe = givenACas1Application(
-      arrivalDate = application8ArrivalDate,
+    val application7ArrivalDate = OffsetDateTime.now().minusDays(8).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application7ApTypePipe = givenACas1Application(
+      arrivalDate = application7ArrivalDate,
       apType = ApprovedPremisesType.ESAP,
     )
 
     migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillApplicationDuration)
 
-    val updatedApplication1 = approvedPremisesApplicationRepository.findByIdOrNull(application1NoArrivalDate.id)!!
-    assertThat(updatedApplication1.arrivalDate).isNull()
-    assertThat(updatedApplication1.duration).isNull()
+    val updatedApplication1 = approvedPremisesApplicationRepository.findByIdOrNull(application1OverriddenDuration.id)!!
+    assertThat(updatedApplication1.arrivalDate).isEqualTo(application1ArrivalDate)
+    assertThat(updatedApplication1.duration).isEqualTo(25)
 
-    val updatedApplication2 = approvedPremisesApplicationRepository.findByIdOrNull(application2OverriddenDuration.id)!!
+    val updatedApplication2 = approvedPremisesApplicationRepository.findByIdOrNull(application2ApTypeStandard.id)!!
     assertThat(updatedApplication2.arrivalDate).isEqualTo(application2ArrivalDate)
-    assertThat(updatedApplication2.duration).isEqualTo(25)
+    assertThat(updatedApplication2.duration).isEqualTo(12 * 7)
 
-    val updatedApplication3 = approvedPremisesApplicationRepository.findByIdOrNull(application3ApTypeStandard.id)!!
+    val updatedApplication3 = approvedPremisesApplicationRepository.findByIdOrNull(application3ApTypeMhapStJosephs.id)!!
     assertThat(updatedApplication3.arrivalDate).isEqualTo(application3ArrivalDate)
     assertThat(updatedApplication3.duration).isEqualTo(12 * 7)
 
-    val updatedApplication4 = approvedPremisesApplicationRepository.findByIdOrNull(application4ApTypeMhapStJosephs.id)!!
+    val updatedApplication4 = approvedPremisesApplicationRepository.findByIdOrNull(application4ApTypeMhapStElliots.id)!!
     assertThat(updatedApplication4.arrivalDate).isEqualTo(application4ArrivalDate)
     assertThat(updatedApplication4.duration).isEqualTo(12 * 7)
 
-    val updatedApplication5 = approvedPremisesApplicationRepository.findByIdOrNull(application5ApTypeMhapStElliots.id)!!
+    val updatedApplication5 = approvedPremisesApplicationRepository.findByIdOrNull(application5ApTypeRfap.id)!!
     assertThat(updatedApplication5.arrivalDate).isEqualTo(application5ArrivalDate)
     assertThat(updatedApplication5.duration).isEqualTo(12 * 7)
 
-    val updatedApplication6 = approvedPremisesApplicationRepository.findByIdOrNull(application6ApTypeRfap.id)!!
+    val updatedApplication6 = approvedPremisesApplicationRepository.findByIdOrNull(application6ApTypePipe.id)!!
     assertThat(updatedApplication6.arrivalDate).isEqualTo(application6ArrivalDate)
-    assertThat(updatedApplication6.duration).isEqualTo(12 * 7)
+    assertThat(updatedApplication6.duration).isEqualTo(26 * 7)
 
     val updatedApplication7 = approvedPremisesApplicationRepository.findByIdOrNull(application7ApTypePipe.id)!!
     assertThat(updatedApplication7.arrivalDate).isEqualTo(application7ArrivalDate)
-    assertThat(updatedApplication7.duration).isEqualTo(26 * 7)
-
-    val updatedApplication8 = approvedPremisesApplicationRepository.findByIdOrNull(application8ApTypePipe.id)!!
-    assertThat(updatedApplication8.arrivalDate).isEqualTo(application8ArrivalDate)
-    assertThat(updatedApplication8.duration).isEqualTo(52 * 7)
+    assertThat(updatedApplication7.duration).isEqualTo(52 * 7)
   }
 }


### PR DESCRIPTION
This commit updates the backfill job for `approved_premises_application.duration` to always popualte the duration, regardless of whether an arrival date is provided, matching the behaviour expected by the UI.

