### PR TITLE
CAS3 V2 Create Extension API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2PremisesController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewConfirmation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3NewBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Arrival
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Cancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Departure
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Extension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3NewDeparture
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.NewCas3Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2BookingService
@@ -28,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3Boo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3CancellationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3ConfirmationTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3DepartureTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3ExtensionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -57,6 +60,7 @@ class Cas3v2PremisesController(
   private val cas3ArrivalTransformer: Cas3ArrivalTransformer,
   private val cas3DepartureTransformer: Cas3DepartureTransformer,
   private val cas3ConfirmationTransformer: Cas3ConfirmationTransformer,
+  private val cas3ExtensionTransformer: Cas3ExtensionTransformer,
 ) {
 
   @GetMapping("/premises/{premisesId}/bookings")
@@ -255,6 +259,29 @@ class Cas3v2PremisesController(
 
     return ResponseEntity.status(HttpStatus.CREATED).body(
       cas3ConfirmationTransformer.transformJpaToApi(
+        jpa = extractEntityFromCasResult(result),
+      ),
+    )
+  }
+
+  @PostMapping("/premises/{premisesId}/bookings/{bookingId}/extensions")
+  fun postPremisesBookingExtension(
+    @PathVariable premisesId: UUID,
+    @PathVariable bookingId: UUID,
+    @RequestBody newExtension: NewExtension,
+  ): ResponseEntity<Cas3Extension> {
+    val user = usersService.getUserForRequest()
+    val booking = getBookingForPremisesOrThrow(premisesId, bookingId, user)
+    if (!userAccessService.userCanManagePremisesBookings(user, booking.premises)) {
+      throw ForbiddenProblem()
+    }
+    val result = cas3BookingService.createExtension(
+      booking = booking,
+      newDepartureDate = newExtension.newDepartureDate,
+      notes = newExtension.notes,
+    )
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+      cas3ExtensionTransformer.transformJpaToApi(
         jpa = extractEntityFromCasResult(result),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3ExtensionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3ExtensionEntity.kt
@@ -6,10 +6,15 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.UUID
+
+@Repository
+interface Cas3ExtensionRepository : JpaRepository<Cas3ExtensionEntity, UUID>
 
 @Entity
 @Table(name = "extensions")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingTest.kt
@@ -10,6 +10,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewConfirmation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenACas3Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenCas3PremisesAndBedspace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.withConflictMessage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
@@ -609,11 +611,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .is4xxClientError
-          .expectBody()
-          .jsonPath("title").isEqualTo("Conflict")
-          .jsonPath("status").isEqualTo(409)
-          .jsonPath("detail")
-          .isEqualTo("BedSpace is archived from ${bedspace.endDate} which overlaps with the desired dates: ${bedspace.id}")
+          .withConflictMessage("BedSpace is archived from ${bedspace.endDate} which overlaps with the desired dates: ${bedspace.id}")
       }
     }
   }
@@ -651,11 +649,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .is4xxClientError
-          .expectBody()
-          .jsonPath("title").isEqualTo("Conflict")
-          .jsonPath("status").isEqualTo(409)
-          .jsonPath("detail")
-          .isEqualTo("BedSpace is archived from ${bedspace.endDate} which overlaps with the desired dates: ${bedspace.id}")
+          .withConflictMessage("BedSpace is archived from ${bedspace.endDate} which overlaps with the desired dates: ${bedspace.id}")
       }
     }
   }
@@ -693,11 +687,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .is4xxClientError
-          .expectBody()
-          .jsonPath("title").isEqualTo("Conflict")
-          .jsonPath("status").isEqualTo(409)
-          .jsonPath("detail")
-          .isEqualTo("BedSpace is archived from ${bedspace.endDate} which overlaps with the desired dates: ${bedspace.id}")
+          .withConflictMessage("BedSpace is archived from ${bedspace.endDate} which overlaps with the desired dates: ${bedspace.id}")
       }
     }
   }
@@ -1063,11 +1053,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .is4xxClientError
-          .expectBody()
-          .jsonPath("title").isEqualTo("Conflict")
-          .jsonPath("status").isEqualTo(409)
-          .jsonPath("detail")
-          .isEqualTo("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingBooking.id}")
+          .withConflictMessage("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingBooking.id}")
       }
     }
   }
@@ -1114,11 +1100,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .is4xxClientError
-          .expectBody()
-          .jsonPath("title").isEqualTo("Conflict")
-          .jsonPath("status").isEqualTo(409)
-          .jsonPath("detail")
-          .isEqualTo("A Booking already exists for dates from 2022-07-15 to 2022-08-22 which overlaps with the desired dates: ${existingBooking.id}")
+          .withConflictMessage("A Booking already exists for dates from 2022-07-15 to 2022-08-22 which overlaps with the desired dates: ${existingBooking.id}")
       }
     }
   }
@@ -1215,11 +1197,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .is4xxClientError
-          .expectBody()
-          .jsonPath("title").isEqualTo("Conflict")
-          .jsonPath("status").isEqualTo(409)
-          .jsonPath("detail")
-          .isEqualTo("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingLostBed.id}")
+          .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingLostBed.id}")
       }
     }
   }
@@ -1370,11 +1348,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .is4xxClientError
-            .expectBody()
-            .jsonPath("title").isEqualTo("Conflict")
-            .jsonPath("status").isEqualTo(409)
-            .jsonPath("detail")
-            .isEqualTo("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingBooking.id}")
+            .withConflictMessage("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingBooking.id}")
         }
       }
     }
@@ -1416,11 +1390,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .is4xxClientError
-            .expectBody()
-            .jsonPath("title").isEqualTo("Conflict")
-            .jsonPath("status").isEqualTo(409)
-            .jsonPath("detail")
-            .isEqualTo("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
+            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
         }
       }
     }
@@ -1504,8 +1474,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
 
           webTestClient.post()
             .uri("/cas3/v2/premises/${booking.premises.id}/bookings/${booking.id}/arrivals")
-            .header("Authorization", "Bearer $jwt")
-            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .headers(buildTemporaryAccommodationHeaders(jwt))
             .bodyValue(
               NewCas3Arrival(
                 type = "CAS3",
@@ -1723,7 +1692,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             .isBadRequest
             .expectBody()
             .jsonPath("$.title").isEqualTo("Bad Request")
-            .jsonPath("$.invalid-params[0].propertyName").isEqualTo("\$.arrivalDate")
+            .jsonPath("$.invalid-params[0].propertyName").isEqualTo("$.arrivalDate")
             .jsonPath("$.invalid-params[0].errorType").isEqualTo("arrivalAfterLatestDate")
         }
       }
@@ -2337,6 +2306,250 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .isNotFound
           .expectBody()
           .jsonPath("$.detail").isEqualTo("No Premises with an ID of $notFoundPremisesId could be found")
+      }
+    }
+  }
+
+  @Nested
+  inner class CreateExtension {
+
+    @Test
+    fun `Create Extension returns 409 Conflict when another booking for the same bed overlaps with the new departure date`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+          val conflictingBooking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withCrn("CRN123")
+            withPremises(premises)
+            withBedspace(bedspace)
+            withArrivalDate(LocalDate.parse("2022-07-15"))
+            withDepartureDate(LocalDate.parse("2022-08-15"))
+          }
+          val booking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withCrn(offenderDetails.otherIds.crn)
+            withPremises(premises)
+            withBedspace(bedspace)
+            withArrivalDate(LocalDate.parse("2022-06-14"))
+            withDepartureDate(LocalDate.parse("2022-07-14"))
+          }
+
+          govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+          webTestClient.post()
+            .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/extensions")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              NewExtension(
+                newDepartureDate = LocalDate.parse("2022-07-16"),
+                notes = null,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+            .withConflictMessage("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingBooking.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `Create Extension returns 409 Conflict when another booking for the same bed overlaps with the updated booking's turnaround time`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+          val conflictingBooking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withCrn("CRN123")
+            withPremises(premises)
+            withBedspace(bedspace)
+            withArrivalDate(LocalDate.parse("2022-07-15"))
+            withDepartureDate(LocalDate.parse("2022-08-15"))
+          }
+          val booking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withCrn(offenderDetails.otherIds.crn)
+            withPremises(premises)
+            withBedspace(bedspace)
+            withArrivalDate(LocalDate.parse("2022-06-12"))
+            withDepartureDate(LocalDate.parse("2022-07-12"))
+          }
+          val turnarounds = cas3v2TurnaroundFactory.produceAndPersistMultiple(1) {
+            withWorkingDayCount(2)
+            withCreatedAt(booking.createdAt)
+            withBooking(booking)
+          }
+          booking.turnarounds += turnarounds
+
+          govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+          webTestClient.post()
+            .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/extensions")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              NewExtension(
+                newDepartureDate = LocalDate.parse("2022-07-13"),
+                notes = null,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+            .withConflictMessage("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingBooking.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `Create Extension returns 409 Conflict when a void bedspace for the same bed overlaps with the new departure date`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+          val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
+            withBedspace(bedspace)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
+          }
+          val booking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withCrn(offenderDetails.otherIds.crn)
+            withPremises(premises)
+            withBedspace(bedspace)
+            withArrivalDate(LocalDate.parse("2022-06-14"))
+            withDepartureDate(LocalDate.parse("2022-07-14"))
+          }
+
+          govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+          webTestClient.post()
+            .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/extensions")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              NewExtension(
+                newDepartureDate = LocalDate.parse("2022-07-16"),
+                notes = null,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `Create Extension returns 409 Conflict when a void bedspace for the same bed overlaps with the updated booking's turnaround time`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+          val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
+            withBedspace(bedspace)
+            withStartDate(LocalDate.parse("2022-07-15"))
+            withEndDate(LocalDate.parse("2022-08-15"))
+            withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
+          }
+          val booking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withCrn(offenderDetails.otherIds.crn)
+            withPremises(premises)
+            withBedspace(bedspace)
+            withArrivalDate(LocalDate.parse("2022-06-12"))
+            withDepartureDate(LocalDate.parse("2022-07-12"))
+          }
+          val turnarounds = cas3v2TurnaroundFactory.produceAndPersistMultiple(1) {
+            withWorkingDayCount(2)
+            withCreatedAt(booking.createdAt)
+            withBooking(booking)
+          }
+          booking.turnarounds += turnarounds
+
+          govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+          webTestClient.post()
+            .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/extensions")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              NewExtension(
+                newDepartureDate = LocalDate.parse("2022-07-13"),
+                notes = null,
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `Create Extension returns 403 Forbidden for a premises that's not in the user's region`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        val premises = givenACas3Premises()
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withDepartureDate(LocalDate.parse("2022-08-20"))
+          withPremises(premises)
+          withBedspace(
+            cas3BedspaceEntityFactory.produceAndPersist {
+              withPremises(premises)
+            },
+          )
+        }
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/extensions")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            NewExtension(
+              newDepartureDate = LocalDate.parse("2022-08-22"),
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+
+    @Test
+    fun `Create Extension returns OK with expected body, updates departureDate on Booking entity when user has one of roles CAS3_ASSESSOR`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withServiceName(ServiceName.temporaryAccommodation)
+          withArrivalDate(LocalDate.parse("2022-08-18"))
+          withDepartureDate(LocalDate.parse("2022-08-20"))
+          withPremises(premises)
+          withBedspace(bedspace)
+        }
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val newDate = "2022-08-22"
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${booking.premises.id}/bookings/${booking.id}/extensions")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            NewExtension(
+              newDepartureDate = LocalDate.parse(newDate),
+              notes = "notes",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isCreated
+          .expectBody()
+          .jsonPath(".bookingId").isEqualTo(booking.id.toString())
+          .jsonPath(".previousDepartureDate").isEqualTo(booking.departureDate.toString())
+          .jsonPath(".newDepartureDate").isEqualTo(newDate)
+          .jsonPath(".notes").isEqualTo("notes")
+          .jsonPath("$.createdAt").value(OffsetDateTime::class.java, withinSeconds(5L))
+
+        val actualBooking = bookingRepository.findByIdOrNull(booking.id)
+        assertThat(actualBooking?.departureDate).isEqualTo(LocalDate.parse(newDate))
+        assertThat(actualBooking?.originalDepartureDate).isEqualTo(booking.departureDate)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingServiceTest.kt
@@ -36,6 +36,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Canc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3CancellationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3DepartureRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3ExtensionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3ExtensionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspacesRepository
@@ -101,6 +103,7 @@ class Cas3v2BookingServiceTest {
   private val mockDepartureReasonRepository = mockk<DepartureReasonRepository>()
   private val mockMoveOnCategoryRepository = mockk<MoveOnCategoryRepository>()
   private val mockFeatureFlagService = mockk<FeatureFlagService>()
+  private val mockExtensionRepository = mockk<Cas3ExtensionRepository>()
 
   private fun createCas3v2BookingService(): Cas3v2BookingService = Cas3v2BookingService(
     cas3BookingRepository = mockBookingRepository,
@@ -117,6 +120,7 @@ class Cas3v2BookingServiceTest {
     cas3VoidBedspacesRepository = mockCas3VoidBedspacesRepository,
     offenderService = mockOffenderService,
     workingDayService = mockWorkingDayService,
+    cas3ExtensionRepository = mockExtensionRepository,
     cas3DomainEventService = mockCas3DomainEventService,
     userAccessService = mockUserAccessService,
     assessmentService = mockAssessmentService,
@@ -154,8 +158,7 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value).isEqualTo(bookingEntity)
+        assertThat(it).isEqualTo(bookingEntity)
       }
     }
 
@@ -172,8 +175,7 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value).isEqualTo(bookingEntity)
+        assertThat(it).isEqualTo(bookingEntity)
       }
     }
 
@@ -1208,12 +1210,11 @@ class Cas3v2BookingServiceTest {
       assertThatCasResult(result).isSuccess()
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.arrivalDate).isEqualTo(arrivalDate)
-        assertThat(result.value.arrivalDateTime).isEqualTo(arrivalDate.toLocalDateTime().toInstant())
-        assertThat(result.value.expectedDepartureDate).isEqualTo(expectedDepartureDate)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.arrived)
+        assertThat(it.arrivalDate).isEqualTo(arrivalDate)
+        assertThat(it.arrivalDateTime).isEqualTo(arrivalDate.toLocalDateTime().toInstant())
+        assertThat(it.expectedDepartureDate).isEqualTo(expectedDepartureDate)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.arrived)
       }
 
       verify(exactly = 1) { mockArrivalRepository.save(any()) }
@@ -1244,12 +1245,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.arrivalDate).isEqualTo(arrivalDate)
-        assertThat(result.value.arrivalDateTime).isEqualTo(arrivalDate.toLocalDateTime().toInstant())
-        assertThat(result.value.expectedDepartureDate).isEqualTo(expectedDepartureDate)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.arrived)
+        assertThat(it.arrivalDate).isEqualTo(arrivalDate)
+        assertThat(it.arrivalDateTime).isEqualTo(arrivalDate.toLocalDateTime().toInstant())
+        assertThat(it.expectedDepartureDate).isEqualTo(expectedDepartureDate)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.arrived)
       }
 
       verify(exactly = 1) { mockArrivalRepository.save(any()) }
@@ -1273,12 +1273,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.arrivalDate).isEqualTo(arrivalDate)
-        assertThat(result.value.arrivalDateTime).isEqualTo(arrivalDate.toLocalDateTime().toInstant())
-        assertThat(result.value.expectedDepartureDate).isEqualTo(expectedDepartureDate)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.arrived)
+        assertThat(it.arrivalDate).isEqualTo(arrivalDate)
+        assertThat(it.arrivalDateTime).isEqualTo(arrivalDate.toLocalDateTime().toInstant())
+        assertThat(it.expectedDepartureDate).isEqualTo(expectedDepartureDate)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.arrived)
       }
 
       verify(exactly = 1) { mockArrivalRepository.save(any()) }
@@ -1310,12 +1309,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.date).isEqualTo(LocalDate.parse("2022-08-25"))
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(cas3BookingEntity.cancellations).contains(result.value)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
+        assertThat(it.date).isEqualTo(LocalDate.parse("2022-08-25"))
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(cas3BookingEntity.cancellations).contains(it)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
       }
 
       verify(exactly = 1) {
@@ -1352,12 +1350,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.date).isEqualTo(LocalDate.parse("2022-08-25"))
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(cas3BookingEntity.cancellations).contains(result.value)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
+        assertThat(it.date).isEqualTo(LocalDate.parse("2022-08-25"))
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(cas3BookingEntity.cancellations).contains(it)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
       }
 
       verify(exactly = 1) {
@@ -1394,12 +1391,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.date).isEqualTo(LocalDate.parse("2022-08-25"))
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(bookingWithAssessmentEntity.cancellations).contains(result.value)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
+        assertThat(it.date).isEqualTo(LocalDate.parse("2022-08-25"))
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(bookingWithAssessmentEntity.cancellations).contains(it)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
       }
 
       verify(exactly = 1) {
@@ -1446,12 +1442,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.date).isEqualTo(LocalDate.parse("2022-08-25"))
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(bookingWithAssessmentEntity.cancellations).contains(result.value)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
+        assertThat(it.date).isEqualTo(LocalDate.parse("2022-08-25"))
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(bookingWithAssessmentEntity.cancellations).contains(it)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
       }
 
       verify(exactly = 1) {
@@ -1497,12 +1492,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.date).isEqualTo(LocalDate.parse("2022-08-25"))
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(bookingWithAssessmentEntity.cancellations).contains(result.value)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
+        assertThat(it.date).isEqualTo(LocalDate.parse("2022-08-25"))
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(bookingWithAssessmentEntity.cancellations).contains(it)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
       }
 
       verify(exactly = 1) {
@@ -1636,12 +1630,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.date).isEqualTo(LocalDate.parse("2022-08-25"))
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(bookingWithAssessmentEntity.cancellations).contains(result.value)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
+        assertThat(it.date).isEqualTo(LocalDate.parse("2022-08-25"))
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(bookingWithAssessmentEntity.cancellations).contains(it)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
       }
 
       verify(exactly = 1) {
@@ -1681,12 +1674,11 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.date).isEqualTo(LocalDate.parse("2022-08-25"))
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(bookingWithoutAssessmentEntity.cancellations).contains(result.value)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
+        assertThat(it.date).isEqualTo(LocalDate.parse("2022-08-25"))
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(bookingWithoutAssessmentEntity.cancellations).contains(it)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.cancelled)
       }
 
       verify(exactly = 1) {
@@ -1932,15 +1924,14 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.booking).isEqualTo(bookingEntity)
-        assertThat(result.value.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-24T15:00:00+01:00"))
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.moveOnCategory).isEqualTo(moveOnCategoryEntity)
-        assertThat(result.value.destinationProvider).isEqualTo(null)
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.departed)
+        assertThat(it.booking).isEqualTo(bookingEntity)
+        assertThat(it.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-24T15:00:00+01:00"))
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.moveOnCategory).isEqualTo(moveOnCategoryEntity)
+        assertThat(it.destinationProvider).isEqualTo(null)
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.departed)
       }
 
       verify(exactly = 1) {
@@ -2006,15 +1997,14 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.booking).isEqualTo(bookingEntity)
-        assertThat(result.value.dateTime).isEqualTo(departureDateTime)
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.moveOnCategory).isEqualTo(moveOnCategoryEntity)
-        assertThat(result.value.destinationProvider).isEqualTo(null)
-        assertThat(result.value.reason).isEqualTo(reasonEntity)
-        assertThat(result.value.notes).isEqualTo(notes)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.departed)
+        assertThat(it.booking).isEqualTo(bookingEntity)
+        assertThat(it.dateTime).isEqualTo(departureDateTime)
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.moveOnCategory).isEqualTo(moveOnCategoryEntity)
+        assertThat(it.destinationProvider).isEqualTo(null)
+        assertThat(it.reason).isEqualTo(reasonEntity)
+        assertThat(it.notes).isEqualTo(notes)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.departed)
       }
 
       verify(exactly = 1) {
@@ -2061,11 +2051,10 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value).isEqualTo(bookingEntity.confirmation)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
+        assertThat(it.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it).isEqualTo(bookingEntity.confirmation)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
       }
 
       verify(exactly = 1) {
@@ -2090,11 +2079,10 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value).isEqualTo(bookingEntity.confirmation)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
+        assertThat(it.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it).isEqualTo(bookingEntity.confirmation)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
       }
 
       verify(exactly = 1) {
@@ -2140,11 +2128,10 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value).isEqualTo(bookingEntity.confirmation)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
+        assertThat(it.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it).isEqualTo(bookingEntity.confirmation)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
       }
 
       verify(exactly = 1) {
@@ -2186,11 +2173,10 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value).isEqualTo(bookingEntity.confirmation)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
+        assertThat(it.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it).isEqualTo(bookingEntity.confirmation)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
       }
 
       verify(exactly = 1) {
@@ -2237,11 +2223,10 @@ class Cas3v2BookingServiceTest {
       )
 
       assertThatCasResult(result).isSuccess().with {
-        result as CasResult.Success
-        assertThat(result.value.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
-        assertThat(result.value.notes).isEqualTo("notes")
-        assertThat(result.value).isEqualTo(bookingEntity.confirmation)
-        assertThat(result.value.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
+        assertThat(it.dateTime).isEqualTo(OffsetDateTime.parse("2022-08-25T12:34:56.789Z"))
+        assertThat(it.notes).isEqualTo("notes")
+        assertThat(it).isEqualTo(bookingEntity.confirmation)
+        assertThat(it.booking.status).isEqualTo(Cas3BookingStatus.confirmed)
       }
 
       verify(exactly = 1) {
@@ -2262,8 +2247,54 @@ class Cas3v2BookingServiceTest {
     }
   }
 
+  @Nested
+  inner class CreateExtension {
+
+    @BeforeEach
+    fun setup() {
+      every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as Cas3BookingEntity }
+      every { mockExtensionRepository.save(any()) } answers { it.invocation.args[0] as Cas3ExtensionEntity }
+      every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
+      every { mockBookingRepository.findByBedspaceIdAndArrivingBeforeDate(any(), any(), any()) } returns listOf()
+      every { mockCas3VoidBedspacesRepository.findByBedspaceIdAndOverlappingDateV2(any(), any(), any(), any()) } returns listOf()
+    }
+
+    @Test
+    fun `Success with correct result when a booking has a new departure date before the existing departure date`() {
+      val bookingEntity = createCas3Booking(
+        arrivalDate = LocalDate.parse("2022-08-10"),
+        departureDate = LocalDate.parse("2022-08-26"),
+      )
+      val result = cas3BookingService.createExtension(
+        booking = bookingEntity,
+        newDepartureDate = LocalDate.parse("2022-08-25"),
+        notes = "notes",
+      )
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.newDepartureDate).isEqualTo(LocalDate.parse("2022-08-25"))
+        assertThat(it.previousDepartureDate).isEqualTo(LocalDate.parse("2022-08-26"))
+        assertThat(it.notes).isEqualTo("notes")
+      }
+    }
+
+    @Test
+    fun `FieldValidationError when a booking has a new departure date before the arrival date`() {
+      val bookingEntity = createCas3Booking(
+        arrivalDate = LocalDate.parse("2022-08-26"),
+      )
+      val result = cas3BookingService.createExtension(
+        booking = bookingEntity,
+        newDepartureDate = LocalDate.parse("2022-08-25"),
+        notes = "notes",
+      )
+      assertThatCasResult(result).isFieldValidationError()
+        .hasMessage("$.newDepartureDate", "beforeBookingArrivalDate")
+    }
+  }
+
   private fun createCas3Booking(
     arrivalDate: LocalDate = LocalDate.now().randomDateBefore(14),
+    departureDate: LocalDate = LocalDate.now().randomDateAfter(14),
     application: TemporaryAccommodationApplicationEntity? = null,
   ): Cas3BookingEntity {
     val premises = Cas3PremisesEntityFactory()
@@ -2278,6 +2309,7 @@ class Cas3v2BookingServiceTest {
       .withBedspace(bedspace)
       .withServiceName(ServiceName.temporaryAccommodation)
       .withArrivalDate(arrivalDate)
+      .withDepartureDate(departureDate)
       .withApplication(application)
       .produce()
   }


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" height="1152" alt="swags" src="https://github.com/user-attachments/assets/a7eed5f7-ae84-48be-8c90-211da16dc61c" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `POST /cas3/v2/premises/{premisesId}/bookings/{bookingId}/extensions`
2. This endpoint was modelled on the `POST /premises/{premisesId}/bookings/{bookingId}/extensions` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models
