### PR TITLE
Remove unused mocks

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3BookingSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3BookingSearchServiceTest.kt
@@ -19,12 +19,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3Booking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas3BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.TestBookingSearchResult
@@ -163,12 +161,6 @@ class Cas3BookingSearchServiceTest {
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.NotFound("crn3"),
       )
-
-    every { mockOffenderService.getOffenderByCrn(any(), any()) } returnsMany listOf(
-      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
-      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
-      AuthorisableActionResult.NotFound(),
-    )
 
     val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
@@ -398,7 +390,7 @@ class Cas3BookingSearchServiceTest {
   }
 
   @Test
-  fun `throw exception when DB exception happend`() {
+  fun `throw exception when DB exception happened`() {
     every { mockUserService.getUserForRequest() } returns UserEntityFactory()
       .withYieldedProbationRegion {
         ProbationRegionEntityFactory()
@@ -425,9 +417,6 @@ class Cas3BookingSearchServiceTest {
     }
     verify(exactly = 1) {
       mockBookingRepository.findTemporaryAccommodationBookings(any(), any(), any(), any())
-    }
-    verify(exactly = 0) {
-      mockOffenderService.getOffenderByCrn(any(), any())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3BookingServiceTest.kt
@@ -44,7 +44,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
@@ -73,7 +72,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
@@ -556,12 +554,6 @@ class Cas3BookingServiceTest {
         .withProbationRegion(probationRegion)
         .produce()
 
-      val offenderDetails = OffenderDetailsSummaryFactory()
-        .withCrn(bookingEntity.crn)
-        .produce()
-
-      every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
-
       every { mockCas3DomainEventService.savePersonDepartedEvent(any(BookingEntity::class), user) } just Runs
 
       val result = cas3BookingService.createDeparture(
@@ -618,10 +610,6 @@ class Cas3BookingServiceTest {
         .withProbationRegion(probationRegion)
         .produce()
 
-      val offenderDetails = OffenderDetailsSummaryFactory()
-        .withCrn(bookingEntity.crn)
-        .produce()
-
       val departureEntity = DepartureEntityFactory()
         .withBooking(bookingEntity)
         .withDateTime(departureDateTime)
@@ -636,7 +624,6 @@ class Cas3BookingServiceTest {
       every { mockDepartureRepository.save(any()) } answers { it.invocation.args[0] as DepartureEntity }
       every { mockArrivalRepository.save(any()) } answers { it.invocation.args[0] as ArrivalEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as BookingEntity }
-      every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
       every { mockCas3DomainEventService.savePersonDepartureUpdatedEvent(any(BookingEntity::class), user) } just Runs
       every { mockFeatureFlagService.getBooleanFlag("cas3-validate-booking-departure-in-future") } returns false
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingSearchServiceTest.kt
@@ -21,11 +21,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.service.TestCa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PaginationConfig
@@ -163,12 +161,6 @@ class Cas3v2BookingSearchServiceTest {
         PersonSummaryInfoResult.Success.Full("crn2", CaseSummaryFactory().produce()),
         PersonSummaryInfoResult.NotFound("crn3"),
       )
-
-    every { mockOffenderService.getOffenderByCrn(any(), any()) } returnsMany listOf(
-      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
-      AuthorisableActionResult.Success(OffenderDetailsSummaryFactory().produce()),
-      AuthorisableActionResult.NotFound(),
-    )
 
     val (results, metaData) = cas3BookingSearchService.findBookings(
       null,
@@ -425,9 +417,6 @@ class Cas3v2BookingSearchServiceTest {
     }
     verify(exactly = 1) {
       mockCas3v2BookingRepository.findBookings(any(), any(), any(), any())
-    }
-    verify(exactly = 0) {
-      mockOffenderService.getOffenderByCrn(any(), any())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingServiceTest.kt
@@ -51,7 +51,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentRepository
@@ -62,7 +61,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
@@ -1917,12 +1915,6 @@ class Cas3v2BookingServiceTest {
         .withProbationRegion(probationRegion)
         .produce()
 
-      val offenderDetails = OffenderDetailsSummaryFactory()
-        .withCrn(bookingEntity.crn)
-        .produce()
-
-      every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
-
       every { mockCas3DomainEventService.savePersonDepartedEvent(any(Cas3BookingEntity::class), user) } just Runs
 
       val result = cas3BookingService.createDeparture(
@@ -1982,10 +1974,6 @@ class Cas3v2BookingServiceTest {
         .withProbationRegion(probationRegion)
         .produce()
 
-      val offenderDetails = OffenderDetailsSummaryFactory()
-        .withCrn(bookingEntity.crn)
-        .produce()
-
       val departureEntity = Cas3DepartureEntityFactory()
         .withBooking(bookingEntity)
         .withDateTime(departureDateTime)
@@ -2000,7 +1988,6 @@ class Cas3v2BookingServiceTest {
       every { mockDepartureRepository.save(any()) } answers { it.invocation.args[0] as Cas3DepartureEntity }
       every { mockArrivalRepository.save(any()) } answers { it.invocation.args[0] as Cas3ArrivalEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as Cas3BookingEntity }
-      every { mockOffenderService.getOffenderByCrn(bookingEntity.crn, user.deliusUsername) } returns AuthorisableActionResult.Success(offenderDetails)
       every { mockCas3DomainEventService.savePersonDepartureUpdatedEvent(any(Cas3BookingEntity::class), user) } just Runs
       every { mockFeatureFlagService.getBooleanFlag("cas3-validate-booking-departure-in-future") } returns false
 


### PR DESCRIPTION
This commit removes mocks configured in various cas3 booking unit tests, but the corresponding code doesn’t used the mocked functions

