### PR TITLE
APS-2676 - Only allow future managers in cas1 staff list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -71,6 +71,14 @@ interface UserRepository :
   )
   fun findRoleAssignmentByUsername(deliusUsername: String): List<RoleAssignmentByUsername>
 
+  @Query(
+    """SELECT u FROM UserEntity u 
+        join u.roles r ON r.role = "CAS1_FUTURE_MANAGER" 
+        where UPPER(u.deliusStaffCode) IN :staffCodes
+      """,
+  )
+  fun findFutureManagersByStaffCode(staffCodes: List<String>): List<UserEntity>
+
   interface RoleAssignmentByUsername {
     val userId: UUID
     val roleName: String?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1UserService.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+
+@Service
+class Cas1UserService(
+  val userRepository: UserRepository,
+) {
+  fun findFutureManagersByStaffCode(staffCodes: List<String>) = userRepository.findFutureManagersByStaffCode(staffCodes.map { it.uppercase() })
+}


### PR DESCRIPTION
**Blocked - Do not merge, see text below for context**

The endpoint `/cas1/premises/{premisesId}/staff` is used to retrieve a list of staff members from delius that can be used in CAS1 as key workers.

As part of our move to use the user’s table to manage the list of potential keyworkers, we want to move away from using this endpoint.

In the meantime, Once we’ve backfilled the new `cas1_space_bookings.key_worker_user_id` for all records in production we want to ensure that only staff members with a correspoding entry in the `users` table with the role `CAS1_FUTURE_MANAGER` can be assigned as key workers.

This commit updates `/cas1/premises/{premisesId}/staff` to ensure this is the case (and will only be merged/deployed once the user id backfill is complete, and we can ensure all keyworkers have the `CAS1_FUTURE_MANAGER` role)

