### PR TITLE
Feature/cas 1795 v2 voidbedspaces cancellations put

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3VoidBedspaceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3VoidBedspaceEntity.kt
@@ -100,6 +100,12 @@ interface Cas3VoidBedspacesRepository : JpaRepository<Cas3VoidBedspaceEntity, UU
 
   @Query("""select vb from Cas3VoidBedspaceEntity vb where vb.id = :voidBedspaceId and vb.bedspace.premises.id = :premisesId""")
   fun findVoidBedspace(premisesId: UUID, voidBedspaceId: UUID): Cas3VoidBedspaceEntity?
+
+  @Query(
+    """select vb from Cas3VoidBedspaceEntity vb 
+      where vb.id = :voidBedspaceId and vb.bedspace.id = :bedspaceId and vb.bedspace.premises.id = :premisesId""",
+  )
+  fun findVoidBedspace(premisesId: UUID, bedspaceId: UUID, voidBedspaceId: UUID): Cas3VoidBedspaceEntity?
 }
 
 @SuppressWarnings("LongParameterList")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3v2VoidBedspaceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3v2VoidBedspaceService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Void
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
@@ -19,6 +20,7 @@ class Cas3v2VoidBedspaceService(
   fun findVoidBedspaces(premisesId: UUID): List<Cas3VoidBedspaceEntity> = cas3VoidBedspacesRepository.findActiveVoidBedspacesByPremisesId(premisesId)
 
   fun findVoidBedspace(premisesId: UUID, voidBedspaceId: UUID): Cas3VoidBedspaceEntity? = cas3VoidBedspacesRepository.findVoidBedspace(premisesId, voidBedspaceId)
+  fun findVoidBedspace(premisesId: UUID, bedspaceId: UUID, voidBedspaceId: UUID): Cas3VoidBedspaceEntity? = cas3VoidBedspacesRepository.findVoidBedspace(premisesId, bedspaceId, voidBedspaceId)
 
   fun createVoidBedspace(
     startDate: LocalDate,
@@ -70,5 +72,23 @@ class Cas3v2VoidBedspaceService(
     )
 
     return success(voidBedspacesEntity)
+  }
+
+  fun cancelVoidBedspace(
+    voidBedspace: Cas3VoidBedspaceEntity,
+    notes: String?,
+  ) = validatedCasResult<Cas3VoidBedspaceEntity> {
+    if (voidBedspace.cancellationDate != null) {
+      return generalError("This Void Bedspace already has a cancellation set")
+    }
+
+    voidBedspace.cancellationDate = OffsetDateTime.now()
+    voidBedspace.cancellationNotes = notes
+
+    val cancellationEntity = cas3VoidBedspacesRepository.save(
+      voidBedspace,
+    )
+
+    return success(cancellationEntity)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -992,3 +992,16 @@ abstract class InitialiseDatabasePerClassTestBase : IntegrationTestBase() {
     this.teardownTests()
   }
 }
+
+fun WebTestClient.ResponseSpec.withNotFoundMessage(message: String): WebTestClient.BodyContentSpec = this.expectStatus()
+  .isNotFound.expectBody()
+  .jsonPath("title").isEqualTo("Not Found")
+  .jsonPath("status").isEqualTo(404)
+  .jsonPath("detail").isEqualTo(message)
+
+fun WebTestClient.ResponseSpec.withConflictMessage(message: String): WebTestClient.BodyContentSpec = this.expectStatus()
+  .is4xxClientError
+  .expectBody()
+  .jsonPath("title").isEqualTo("Conflict")
+  .jsonPath("status").isEqualTo(409)
+  .jsonPath("detail").isEqualTo(message)


### PR DESCRIPTION
This PR creates the void bedspaces cancellations endpoint. It's based on the existing /lost-beds/cancellations.

As cancellations have been combined in to the void bedspace model, this has been updated from POST to PUT. The path has also been updated to include the bedspace ID, which will be updated to the existing endpoints in a future PR.