### PR TITLE
APS-2615 - Handle NaN in duration backfill job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDuration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDuration.kt
@@ -48,7 +48,8 @@ interface Cas1BackfillApplicationDurationRepository : JpaRepository<ApprovedPrem
           where  
           a.submitted_at IS NOT NULL AND
           apa.duration IS NULL AND 
-          a.data -> 'move-on' -> 'placement-duration' ->> 'differentDuration' = 'yes'
+          a.data -> 'move-on' -> 'placement-duration' ->> 'differentDuration' = 'yes' AND 
+          a.data -> 'move-on' -> 'placement-duration' ->> 'duration' != 'NaN'
       )
       UPDATE approved_premises_applications
       SET duration = to_update.duration

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDurationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDurationJobTest.kt
@@ -131,6 +131,24 @@ class Cas1BackfillApplicationDurationJobTest : IntegrationTestBase() {
       submittedAt = null,
     )
 
+    val application8ArrivalDate = OffsetDateTime.now().minusDays(9).roundNanosToMillisToAccountForLossOfPrecisionInPostgres()
+    val application8ApTypeStandardNaN = givenACas1Application(
+      arrivalDate = application8ArrivalDate,
+      apType = ApprovedPremisesType.NORMAL,
+      submittedAt = OffsetDateTime.now(),
+      data = """{
+                "move-on": {
+                    "placement-duration": {
+                        "differentDuration": "yes",
+                        "duration": "NaN",
+                        "durationDays": "?",
+                        "durationWeeks": "?",
+                        "reason": "i don't know yet"
+                    }
+                }
+            }""",
+    )
+
     migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillApplicationDuration)
 
     val updatedApplication1 = approvedPremisesApplicationRepository.findByIdOrNull(application1OverriddenDuration.id)!!
@@ -188,5 +206,9 @@ class Cas1BackfillApplicationDurationJobTest : IntegrationTestBase() {
     val updatedApplication7NotSubmitted = approvedPremisesApplicationRepository.findByIdOrNull(application7ApTypePipeNotSubmitted.id)!!
     assertThat(updatedApplication7NotSubmitted.arrivalDate).isEqualTo(application7ArrivalDate)
     assertThat(updatedApplication7NotSubmitted.duration).isNull()
+
+    val updatedApplication8ApTypeStandardNaN = approvedPremisesApplicationRepository.findByIdOrNull(application8ApTypeStandardNaN.id)!!
+    assertThat(updatedApplication8ApTypeStandardNaN.arrivalDate).isEqualTo(application8ArrivalDate)
+    assertThat(updatedApplication8ApTypeStandardNaN.duration).isEqualTo(12 * 7)
   }
 }


### PR DESCRIPTION
A small number of CAS1 applications have a NaN for duration override, as detailed on APS-2686.

This commit updates the duration backfill job to handle these NaN values by using the ap type’s default duration instead, which is the number that is currently presented to the assessor in these cases

