### PR TITLE
APS-2673 - Filter space booking list on keyworker user id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1SpaceBookingController.kt
@@ -147,7 +147,8 @@ class Cas1SpaceBookingController(
     @Parameter(description = "ID of the premises to show space bookings for", required = true) @PathVariable premisesId: UUID,
     @RequestParam residency: Cas1SpaceBookingResidency?,
     @RequestParam crnOrName: String?,
-    @RequestParam keyWorkerStaffCode: String?,
+    @Schema(deprecated = true, description = "Use keyworker user id") @RequestParam keyWorkerStaffCode: String?,
+    @RequestParam keyWorkerUserId: UUID?,
     @RequestParam sortDirection: SortDirection?,
     @RequestParam sortBy: Cas1SpaceBookingSummarySortField?,
     @RequestParam page: Int?,
@@ -161,6 +162,7 @@ class Cas1SpaceBookingController(
         residency = residency,
         crnOrName = crnOrName,
         keyWorkerStaffCode = keyWorkerStaffCode,
+        keyWorkerUserId = keyWorkerUserId,
       ),
       PageCriteria(
         sortBy = sortBy ?: Cas1SpaceBookingSummarySortField.personName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -157,6 +157,9 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
         (
             (b.key_worker_staff_code = :keyWorkerStaffCode)
         ) 
+      ) AND 
+      (
+        (:keyWorkerUserId IS NULL OR b.key_worker_user_id = :keyWorkerUserId)
       )
     """
   }
@@ -176,6 +179,7 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
     residency: String?,
     crnOrName: String?,
     keyWorkerStaffCode: String?,
+    keyWorkerUserId: UUID?,
     premisesId: UUID,
     pageable: Pageable?,
   ): Page<Cas1SpaceBookingSearchResult>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1SpaceBookingService.kt
@@ -129,6 +129,7 @@ class Cas1SpaceBookingService(
       filterCriteria.residency?.name,
       filterCriteria.crnOrName,
       filterCriteria.keyWorkerStaffCode,
+      filterCriteria.keyWorkerUserId,
       premisesId,
       pageCriteria.toPageableOrAllPages(
         sortBy = when (pageCriteria.sortBy) {
@@ -502,6 +503,7 @@ class Cas1SpaceBookingService(
     val residency: Cas1SpaceBookingResidency?,
     val crnOrName: String?,
     val keyWorkerStaffCode: String?,
+    val keyWorkerUserId: UUID?,
   )
 
   enum class UpdateType {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingEntityFactory.kt
@@ -151,6 +151,10 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
     this.keyWorkerAssignedAt = { keyWorkerAssignedAt }
   }
 
+  fun withKeyWorkerUser(keyWorkerUser: UserEntity?) = apply {
+    this.keyWorkerUser = { keyWorkerUser }
+  }
+
   fun withCancellationOccurredAt(occurredAt: LocalDate?) = apply {
     this.cancellationOccurredAt = { occurredAt }
   }
@@ -209,10 +213,6 @@ class Cas1SpaceBookingEntityFactory : Factory<Cas1SpaceBookingEntity> {
 
   fun withTransferType(transferType: TransferType?) = apply {
     this.transferType = { transferType }
-  }
-
-  fun withKeyWorkerUser(keyWorkerUser: UserEntity?) = apply {
-    this.keyWorkerUser = { keyWorkerUser }
   }
 
   override fun produce() = Cas1SpaceBookingEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -467,6 +467,7 @@ class Cas1SpaceBookingTest {
           withKeyworkerName(keyWorker.name)
           withKeyworkerStaffCode(keyWorker.deliusStaffCode)
           withKeyworkerAssignedAt(Instant.now())
+          withKeyWorkerUser(keyWorker)
         }
 
       upcomingCancelledSpaceBooking =
@@ -735,6 +736,27 @@ class Cas1SpaceBookingTest {
 
       val response = webTestClient.get()
         .uri("/cas1/premises/${premisesWithBookings.id}/space-bookings?keyWorkerStaffCode=${keyWorker.deliusStaffCode}&sortBy=canonicalArrivalDate&sortDirection=asc")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsListOfObjects<Cas1SpaceBookingSummary>()
+
+      assertThat(response).hasSize(1)
+      assertThat(response[0].person.crn).isEqualTo("CRN_UPCOMING")
+
+      val spaceBookingKeyWorker = response[0].keyWorkerAllocation!!.keyWorker
+
+      assertThat(spaceBookingKeyWorker.name).isEqualTo(keyWorker.name)
+      assertThat(spaceBookingKeyWorker.code).isEqualTo(keyWorker.deliusStaffCode)
+    }
+
+    @Test
+    fun `Filter on Key Worker Staff User Id`() {
+      val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
+
+      val response = webTestClient.get()
+        .uri("/cas1/premises/${premisesWithBookings.id}/space-bookings?keyWorkerUserId=${keyWorker.id}&sortBy=canonicalArrivalDate&sortDirection=asc")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1SpaceBookingServiceTest.kt
@@ -362,6 +362,7 @@ class Cas1SpaceBookingServiceTest {
           residency = null,
           crnOrName = null,
           keyWorkerStaffCode = null,
+          keyWorkerUserId = null,
         ),
         PageCriteriaFactory(Cas1SpaceBookingSummarySortField.canonicalArrivalDate)
           .produce(),
@@ -394,11 +395,14 @@ class Cas1SpaceBookingServiceTest {
       )
       val pageableCaptor = slot<Pageable>()
 
+      val keyWorkerUserId = UUID.randomUUID()
+
       every {
         spaceBookingRepository.search(
           "current",
           "theCrnOrName",
           "keyWorkerStaffCode",
+          keyWorkerUserId,
           PREMISES_ID,
           capture(pageableCaptor),
         )
@@ -410,13 +414,14 @@ class Cas1SpaceBookingServiceTest {
           residency = Cas1SpaceBookingResidency.current,
           crnOrName = "theCrnOrName",
           keyWorkerStaffCode = "keyWorkerStaffCode",
+          keyWorkerUserId = keyWorkerUserId,
         ),
         PageCriteriaFactory(inputSortField).produce(),
       )
 
-      assertThat(result).isInstanceOf(CasResult.Success::class.java)
-      result as CasResult.Success
-      assertThat(result.value.results).hasSize(3)
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.results).hasSize(3)
+      }
 
       assertThat(pageableCaptor.captured.sort.toList()[0].property).isEqualTo(sqlSortField)
     }


### PR DESCRIPTION
This commit updates `/premises/{premisesId}/space-bookings` to allow space bookings to be filtered on the key worker user id