### PR TITLE
CAS-1625 Add validation to archive bedspace

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -130,7 +130,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     return bedspace
   }
 
-  fun getUnarchivePremisesEvent(
+  fun createUnarchivePremisesEvent(
     premises: TemporaryAccommodationPremisesEntity,
     userEntity: UserEntity,
     currentStartDate: LocalDate,
@@ -159,7 +159,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     }
   }
 
-  fun getArchivePremisesEvent(
+  fun createArchivePremisesEvent(
     premises: TemporaryAccommodationPremisesEntity,
     userEntity: UserEntity,
     date: LocalDate,


### PR DESCRIPTION
This [PR CAS-1625](https://dsdmoj.atlassian.net/browse/CAS-1625) is to extend the validations to archive bedspace to include:
- when archive bedspace is before bedspace start date
- when archive date clashes with previous archive date