### PR TITLE
Feature/CAS-1791 Void Bedspaces - Get

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2VoidBedspaceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2VoidBedspaceController.kt
@@ -40,6 +40,23 @@ class Cas3v2VoidBedspaceController(
     return ResponseEntity.ok(voidBedspaces)
   }
 
+  @GetMapping("/v2/premises/{premisesId}/void-bedspaces/{voidBedspaceId}")
+  fun getVoidBedspace(
+    @PathVariable premisesId: UUID,
+    @PathVariable voidBedspaceId: UUID,
+  ): ResponseEntity<Cas3VoidBedspace> {
+    val voidBedspace = voidBedspaceService.findVoidBedspace(premisesId, voidBedspaceId) ?: throw NotFoundProblem(
+      voidBedspaceId,
+      "Cas3VoidBedspace",
+    )
+
+    if (!cas3UserAccessService.canViewVoidBedspaces(voidBedspace.bedspace!!.premises.probationDeliveryUnit.probationRegion.id)) {
+      throw ForbiddenProblem()
+    }
+
+    return ResponseEntity.ok(cas3VoidBedspacesTransformer.toCas3VoidBedspace(voidBedspace))
+  }
+
   @PostMapping("/v2/premises/{premisesId}/void-bedspaces")
   fun createVoidBedspace(
     @PathVariable premisesId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3VoidBedspaceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3VoidBedspaceEntity.kt
@@ -97,6 +97,9 @@ interface Cas3VoidBedspacesRepository : JpaRepository<Cas3VoidBedspaceEntity, UU
       "and vb.cancellationDate is null",
   )
   fun findActiveVoidBedspacesByPremisesId(premisesId: UUID): List<Cas3VoidBedspaceEntity>
+
+  @Query("""select vb from Cas3VoidBedspaceEntity vb where vb.id = :voidBedspaceId and vb.bedspace.premises.id = :premisesId""")
+  fun findVoidBedspace(premisesId: UUID, voidBedspaceId: UUID): Cas3VoidBedspaceEntity?
 }
 
 @SuppressWarnings("LongParameterList")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3v2VoidBedspaceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3v2VoidBedspaceService.kt
@@ -18,6 +18,8 @@ class Cas3v2VoidBedspaceService(
 ) {
   fun findVoidBedspaces(premisesId: UUID): List<Cas3VoidBedspaceEntity> = cas3VoidBedspacesRepository.findActiveVoidBedspacesByPremisesId(premisesId)
 
+  fun findVoidBedspace(premisesId: UUID, voidBedspaceId: UUID): Cas3VoidBedspaceEntity? = cas3VoidBedspacesRepository.findVoidBedspace(premisesId, voidBedspaceId)
+
   fun createVoidBedspace(
     startDate: LocalDate,
     endDate: LocalDate,


### PR DESCRIPTION
This adds the new V2 endpoint for getting a single cas3 void bedspace. There are no unit tests because the logic for failures is in the controller, which is covered by integration tests. A future PR will refactor all methods in this class and move the validation logic for this into the service layer, and return a cas result instead of the entity (to be consistent). Unit tests will be added at this point.

It's based on the existing `premises/$premisesId/lost-beds/$lostBedId`

[https://dsdmoj.atlassian.net/browse/CAS-1791](url)