### PR TITLE
Remove unused assessment note endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/AssessmentController.kt
@@ -18,14 +18,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentReje
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ClarificationNote
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReferralHistoryUserNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralHistoryNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdatedClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
@@ -39,7 +36,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger.PaginationHeaders
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentClarificationNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentReferralHistoryNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
@@ -55,7 +51,6 @@ class AssessmentController(
   private val userService: UserService,
   private val offenderDetailService: OffenderDetailService,
   private val assessmentTransformer: AssessmentTransformer,
-  private val assessmentClarificationNoteTransformer: AssessmentClarificationNoteTransformer,
   private val assessmentReferralHistoryNoteTransformer: AssessmentReferralHistoryNoteTransformer,
   private val cas3AssessmentService: Cas3AssessmentService,
 ) {
@@ -289,58 +284,6 @@ class AssessmentController(
     val assessmentAuthResult = assessmentService.closeAssessment(user, assessmentId)
     extractEntityFromCasResult(assessmentAuthResult)
     return ResponseEntity(HttpStatus.OK)
-  }
-
-  @Operation(
-    tags = ["Assessment data"],
-    summary = "Adds a clarification note to an assessment",
-  )
-  @RequestMapping(
-    method = [RequestMethod.POST],
-    value = ["/assessments/{assessmentId}/notes"],
-    produces = ["application/json"],
-    consumes = ["application/json"],
-  )
-  fun assessmentsAssessmentIdNotesPost(
-    @PathVariable assessmentId: UUID,
-    @RequestBody newClarificationNote: NewClarificationNote,
-  ): ResponseEntity<ClarificationNote> {
-    val user = userService.getUserForRequest()
-
-    val clarificationNoteResult = assessmentService.addAssessmentClarificationNote(user, assessmentId, newClarificationNote.query)
-
-    return ResponseEntity.ok(
-      assessmentClarificationNoteTransformer.transformJpaToApi(extractEntityFromCasResult(clarificationNoteResult)),
-    )
-  }
-
-  @Operation(
-    tags = ["Assessment data"],
-    summary = "Updates an assessment's clarification note",
-  )
-  @RequestMapping(
-    method = [RequestMethod.PUT],
-    value = ["/assessments/{assessmentId}/notes/{noteId}"],
-    produces = ["application/json"],
-    consumes = ["application/json"],
-  )
-  fun assessmentsAssessmentIdNotesNoteIdPut(
-    @PathVariable assessmentId: UUID,
-    @PathVariable noteId: UUID,
-    @RequestBody updatedClarificationNote: UpdatedClarificationNote,
-  ): ResponseEntity<ClarificationNote> {
-    val user = userService.getUserForRequest()
-    val clarificationNoteResult = assessmentService.updateAssessmentClarificationNote(
-      user,
-      assessmentId,
-      noteId,
-      updatedClarificationNote.response,
-      updatedClarificationNote.responseReceivedOn,
-    )
-
-    return ResponseEntity.ok(
-      assessmentClarificationNoteTransformer.transformJpaToApi(extractEntityFromCasResult(clarificationNoteResult)),
-    )
   }
 
   @Operation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/ApplicationStateTest.kt
@@ -43,7 +43,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.go
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -55,9 +54,6 @@ import java.util.UUID
 class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var realApplicationRepository: ApplicationRepository
-
-  @Autowired
-  lateinit var realBookingRepository: BookingRepository
 
   @Autowired
   lateinit var realSpaceBookingRepository: Cas1SpaceBookingRepository
@@ -275,7 +271,7 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
     val assessment = application.getLatestAssessment()!!
 
     webTestClient.post()
-      .uri("/assessments/${assessment.id}/notes")
+      .uri("/cas1/assessments/${assessment.id}/notes")
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         NewClarificationNote(
@@ -294,7 +290,7 @@ class ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
     val clarificationNote = assessment.clarificationNotes[0]
 
     webTestClient.put()
-      .uri("/assessments/${assessment.id}/notes/${clarificationNote.id}")
+      .uri("/cas1/assessments/${assessment.id}/notes/${clarificationNote.id}")
       .header("Authorization", "Bearer $jwt")
       .bodyValue(
         UpdatedClarificationNote(


### PR DESCRIPTION
This commit removes the following endpoints:

```
POST /assessments/{assessmentId}/notes
PUT /assessments/{assessmentId}/notes/{noteId}
```

These has been moved to the following endpoints that are now in usage in prod:

```
POST /cas1/assessments/{assessmentId}/notes
PUT /cas1/assessments/{assessmentId}/notes/{noteId}
```

Assessment notes are used exclusively by CAS1

```
assessments a inner join assessment_clarification_notes note on note.assessment_id = a.id group by service;
-- success --
service           count
----------------- -----
approved-premises  3376
```

