### PR TITLE
APS-2658 - Create /cas1/users endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt
@@ -1,14 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1UsersController
@@ -43,7 +43,7 @@ class UsersController(
     page,
     sortBy,
     sortDirection,
-  )
+  ) as ResponseEntity<List<User>>
 
   @Operation(summary = "Returns a list of user summaries (i.e. id and name only). Deprecated, use /cas1/users/summary")
   @GetMapping("/users/summary")
@@ -69,13 +69,12 @@ class UsersController(
   @GetMapping("/users/search")
   fun usersSearchGet(
     @RequestParam name: String,
-  ) = cas1UsersController.usersSearchGet(name)
+  ) = cas1UsersController.usersSearchGet(name) as ResponseEntity<List<User>>
 
   @SuppressWarnings("TooGenericExceptionThrown")
   @Operation(summary = "Returns a user with match on name. Deprecated, use /cas1/users/delius")
   @GetMapping("/users/delius")
   fun usersDeliusGet(
     @RequestParam name: String,
-    @RequestHeader(value = "X-Service-Name") xServiceName: ServiceName,
-  ) = cas1UsersController.usersDeliusGet(name, xServiceName)
+  ) = cas1UsersController.usersDeliusGet(name) as ResponseEntity<User>
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1UsersTest.kt
@@ -476,7 +476,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         webTestClient.get()
           .uri("/cas1/users")
           .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()
           .expectStatus()
           .isForbidden
@@ -489,7 +488,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         webTestClient.get()
           .uri("/cas1/users")
           .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()
           .expectStatus()
           .isForbidden
@@ -506,7 +504,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -555,7 +552,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users?probationRegionId=${probationRegion.id}")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -606,7 +602,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users?apAreaId=${apArea.id}")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -665,7 +660,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users?cruManagementAreaId=${cruManagementArea.id}")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -697,7 +691,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users?page=1")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -729,7 +722,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users?roles=report_viewer,future_manager")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -757,7 +749,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users?qualifications=emergency")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -794,7 +785,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
                 webTestClient.get()
                   .uri("/cas1/users?roles=assessor&qualifications=emergency")
                   .header("Authorization", "Bearer $jwt")
-                  .header("X-Service-Name", ServiceName.approvedPremises.value)
                   .exchange()
                   .expectStatus()
                   .isOk
@@ -828,7 +818,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         webTestClient.get()
           .uri("/cas1/users/summary")
           .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()
           .expectStatus()
           .isForbidden
@@ -858,7 +847,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users/summary")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -905,7 +893,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users/summary?probationRegionId=${probationRegion.id}")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -954,7 +941,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users/summary?apAreaId=${apArea.id}")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -986,7 +972,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users/summary?page=1")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -1018,7 +1003,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users/summary?roles=report_viewer,future_manager")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -1046,7 +1030,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
               webTestClient.get()
                 .uri("/cas1/users/summary?qualifications=emergency")
                 .header("Authorization", "Bearer $jwt")
-                .header("X-Service-Name", ServiceName.approvedPremises.value)
                 .exchange()
                 .expectStatus()
                 .isOk
@@ -1083,7 +1066,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
                 webTestClient.get()
                   .uri("/cas1/users/summary?roles=assessor&qualifications=emergency")
                   .header("Authorization", "Bearer $jwt")
-                  .header("X-Service-Name", ServiceName.approvedPremises.value)
                   .exchange()
                   .expectStatus()
                   .isOk
@@ -1117,7 +1099,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         webTestClient.get()
           .uri("/cas1/users/search?name=some")
           .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()
           .expectStatus()
           .isForbidden
@@ -1130,7 +1111,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         webTestClient.get()
           .uri("/cas1/users/search?name=some")
           .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()
           .expectStatus()
           .isForbidden
@@ -1150,7 +1130,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
             webTestClient.get()
               .uri("/cas1/users/search?name=some")
               .header("Authorization", "Bearer $jwt")
-              .header("X-Service-Name", ServiceName.approvedPremises.value)
               .exchange()
               .expectStatus()
               .isOk
@@ -1182,7 +1161,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         webTestClient.get()
           .uri("/cas1/users/delius?name=some")
           .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()
           .expectStatus()
           .isForbidden
@@ -1195,7 +1173,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         webTestClient.get()
           .uri("/cas1/users/delius?name=some")
           .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()
           .expectStatus()
           .isForbidden
@@ -1215,7 +1192,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
             webTestClient.get()
               .uri("/cas1/users/delius?name=some")
               .header("Authorization", "Bearer $jwt")
-              .header("X-Service-Name", ServiceName.approvedPremises.value)
               .exchange()
               .expectStatus()
               .isOk
@@ -1239,7 +1215,6 @@ class Cas1UsersTest : InitialiseDatabasePerClassTestBase() {
         webTestClient.get()
           .uri("/cas1/users/delius?name=noone")
           .header("Authorization", "Bearer $jwt")
-          .header("X-Service-Name", ServiceName.approvedPremises.value)
           .exchange()
           .expectHeader().contentType("application/problem+json")
           .expectStatus()


### PR DESCRIPTION
Create `/cas1/users` endpoints that are straight copies of existing `/users` endpoints, but instead return CAS1 specific types.

The existing `/users` endpoints have bene deprecated as these endpoints are used exclusively by CAS1