### PR TITLE
Extend the Api endpoint bedspace totals to include premises end date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PremisesController.kt
@@ -161,6 +161,7 @@ class Cas3PremisesController(
     val result = Cas3PremisesBedspaceTotals(
       id = premises.id,
       status = if (premises.status == PropertyStatus.active) Cas3PremisesStatus.online else Cas3PremisesStatus.archived,
+      premisesEndDate = premises.endDate,
       totalOnlineBedspaces = totalBedspaceByStatus.onlineBedspaces,
       totalUpcomingBedspaces = totalBedspaceByStatus.upcomingBedspaces,
       totalArchivedBedspaces = totalBedspaceByStatus.archivedBedspaces,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3PremisesBedspaceTotals.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3PremisesBedspaceTotals.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3PremisesStatus
+import java.time.LocalDate
 import java.util.UUID
 
 data class Cas3PremisesBedspaceTotals(
   val id: UUID,
   val status: Cas3PremisesStatus,
+  val premisesEndDate: LocalDate?,
   val totalOnlineBedspaces: Int,
   val totalUpcomingBedspaces: Int,
   val totalArchivedBedspaces: Int,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
@@ -3616,6 +3616,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
             .expectBody()
             .jsonPath("$.id").isEqualTo(premises.id.toString())
             .jsonPath("$.status").isEqualTo("online")
+            .jsonPath("$.premisesEndDate").isEqualTo(null)
             .jsonPath("$.totalOnlineBedspaces").isEqualTo(3)
             .jsonPath("$.totalUpcomingBedspaces").isEqualTo(4)
             .jsonPath("$.totalArchivedBedspaces").isEqualTo(3)
@@ -3640,6 +3641,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
             .expectBody()
             .jsonPath("$.id").isEqualTo(premises.id.toString())
             .jsonPath("$.status").isEqualTo("online")
+            .jsonPath("$.premisesEndDate").isEqualTo(null)
             .jsonPath("$.totalOnlineBedspaces").isEqualTo(0)
             .jsonPath("$.totalUpcomingBedspaces").isEqualTo(0)
             .jsonPath("$.totalArchivedBedspaces").isEqualTo(0)
@@ -3680,6 +3682,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         givenATemporaryAccommodationPremises(
           region = userEntity.probationRegion,
+          endDate = LocalDate.now().minusDays(1),
           status = PropertyStatus.archived,
         ) { premises ->
 
@@ -3692,6 +3695,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
             .expectBody()
             .jsonPath("$.id").isEqualTo(premises.id.toString())
             .jsonPath("$.status").isEqualTo("archived")
+            .jsonPath("$.premisesEndDate").isEqualTo(premises.endDate.toString())
             .jsonPath("$.totalOnlineBedspaces").isEqualTo(0)
             .jsonPath("$.totalUpcomingBedspaces").isEqualTo(0)
             .jsonPath("$.totalArchivedBedspaces").isEqualTo(0)


### PR DESCRIPTION
This [PR CAS-1820](https://dsdmoj.atlassian.net/browse/CAS-1820) is to extend the Api endpoint bedspace totals to include premises end date