### PR TITLE
CAS-1726 Extend validation message when overlap archiving premises dates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -565,7 +565,17 @@ class Cas3PremisesService(
       .asSequence()
       .map { objectMapper.readValue(it.data, CAS3PremisesArchiveEvent::class.java).eventDetails.endDate }
       .firstOrNull { it >= endDate }
-      ?.let { return "$.endDate" hasSingleValidationError "endDateOverlapPreviousPremisesArchiveEndDate" }
+      ?.let { archiveDate ->
+        return Cas3FieldValidationError(
+          mapOf(
+            "$.endDate" to Cas3ValidationMessage(
+              entityId = premises.id.toString(),
+              message = "endDateOverlapPreviousPremisesArchiveEndDate",
+              value = archiveDate.toString(),
+            ),
+          ),
+        )
+      }
 
     if (validationErrors.any()) {
       return fieldValidationError

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
@@ -2667,6 +2667,8 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
           .jsonPath("$.title").isEqualTo("Bad Request")
           .jsonPath("$.invalid-params[0].propertyName").isEqualTo("\$.endDate")
           .jsonPath("$.invalid-params[0].errorType").isEqualTo("endDateOverlapPreviousPremisesArchiveEndDate")
+          .jsonPath("$.invalid-params[0].entityId").isEqualTo(premises.id.toString())
+          .jsonPath("$.invalid-params[0].value").isEqualTo(previousPremisesArchiveDate.toString())
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
@@ -2671,7 +2671,7 @@ class Cas3PremisesServiceTest {
 
       val result = premisesService.archivePremises(premises, previousPremisesArchiveDate.minusDays(2))
 
-      assertThatCasResult(result).isFieldValidationError().hasMessage("$.endDate", "endDateOverlapPreviousPremisesArchiveEndDate")
+      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", premises.id.toString(), "endDateOverlapPreviousPremisesArchiveEndDate", previousPremisesArchiveDate.toString())
     }
 
     @Test


### PR DESCRIPTION
This [PR CAS-1726](https://dsdmoj.atlassian.net/browse/CAS-1726) is to extend the validation message when archiving premises date overlaps 