### PR TITLE
CAS3 V2 Create Departure API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BookingController.kt
@@ -33,7 +33,7 @@ class Cas3v2BookingController(
 ) {
 
   @GetMapping("/bookings/{bookingId}")
-  fun bookingsBookingIdGet(@PathVariable bookingId: UUID): ResponseEntity<Cas3Booking> {
+  fun getBookingById(@PathVariable bookingId: UUID): ResponseEntity<Cas3Booking> {
     val user = userService.getUserForRequest()
     val bookingResult = bookingService.getBooking(bookingId, premisesId = null, user)
     val booking = extractEntityFromCasResult(bookingResult)
@@ -55,7 +55,7 @@ class Cas3v2BookingController(
 
   @PaginationHeaders
   @GetMapping("/bookings/search")
-  fun bookingsSearch(
+  fun searchBookings(
     @RequestParam status: Cas3BookingStatus?,
     @RequestParam(defaultValue = "asc") sortDirection: SortDirection,
     @RequestParam(defaultValue = "createdAt") sortField: Cas3BookingSearchSortField,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3DepartureEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3DepartureEntity.kt
@@ -6,12 +6,17 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
+
+@Repository
+interface Cas3DepartureRepository : JpaRepository<Cas3DepartureEntity, UUID>
 
 @Entity
 @Table(name = "departures")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventService.kt
@@ -247,6 +247,18 @@ class Cas3DomainEventService(
   }
 
   @Transactional
+  fun savePersonDepartedEvent(booking: Cas3BookingEntity, user: UserEntity) {
+    val domainEvent = cas3DomainEventBuilder.getPersonDepartedDomainEvent(booking, user)
+
+    saveAndEmit(
+      domainEvent = domainEvent,
+      crn = domainEvent.data.eventDetails.personReference.crn,
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
+      triggerSourceType = TriggerSourceType.USER,
+    )
+  }
+
+  @Transactional
   fun saveReferralSubmittedEvent(application: TemporaryAccommodationApplicationEntity) {
     val domainEvent = cas3DomainEventBuilder.getReferralSubmittedDomainEvent(application)
 
@@ -260,6 +272,18 @@ class Cas3DomainEventService(
 
   @Transactional
   fun savePersonDepartureUpdatedEvent(booking: BookingEntity, user: UserEntity) {
+    val domainEvent = cas3DomainEventBuilder.buildDepartureUpdatedDomainEvent(booking, user)
+
+    saveAndEmit(
+      domainEvent = domainEvent,
+      crn = domainEvent.data.eventDetails.personReference.crn,
+      nomsNumber = domainEvent.data.eventDetails.personReference.noms,
+      triggerSourceType = TriggerSourceType.USER,
+    )
+  }
+
+  @Transactional
+  fun savePersonDepartureUpdatedEvent(booking: Cas3BookingEntity, user: UserEntity) {
     val domainEvent = cas3DomainEventBuilder.buildDepartureUpdatedDomainEvent(booking, user)
 
     saveAndEmit(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3BookingServiceTest.kt
@@ -98,7 +98,6 @@ class Cas3BookingServiceTest {
   private val mockOffenderService = mockk<OffenderService>()
   private val mockCas3DomainEventService = mockk<Cas3DomainEventService>()
   private val mockWorkingDayService = mockk<WorkingDayService>()
-
   private val mockBookingRepository = mockk<BookingRepository>()
   private val mockArrivalRepository = mockk<ArrivalRepository>()
   private val mockCancellationRepository = mockk<CancellationRepository>()
@@ -563,7 +562,7 @@ class Cas3BookingServiceTest {
 
       every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
 
-      every { mockCas3DomainEventService.savePersonDepartedEvent(any(), user) } just Runs
+      every { mockCas3DomainEventService.savePersonDepartedEvent(any(BookingEntity::class), user) } just Runs
 
       val result = cas3BookingService.createDeparture(
         booking = bookingEntity,
@@ -589,10 +588,10 @@ class Cas3BookingServiceTest {
         mockCas3DomainEventService.savePersonDepartedEvent(bookingEntity, user)
       }
       verify(exactly = 1) {
-        mockCas3DomainEventService.savePersonDepartedEvent(any(), user)
+        mockCas3DomainEventService.savePersonDepartedEvent(any(BookingEntity::class), user)
       }
       verify(exactly = 0) {
-        mockCas3DomainEventService.savePersonDepartureUpdatedEvent(any(), user)
+        mockCas3DomainEventService.savePersonDepartureUpdatedEvent(any(BookingEntity::class), user)
       }
     }
 
@@ -638,7 +637,7 @@ class Cas3BookingServiceTest {
       every { mockArrivalRepository.save(any()) } answers { it.invocation.args[0] as ArrivalEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
       every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
-      every { mockCas3DomainEventService.savePersonDepartureUpdatedEvent(any(), user) } just Runs
+      every { mockCas3DomainEventService.savePersonDepartureUpdatedEvent(any(BookingEntity::class), user) } just Runs
       every { mockFeatureFlagService.getBooleanFlag("cas3-validate-booking-departure-in-future") } returns false
 
       val result = cas3BookingService.createDeparture(
@@ -662,10 +661,10 @@ class Cas3BookingServiceTest {
       assertThat(result.value.booking.status).isEqualTo(BookingStatus.departed)
 
       verify(exactly = 1) {
-        mockCas3DomainEventService.savePersonDepartureUpdatedEvent(any(), user)
+        mockCas3DomainEventService.savePersonDepartureUpdatedEvent(any(BookingEntity::class), user)
       }
       verify(exactly = 0) {
-        mockCas3DomainEventService.savePersonDepartedEvent(any(), user)
+        mockCas3DomainEventService.savePersonDepartedEvent(any(BookingEntity::class), user)
       }
     }
   }


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" height="1152" alt="departure_swag" src="https://github.com/user-attachments/assets/dfbcdced-b0bb-48d9-9ba5-5ac1ddd57d72" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `POST /cas3/v2/premises/{premisesId}/bookings/{bookingId}/departures`.
2. This endpoint was modelled on the `POST /cas3/premises/{premisesId}/bookings/{bookingId}/departures` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models.
