### PR TITLE
APS-2620 Provide Request for Placement requested & authorised durations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/cas1/Cas1RequestedPlacementPeriod.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/cas1/Cas1RequestedPlacementPeriod.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1
+
+data class Cas1RequestedPlacementPeriod(
+  val arrival: java.time.LocalDate,
+  val arrivalFlexible: Boolean?,
+  val duration: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/RequestForPlacement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/RequestForPlacement.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
 
 data class RequestForPlacement(
   @Schema(description = "If `type` is `\"manual\"`, provides the `PlacementApplication` ID. If `type` is `\"automatic\"` this field provides a `PlacementRequest` ID. ")
@@ -11,9 +12,10 @@ data class RequestForPlacement(
   val canBeDirectlyWithdrawn: Boolean,
   val isWithdrawn: Boolean,
   val type: RequestForPlacementType,
-  val dates: PlacementDates,
   @Schema(description = "Requests for placements only have one set of placement dates, use 'dates' instead")
   val placementDates: List<PlacementDates>,
+  val requestedPlacementPeriod: Cas1RequestedPlacementPeriod,
+  val authorisedPlacementPeriod: Cas1RequestedPlacementPeriod?,
   val status: RequestForPlacementStatus,
   val submittedAt: java.time.Instant? = null,
   @Schema(description = "If `type` is `\"manual\"`, provides the value of `PlacementApplication.decisionMadeAt`. If `type` is `\"automatic\"` this field provides the value of `PlacementRequest.assessmentCompletedAt`. ")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/RequestForPlacement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/RequestForPlacement.kt
@@ -1,62 +1,23 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-/**
- *
- * @param id If `type` is `\"manual\"`, provides the `PlacementApplication` ID. If `type` is `\"automatic\"` this field provides a `PlacementRequest` ID.
- * @param createdByUserId
- * @param createdAt
- * @param canBeDirectlyWithdrawn If true, the user making this request can withdraw this request for placement.  If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application.
- * @param isWithdrawn
- * @param type
- * @param dates
- * @param placementDates Requests for placements only have one set of placement dates, use 'dates' instead
- * @param status
- * @param submittedAt
- * @param requestReviewedAt If `type` is `\"manual\"`, provides the value of `PlacementApplication.decisionMadeAt`. If `type` is `\"automatic\"` this field provides the value of `PlacementRequest.assessmentCompletedAt`.
- * @param document Any object
- * @param withdrawalReason
- */
 data class RequestForPlacement(
-
-  @Schema(example = "null", required = true, description = "If `type` is `\"manual\"`, provides the `PlacementApplication` ID. If `type` is `\"automatic\"` this field provides a `PlacementRequest` ID. ")
-  @get:JsonProperty("id", required = true) val id: java.util.UUID,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("createdByUserId", required = true) val createdByUserId: java.util.UUID,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("createdAt", required = true) val createdAt: java.time.Instant,
-
-  @Schema(example = "null", required = true, description = "If true, the user making this request can withdraw this request for placement.  If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application. ")
-  @get:JsonProperty("canBeDirectlyWithdrawn", required = true) val canBeDirectlyWithdrawn: kotlin.Boolean,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("isWithdrawn", required = true) val isWithdrawn: kotlin.Boolean,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("type", required = true) val type: RequestForPlacementType,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("dates", required = true) val dates: PlacementDates,
-
-  @Schema(example = "null", required = true, description = "Requests for placements only have one set of placement dates, use 'dates' instead")
-  @get:JsonProperty("placementDates", required = true) val placementDates: kotlin.collections.List<PlacementDates>,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("status", required = true) val status: RequestForPlacementStatus,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("submittedAt") val submittedAt: java.time.Instant? = null,
-
-  @Schema(example = "null", description = "If `type` is `\"manual\"`, provides the value of `PlacementApplication.decisionMadeAt`. If `type` is `\"automatic\"` this field provides the value of `PlacementRequest.assessmentCompletedAt`. ")
-  @get:JsonProperty("requestReviewedAt") val requestReviewedAt: java.time.Instant? = null,
-
-  @Schema(example = "null", description = "Any object")
-  @get:JsonProperty("document") val document: kotlin.Any? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("withdrawalReason") val withdrawalReason: WithdrawPlacementRequestReason? = null,
+  @Schema(description = "If `type` is `\"manual\"`, provides the `PlacementApplication` ID. If `type` is `\"automatic\"` this field provides a `PlacementRequest` ID. ")
+  val id: java.util.UUID,
+  val createdByUserId: java.util.UUID,
+  val createdAt: java.time.Instant,
+  @Schema(description = "If true, the user making this request can withdraw this request for placement.  If false, it may still be possible to indirectly withdraw this request for placement by withdrawing the application. ")
+  val canBeDirectlyWithdrawn: Boolean,
+  val isWithdrawn: Boolean,
+  val type: RequestForPlacementType,
+  val dates: PlacementDates,
+  @Schema(description = "Requests for placements only have one set of placement dates, use 'dates' instead")
+  val placementDates: List<PlacementDates>,
+  val status: RequestForPlacementStatus,
+  val submittedAt: java.time.Instant? = null,
+  @Schema(description = "If `type` is `\"manual\"`, provides the value of `PlacementApplication.decisionMadeAt`. If `type` is `\"automatic\"` this field provides the value of `PlacementRequest.assessmentCompletedAt`. ")
+  val requestReviewedAt: java.time.Instant? = null,
+  val document: Any? = null,
+  val withdrawalReason: WithdrawPlacementRequestReason? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
@@ -23,8 +24,19 @@ class RequestForPlacementTransformer(
     createdAt = placementApplicationEntity.createdAt.toInstant(),
     isWithdrawn = placementApplicationEntity.isWithdrawn,
     type = RequestForPlacementType.manual,
-    dates = placementApplicationEntity.placementDates()!!.toApiType(),
     placementDates = listOf(placementApplicationEntity.placementDates()!!.toApiType()),
+    requestedPlacementPeriod = Cas1RequestedPlacementPeriod(
+      arrival = placementApplicationEntity.expectedArrival!!,
+      arrivalFlexible = null,
+      duration = placementApplicationEntity.requestedDuration!!,
+    ),
+    authorisedPlacementPeriod = placementApplicationEntity.authorisedDuration?.let {
+      Cas1RequestedPlacementPeriod(
+        arrival = placementApplicationEntity.expectedArrival!!,
+        arrivalFlexible = null,
+        duration = it,
+      )
+    },
     submittedAt = placementApplicationEntity.submittedAt?.toInstant(),
     requestReviewedAt = placementApplicationEntity.decisionMadeAt?.toInstant(),
     document = placementApplicationEntity.document?.let(objectMapper::readTree),
@@ -55,8 +67,14 @@ class RequestForPlacementTransformer(
       createdAt = placementRequestEntity.createdAt.toInstant(),
       isWithdrawn = placementRequestEntity.isWithdrawn,
       type = RequestForPlacementType.automatic,
-      dates = PlacementDates(
-        expectedArrival = placementRequestEntity.expectedArrival,
+      requestedPlacementPeriod = Cas1RequestedPlacementPeriod(
+        arrival = placementRequestEntity.expectedArrival,
+        arrivalFlexible = null,
+        duration = placementRequestEntity.duration,
+      ),
+      authorisedPlacementPeriod = Cas1RequestedPlacementPeriod(
+        arrival = placementRequestEntity.expectedArrival,
+        arrivalFlexible = null,
         duration = placementRequestEntity.duration,
       ),
       placementDates = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -34,6 +34,8 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var isWithdrawn: Yielded<Boolean> = { false }
   private var expectedArrival: Yielded<LocalDate?> = { null }
   private var duration: Yielded<Int?> = { null }
+  private var requestedDuration: Yielded<Int?> = { null }
+  private var authorisedDuration: Yielded<Int?> = { null }
 
   fun withDefaults() = apply {
     this.createdByUser = { UserEntityFactory().withDefaultProbationRegion().produce() }
@@ -112,6 +114,14 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     this.duration = { duration }
   }
 
+  fun withRequestedDuration(requestedDuration: Int?) = apply {
+    this.requestedDuration = { requestedDuration }
+  }
+
+  fun withAuthorisedDuration(authorisedDuration: Int?) = apply {
+    this.authorisedDuration = { authorisedDuration }
+  }
+
   override fun produce(): PlacementApplicationEntity = PlacementApplicationEntity(
     id = this.id(),
     application = this.application?.invoke() ?: throw RuntimeException("Must provide an application"),
@@ -134,5 +144,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     isWithdrawn = this.isWithdrawn(),
     expectedArrival = this.expectedArrival(),
     duration = this.duration(),
+    requestedDuration = this.requestedDuration(),
+    authorisedDuration = this.authorisedDuration(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/RequestsForPlacementTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/RequestsForPlacementTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
@@ -11,7 +10,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsListOfObjects
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
 import java.time.LocalDate
@@ -19,8 +17,6 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 class RequestsForPlacementTest : IntegrationTestBase() {
-  @Autowired
-  lateinit var requestForPlacementTransformer: RequestForPlacementTransformer
 
   @Nested
   inner class AllRequestsForPlacementForApplication {
@@ -64,6 +60,7 @@ class RequestsForPlacementTest : IntegrationTestBase() {
             withSubmittedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
             withExpectedArrival(LocalDate.now())
             withDuration(1)
+            withRequestedDuration(2)
           }
 
           val submittedButReallocatedPlacementApplication = placementApplicationFactory.produceAndPersist {
@@ -73,6 +70,7 @@ class RequestsForPlacementTest : IntegrationTestBase() {
             withReallocatedAt(OffsetDateTime.now())
             withExpectedArrival(LocalDate.now())
             withDuration(1)
+            withRequestedDuration(2)
           }
 
           val withdrawnPlacementApplication = placementApplicationFactory.produceAndPersist {
@@ -83,6 +81,7 @@ class RequestsForPlacementTest : IntegrationTestBase() {
             withWithdrawalReason(PlacementApplicationWithdrawalReason.ALTERNATIVE_PROVISION_IDENTIFIED)
             withExpectedArrival(LocalDate.now())
             withDuration(1)
+            withRequestedDuration(2)
           }
 
           val placementRequirements = placementRequirementsFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
@@ -61,6 +61,8 @@ class RequestForPlacementTransformerTest {
         .withWithdrawalReason(randomOf(PlacementApplicationWithdrawalReason.entries))
         .withExpectedArrival(LocalDate.of(2012, 9, 9))
         .withDuration(47)
+        .withRequestedDuration(48)
+        .withAuthorisedDuration(49)
         .produce()
 
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
@@ -74,8 +76,12 @@ class RequestForPlacementTransformerTest {
       assertThat(result.requestReviewedAt).isEqualTo(placementApplication.decisionMadeAt?.toInstant())
       assertThat(result.document).isNotNull
       assertThat(result.withdrawalReason).isEqualTo(placementApplication.withdrawalReason?.apiValue)
-      assertThat(result.dates.expectedArrival).isEqualTo(LocalDate.of(2012, 9, 9))
-      assertThat(result.dates.duration).isEqualTo(47)
+      assertThat(result.requestedPlacementPeriod.arrival).isEqualTo(LocalDate.of(2012, 9, 9))
+      assertThat(result.requestedPlacementPeriod.arrivalFlexible).isNull()
+      assertThat(result.requestedPlacementPeriod.duration).isEqualTo(48)
+      assertThat(result.authorisedPlacementPeriod!!.arrival).isEqualTo(LocalDate.of(2012, 9, 9))
+      assertThat(result.authorisedPlacementPeriod.arrivalFlexible).isNull()
+      assertThat(result.authorisedPlacementPeriod.duration).isEqualTo(49)
       assertThat(result.placementDates).hasSize(1)
       assertThat(result.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2012, 9, 9))
       assertThat(result.placementDates[0].duration).isEqualTo(47)
@@ -98,6 +104,8 @@ class RequestForPlacementTransformerTest {
         .withWithdrawalReason(randomOf(PlacementApplicationWithdrawalReason.entries))
         .withExpectedArrival(LocalDate.of(2012, 9, 9))
         .withDuration(47)
+        .withRequestedDuration(6)
+        .withAuthorisedDuration(7)
         .produce()
 
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
@@ -119,6 +127,8 @@ class RequestForPlacementTransformerTest {
         .withDecision(PlacementApplicationDecision.ACCEPTED)
         .withExpectedArrival(LocalDate.of(2012, 9, 9))
         .withDuration(47)
+        .withRequestedDuration(6)
+        .withAuthorisedDuration(7)
         .produce()
 
       val assessment = ApprovedPremisesAssessmentEntityFactory()
@@ -172,6 +182,8 @@ class RequestForPlacementTransformerTest {
         .withDecision(PlacementApplicationDecision.REJECTED)
         .withExpectedArrival(LocalDate.of(2012, 9, 9))
         .withDuration(47)
+        .withRequestedDuration(6)
+        .withAuthorisedDuration(7)
         .produce()
 
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
@@ -193,6 +205,8 @@ class RequestForPlacementTransformerTest {
         .withDecision(PlacementApplicationDecision.ACCEPTED)
         .withExpectedArrival(LocalDate.of(2012, 9, 9))
         .withDuration(47)
+        .withRequestedDuration(6)
+        .withAuthorisedDuration(7)
         .produce()
 
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
@@ -212,6 +226,8 @@ class RequestForPlacementTransformerTest {
         .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
         .withExpectedArrival(LocalDate.of(2012, 9, 9))
         .withDuration(47)
+        .withRequestedDuration(6)
+        .withAuthorisedDuration(7)
         .produce()
 
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
@@ -232,6 +248,8 @@ class RequestForPlacementTransformerTest {
         .withSubmittedAt(OffsetDateTime.now())
         .withExpectedArrival(LocalDate.now())
         .withDuration(5)
+        .withRequestedDuration(6)
+        .withAuthorisedDuration(7)
         .produce()
 
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(
@@ -275,6 +293,12 @@ class RequestForPlacementTransformerTest {
       assertThat(result.createdAt).isEqualTo(placementRequest.createdAt.toInstant())
       assertThat(result.isWithdrawn).isEqualTo(placementRequest.isWithdrawn)
       assertThat(result.type).isEqualTo(RequestForPlacementType.automatic)
+      assertThat(result.requestedPlacementPeriod.arrival).isEqualTo(placementRequest.expectedArrival)
+      assertThat(result.requestedPlacementPeriod.arrivalFlexible).isNull()
+      assertThat(result.requestedPlacementPeriod.duration).isEqualTo(placementRequest.duration)
+      assertThat(result.authorisedPlacementPeriod!!.arrival).isEqualTo(placementRequest.expectedArrival)
+      assertThat(result.authorisedPlacementPeriod.arrivalFlexible).isNull()
+      assertThat(result.authorisedPlacementPeriod.duration).isEqualTo(placementRequest.duration)
       assertThat(result.placementDates).hasSize(1)
       assertThat(result.placementDates[0].expectedArrival).isEqualTo(placementRequest.expectedArrival)
       assertThat(result.placementDates[0].duration).isEqualTo(placementRequest.duration)


### PR DESCRIPTION
It’s safe to remove RequestForPlacement.duration as it’s a relatively new field that the UI isn’t currently using