### PR TITLE
APS-2663 - Add CAS1_OUT_OF_SERVICE_BED_NO_DATE_LIMIT

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/ApprovedPremisesUserPermission.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/ApprovedPremisesUserPermission.kt
@@ -18,6 +18,7 @@ enum class ApprovedPremisesUserPermission(@get:JsonValue val value: String) {
   outOfServiceBedCreate("cas1_out_of_service_bed_create"),
   outOfServiceBedCreateBedOnHold("cas1_out_of_service_bed_create_bed_on_hold"),
   outOfServiceBedCancel("cas1_out_of_service_bed_cancel"),
+  outOfServiceNoDateLimit("cas1_out_of_service_bed_no_date_limit"),
   placementAppealCreate("cas1_placement_appeal_create"),
   placementAppealAssess("cas1_placement_appeal_assess"),
   placementRequestRecordUnableToMatch("cas1_placement_request_record_unable_to_match"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserPermission.kt
@@ -33,6 +33,7 @@ enum class UserPermission(val cas1ApiValue: ApprovedPremisesUserPermission?, val
   CAS1_OUT_OF_SERVICE_BED_CREATE(ApprovedPremisesUserPermission.outOfServiceBedCreate),
   CAS1_OUT_OF_SERVICE_BED_CREATE_BED_ON_HOLD(ApprovedPremisesUserPermission.outOfServiceBedCreateBedOnHold),
   CAS1_OUT_OF_SERVICE_BED_CANCEL(ApprovedPremisesUserPermission.outOfServiceBedCancel),
+  CAS1_OUT_OF_SERVICE_BED_NO_DATE_LIMIT(ApprovedPremisesUserPermission.outOfServiceNoDateLimit),
 
   CAS1_PLACEMENT_REQUEST_RECORD_UNABLE_TO_MATCH(ApprovedPremisesUserPermission.placementRequestRecordUnableToMatch),
 

--- a/src/main/resources/static/codegen/built-cas1-roles.json
+++ b/src/main/resources/static/codegen/built-cas1-roles.json
@@ -120,6 +120,7 @@
       "cas1_out_of_service_bed_cancel",
       "cas1_out_of_service_bed_create",
       "cas1_out_of_service_bed_create_bed_on_hold",
+      "cas1_out_of_service_bed_no_date_limit",
       "cas1_placement_appeal_assess",
       "cas1_placement_appeal_create",
       "cas1_placement_request_record_unable_to_match",


### PR DESCRIPTION
This will be used to determine if a user can enter any date when creating/updating an out of service bed. By default this is implicitly assigned to janitor

