### PR TITLE
CAS-1574 create v2 POST void bedspace

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/NewLostBed.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/NewLostBed.kt
@@ -1,34 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import io.swagger.v3.oas.annotations.media.Schema
-
-/**
- *
- * @param startDate
- * @param endDate
- * @param reason
- * @param bedId
- * @param referenceNumber
- * @param notes
- */
 data class NewLostBed(
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("startDate", required = true) val startDate: java.time.LocalDate,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("endDate", required = true) val endDate: java.time.LocalDate,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("reason", required = true) val reason: java.util.UUID,
-
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("bedId", required = true) val bedId: java.util.UUID,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("referenceNumber") val referenceNumber: kotlin.String? = null,
-
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("notes") val notes: kotlin.String? = null,
+  val startDate: java.time.LocalDate,
+  val endDate: java.time.LocalDate,
+  val reason: java.util.UUID,
+  val bedId: java.util.UUID,
+  val referenceNumber: kotlin.String? = null,
+  val notes: kotlin.String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2PremisesController.kt
@@ -12,22 +12,18 @@ import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3NewBooking
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3VoidBedspace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Cancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Departure
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3NewDeparture
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.NewCas3Arrival
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3UserAccessService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3v2VoidBedspaceService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3ArrivalTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3BookingTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3CancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3DepartureTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3VoidBedspacesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -51,11 +47,8 @@ class Cas3v2PremisesController(
   private val cas3PremisesService: Cas3v2PremisesService,
   private val cas3BookingService: Cas3v2BookingService,
   private val bookingTransformer: Cas3BookingTransformer,
-  private val voidBedspaceService: Cas3v2VoidBedspaceService,
   private val cas3CancellationTransformer: Cas3CancellationTransformer,
   private val offenderDetailService: OffenderDetailService,
-  private val cas3UserAccessService: Cas3UserAccessService,
-  private val cas3VoidBedspacesTransformer: Cas3VoidBedspacesTransformer,
   private val cas3ArrivalTransformer: Cas3ArrivalTransformer,
   private val cas3DepartureTransformer: Cas3DepartureTransformer,
 ) {
@@ -144,19 +137,6 @@ class Cas3v2PremisesController(
     )
 
     return ResponseEntity.ok(bookingTransformer.transformJpaToApi(extractEntityFromCasResult(createdBookingResult), personInfo))
-  }
-
-  @GetMapping("/premises/{premisesId}/void-bedspaces")
-  fun getVoidBedspaces(@PathVariable premisesId: UUID): ResponseEntity<List<Cas3VoidBedspace>> {
-    val premises = cas3PremisesService.getPremises(premisesId) ?: throw NotFoundProblem(premisesId, "Premises")
-    val probationRegionId = premises.probationDeliveryUnit.probationRegion.id
-
-    if (!cas3UserAccessService.canViewVoidBedspaces(probationRegionId)) throw ForbiddenProblem()
-
-    val voidBedspaces = voidBedspaceService.findVoidBedspaces(premises.id)
-      .map(cas3VoidBedspacesTransformer::toCas3VoidBedspace)
-
-    return ResponseEntity.ok(voidBedspaces)
   }
 
   @PostMapping("/premises/{premisesId}/bookings/{bookingId}/arrivals")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2VoidBedspaceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2VoidBedspaceController.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3NewVoidBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3VoidBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3v2VoidBedspaceService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2BookingService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3VoidBedspacesTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+import java.util.UUID
+
+@Cas3Controller
+class Cas3v2VoidBedspaceController(
+  private val voidBedspaceService: Cas3v2VoidBedspaceService,
+  private val cas3PremisesService: Cas3v2PremisesService,
+  private val cas3UserAccessService: Cas3UserAccessService,
+  private val cas3VoidBedspacesTransformer: Cas3VoidBedspacesTransformer,
+  private val cas3BookingService: Cas3v2BookingService,
+) {
+
+  @GetMapping("/v2/premises/{premisesId}/void-bedspaces")
+  fun getVoidBedspaces(@PathVariable premisesId: UUID): ResponseEntity<List<Cas3VoidBedspace>> {
+    val premises = cas3PremisesService.getPremises(premisesId) ?: throw NotFoundProblem(premisesId, "Premises")
+    val probationRegionId = premises.probationDeliveryUnit.probationRegion.id
+
+    if (!cas3UserAccessService.canViewVoidBedspaces(probationRegionId)) throw ForbiddenProblem()
+
+    val voidBedspaces = voidBedspaceService.findVoidBedspaces(premises.id)
+      .map(cas3VoidBedspacesTransformer::toCas3VoidBedspace)
+
+    return ResponseEntity.ok(voidBedspaces)
+  }
+
+  @PostMapping("/v2/premises/{premisesId}/void-bedspaces")
+  fun createVoidBedspace(
+    @PathVariable premisesId: UUID,
+    @RequestBody body: Cas3NewVoidBedspace,
+  ): ResponseEntity<Cas3VoidBedspace> {
+    val bedspace = cas3PremisesService.findBedspace(premisesId, body.bedspaceId) ?: throw NotFoundProblem(
+      body.bedspaceId,
+      "Cas3Bedspace",
+    )
+
+    if (!cas3UserAccessService.canViewVoidBedspaces(bedspace.premises.probationDeliveryUnit.probationRegion.id)) {
+      throw ForbiddenProblem()
+    }
+
+    cas3BookingService.throwIfBookingDatesConflict(body.startDate, body.endDate, null, body.bedspaceId)
+    cas3BookingService.throwIfVoidBedspaceDatesConflict(body.startDate, body.endDate, null, body.bedspaceId)
+
+    val voidBedspace = voidBedspaceService.createVoidBedspace(
+      startDate = body.startDate,
+      endDate = body.endDate,
+      reasonId = body.reasonId,
+      referenceNumber = body.referenceNumber,
+      notes = body.notes,
+      bedspace = bedspace,
+    )
+
+    val result = extractEntityFromCasResult(voidBedspace)
+    return ResponseEntity.status(HttpStatus.CREATED).body(cas3VoidBedspacesTransformer.toCas3VoidBedspace(result))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
@@ -47,6 +47,12 @@ data class Cas3BedspacesEntity(
 interface Cas3BedspacesRepository : JpaRepository<Cas3BedspacesEntity, UUID> {
 
   @Query(
+    """select bedspace from Cas3BedspacesEntity bedspace 
+          where bedspace.id = :bedspaceId and bedspace.premises.id = :premisesId""",
+  )
+  fun findCas3Bedspace(premisesId: UUID, bedspaceId: UUID): Cas3BedspacesEntity?
+
+  @Query(
     """
     SELECT b 
     FROM Cas3BedspacesEntity b 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3VoidBedspace.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3VoidBedspace.kt
@@ -20,6 +20,15 @@ data class Cas3VoidBedspace(
   val cancellationNotes: String?,
 )
 
+data class Cas3NewVoidBedspace(
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+  val reasonId: UUID,
+  val bedspaceId: UUID,
+  val referenceNumber: String? = null,
+  val notes: String? = null,
+)
+
 data class Cas3VoidBedspaceReason(
   val id: UUID,
   val name: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3v2VoidBedspaceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3v2VoidBedspaceService.kt
@@ -1,13 +1,72 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
 class Cas3v2VoidBedspaceService(
   private val cas3VoidBedspacesRepository: Cas3VoidBedspacesRepository,
+  private val cas3VoidBedspaceReasonRepository: Cas3VoidBedspaceReasonRepository,
 ) {
   fun findVoidBedspaces(premisesId: UUID): List<Cas3VoidBedspaceEntity> = cas3VoidBedspacesRepository.findActiveVoidBedspacesByPremisesId(premisesId)
+
+  fun createVoidBedspace(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    reasonId: UUID,
+    referenceNumber: String?,
+    notes: String?,
+    bedspace: Cas3BedspacesEntity,
+  ): CasResult<Cas3VoidBedspaceEntity> = validatedCasResult {
+    if (endDate.isBefore(startDate)) {
+      "$.endDate" hasValidationError "beforeStartDate"
+    }
+
+    if (bedspace.endDate != null && startDate.isAfter(bedspace.endDate)) {
+      "$.startDate" hasValidationError "voidStartDateAfterBedspaceEndDate"
+    }
+    if (bedspace.startDate != null && startDate.isBefore(bedspace.startDate)) {
+      "$.startDate" hasValidationError "voidStartDateBeforeBedspaceStartDate"
+    }
+    if (bedspace.endDate != null && endDate.isAfter(bedspace.endDate)) {
+      "$.endDate" hasValidationError "voidEndDateAfterBedspaceEndDate"
+    }
+
+    val reason = cas3VoidBedspaceReasonRepository.findByIdOrNull(reasonId)
+
+    if (reason == null) {
+      ("$.reason" hasValidationError "doesNotExist")
+    }
+
+    if (validationErrors.any()) {
+      return fieldValidationError
+    }
+
+    val voidBedspacesEntity = cas3VoidBedspacesRepository.save(
+      Cas3VoidBedspaceEntity(
+        id = UUID.randomUUID(),
+        startDate = startDate,
+        endDate = endDate,
+        bedspace = bedspace,
+        reason = reason!!,
+        referenceNumber = referenceNumber,
+        notes = notes,
+        cancellation = null,
+        cancellationDate = null,
+        cancellationNotes = null,
+        bed = null,
+        premises = null,
+      ),
+    )
+
+    return success(voidBedspacesEntity)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BookingService.kt
@@ -106,7 +106,7 @@ class Cas3v2BookingService(
       startDate = arrivalDate,
       endDate = departureDate,
     ).firstOrNull()?.let {
-      return@validatedCasResult it.id hasConflictError "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
+      return@validatedCasResult it.id hasConflictError "A Void Bedspace already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates"
     }
 
     cas3BedspaceRepository.findArchivedBedspaceByBedspaceIdAndDate(bedspaceId, departureDate)?.let {
@@ -402,7 +402,7 @@ class Cas3v2BookingService(
     getVoidBedspaceWithConflictingDates(startDate, endDate, bookingId, bedspaceId)?.let {
       throw ConflictProblem(
         it.id,
-        "A Lost Bed already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates",
+        "A Void Bedspace already exists for dates from ${it.startDate} to ${it.endDate} which overlaps with the desired dates",
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
@@ -2,11 +2,17 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesRepository
 import java.util.UUID
 
 @Service
-class Cas3v2PremisesService(private val cas3PremisesRepository: Cas3PremisesRepository) {
+class Cas3v2PremisesService(
+  private val cas3PremisesRepository: Cas3PremisesRepository,
+  private val cas3BedspacesRepository: Cas3BedspacesRepository,
+) {
   fun getPremises(premisesId: UUID): Cas3PremisesEntity? = cas3PremisesRepository.findByIdOrNull(premisesId)
+  fun findBedspace(premisesId: UUID, bedspaceId: UUID): Cas3BedspacesEntity? = cas3BedspacesRepository.findCas3Bedspace(premisesId = premisesId, bedspaceId = bedspaceId)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3VoidBedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3VoidBedspaceEntityFactory.kt
@@ -81,6 +81,7 @@ class Cas3VoidBedspaceEntityFactory : Factory<Cas3VoidBedspaceEntity> {
     this.cancellationNotes = { cancellationNotes }
   }
 
+  @Deprecated("This will be replaced by produceV2")
   @SuppressWarnings("TooGenericExceptionThrown")
   override fun produce() = Cas3VoidBedspaceEntity(
     id = this.id(),
@@ -92,6 +93,22 @@ class Cas3VoidBedspaceEntityFactory : Factory<Cas3VoidBedspaceEntity> {
     premises = this.premises?.let { it() },
     bed = this.bed?.let { it() },
     cancellation = this.voidBedspaceCancellation?.invoke(),
+    bedspace = this.bedspace?.let { it() },
+    cancellationDate = this.cancellationDate?.let { it() },
+    cancellationNotes = this.cancellationNotes?.let { it() },
+  )
+
+  @SuppressWarnings("TooGenericExceptionThrown")
+  fun produceV2() = Cas3VoidBedspaceEntity(
+    id = this.id(),
+    startDate = this.startDate(),
+    endDate = this.endDate(),
+    reason = this.reason!!.invoke(),
+    referenceNumber = this.referenceNumber(),
+    notes = this.notes(),
+    premises = null,
+    bed = null,
+    cancellation = null,
     bedspace = this.bedspace?.let { it() },
     cancellationDate = this.cancellationDate?.let { it() },
     cancellationNotes = this.cancellationNotes?.let { it() },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingTest.kt
@@ -1248,7 +1248,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .jsonPath("title").isEqualTo("Conflict")
           .jsonPath("status").isEqualTo(409)
           .jsonPath("detail")
-          .isEqualTo("A Lost Bed already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingLostBed.id}")
+          .isEqualTo("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingLostBed.id}")
       }
     }
   }
@@ -1453,7 +1453,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             .jsonPath("title").isEqualTo("Conflict")
             .jsonPath("status").isEqualTo(409)
             .jsonPath("detail")
-            .isEqualTo("A Lost Bed already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
+            .isEqualTo("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2VoidBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2VoidBedspaceTest.kt
@@ -1,0 +1,140 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.service.v2
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3VoidBedspaceReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceReasonEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3v2VoidBedspaceService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas3v2VoidBedspaceTest {
+  @MockK
+  lateinit var cas3VoidBedspacesRepository: Cas3VoidBedspacesRepository
+
+  @MockK
+  lateinit var cas3VoidBedspaceReasonRepository: Cas3VoidBedspaceReasonRepository
+
+  @InjectMockKs
+  lateinit var cas3v2VoidBedspaceService: Cas3v2VoidBedspaceService
+
+  lateinit var voidBedspaceReason: Cas3VoidBedspaceReasonEntity
+
+  @BeforeEach
+  fun setup() {
+    voidBedspaceReason = Cas3VoidBedspaceReasonEntityFactory().produce()
+    every { cas3VoidBedspaceReasonRepository.findByIdOrNull(voidBedspaceReason.id) } returns voidBedspaceReason
+    every { cas3VoidBedspacesRepository.save(any()) } answers { it.invocation.args[0] as Cas3VoidBedspaceEntity }
+  }
+
+  @Nested
+  inner class CreateVoidBedspace {
+    private val bedspaceStartDate = LocalDate.now().plusDays(2)
+    private val bedspaceEndDate = LocalDate.now().plusDays(10)
+    private val bedspace =
+      Cas3BedspaceEntityFactory().withStartDate(bedspaceStartDate).withEndDate(bedspaceEndDate).produce()
+
+    @Test
+    fun `createVoidBedspaces returns Success with correct result when validation passed`() {
+      val voidBedspaceStartDate = bedspaceStartDate.plusDays(1)
+      val voidBedspaceEndDate = bedspaceEndDate.minusDays(1)
+
+      val result = cas3v2VoidBedspaceService.createVoidBedspace(
+        startDate = voidBedspaceStartDate,
+        endDate = voidBedspaceEndDate,
+        reasonId = voidBedspaceReason.id,
+        referenceNumber = "12345",
+        notes = "notes",
+        bedspace = bedspace,
+      )
+
+      assertThatCasResult(result).isSuccess().with {
+        assertAll({
+          assertThat(it.reason).isEqualTo(voidBedspaceReason)
+          assertThat(it.startDate).isEqualTo(voidBedspaceStartDate)
+          assertThat(it.endDate).isEqualTo(voidBedspaceEndDate)
+          assertThat(it.referenceNumber).isEqualTo("12345")
+          assertThat(it.notes).isEqualTo("notes")
+        })
+      }
+      verify(exactly = 1) { cas3VoidBedspacesRepository.save(match { it.bedspace?.id == bedspace.id }) }
+    }
+
+    @Test
+    fun `createVoidBedspaces returns FieldValidationError with correct param to message map when invalid parameters supplied`() {
+      // with an invalid reason and a void bedspace end date that is before the start date
+      val invalidReasonId = UUID.randomUUID()
+      every { cas3VoidBedspaceReasonRepository.findByIdOrNull(invalidReasonId) } returns null
+
+      val result = cas3v2VoidBedspaceService.createVoidBedspace(
+        startDate = bedspaceEndDate.minusDays(1),
+        endDate = bedspaceEndDate.minusDays(2),
+        reasonId = invalidReasonId,
+        referenceNumber = "12345",
+        notes = "notes",
+        bedspace = bedspace,
+      )
+
+      assertThatCasResult(result)
+        .isFieldValidationError()
+        .hasMessage("$.reason", "doesNotExist")
+        .hasMessage("$.endDate", "beforeStartDate")
+    }
+
+    @Test
+    fun `createVoidBedspaces returns error when void start date is after bed end date`() {
+      // when void bedspace dates are after the bedspace end date
+      val voidBedspaceStartDate = bedspaceEndDate.plusDays(1)
+      val voidBedspaceEndDate = bedspaceEndDate.plusDays(2)
+
+      val result = cas3v2VoidBedspaceService.createVoidBedspace(
+        startDate = voidBedspaceStartDate,
+        endDate = voidBedspaceEndDate,
+        reasonId = voidBedspaceReason.id,
+        referenceNumber = "12345",
+        notes = "notes",
+        bedspace = bedspace,
+      )
+
+      assertThatCasResult(result)
+        .isFieldValidationError()
+        .hasMessage("$.startDate", "voidStartDateAfterBedspaceEndDate")
+        .hasMessage("$.endDate", "voidEndDateAfterBedspaceEndDate")
+    }
+
+    @Test
+    fun `createVoidBedspaces returns validation error when void start date is before bedspace start date`() {
+      // when void bedspace dates are before bedspace start date
+      val voidBedspaceStartDate = bedspaceStartDate.minusDays(2)
+      val voidBedspaceEndDate = bedspaceStartDate.minusDays(1)
+      val result = cas3v2VoidBedspaceService.createVoidBedspace(
+        startDate = voidBedspaceStartDate,
+        endDate = voidBedspaceEndDate,
+        reasonId = voidBedspaceReason.id,
+        referenceNumber = "12345",
+        notes = "notes",
+        bedspace = bedspace,
+      )
+
+      assertThatCasResult(result)
+        .isFieldValidationError()
+        .hasMessage("$.startDate", "voidStartDateBeforeBedspaceStartDate")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas3PremisesAndBedspace.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas3PremisesAndBedspace.kt
@@ -10,6 +10,7 @@ import java.time.LocalDate
 fun IntegrationTestBase.givenCas3PremisesAndBedspace(
   user: UserEntity,
   startDate: LocalDate = LocalDate.now(),
+  endDate: LocalDate? = LocalDate.now().plusDays(100),
   premises: Cas3PremisesEntity = givenACas3Premises(
     probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
       withProbationRegion(user.probationRegion)
@@ -19,5 +20,6 @@ fun IntegrationTestBase.givenCas3PremisesAndBedspace(
     withReference("test-bed")
     withPremises(premises)
     withStartDate(startDate)
+    withEndDate(endDate)
   },
 ) = Pair(premises, bedspace)


### PR DESCRIPTION
This creates the POST endpoint for void bedspaces. It's based on `/premises/${premises.id}/lost-beds`.

Some fields (premises, bed, cancellation) will not be used in v2.

[https://dsdmoj.atlassian.net/browse/CAS-1574](url)

<img width="1158" height="901" alt="image" src="https://github.com/user-attachments/assets/06f015f1-1463-4427-b5db-066327f4699e" />
