### PR TITLE
CAS-1729 Should be able to archive/unarchive premises/bedspace in the same day

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -969,7 +969,7 @@ class Cas3PremisesService(
       "$.restartDate" hasValidationError "invalidRestartDateInTheFuture"
     }
 
-    if (restartDate.isBefore(bedspace.endDate) || restartDate.isEqual(bedspace.endDate)) {
+    if (restartDate.isBefore(bedspace.endDate)) {
       "$.restartDate" hasValidationError "beforeLastBedspaceArchivedDate"
     }
 
@@ -1054,7 +1054,7 @@ class Cas3PremisesService(
       "$.restartDate" hasValidationError "invalidRestartDateInTheFuture"
     }
 
-    if (restartDate.isBefore(premises.endDate) || restartDate.isEqual(premises.endDate)) {
+    if (restartDate.isBefore(premises.endDate)) {
       "$.restartDate" hasValidationError "beforeLastPremisesArchivedDate"
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
@@ -3050,9 +3050,8 @@ class Cas3PremisesServiceTest {
       assertThatCasResult(result).isFieldValidationError().hasMessage("$.restartDate", "invalidRestartDateInTheFuture")
     }
 
-    @ParameterizedTest
-    @CsvSource("0", "1")
-    fun `unarchivePremises returns FieldValidationError when restart date is equal or before last archive end date`(minusDays: Long) {
+    @Test
+    fun `unarchivePremises returns FieldValidationError when restart date is before last archive end date`() {
       val lastArchiveEndDate = LocalDate.now().minusDays(1)
       val archivedPremises = temporaryAccommodationPremisesFactory
         .withStartDate(LocalDate.now().minusDays(30))
@@ -3060,7 +3059,7 @@ class Cas3PremisesServiceTest {
         .withStatus(PropertyStatus.archived)
         .produce()
 
-      val restartDate = lastArchiveEndDate.minusDays(minusDays)
+      val restartDate = lastArchiveEndDate.minusDays(1)
 
       every { premisesRepositoryMock.findByIdOrNull(archivedPremises.id) } returns archivedPremises
 
@@ -3321,21 +3320,6 @@ class Cas3PremisesServiceTest {
       val archivedBedspace = createBedspace(premises, endDate = lastArchiveEndDate)
 
       val restartDate = lastArchiveEndDate.minusDays(1)
-
-      every { bedRepositoryMock.findCas3Bedspace(premises.id, archivedBedspace.id) } returns archivedBedspace
-
-      val result = premisesService.unarchiveBedspace(premises, archivedBedspace.id, restartDate)
-
-      assertThatCasResult(result).isFieldValidationError().hasMessage("$.restartDate", "beforeLastBedspaceArchivedDate")
-    }
-
-    @Test
-    fun `unarchiveBedspace returns FieldValidationError when restart date equals last archive end date`() {
-      val premises = temporaryAccommodationPremisesFactory.produce()
-      val lastArchiveEndDate = LocalDate.now().minusDays(5)
-      val archivedBedspace = createBedspace(premises, endDate = lastArchiveEndDate)
-
-      val restartDate = lastArchiveEndDate
 
       every { bedRepositoryMock.findCas3Bedspace(premises.id, archivedBedspace.id) } returns archivedBedspace
 


### PR DESCRIPTION
This PR CAS-1729 is to enable the user to archive/unarchive premises/bedspace in the same day