### PR TITLE
APS-2674 - Populate `Cas1KeyWorkerAllocation.keyWorkerUser`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1KeyWorkerAllocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1KeyWorkerAllocation.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
 data class Cas1KeyWorkerAllocation(
+  @Deprecated("Once keyWorkerUser is non optional, this will be removed")
   val keyWorker: StaffMember,
   val keyWorkerUser: UserSummary? = null,
   val allocatedAt: java.time.LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -90,6 +90,8 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
         b.key_worker_staff_code AS keyWorkerStaffCode,
         b.key_worker_assigned_at AS keyWorkerAssignedAt,
         b.key_worker_name AS keyWorkerName,
+        key_worker_user.id as keyWorkerUserId,
+        key_worker_user.email AS keyWorkerEmail,
         CASE 
           WHEN apa.id IS NOT NULL THEN apa.name
           ELSE offline_app.name
@@ -114,6 +116,7 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
       FROM cas1_space_bookings b
       LEFT OUTER JOIN approved_premises_applications apa ON b.approved_premises_application_id = apa.id
       LEFT OUTER JOIN offline_applications offline_app ON b.offline_application_id = offline_app.id
+      LEFT OUTER JOIN users key_worker_user ON b.key_worker_user_id = key_worker_user.id
       WHERE 
       b.premises_id = :premisesId AND 
       b.cancellation_occurred_at IS NULL AND 
@@ -199,6 +202,8 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
       b.key_worker_staff_code AS keyWorkerStaffCode,
       b.key_worker_assigned_at AS keyWorkerAssignedAt,
       b.key_worker_name AS keyWorkerName,
+      key_worker_user.id as keyWorkerUserId,
+      key_worker_user.email AS keyWorkerEmail,
     CASE
         WHEN apa.id IS NOT NULL THEN apa.name
         ELSE offline_app.name
@@ -226,6 +231,7 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
       FROM cas1_space_bookings b
       LEFT JOIN approved_premises_applications apa ON b.approved_premises_application_id = apa.id
       LEFT JOIN offline_applications offline_app ON b.offline_application_id = offline_app.id
+      LEFT OUTER JOIN users key_worker_user ON b.key_worker_user_id = key_worker_user.id
       WHERE 
         b.canonical_arrival_date <= :date AND 
         b.canonical_departure_date > :date AND
@@ -394,6 +400,8 @@ interface Cas1SpaceBookingSearchResult {
   val keyWorkerStaffCode: String?
   val keyWorkerAssignedAt: Instant?
   val keyWorkerName: String?
+  val keyWorkerUserId: UUID?
+  val keyWorkerEmail: String?
   val characteristicsPropertyNamesCsv: String?
   val deliusEventNumber: String?
   val cancelled: Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceChara
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.StaffMember
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingAtPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
@@ -221,6 +222,13 @@ class Cas1SpaceBookingTransformer(
           keyWorker = true,
           name = searchResult.keyWorkerName!!,
         ),
+        keyWorkerUser = searchResult.keyWorkerUserId?.let {
+          UserSummary(
+            id = it,
+            name = searchResult.keyWorkerName!!,
+            emailAddress = searchResult.keyWorkerEmail,
+          )
+        },
       )
     },
     characteristics = searchResult.getCharacteristicPropertyNames().mapNotNull { propertyName ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -1007,6 +1007,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
     lateinit var premises: ApprovedPremisesEntity
     lateinit var spaceBookingEarly: Cas1SpaceBookingEntity
     lateinit var spaceBookingLate: Cas1SpaceBookingEntity
+    lateinit var spaceBookingOfflineApplicationKeyWorker: UserEntity
     lateinit var spaceBookingOfflineApplication: Cas1SpaceBookingEntity
     lateinit var applicationA: ApprovedPremisesApplicationEntity
     lateinit var placementRequestA: PlacementRequestEntity
@@ -1025,7 +1026,6 @@ class Cas1PremisesTest : IntegrationTestBase() {
     val summaryDate: LocalDate = now()
     val tierA = "A2"
     val tierB = "B3"
-    val releaseTypeToBeDetermined = "TBD"
 
     @SuppressWarnings("UnusedPrivateProperty", "LongMethod")
     @BeforeAll
@@ -1130,6 +1130,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
         )
       }
 
+      spaceBookingOfflineApplicationKeyWorker = givenAUser().first
       spaceBookingOfflineApplication = createSpaceBookingWithOfflineApplication(
         crn = offenderOffline.crn,
         firstName = offenderOffline.name.forename,
@@ -1143,6 +1144,9 @@ class Cas1PremisesTest : IntegrationTestBase() {
         withCriteria(
           findCharacteristic(CAS1_PROPERTY_NAME_SINGLE_ROOM),
         )
+        withKeyworkerStaffCode("key worker 1 code")
+        withKeyworkerName("key worker 1 name")
+        withKeyWorkerUser(spaceBookingOfflineApplicationKeyWorker)
       }
 
       // cancelled - ignored
@@ -1296,6 +1300,13 @@ class Cas1PremisesTest : IntegrationTestBase() {
       assertThat(bookingSummary1.canonicalDepartureDate).isEqualTo(bookingSummary1.canonicalDepartureDate)
       assertThat(bookingSummary1.characteristics.size).isEqualTo(1)
       assertThat(bookingSummary1.characteristics[0].value).isEqualTo(CAS1_PROPERTY_NAME_SINGLE_ROOM)
+
+      val bookingSummary1KeyWorkerAllocation = bookingSummary1.keyWorkerAllocation!!
+      assertThat(bookingSummary1KeyWorkerAllocation.keyWorker.name).isEqualTo("key worker 1 name")
+      assertThat(bookingSummary1KeyWorkerAllocation.keyWorker.code).isEqualTo("key worker 1 code")
+      assertThat(bookingSummary1KeyWorkerAllocation.keyWorkerUser!!.id).isEqualTo(spaceBookingOfflineApplicationKeyWorker.id)
+      assertThat(bookingSummary1KeyWorkerAllocation.keyWorkerUser!!.name).isEqualTo("key worker 1 name")
+      assertThat(bookingSummary1KeyWorkerAllocation.keyWorkerUser!!.emailAddress).isEqualTo(spaceBookingOfflineApplicationKeyWorker.email)
 
       val offender1 = bookingSummary1.person
       assertThat(offender1.crn).isEqualTo(offenderOffline.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -471,6 +471,7 @@ class Cas1SpaceBookingTransformerTest {
 
       every { personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
 
+      val keyWorkerId = UUID.randomUUID()
       val result = transformer.transformSearchResultToSummary(
         Cas1SpaceBookingSearchResultImpl(
           id = id,
@@ -488,6 +489,8 @@ class Cas1SpaceBookingTransformerTest {
           keyWorkerStaffCode = "the staff code",
           keyWorkerAssignedAt = LocalDateTime.of(2023, 12, 12, 0, 0, 0).toInstant(ZoneOffset.UTC),
           keyWorkerName = "the keyworker name",
+          keyWorkerUserId = keyWorkerId,
+          keyWorkerEmail = "the keyworker email",
           characteristicsPropertyNamesCsv = "hasTurningSpace,isCatered",
           deliusEventNumber = "event8",
           cancelled = true,
@@ -516,6 +519,9 @@ class Cas1SpaceBookingTransformerTest {
       assertThat(result.keyWorkerAllocation!!.allocatedAt).isEqualTo(LocalDate.parse("2023-12-12"))
       assertThat(result.keyWorkerAllocation!!.keyWorker.name).isEqualTo("the keyworker name")
       assertThat(result.keyWorkerAllocation!!.keyWorker.code).isEqualTo("the staff code")
+      assertThat(result.keyWorkerAllocation!!.keyWorkerUser!!.id).isEqualTo(keyWorkerId)
+      assertThat(result.keyWorkerAllocation!!.keyWorkerUser!!.name).isEqualTo("the keyworker name")
+      assertThat(result.keyWorkerAllocation!!.keyWorkerUser!!.emailAddress).isEqualTo("the keyworker email")
       assertThat(result.deliusEventNumber).isEqualTo("event8")
       assertThat(result.isCancelled).isTrue()
       assertThat(result.plannedTransferRequested).isFalse()
@@ -555,6 +561,8 @@ class Cas1SpaceBookingTransformerTest {
           keyWorkerStaffCode = null,
           keyWorkerAssignedAt = null,
           keyWorkerName = null,
+          keyWorkerUserId = null,
+          keyWorkerEmail = null,
           characteristicsPropertyNamesCsv = null,
           deliusEventNumber = "event8",
           cancelled = false,
@@ -589,6 +597,8 @@ data class Cas1SpaceBookingSearchResultImpl(
   override val keyWorkerStaffCode: String?,
   override val keyWorkerAssignedAt: Instant?,
   override val keyWorkerName: String?,
+  override val keyWorkerUserId: UUID?,
+  override val keyWorkerEmail: String?,
   override val characteristicsPropertyNamesCsv: String?,
   override val deliusEventNumber: String?,
   override val cancelled: Boolean,


### PR DESCRIPTION
`Cas1KeyWorkerAllocation.keyWorkerUser` is currently a nullable field. Once we’ve backfilled all key worker user information we can make this non-nullable.

Furthermore, we can derive the name from the `users.name`, instead of the soon to be removed `cas1_space_bookings.key_worker_name` column