### PR TITLE
APS-2662 - Add CAS1_EXPERIMENTAL_NEW_ASSIGN_KEYWORKER_FLOW permission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/ApprovedPremisesUserPermission.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/ApprovedPremisesUserPermission.kt
@@ -12,6 +12,7 @@ enum class ApprovedPremisesUserPermission(@get:JsonValue val value: String) {
   bookingWithdraw("cas1_booking_withdraw"),
   changeRequestList("cas1_change_request_list"),
   changeRequestView("cas1_change_request_view"),
+  experimentalNewAssignKeyworkerFlow("cas1_experimental_new_assign_keyworker_flow"),
   experimentalNewRequestForPlacementFlow("cas1_experimental_new_request_for_placement_flow"),
   nationalOccupancyView("cas1_national_occupancy_view"),
   offlineApplicationView("cas1_offline_application_view"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
@@ -26,6 +26,8 @@ enum class UserPermission(val cas1ApiValue: ApprovedPremisesUserPermission?, val
   CAS1_CHANGE_REQUEST_LIST(ApprovedPremisesUserPermission.changeRequestList, experimental = true),
   CAS1_CHANGE_REQUEST_VIEW(ApprovedPremisesUserPermission.changeRequestView, experimental = true),
 
+  CAS1_EXPERIMENTAL_NEW_ASSIGN_KEYWORKER_FLOW(ApprovedPremisesUserPermission.experimentalNewAssignKeyworkerFlow, experimental = true),
+
   CAS1_EXPERIMENTAL_NEW_REQUEST_FOR_PLACEMENT_FLOW(ApprovedPremisesUserPermission.experimentalNewRequestForPlacementFlow, experimental = true),
 
   CAS1_OFFLINE_APPLICATION_VIEW(ApprovedPremisesUserPermission.offlineApplicationView),

--- a/src/main/resources/static/codegen/built-cas1-roles.json
+++ b/src/main/resources/static/codegen/built-cas1-roles.json
@@ -114,6 +114,7 @@
       "cas1_booking_withdraw",
       "cas1_change_request_list",
       "cas1_change_request_view",
+      "cas1_experimental_new_assign_keyworker_flow",
       "cas1_experimental_new_request_for_placement_flow",
       "cas1_national_occupancy_view",
       "cas1_offline_application_view",


### PR DESCRIPTION
This is an experimental permission implicitly assigned to the janitor user to enable testing of the feature outside of production

