### PR TITLE
APS-2620 Backfill placement app requested/authorised dates

### DIFF
--- a/src/main/resources/db/migration/all/20250804141027__backfill_placement_app_authorised_and_requested_durations.sql
+++ b/src/main/resources/db/migration/all/20250804141027__backfill_placement_app_authorised_and_requested_durations.sql
@@ -1,0 +1,7 @@
+update placement_applications
+set requested_duration_days = duration
+where requested_duration_days is null and duration is not null;
+
+update placement_applications
+set authorised_duration_days = duration
+where authorised_duration_days is null and decision = 'ACCEPTED';


### PR DESCRIPTION
This is only populating ‘non automatic’ placement applications (by virtue of there not being any ‘automatic’ placement applications in the database currently)

For these placement applications there is no way for the authoriser to modify the duration, so the values will always be the same.

