### PR TITLE
APS-2476 Add new CAS 3 DELETE and POST assessment allocation endpoonts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3AssessmentController.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.controller
+
+import jakarta.transaction.Transactional
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromCasResultIsSuccess
+import java.util.UUID
+
+@Cas3Controller
+class Cas3AssessmentController(
+  private val cas3AssessmentService: Cas3AssessmentService,
+  private val userService: UserService,
+) {
+  @DeleteMapping("/assessments/{assessmentId}/allocations")
+  @Transactional
+  fun deallocateAssessment(@PathVariable assessmentId: UUID): ResponseEntity<Unit> {
+    val user = userService.getUserForRequest()
+
+    ensureEntityFromCasResultIsSuccess(cas3AssessmentService.deallocateAssessment(user, assessmentId))
+
+    return ResponseEntity(Unit, HttpStatus.NO_CONTENT)
+  }
+
+  @PostMapping("/assessments/{assessmentId}/reallocateToMe")
+  @Transactional
+  fun reallocateAssessmentToMe(@PathVariable assessmentId: UUID): ResponseEntity<Unit> {
+    val user = userService.getUserForRequest()
+
+    ensureEntityFromCasResultIsSuccess(
+      cas3AssessmentService.reallocateAssessmentToMe(user, assessmentId),
+    )
+
+    return ResponseEntity(HttpStatus.CREATED)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3AssessmentService.kt
@@ -1,23 +1,36 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.CAS3AssessmentUpdatedField
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.findAssessmentById
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
 class Cas3AssessmentService(
   private val assessmentRepository: AssessmentRepository,
+  private val temporaryAccommodationAssessmentRepository: TemporaryAccommodationAssessmentRepository,
   private val userAccessService: UserAccessService,
   private val cas3DomainEventService: Cas3DomainEventService,
   private val cas3DomainEventBuilder: Cas3DomainEventBuilder,
+  private val userService: UserService,
+  private val assessmentReferralHistoryNoteRepository: AssessmentReferralHistoryNoteRepository,
+  private val lockableAssessmentRepository: LockableAssessmentRepository,
 ) {
   @Suppress("ReturnCount")
   fun updateAssessment(
@@ -83,6 +96,65 @@ class Cas3AssessmentService(
     }
 
     return CasResult.Success(assessmentRepository.save(assessment))
+  }
+
+  fun deallocateAssessment(requestUser: UserEntity, assessmentId: UUID): CasResult<Unit> {
+    if (!userAccessService.userCanDeallocateTask(requestUser)) {
+      return CasResult.Unauthorised()
+    }
+
+    val currentAssessment = temporaryAccommodationAssessmentRepository.findByIdOrNull(assessmentId)
+      ?: return CasResult.NotFound("assessment", assessmentId.toString())
+
+    currentAssessment.allocatedToUser = null
+    currentAssessment.allocatedAt = null
+    currentAssessment.decision = null
+    currentAssessment.submittedAt = null
+
+    val savedAssessment = assessmentRepository.save(currentAssessment)
+    savedAssessment.addSystemNote(userService.getUserForRequest(), ReferralHistorySystemNoteType.UNALLOCATED)
+
+    return CasResult.Success(Unit)
+  }
+
+  private fun AssessmentEntity.addSystemNote(user: UserEntity, type: ReferralHistorySystemNoteType) {
+    this.referralHistoryNotes += assessmentReferralHistoryNoteRepository.save(
+      AssessmentReferralHistorySystemNoteEntity(
+        id = UUID.randomUUID(),
+        assessment = this,
+        createdAt = OffsetDateTime.now(),
+        message = "",
+        createdByUser = user,
+        type = type,
+      ),
+    )
+  }
+
+  fun reallocateAssessmentToMe(requestUser: UserEntity, assessmentId: UUID): CasResult<AssessmentEntity?> {
+    if (!userAccessService.userCanReallocateTask(requestUser)) {
+      return CasResult.Unauthorised()
+    }
+
+    lockableAssessmentRepository.acquirePessimisticLock(assessmentId)
+
+    val currentAssessment = temporaryAccommodationAssessmentRepository.findByIdOrNull(assessmentId)
+      ?: return CasResult.NotFound("assessment", assessmentId.toString())
+
+    if (currentAssessment.reallocatedAt != null) {
+      return CasResult.ConflictError(
+        currentAssessment.id,
+        "This assessment has already been reallocated",
+      )
+    }
+
+    currentAssessment.allocatedToUser = requestUser
+    currentAssessment.allocatedAt = OffsetDateTime.now()
+    currentAssessment.decision = null
+
+    val savedAssessment = assessmentRepository.save(currentAssessment)
+    savedAssessment.addSystemNote(userService.getUserForRequest(), ReferralHistorySystemNoteType.IN_REVIEW)
+
+    return CasResult.Success(savedAssessment)
   }
 
   private fun notBeforeValidationResult(existingDate: LocalDate) = CasResult.GeneralValidationError<TemporaryAccommodationAssessmentEntity>(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/TasksController.kt
@@ -15,6 +15,7 @@ class TasksController(
   private val cas1TasksController: Cas1TasksController,
 ) : TasksApiDelegate {
 
+  @Deprecated("Superseded by Cas3AssessmentController.reallocateAssessment()")
   @Transactional
   override fun tasksTaskTypeIdAllocationsPost(
     id: UUID,
@@ -23,6 +24,7 @@ class TasksController(
     body: NewReallocation?,
   ): ResponseEntity<Reallocation> = cas1TasksController.reallocateTask(id, taskType, xServiceName, body)
 
+  @Deprecated("Superseded by Cas3AssessmentController.deallocateAssessment()")
   @Transactional
   override fun tasksTaskTypeIdAllocationsDelete(id: UUID, taskType: String): ResponseEntity<Unit> = cas1TasksController.unallocateTask(id, taskType)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -311,6 +311,9 @@ class ApprovedPremisesAssessmentEntity(
   fun cas1Application() = this.application as ApprovedPremisesApplicationEntity
 }
 
+@Repository
+interface TemporaryAccommodationAssessmentRepository : JpaRepository<TemporaryAccommodationAssessmentEntity, UUID>
+
 @Entity
 @DiscriminatorValue("temporary-accommodation")
 @Table(name = "temporary_accommodation_assessments")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/AssessmentService.kt
@@ -537,6 +537,7 @@ class AssessmentService(
       )
   }
 
+  @Deprecated("Superseded by Cas3AssessmentService.reallocateAssessment()")
   private fun reallocateTemporaryAccommodationAssessment(
     assigneeUser: UserEntity,
     currentAssessment: TemporaryAccommodationAssessmentEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1TaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1TaskService.kt
@@ -175,6 +175,7 @@ class Cas1TaskService(
     }
   }
 
+  @Deprecated("Not used by CAS1.  For CAS3, superseded by Cas3AssessmentService.deallocateAssessment()")
   fun deallocateTask(
     requestUser: UserEntity,
     taskType: TaskType,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3AssessmentTest.kt
@@ -1,0 +1,140 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForTemporaryAccommodation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
+import java.util.UUID
+
+class Cas3AssessmentTest : IntegrationTestBase() {
+  @Nested
+  inner class DeallocateAssessmentTest {
+    @Test
+    fun `Deallocate assessment without JWT returns 401 Unauthorized`() {
+      webTestClient.delete()
+        .uri("/cas3/assessments/9c7abdf6-fd39-4670-9704-98a5bbfec95e/allocations")
+        .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Deallocate Temporary Accommodation assessment without CAS3_ASSESSOR role returns 403 Forbidden`() {
+      givenAUser { _, jwt ->
+        webTestClient.delete()
+          .uri("/cas3/assessments/9c7abdf6-fd39-4670-9704-98a5bbfec95e/allocations")
+          .header("Authorization", "Bearer $jwt")
+          .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @Test
+    fun `Deallocate Temporary Accommodation assessment returns 200 and unassigns the allocated user`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          givenAnAssessmentForTemporaryAccommodation(
+            allocatedToUser = user,
+            createdByUser = user,
+            crn = offenderDetails.otherIds.crn,
+          ) { existingAssessment, _ ->
+
+            webTestClient.delete()
+              .uri("/cas3/assessments/${existingAssessment.id}/allocations")
+              .header("Authorization", "Bearer $jwt")
+              .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+              .exchange()
+              .expectStatus()
+              .isNoContent
+
+            val assessment =
+              temporaryAccommodationAssessmentRepository.findAll().first { it.id == existingAssessment.id }
+            val note = assessmentReferralSystemNoteRepository.findAll().first { it.assessment.id == assessment.id }
+
+            assertThat(assessment.allocatedToUser).isNull()
+            assertThat(assessment.allocatedAt).isNull()
+            assertThat(assessment.decision).isNull()
+            assertThat(assessment.submittedAt).isNull()
+            assertThat(assessment.referralHistoryNotes).isNotNull()
+            assertThat(note.type).isEqualTo(ReferralHistorySystemNoteType.UNALLOCATED)
+            assertThat(note.createdByUser.id).isEqualTo(user.id)
+          }
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class ReallocateAssessmentToMeTest {
+    @Autowired
+    lateinit var userTransformer: UserTransformer
+
+    @BeforeEach
+    fun stubBankHolidaysApi() {
+      govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+    }
+
+    @Test
+    fun `Reallocate application to different assessor without JWT returns 401`() {
+      webTestClient.post()
+        .uri("/cas3/assessments/9c7abdf6-fd39-4670-9704-98a5bbfec95e/reallocateToMe")
+        .bodyValue(
+          NewReallocation(
+            userId = UUID.randomUUID(),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Reallocating a Temporary Accommodation assessment does not require a request body`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { originalUser, _ ->
+        givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { expectedUser, jwt ->
+          givenAnOffender { offenderDetails, _ ->
+            givenAnAssessmentForTemporaryAccommodation(
+              allocatedToUser = originalUser,
+              createdByUser = originalUser,
+              crn = offenderDetails.otherIds.crn,
+            ) { assessment, _ ->
+              webTestClient.post()
+                .uri("/cas3/assessments/${assessment.id}/reallocateToMe")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+                .bodyValue(Unit)
+                .exchange()
+                .expectStatus()
+                .isCreated
+
+              val assessment = temporaryAccommodationAssessmentRepository.findAll().first { it.id == assessment.id }
+              val note = assessmentReferralSystemNoteRepository.findAll().first { it.assessment.id == assessment.id }
+
+              assertThat(assessment.allocatedToUser).isNotNull()
+              assertThat(assessment.allocatedToUser!!.id).isEqualTo(expectedUser.id)
+              assertThat(assessment.allocatedAt).isNotNull()
+              assertThat(assessment.decision).isNull()
+              assertThat(assessment.referralHistoryNotes).isNotNull()
+              assertThat(note.type).isEqualTo(ReferralHistorySystemNoteType.IN_REVIEW)
+              assertThat(note.createdByUser.id).isEqualTo(expectedUser.id)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3AssessmentServiceTest.kt
@@ -21,12 +21,18 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3DomainEventBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryNoteRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.Optional
 import java.util.UUID
 
@@ -36,7 +42,19 @@ class Cas3AssessmentServiceTest {
   lateinit var assessmentRepository: AssessmentRepository
 
   @MockK
+  lateinit var temporaryAccommodationAssessmentRepository: TemporaryAccommodationAssessmentRepository
+
+  @MockK
+  lateinit var lockableAssessmentRepository: LockableAssessmentRepository
+
+  @MockK
+  lateinit var assessmentReferralHistoryNoteRepository: AssessmentReferralHistoryNoteRepository
+
+  @MockK
   lateinit var userAccessService: UserAccessService
+
+  @MockK
+  lateinit var userService: UserService
 
   @MockK
   lateinit var cas3DomainEventService: Cas3DomainEventService
@@ -188,6 +206,85 @@ class Cas3AssessmentServiceTest {
     assertThat(entity).isNotNull()
     assertThat(entity.releaseDate).isBefore(entity.accommodationRequiredFromDate)
     verify(exactly = 1) { cas3DomainEventService.saveAssessmentUpdatedEvent(any()) }
+  }
+
+  @Test
+  fun `deallocateAssessment deallocates an assessment`() {
+    val user = UserEntityFactory().withDefaultProbationRegion().produce()
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withProbationRegion(user.probationRegion)
+      .withCreatedByUser(user)
+      .produce()
+
+    val assigneeUser = UserEntityFactory().withDefaultProbationRegion().produce()
+    val assessment = TemporaryAccommodationAssessmentEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(assigneeUser)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    assertThat(assessment.allocatedToUser).isNotNull()
+    assertThat(assessment.allocatedAt).isNotNull()
+    assertThat(assessment.decision).isNotNull()
+    assertThat(assessment.submittedAt).isNotNull()
+
+    every { userAccessService.userCanDeallocateTask(user) } returns true
+    every { temporaryAccommodationAssessmentRepository.findById(assessment.id) } returns Optional.of(assessment)
+    every { assessmentRepository.save(any()) } returnsArgument 0
+    every { userService.getUserForRequest() } returns user
+    every { assessmentReferralHistoryNoteRepository.save(any()) } returnsArgument 0
+
+    val result = assessmentService.deallocateAssessment(user, assessment.id)
+
+    assertThat(assessment.allocatedToUser).isNull()
+    assertThat(assessment.allocatedAt).isNull()
+    assertThat(assessment.decision).isNull()
+    assertThat(assessment.submittedAt).isNull()
+    assertThat(assessment.referralHistoryNotes).hasSize(1)
+
+    assertThat(result is CasResult.Success).isTrue
+    assertThat((result as CasResult.Success).value).isNotNull()
+  }
+
+  @Test
+  fun `reallocateAssessment reallocates an assessment`() {
+    val otherUser = UserEntityFactory().withDefaultProbationRegion().produce()
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withProbationRegion(otherUser.probationRegion)
+      .withCreatedByUser(otherUser)
+      .produce()
+
+    val originalAllocationTime = OffsetDateTime.now()
+    val assessment = TemporaryAccommodationAssessmentEntityFactory()
+      .withApplication(application)
+      .withAllocatedToUser(otherUser)
+      .withAllocatedAt(originalAllocationTime)
+      .produce()
+
+    assertThat(assessment.allocatedToUser).isEqualTo(otherUser)
+    assertThat(assessment.allocatedAt).isEqualTo(originalAllocationTime)
+    assertThat(assessment.decision).isNotNull()
+    assertThat(assessment.referralHistoryNotes).hasSize(0)
+
+    val user = UserEntityFactory().withDefaultProbationRegion().produce()
+
+    every { userAccessService.userCanReallocateTask(user) } returns true
+    every { lockableAssessmentRepository.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
+    every { temporaryAccommodationAssessmentRepository.findById(assessment.id) } returns Optional.of(assessment)
+    every { assessmentRepository.save(any()) } returnsArgument 0
+    every { userService.getUserForRequest() } returns user
+    every { assessmentReferralHistoryNoteRepository.save(any()) } returnsArgument 0
+
+    val result = assessmentService.reallocateAssessmentToMe(user, assessment.id)
+
+    assertThat(assessment.allocatedToUser).isEqualTo(user)
+    assertThat(assessment.allocatedAt).isAfter(originalAllocationTime)
+    assertThat(assessment.decision).isNull()
+    assertThat(assessment.referralHistoryNotes).hasSize(1)
+
+    assertThat(result is CasResult.Success).isTrue
+    assertThat((result as CasResult.Success).value).isNotNull()
   }
 
   private fun updateAssessmentEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/TasksTest.kt
@@ -22,6 +22,7 @@ import java.util.UUID
 
 class TasksTest {
 
+  @Deprecated("Superseded by Cas3AssessmentTest.ReallocateAssessmentTest")
   @Nested
   inner class ReallocateTaskTest : IntegrationTestBase() {
     @Autowired
@@ -75,6 +76,7 @@ class TasksTest {
     }
   }
 
+  @Deprecated("Superseded by Cas3AssessmentTest.DeallocateAssessmentTest")
   @Nested
   inner class DeallocateTaskTest : IntegrationTestBase() {
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1TaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1TaskServiceTest.kt
@@ -197,6 +197,7 @@ class Cas1TaskServiceTest {
     assertThatCasResult(result).isUnauthorised()
   }
 
+  @Deprecated("Superseded by Cas3AssessmentServiceTest.`deallocateAssessment deallocates an assessment`")
   @Test
   fun `deallocateTask deallocates an assessment`() {
     every { userAccessServiceMock.userCanDeallocateTask(any()) } returns true


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/APS-2476

- Add new CAS 3 DELETE endpoint to delete assessment allocation.
- Add new CAS 3 POST endpoint to reallocate assessments.
- Deprecate legacy functions which can be removed when CAS 3 UI is switched over to use the new end points.

To do once CAS 3 UI is using the new endpoints:
- Remove TasksTest
- Remove TasksController
- UserAccessService.userCanDeallocateTask() can be made CAS 3 specific
- Remove Cas1TaskService.deallocateTask()
- Remove any other CAS 3 de/reallocation logic from CAS 1 flow

