### PR TITLE
APS-2658 - Retrieve keyworker details by staff code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/StaffMemberService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/StaffMemberService.kt
@@ -16,6 +16,16 @@ class StaffMemberService(
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
+  fun getStaffMemberByCode(code: String) = when (val staffMembersResponse = apDeliusContextApiClient.getStaffDetailByStaffCode(code)) {
+    is ClientResult.Success -> CasResult.Success(staffMembersResponse.body)
+    is ClientResult.Failure.StatusCode -> when (staffMembersResponse.status) {
+      HttpStatus.NOT_FOUND -> CasResult.NotFound("StaffMember", code)
+      HttpStatus.UNAUTHORIZED -> CasResult.Unauthorised()
+      else -> staffMembersResponse.throwException()
+    }
+    is ClientResult.Failure -> staffMembersResponse.throwException()
+  }
+
   fun getStaffMemberByCodeForPremise(code: String, qCode: String): CasResult<StaffMember> {
     val premisesStaffMembers =
       when (val premisesStaffMembersResult = getStaffMembersForQCode(qCode)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
@@ -189,7 +189,7 @@ class Cas1BookingManagementService(
       return existingCas1SpaceBooking.id hasConflictError "The booking has already been cancelled"
     }
 
-    val staffMemberResponse = staffMemberService.getStaffMemberByCodeForPremise(keyWorker.staffCode, premises!!.qCode)
+    val staffMemberResponse = staffMemberService.getStaffMemberByCode(keyWorker.staffCode)
     if (staffMemberResponse !is CasResult.Success) {
       return "$.keyWorker.staffCode" hasSingleValidationError "notFound"
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -49,6 +49,13 @@ fun IntegrationTestBase.apDeliusContextMockSuccessfulStaffMembersCall(staffMembe
   )
 }
 
+fun IntegrationTestBase.apDeliusContextMockSuccessfulStaffDetailByCodeCall(staffDetail: StaffDetail) {
+  mockSuccessfulGetCallWithJsonResponse(
+    url = "/staff?code=${staffDetail.code}",
+    responseBody = staffDetail,
+  )
+}
+
 fun IntegrationTestBase.apDeliusContextMockSuccessfulCaseDetailCall(crn: String, response: CaseDetail, responseStatus: Int = 200) = mockSuccessfulGetCallWithJsonResponse(
   url = "/probation-cases/$crn/details",
   responseBody = response,


### PR DESCRIPTION
Before this commit when retreiving keyworker details to persist on a booking we would use the staff code and premises code. This ensured the keyworker we were assigning belonged to the associated premises.

As we’re changing to allow any FUTURE_MANAGER to be assigned as a keyworker this restriction no longer makes sense, and we don’t want to be restricted by delius user to premises mappings.

This commit updates the logic to retrieve keyworker information using staff code only.

