### PR TITLE
CAS-1730: C3 BE Add end date to premises unarchive domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesUnarchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesUnarchiveEvent.kt
@@ -25,4 +25,7 @@ data class CAS3PremisesUnarchiveEventDetails(
   val currentStartDate: LocalDate,
 
   val newStartDate: LocalDate,
+
+  val currentEndDate: LocalDate,
+
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
@@ -254,6 +254,7 @@ class Cas3DomainEventBuilder(
     premises: TemporaryAccommodationPremisesEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
+    currentEndDate: LocalDate,
     user: UserEntity,
   ): DomainEvent<CAS3PremisesUnarchiveEvent> {
     val domainEventId = UUID.randomUUID()
@@ -269,7 +270,7 @@ class Cas3DomainEventBuilder(
         id = domainEventId,
         timestamp = Instant.now(),
         eventType = EventType.premisesUnarchived,
-        eventDetails = buildCAS3PremisesUnarchiveEventDetails(premises, currentStartDate, newStartDate, user),
+        eventDetails = buildCAS3PremisesUnarchiveEventDetails(premises, currentStartDate, newStartDate, currentEndDate, user),
       ),
     )
   }
@@ -486,12 +487,14 @@ class Cas3DomainEventBuilder(
     premises: PremisesEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
+    currentEndDate: LocalDate,
     user: UserEntity,
   ) = CAS3PremisesUnarchiveEventDetails(
     premisesId = premises.id,
     userId = user.id,
     currentStartDate = currentStartDate,
     newStartDate = newStartDate,
+    currentEndDate = currentEndDate,
   )
 
   private fun buildCAS3BedspaceArchiveEventDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventService.kt
@@ -246,9 +246,9 @@ class Cas3DomainEventService(
   }
 
   @Transactional
-  fun savePremisesUnarchiveEvent(premises: TemporaryAccommodationPremisesEntity, currentStartDate: LocalDate, newStartDate: LocalDate) {
+  fun savePremisesUnarchiveEvent(premises: TemporaryAccommodationPremisesEntity, currentStartDate: LocalDate, newStartDate: LocalDate, currentEndDate: LocalDate) {
     val user = userService.getUserForRequest()
-    val domainEvent = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, user)
+    val domainEvent = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate, user)
 
     saveAndEmit(
       domainEvent = domainEvent,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -1239,11 +1239,12 @@ class Cas3PremisesService(
 
   private fun unarchivePremisesAndSaveDomainEvent(premises: TemporaryAccommodationPremisesEntity, restartDate: LocalDate): TemporaryAccommodationPremisesEntity {
     val currentStartDate = premises.startDate
+    val currentEndDate = premises.endDate!!
     premises.startDate = restartDate
     premises.endDate = null
     premises.status = PropertyStatus.active
     val updatedPremises = premisesRepository.save(premises)
-    cas3DomainEventService.savePremisesUnarchiveEvent(premises, currentStartDate, restartDate)
+    cas3DomainEventService.savePremisesUnarchiveEvent(premises, currentStartDate, restartDate, currentEndDate)
     return updatedPremises
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -135,6 +135,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     userEntity: UserEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
+    currentEndDate: LocalDate,
   ) {
     domainEventFactory.produceAndPersist {
       withService(ServiceName.temporaryAccommodation)
@@ -152,6 +153,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
               userId = userEntity.id,
               currentStartDate = currentStartDate,
               newStartDate = newStartDate,
+              currentEndDate = currentEndDate,
             ),
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
@@ -3730,9 +3730,9 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
           val secondUnarchiveDate = LocalDate.now().minusDays(2)
 
           createArchivePremisesEvent(premises, userEntity, firstArchiveDate)
-          createUnarchivePremisesEvent(premises, userEntity, currentStartDate = LocalDate.now(), firstUnarchiveDate)
+          createUnarchivePremisesEvent(premises, userEntity, currentStartDate = LocalDate.now(), firstUnarchiveDate, firstArchiveDate)
           createArchivePremisesEvent(premises, userEntity, secondArchiveDate)
-          createUnarchivePremisesEvent(premises, userEntity, LocalDate.now(), secondUnarchiveDate)
+          createUnarchivePremisesEvent(premises, userEntity, LocalDate.now(), secondUnarchiveDate, secondArchiveDate)
 
           // Get premises and verify archive history is in chronological order
           webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventBuilderTest.kt
@@ -596,12 +596,14 @@ class Cas3DomainEventBuilderTest {
   @Test
   fun `getPremisesUnarchiveEvent transforms the premises information correctly to a domain event`() {
     val currentStartDate = LocalDate.now().minusDays(20)
+    val currentEndDate = LocalDate.now().minusDays(10)
     val newStartDate = LocalDate.now().plusDays(5)
     val probationRegion = probationRegionEntity()
     val premises = createCas3PremisesEntity(probationRegion)
+    premises.endDate = currentEndDate
     val user = userEntity(probationRegion)
 
-    val event = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, user)
+    val event = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate, user)
 
     assertAll({
       assertThat(event.applicationId).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventServiceTest.kt
@@ -1791,6 +1791,7 @@ class Cas3DomainEventServiceTest {
   fun `savePremisesUnarchiveEvent saves event but does not emit it`() {
     val occurredAt = Instant.now()
     val currentStartDate = LocalDate.now().minusDays(20)
+    val currentEndDate = LocalDate.now().minusDays(10)
     val newStartDate = LocalDate.now().plusDays(5)
     val probationRegion = ProbationRegionEntityFactory().produce()
     val premises = createPremisesEntity(probationRegion)
@@ -1803,6 +1804,7 @@ class Cas3DomainEventServiceTest {
       userId = user.id,
       currentStartDate = currentStartDate,
       newStartDate = newStartDate,
+      currentEndDate = currentEndDate,
     )
     val data = CAS3PremisesUnarchiveEvent(
       eventDetails = eventDetails,
@@ -1822,12 +1824,12 @@ class Cas3DomainEventServiceTest {
       data = data,
     )
 
-    every { cas3DomainEventBuilderMock.getPremisesUnarchiveEvent(eq(premises), eq(currentStartDate), eq(newStartDate), eq(user)) } returns domainEvent
+    every { cas3DomainEventBuilderMock.getPremisesUnarchiveEvent(eq(premises), eq(currentStartDate), eq(newStartDate), eq(currentEndDate), eq(user)) } returns domainEvent
     every { domainEventRepositoryMock.save(any()) } returns null
     every { userService.getUserForRequest() } returns user
     every { userService.getUserForRequestOrNull() } returns user
 
-    cas3DomainEventService.savePremisesUnarchiveEvent(premises, currentStartDate, newStartDate)
+    cas3DomainEventService.savePremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate)
 
     verify(exactly = 1) {
       domainEventRepositoryMock.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
@@ -1046,34 +1046,28 @@ class Cas3PremisesServiceTest {
       val premises = temporaryAccommodationPremisesFactory.produce()
       val userId = UUID.randomUUID()
 
-      // Archive event scheduled for tomorrow (should be filtered out)
-      val endDateTomorrowArchive = LocalDate.now().plusDays(1)
-      val dataTomorrowArchive = createPremisesArchiveEvent(premisesId = premises.id, userId = userId, endDate = endDateTomorrowArchive)
+      val endDate10DaysArchive = LocalDate.now().plusDays(10)
+      val dataTomorrowArchive = createPremisesArchiveEvent(premisesId = premises.id, userId = userId, endDate = endDate10DaysArchive)
       val domainEventTomorrow = createPremisesArchiveDomainEvent(dataTomorrowArchive)
 
-      // Archive event scheduled for today (should be included)
       val endDateTodayArchive = LocalDate.now()
       val dataTodayArchive = createPremisesArchiveEvent(premisesId = premises.id, userId = userId, endDate = endDateTodayArchive)
       val domainEventToday = createPremisesArchiveDomainEvent(dataTodayArchive)
 
-      // Archive event scheduled for yesterday (should be included)
-      val endDateYesterdayArchive = LocalDate.now().minusDays(1)
-      val dataYesterdayArchive = createPremisesArchiveEvent(premisesId = premises.id, userId = userId, endDate = endDateYesterdayArchive)
+      val endDate10DaysAgoArchive = LocalDate.now().minusDays(10)
+      val dataYesterdayArchive = createPremisesArchiveEvent(premisesId = premises.id, userId = userId, endDate = endDate10DaysAgoArchive)
       val domainEventYesterday = createPremisesArchiveDomainEvent(dataYesterdayArchive)
 
-      // Unarchive event scheduled for in 2 days (should be filtered out)
-      val newStartDateIn2DaysUnarchive = LocalDate.now().plusDays(2)
-      val dataIn2DaysUnarchive = createPremisesUnarchiveEvent(premisesId = premises.id, userId = userId, newStartDate = newStartDateIn2DaysUnarchive)
+      val newStartDateIn20DaysUnarchive = LocalDate.now().plusDays(20)
+      val dataIn2DaysUnarchive = createPremisesUnarchiveEvent(premisesId = premises.id, userId = userId, newStartDate = newStartDateIn20DaysUnarchive, endDate10DaysAgoArchive)
       val domainEventIn2Days = createPremisesUnarchiveDomainEvent(dataIn2DaysUnarchive)
 
-      // Unarchive event scheduled for 2 days ago (should be included)
-      val newStartDate2DaysAgoUnarchive = LocalDate.now().minusDays(2)
-      val data2DaysAgoUnarchive = createPremisesUnarchiveEvent(premisesId = premises.id, userId = userId, newStartDate = newStartDate2DaysAgoUnarchive)
+      val newStartDate20DaysAgoUnarchive = LocalDate.now().minusDays(20)
+      val data2DaysAgoUnarchive = createPremisesUnarchiveEvent(premisesId = premises.id, userId = userId, newStartDate = newStartDate20DaysAgoUnarchive, endDate10DaysAgoArchive)
       val domainEvent2DaysAgo = createPremisesUnarchiveDomainEvent(data2DaysAgoUnarchive)
 
-      // Unarchive event scheduled for 3 days ago (should be included)
-      val newStartDate3DaysAgoUnarchive = LocalDate.now().minusDays(3)
-      val data3DaysAgoUnarchive = createPremisesUnarchiveEvent(premisesId = premises.id, userId = userId, newStartDate = newStartDate3DaysAgoUnarchive)
+      val newStartDate30DaysAgoUnarchive = LocalDate.now().minusDays(30)
+      val data3DaysAgoUnarchive = createPremisesUnarchiveEvent(premisesId = premises.id, userId = userId, newStartDate = newStartDate30DaysAgoUnarchive, endDate10DaysAgoArchive)
       val domainEvent3DaysAgo = createPremisesUnarchiveDomainEvent(data3DaysAgoUnarchive)
 
       every { cas3DomainEventServiceMock.getPremisesDomainEvents(premises.id, listOf(DomainEventType.CAS3_PREMISES_ARCHIVED, DomainEventType.CAS3_PREMISES_UNARCHIVED)) } returns
@@ -1118,13 +1112,13 @@ class Cas3PremisesServiceTest {
       val userId = UUID.randomUUID()
 
       // Archive event scheduled for tomorrow (should be filtered out)
-      val endDateTomorrowArchive = LocalDate.now().plusDays(1)
-      val dataTomorrowArchive = createPremisesArchiveEvent(premisesId = premises.id, userId = userId, endDate = endDateTomorrowArchive)
+      val endDate10DaysArchive = LocalDate.now().plusDays(10)
+      val dataTomorrowArchive = createPremisesArchiveEvent(premisesId = premises.id, userId = userId, endDate = endDate10DaysArchive)
       val domainEventTomorrow = createPremisesArchiveDomainEvent(dataTomorrowArchive)
 
       // Unarchive event scheduled for in 2 days (should be filtered out)
-      val newStartDateIn2DaysUnarchive = LocalDate.now().plusDays(2)
-      val dataIn2DaysUnarchive = createPremisesUnarchiveEvent(premisesId = premises.id, userId = userId, newStartDate = newStartDateIn2DaysUnarchive)
+      val newStartDateIn20DaysUnarchive = LocalDate.now().plusDays(20)
+      val dataIn2DaysUnarchive = createPremisesUnarchiveEvent(premisesId = premises.id, userId = userId, newStartDate = newStartDateIn20DaysUnarchive, endDate10DaysArchive)
       val domainEventIn2Days = createPremisesUnarchiveDomainEvent(dataIn2DaysUnarchive)
 
       every { cas3DomainEventServiceMock.getPremisesDomainEvents(premises.id, listOf(DomainEventType.CAS3_PREMISES_ARCHIVED, DomainEventType.CAS3_PREMISES_UNARCHIVED)) } returns
@@ -1168,7 +1162,7 @@ class Cas3PremisesServiceTest {
       DomainEventType.CAS3_PREMISES_UNARCHIVED,
     )
 
-    private fun createPremisesUnarchiveEvent(premisesId: UUID, userId: UUID, newStartDate: LocalDate): CAS3PremisesUnarchiveEvent {
+    private fun createPremisesUnarchiveEvent(premisesId: UUID, userId: UUID, newStartDate: LocalDate, currentEndDate: LocalDate): CAS3PremisesUnarchiveEvent {
       val eventId = UUID.randomUUID()
       val occurredAt = OffsetDateTime.now()
       return CAS3PremisesUnarchiveEvent(
@@ -1180,6 +1174,7 @@ class Cas3PremisesServiceTest {
           userId = userId,
           currentStartDate = LocalDate.now(),
           newStartDate = newStartDate,
+          currentEndDate = currentEndDate,
         ),
       )
     }
@@ -2950,7 +2945,7 @@ class Cas3PremisesServiceTest {
       every { bedRepositoryMock.findCas3Bedspace(archivedPremises.id, archivedBedspace.id) } returns archivedBedspace
       every { bedRepositoryMock.save(any()) } returns updatedBedspace
       every { cas3DomainEventServiceMock.saveBedspaceUnarchiveEvent(any(), any(), any()) } returns Unit
-      every { cas3DomainEventServiceMock.savePremisesUnarchiveEvent(any(), any(), any()) } returns Unit
+      every { cas3DomainEventServiceMock.savePremisesUnarchiveEvent(any(), any(), any(), any()) } returns Unit
       every { bedRepositoryMock.findByRoomPremisesId(archivedPremises.id) } returns listOf(archivedBedspace)
 
       val result = premisesService.unarchivePremises(archivedPremises, restartDate)
@@ -2989,6 +2984,7 @@ class Cas3PremisesServiceTest {
           match<TemporaryAccommodationPremisesEntity> {
             it.id == archivedPremises.id
           },
+          any(),
           any(),
           any(),
         )
@@ -3091,7 +3087,7 @@ class Cas3PremisesServiceTest {
 
       every { premisesRepositoryMock.findByIdOrNull(archivedPremises.id) } returns archivedPremises
       every { premisesRepositoryMock.save(any()) } returns updatedPremises
-      every { cas3DomainEventServiceMock.savePremisesUnarchiveEvent(any(), any(), any()) } returns Unit
+      every { cas3DomainEventServiceMock.savePremisesUnarchiveEvent(any(), any(), any(), any()) } returns Unit
       every { bedRepositoryMock.findByRoomPremisesId(archivedPremises.id) } returns listOf()
 
       val result = premisesService.unarchivePremises(archivedPremises, restartDate)
@@ -3103,6 +3099,7 @@ class Cas3PremisesServiceTest {
           match<TemporaryAccommodationPremisesEntity> {
             it.id == archivedPremises.id
           },
+          any(),
           any(),
           any(),
         )
@@ -3131,7 +3128,7 @@ class Cas3PremisesServiceTest {
 
       every { premisesRepositoryMock.findByIdOrNull(archivedPremises.id) } returns archivedPremises
       every { premisesRepositoryMock.save(any()) } returns updatedPremises
-      every { cas3DomainEventServiceMock.savePremisesUnarchiveEvent(any(), any(), any()) } returns Unit
+      every { cas3DomainEventServiceMock.savePremisesUnarchiveEvent(any(), any(), any(), any()) } returns Unit
       every { bedRepositoryMock.findByRoomPremisesId(archivedPremises.id) } returns listOf()
 
       val result = premisesService.unarchivePremises(archivedPremises, restartDate)
@@ -3143,6 +3140,7 @@ class Cas3PremisesServiceTest {
           match<TemporaryAccommodationPremisesEntity> {
             it.id == archivedPremises.id
           },
+          any(),
           any(),
           any(),
         )
@@ -3205,6 +3203,7 @@ class Cas3PremisesServiceTest {
         .withStatus(PropertyStatus.archived)
         .produce()
       val currentPremisesStartDate = premises.startDate
+      val currentPremisesEndDate = premises.endDate!!
       val currentBedspaceEndDate = LocalDate.now().minusDays(1)
       val archivedBedspace = createBedspace(premises, endDate = currentBedspaceEndDate)
       val currentBedspaceStartDate = archivedBedspace.startDate!!
@@ -3216,7 +3215,7 @@ class Cas3PremisesServiceTest {
       every { bedRepositoryMock.save(match { it.id == archivedBedspace.id }) } returns updatedBedspace
       every { cas3DomainEventServiceMock.saveBedspaceUnarchiveEvent(match { it.id == updatedBedspace.id }, currentBedspaceStartDate, currentBedspaceEndDate) } returns Unit
       every { premisesRepositoryMock.save(match { it.id == premises.id }) } returns premises
-      every { cas3DomainEventServiceMock.savePremisesUnarchiveEvent(match { it.id == premises.id }, premises.startDate, restartDate) } returns Unit
+      every { cas3DomainEventServiceMock.savePremisesUnarchiveEvent(match { it.id == premises.id }, premises.startDate, restartDate, premises.endDate!!) } returns Unit
 
       val result = premisesService.unarchiveBedspace(premises, archivedBedspace.id, restartDate)
 
@@ -3258,6 +3257,7 @@ class Cas3PremisesServiceTest {
           },
           currentPremisesStartDate,
           restartDate,
+          currentPremisesEndDate,
         )
       }
     }


### PR DESCRIPTION
This Pull Request introduces changes to handle the currentEndDate field in various functions and components related to the unarchiving of premises in the system. The change ensures better tracking and processing of the currentEndDate during domain event creation, service logic, and test cases.

Main Changes
 - Added a currentEndDate field to the CAS3PremisesUnarchiveEvent data model.
 - Updated Cas3DomainEventBuilder to include currentEndDate in event creation logic.
 - Modified functionality in Cas3PremisesService and Cas3DomainEventService to handle the currentEndDate parameter when unarchiving premises.
 - Updated integration and unit tests with necessary adjustments to reflect the inclusion of the currentEndDate field.