### PR TITLE
APS-2637 - Add QCode to out of service bed report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/reporting/Cas1OutOfServiceBedsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/reporting/Cas1OutOfServiceBedsReportRepository.kt
@@ -32,6 +32,7 @@ class Cas1OutOfServiceBedsReportRepository(
           latest_revisions.reference_number AS "workOrderId",
           probation_regions.name AS region,
           premises.name AS ap,
+          ap.q_code AS "apQCode",
           latest_revisions.reason AS reason,
           latest_revisions.start_date AS "startDate",
           latest_revisions.end_date AS "endDate",
@@ -55,6 +56,7 @@ class Cas1OutOfServiceBedsReportRepository(
             JOIN beds ON oos_bed.bed_id = beds.id
             JOIN rooms ON beds.room_id = rooms.id
             JOIN premises ON rooms.premises_id = premises.id
+            JOIN approved_premises ap ON premises.id = ap.premises_id
             JOIN probation_regions ON premises.probation_region_id = probation_regions.id
             LEFT JOIN latest_revisions
                 ON oos_bed.id = latest_revisions.out_of_service_bed_id
@@ -74,6 +76,7 @@ class Cas1OutOfServiceBedsReportRepository(
             rooms.name,
             beds.name,
             premises.name,
+            ap.q_code,
             probation_regions.name,
             latest_revisions.start_date,
             latest_revisions.end_date,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1OutOfServiceBedsReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1OutOfServiceBedsReportTest.kt
@@ -34,6 +34,7 @@ class Cas1OutOfServiceBedsReportTest : InitialiseDatabasePerClassTestBase() {
       givenAnOffender { _, _ ->
         val premises = givenAnApprovedPremises(
           name = "ap name",
+          qCode = "Q001",
           region = givenAProbationRegion(name = "the region"),
         )
 
@@ -200,6 +201,7 @@ class Cas1OutOfServiceBedsReportTest : InitialiseDatabasePerClassTestBase() {
         assertThat(actualRows[0].workOrderId).isEqualTo("ref1")
         assertThat(actualRows[0].region).isEqualTo("the region")
         assertThat(actualRows[0].ap).isEqualTo("ap name")
+        assertThat(actualRows[0].apQCode).isEqualTo("Q001")
         assertThat(actualRows[0].reason).isEqualTo("Reason1")
         assertThat(actualRows[0].startDate).isEqualTo(LocalDate.of(2023, 4, 5))
         assertThat(actualRows[0].endDate).isEqualTo(LocalDate.of(2023, 7, 8))
@@ -210,6 +212,7 @@ class Cas1OutOfServiceBedsReportTest : InitialiseDatabasePerClassTestBase() {
         assertThat(actualRows[1].id).isEqualTo(oosbRecordBed2.id.toString())
         assertThat(actualRows[1].workOrderId).isEqualTo("ref2")
         assertThat(actualRows[1].ap).isEqualTo("ap name")
+        assertThat(actualRows[1].apQCode).isEqualTo("Q001")
         assertThat(actualRows[1].reason).isEqualTo("Reason2")
         assertThat(actualRows[1].startDate).isEqualTo(LocalDate.of(2023, 4, 12))
         assertThat(actualRows[1].endDate).isEqualTo(LocalDate.of(2023, 7, 5))
@@ -277,6 +280,7 @@ data class Cas1OutOfServiceBedReportRowWithoutPii(
   val workOrderId: String?,
   val region: String,
   val ap: String,
+  val apQCode: String,
   val reason: String,
   val startDate: LocalDate,
   val endDate: LocalDate,
@@ -290,6 +294,7 @@ data class Cas1OutOfServiceBedReportRowWithPii(
   val workOrderId: String?,
   val region: String,
   val ap: String,
+  val apQCode: String,
   val reason: String,
   val startDate: LocalDate,
   val endDate: LocalDate,


### PR DESCRIPTION
This is to support performance hub mapping rows onto premises as the name can sometimes be unreliable.

