### PR TITLE
CAS-1726 Add validations to archive premises

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenATemporaryAccommodationPremises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenATemporaryAccommodationPremises.kt
@@ -17,6 +17,7 @@ import java.time.LocalDate
 fun IntegrationTestBase.givenATemporaryAccommodationPremises(
   region: ProbationRegionEntity = givenAProbationRegion(),
   status: PropertyStatus = PropertyStatus.active,
+  startDate: LocalDate = LocalDate.now().minusDays(180),
   endDate: LocalDate? = null,
   block: ((premises: TemporaryAccommodationPremisesEntity) -> Unit)? = null,
 ): TemporaryAccommodationPremisesEntity {
@@ -29,6 +30,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremises(
       }
     }
     withStatus(status)
+    withStartDate(startDate)
     withEndDate(endDate)
   }
 
@@ -43,6 +45,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithUser(
   roles: List<UserRole> = emptyList(),
   probationRegion: ProbationRegionEntity? = null,
   premisesStatus: PropertyStatus = PropertyStatus.active,
+  premisesStartDate: LocalDate = LocalDate.now().minusDays(180),
   premisesEndDate: LocalDate? = null,
   block: (user: UserEntity, jwt: String, premises: TemporaryAccommodationPremisesEntity) -> Unit,
 ) {
@@ -53,6 +56,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithUser(
     val premises = givenATemporaryAccommodationPremises(
       region = user.probationRegion,
       status = premisesStatus,
+      startDate = premisesStartDate,
       endDate = premisesEndDate,
     )
     block(user, jwt, premises)


### PR DESCRIPTION
This [PR CAS-1726](https://dsdmoj.atlassian.net/browse/CAS-1726) is to:
- Prevent archive a premises if the archiving date is before premises start date
- Prevent archive a premises when its clashes with an earlier archive premises end date 