### PR TITLE
Remove deprecated upstream calls in Cas1 Booking

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/WithdrawalTest.kt
@@ -749,6 +749,7 @@ class WithdrawalTest : IntegrationTestBase() {
             val placementApplication1 = createPlacementApplication(application, DateSpan(now(), duration = 2))
             val placementRequest1 = createPlacementRequest(application, placementApplication = placementApplication1)
             val bookingNoArrival = givenACas1SpaceBooking(
+              crn = application.crn,
               application = application,
               placementRequest = placementRequest1,
               actualArrivalDate = null,
@@ -943,6 +944,7 @@ class WithdrawalTest : IntegrationTestBase() {
             val placementApplication1 = createPlacementApplication(application, DateSpan(now(), duration = 2), createdBy = placementAppCreator)
             val placementRequest1 = createPlacementRequest(application, placementApplication = placementApplication1)
             val booking1PendingArrival = givenACas1SpaceBooking(
+              crn = application.crn,
               application = application,
               placementRequest = placementRequest1,
               actualArrivalDate = null,
@@ -952,6 +954,7 @@ class WithdrawalTest : IntegrationTestBase() {
             val placementApplication2 = createPlacementApplication(application, DateSpan(now(), duration = 2))
             val placementRequest2 = createPlacementRequest(application, placementApplication = placementApplication2)
             val booking2PendingArrival = givenACas1SpaceBooking(
+              crn = application.crn,
               application = application,
               placementRequest = placementRequest2,
               actualArrivalDate = null,
@@ -1073,6 +1076,7 @@ class WithdrawalTest : IntegrationTestBase() {
 
           val placementRequest = createPlacementRequest(application)
           val bookingPendingArrival = givenACas1SpaceBooking(
+            crn = application.crn,
             application = application,
             placementRequest = placementRequest,
             actualArrivalDate = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -2246,9 +2246,12 @@ class Cas1SpaceBookingTest {
           createdByUser = applicant,
         )
 
+        val (offenderDetails, _) = givenAnOffender()
+
         val reason = cas1ChangeRequestReasonEntityFactory.produceAndPersist()
 
         val spaceBooking = cas1SpaceBookingEntityFactory.produceAndPersist {
+          withCrn(offenderDetails.otherIds.crn)
           withPremises(premises)
           withPlacementRequest(placementRequest)
           withCreatedBy(applicant)
@@ -2409,6 +2412,8 @@ class Cas1SpaceBookingTest {
 
       val (user) = givenAUser()
 
+      val (offenderDetails, _) = givenAnOffender()
+
       val (placementRequest) = givenAPlacementRequest(
         assessmentAllocatedTo = user,
         createdByUser = user,
@@ -2444,6 +2449,7 @@ class Cas1SpaceBookingTest {
       )
 
       val spaceBookingBeforeUpdate = cas1SpaceBookingEntityFactory.produceAndPersist {
+        withCrn(offenderDetails.otherIds.crn)
         withPremises(premises)
         withPlacementRequest(placementRequest)
         withApplication(placementRequest.application)
@@ -2496,6 +2502,8 @@ class Cas1SpaceBookingTest {
 
       val (user) = givenAUser()
 
+      val (offenderDetails, _) = givenAnOffender()
+
       val (placementRequest) = givenAPlacementRequest(
         assessmentAllocatedTo = user,
         createdByUser = user,
@@ -2522,6 +2530,7 @@ class Cas1SpaceBookingTest {
       )
 
       val spaceBookingBeforeUpdate = cas1SpaceBookingEntityFactory.produceAndPersist {
+        withCrn(offenderDetails.otherIds.crn)
         withPremises(premises)
         withPlacementRequest(placementRequest)
         withApplication(placementRequest.application)
@@ -2568,7 +2577,10 @@ class Cas1SpaceBookingTest {
 
     @BeforeAll
     fun setupTestData() {
+      val (offenderDetails, _) = givenAnOffender()
+
       spaceBooking = givenACas1SpaceBooking(
+        crn = offenderDetails.otherIds.crn,
         expectedArrivalDate = LocalDate.now().minusDays(7),
         actualArrivalDate = LocalDate.now().minusDays(7),
         expectedDepartureDate = LocalDate.now().plusDays(7),


### PR DESCRIPTION
This updates the `Cas1BookingDomainEventService` to stop using the deprecated function on `OffenderService` to retrieve the offenders NOMS number. In doing this we’ve simplified the code to remove duplication

