### PR TITLE
CAS-1822 Canceling scheduled archive related bedspaces with premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3BedspaceArchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3BedspaceArchiveEvent.kt
@@ -21,6 +21,8 @@ data class CAS3BedspaceArchiveEventDetails(
 
   val endDate: java.time.LocalDate,
 
+  val currentEndDate: java.time.LocalDate?,
+
   val userId: java.util.UUID,
 
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
@@ -205,6 +205,7 @@ class Cas3DomainEventBuilder(
 
   fun getBedspaceArchiveEvent(
     bedspace: BedEntity,
+    currentEndDate: LocalDate?,
     user: UserEntity,
   ): DomainEvent<CAS3BedspaceArchiveEvent> {
     val domainEventId = UUID.randomUUID()
@@ -222,7 +223,7 @@ class Cas3DomainEventBuilder(
         id = domainEventId,
         timestamp = Instant.now(),
         eventType = EventType.bedspaceArchived,
-        eventDetails = buildCAS3BedspaceArchiveEventDetails(bedspace, user),
+        eventDetails = buildCAS3BedspaceArchiveEventDetails(bedspace, currentEndDate, user),
       ),
     )
   }
@@ -499,10 +500,12 @@ class Cas3DomainEventBuilder(
 
   private fun buildCAS3BedspaceArchiveEventDetails(
     bedspace: BedEntity,
+    currentEndDate: LocalDate?,
     user: UserEntity,
   ) = CAS3BedspaceArchiveEventDetails(
     bedspaceId = bedspace.id,
     userId = user.id,
+    currentEndDate = currentEndDate,
     endDate = bedspace.endDate!!,
     premisesId = bedspace.room.premises.id,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventService.kt
@@ -260,9 +260,9 @@ class Cas3DomainEventService(
   }
 
   @Transactional
-  fun saveBedspaceArchiveEvent(bedspace: BedEntity) {
+  fun saveBedspaceArchiveEvent(bedspace: BedEntity, currentEndDate: LocalDate?) {
     val user = userService.getUserForRequest()
-    val domainEvent = cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, user)
+    val domainEvent = cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, currentEndDate, user)
 
     saveAndEmit(
       domainEvent = domainEvent,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -98,6 +98,8 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 
   fun findFirstByCas3BedspaceIdAndTypeOrderByCreatedAtDesc(cas3BedspaceId: UUID, type: DomainEventType): DomainEventEntity?
 
+  fun findFirstByCas3PremisesIdAndTypeOrderByCreatedAtDesc(cas3PremisesId: UUID, type: DomainEventType): DomainEventEntity?
+
   @Query(
     """
     SELECT d

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -130,7 +130,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     return bedspace
   }
 
-  fun createUnarchivePremisesEvent(
+  fun createUnarchivePremisesDomainEvent(
     premises: TemporaryAccommodationPremisesEntity,
     userEntity: UserEntity,
     currentStartDate: LocalDate,
@@ -161,7 +161,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     }
   }
 
-  fun createArchivePremisesEvent(
+  fun createArchivePremisesDomainEvent(
     premises: TemporaryAccommodationPremisesEntity,
     userEntity: UserEntity,
     date: LocalDate,
@@ -218,7 +218,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     serviceScope = ServiceName.temporaryAccommodation.value,
   )
 
-  protected fun createBedspaceArchiveDomainEvent(bedspaceId: UUID, premisesId: UUID, userId: UUID, endDate: LocalDate) = domainEventFactory.produceAndPersist {
+  protected fun createBedspaceArchiveDomainEvent(bedspaceId: UUID, premisesId: UUID, userId: UUID, currentEndDate: LocalDate?, endDate: LocalDate) = domainEventFactory.produceAndPersist {
     withService(ServiceName.temporaryAccommodation)
     withCas3BedspaceId(bedspaceId)
     withType(DomainEventType.CAS3_BEDSPACE_ARCHIVED)
@@ -232,6 +232,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
             bedspaceId = bedspaceId,
             userId = userId,
             premisesId = premisesId,
+            currentEndDate = currentEndDate,
             endDate = endDate,
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
@@ -19,9 +19,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenATemporaryAccommodationPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenATemporaryAccommodationPremisesComplete
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenATemporaryAccommodationPremisesWithRoomsAndBeds
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenATemporaryAccommodationPremisesWithUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenATemporaryAccommodationPremisesWithUserScheduledForArchive
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenATemporaryAccommodationRooms
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3BedspaceUnarchiveEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3BedspaceUnarchiveEventDetails
@@ -1335,7 +1335,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
 
         val bedspaceTwo = createBedspaceInPremises(premises, startDate = LocalDate.now().minusDays(5), endDate = LocalDate.now().plusDays(5))
         val archiveBedspaceInFiveDays = LocalDate.now().plusDays(5)
-        createBedspaceArchiveDomainEvent(bedspaceTwo.id, premises.id, user.id, archiveBedspaceInFiveDays)
+        createBedspaceArchiveDomainEvent(bedspaceTwo.id, premises.id, user.id, null, archiveBedspaceInFiveDays)
         expectedBedspaces.add(
           getExpectedBedspaceWithArchiveHistory(
             bedspaceTwo,
@@ -1481,7 +1481,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
     ): Cas3Bedspace {
       history.forEach { (eventStatus, date) ->
         when (eventStatus) {
-          Cas3BedspaceStatus.archived -> createBedspaceArchiveDomainEvent(bedspace.id, premisesId, userId, date)
+          Cas3BedspaceStatus.archived -> createBedspaceArchiveDomainEvent(bedspace.id, premisesId, userId, null, date)
           Cas3BedspaceStatus.online -> createBedspaceUnarchiveDomainEvent(
             bedspace.copy(endDate = date),
             premisesId,
@@ -1516,13 +1516,13 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
         )
 
         val archiveBedspaceYesterday = LocalDate.now().minusDays(1)
-        createBedspaceArchiveDomainEvent(bedspace.id, premises.id, user.id, archiveBedspaceYesterday)
+        createBedspaceArchiveDomainEvent(bedspace.id, premises.id, user.id, null, archiveBedspaceYesterday)
 
         val archiveBedspace3DaysAgo = LocalDate.now().minusDays(3)
-        createBedspaceArchiveDomainEvent(bedspace.id, premises.id, user.id, archiveBedspace3DaysAgo)
+        createBedspaceArchiveDomainEvent(bedspace.id, premises.id, user.id, null, archiveBedspace3DaysAgo)
 
         val archiveBedspaceDayAfterTomorrow = LocalDate.now().plusDays(2)
-        createBedspaceArchiveDomainEvent(bedspace.id, premises.id, user.id, archiveBedspaceDayAfterTomorrow)
+        createBedspaceArchiveDomainEvent(bedspace.id, premises.id, user.id, null, archiveBedspaceDayAfterTomorrow)
 
         val archivedBedspace = bedspace.copy(
           endDate = LocalDate.now().minusDays(7),
@@ -2231,7 +2231,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
 
         val bedspace = createBedspaceInPremises(premises, startDate = LocalDate.now().minusDays(300), endDate = null)
 
-        createBedspaceArchiveDomainEvent(bedspace.id, premises.id, user.id, previousBedspaceArchiveDate)
+        createBedspaceArchiveDomainEvent(bedspace.id, premises.id, user.id, null, previousBedspaceArchiveDate)
 
         val archiveBedspace = Cas3ArchiveBedspace(LocalDate.now().minusDays(3))
 
@@ -2568,7 +2568,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
             LocalDate.now().minusDays(2),
             null,
           ),
-          roomCount = 3,
+          bedspaceCount = 3,
         ) { premises, rooms, bedspaces ->
           val archivePremises = Cas3ArchivePremises(LocalDate.now())
           val bedspaceOne = bedspaces.first()
@@ -2629,7 +2629,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
         givenATemporaryAccommodationPremisesWithRoomsAndBeds(
           region = user.probationRegion,
-          roomCount = 2,
+          bedspaceCount = 2,
         ) { premises, rooms, bedspaces ->
 
           val archivePremises = Cas3ArchivePremises(LocalDate.now().minusDays(8))
@@ -2654,7 +2654,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
         givenATemporaryAccommodationPremisesWithRoomsAndBeds(
           region = user.probationRegion,
-          roomCount = 2,
+          bedspaceCount = 2,
         ) { premises, rooms, bedspaces ->
 
           val archivePremises = Cas3ArchivePremises(LocalDate.now().plusMonths(3).plusDays(1))
@@ -2702,7 +2702,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
       givenATemporaryAccommodationPremisesWithUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt, premises ->
         val previousPremisesArchiveDate = LocalDate.now().minusDays(3)
 
-        createArchivePremisesEvent(premises, user, previousPremisesArchiveDate)
+        createArchivePremisesDomainEvent(premises, user, previousPremisesArchiveDate)
 
         val archivePremises = Cas3ArchivePremises(previousPremisesArchiveDate.minusDays(3))
 
@@ -2727,7 +2727,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
         givenATemporaryAccommodationPremisesWithRoomsAndBeds(
           region = user.probationRegion,
-          roomCount = 2,
+          bedspaceCount = 2,
           bedStartDates = listOf(LocalDate.now().minusDays(100), LocalDate.now().plusDays(5)),
         ) { premises, rooms, bedspaces ->
 
@@ -2761,7 +2761,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
             LocalDate.now().minusDays(75),
             LocalDate.now().minusDays(30),
           ),
-          roomCount = 3,
+          bedspaceCount = 3,
         ) { premises, rooms, bedspaces ->
           val premisesArchiveDate = LocalDate.now().plusDays(5)
 
@@ -3438,12 +3438,28 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
   inner class CancelScheduledArchivePremises {
     @Test
     fun `Cancel scheduled archive premises returns 200 OK when successful`() {
-      givenATemporaryAccommodationPremisesWithUserScheduledForArchive(
+      givenATemporaryAccommodationPremisesComplete(
         roles = listOf(UserRole.CAS3_ASSESSOR),
-        archiveDate = LocalDate.now().plusDays(10),
+        premisesEndDate = LocalDate.now().plusDays(10),
         premisesStatus = PropertyStatus.archived,
-      ) { _, jwt, premises ->
-        givenATemporaryAccommodationRooms(premises = premises)
+        bedspaceCount = 3,
+        bedEndDates = listOf(
+          LocalDate.now().plusDays(10),
+          LocalDate.now().plusDays(10),
+          LocalDate.now().plusDays(10),
+        ),
+      ) { user, jwt, premises, rooms, bedspaces ->
+
+        val premisesArchiveDate = premises.endDate!!
+        createArchivePremisesDomainEvent(premises, user, premisesArchiveDate)
+
+        val bedspaceOne = bedspaces.first()
+        createBedspaceArchiveDomainEvent(bedspaceOne.id, premises.id, user.id, null, premisesArchiveDate)
+        val bedspaceTwo = bedspaces.drop(1).first()
+        val bedspaceTwoCurrentEndDate = bedspaceTwo.endDate ?: premisesArchiveDate.plusDays(12)
+        createBedspaceArchiveDomainEvent(bedspaceTwo.id, premises.id, user.id, bedspaceTwoCurrentEndDate, premisesArchiveDate)
+        val bedspaceThree = bedspaces.drop(2).first()
+        createBedspaceArchiveDomainEvent(bedspaceThree.id, premises.id, user.id, null, premisesArchiveDate)
 
         webTestClient.put()
           .uri("/cas3/premises/${premises.id}/cancel-archive")
@@ -3456,9 +3472,17 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
           .jsonPath("endDate").doesNotExist()
 
         // Verify the premise was updated
-        val updatePremises = temporaryAccommodationPremisesRepository.findById(premises.id).get()
-        assertThat(updatePremises.endDate).isNull()
-        assertThat(updatePremises.status).isEqualTo(PropertyStatus.active)
+        val updatedPremises = temporaryAccommodationPremisesRepository.findById(premises.id).get()
+        assertThat(updatedPremises.endDate).isNull()
+        assertThat(updatedPremises.status).isEqualTo(PropertyStatus.active)
+
+        // Verify bedspace were updated
+        val updatedBedspaces = bedRepository.findByRoomPremisesId(premises.id)
+        updatedBedspaces.containsAll(listOf(bedspaceOne, bedspaceTwo, bedspaceThree))
+        assertThat(updatedBedspaces).hasSize(3)
+        assertThat(updatedBedspaces.first { it.id == bedspaceOne.id }.endDate).isNull()
+        assertThat(updatedBedspaces.first { it.id == bedspaceTwo.id }.endDate).isEqualTo(bedspaceTwoCurrentEndDate)
+        assertThat(updatedBedspaces.first { it.id == bedspaceThree.id }.endDate).isNull()
       }
     }
 
@@ -3734,10 +3758,10 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
           val secondArchiveDate = LocalDate.now().minusDays(3)
           val secondUnarchiveDate = LocalDate.now().minusDays(2)
 
-          createArchivePremisesEvent(premises, userEntity, firstArchiveDate)
-          createUnarchivePremisesEvent(premises, userEntity, currentStartDate = LocalDate.now(), firstUnarchiveDate, firstArchiveDate)
-          createArchivePremisesEvent(premises, userEntity, secondArchiveDate)
-          createUnarchivePremisesEvent(premises, userEntity, LocalDate.now(), secondUnarchiveDate, secondArchiveDate)
+          createArchivePremisesDomainEvent(premises, userEntity, firstArchiveDate)
+          createUnarchivePremisesDomainEvent(premises, userEntity, currentStartDate = LocalDate.now(), firstUnarchiveDate, firstArchiveDate)
+          createArchivePremisesDomainEvent(premises, userEntity, secondArchiveDate)
+          createUnarchivePremisesDomainEvent(premises, userEntity, LocalDate.now(), secondUnarchiveDate, secondArchiveDate)
 
           // Get premises and verify archive history is in chronological order
           webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenATemporaryAccommodationBed.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenATemporaryAccommodationBed.kt
@@ -24,14 +24,14 @@ fun IntegrationTestBase.givenATemporaryAccommodationBed(
   return bed
 }
 
-fun IntegrationTestBase.givenATemporaryAccommodationBeds(
-  room: RoomEntity? = null,
+fun IntegrationTestBase.givenATemporaryAccommodationBedsWithPremises(
+  premises: TemporaryAccommodationPremisesEntity? = null,
   count: Int = 1,
   startDates: List<LocalDate> = emptyList(),
   endDates: List<LocalDate?> = emptyList(),
   block: ((beds: List<BedEntity>) -> Unit)? = null,
 ): List<BedEntity> {
-  val resolvedRoom = room ?: givenATemporaryAccommodationRoom()
+  val resolvedPremises = premises ?: givenATemporaryAccommodationPremises()
   val beds = mutableListOf<BedEntity>()
 
   repeat(count) { index ->
@@ -39,7 +39,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationBeds(
     val endDate = if (endDates.size > index) endDates[index] else null
 
     val bed = givenATemporaryAccommodationBed(
-      room = resolvedRoom,
+      room = givenATemporaryAccommodationRoom(resolvedPremises),
       startDate = startDate,
       endDate = endDate,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenATemporaryAccommodationPremises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenATemporaryAccommodationPremises.kt
@@ -68,7 +68,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithUser(
  */
 fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithRooms(
   region: ProbationRegionEntity = givenAProbationRegion(),
-  roomCount: Int = 1,
+  bedspaceCount: Int = 1,
   roomNames: List<String> = emptyList(),
   roomCharacteristics: List<CharacteristicEntity> = emptyList(),
   block: (premises: TemporaryAccommodationPremisesEntity, rooms: List<RoomEntity>) -> Unit,
@@ -76,7 +76,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithRooms(
   val premises = givenATemporaryAccommodationPremises(region)
   val rooms = mutableListOf<RoomEntity>()
 
-  repeat(roomCount) { index ->
+  repeat(bedspaceCount) { index ->
     val roomName = if (roomNames.size > index) roomNames[index] else randomStringMultiCaseWithNumbers(8)
     val room = roomEntityFactory.produceAndPersist {
       withPremises(premises)
@@ -91,7 +91,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithRooms(
 
 fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithRoomsAndBeds(
   region: ProbationRegionEntity = givenAProbationRegion(),
-  roomCount: Int = 1,
+  bedspaceCount: Int = 1,
   bedStartDates: List<LocalDate> = emptyList(),
   bedEndDates: List<LocalDate?> = emptyList(),
   roomNames: List<String> = emptyList(),
@@ -100,7 +100,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithRoomsAndBeds(
 ) {
   givenATemporaryAccommodationPremisesWithRooms(
     region = region,
-    roomCount = roomCount,
+    bedspaceCount = bedspaceCount,
     roomNames = roomNames,
     roomCharacteristics = roomCharacteristics,
   ) { premises, rooms ->
@@ -124,7 +124,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithRoomsAndBeds(
 
 fun IntegrationTestBase.givenATemporaryAccommodationPremisesComplete(
   roles: List<UserRole> = emptyList(),
-  roomCount: Int = 1,
+  bedspaceCount: Int = 1,
   premisesStatus: PropertyStatus = PropertyStatus.active,
   premisesEndDate: LocalDate? = null,
   bedStartDates: List<LocalDate> = emptyList(),
@@ -138,7 +138,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesComplete(
   ) { user, jwt ->
     givenATemporaryAccommodationPremisesWithRoomsAndBeds(
       region = user.probationRegion,
-      roomCount = roomCount,
+      bedspaceCount = bedspaceCount,
       bedStartDates = bedStartDates,
       bedEndDates = bedEndDates,
       roomNames = roomNames,
@@ -153,20 +153,5 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesComplete(
 
       block(user, jwt, premises, rooms, beds)
     }
-  }
-}
-
-fun IntegrationTestBase.givenATemporaryAccommodationPremisesWithUserScheduledForArchive(
-  roles: List<UserRole> = emptyList(),
-  archiveDate: LocalDate = LocalDate.now().plusDays(10),
-  premisesStatus: PropertyStatus = PropertyStatus.active,
-  block: (user: UserEntity, jwt: String, premises: TemporaryAccommodationPremisesEntity) -> Unit,
-) {
-  givenATemporaryAccommodationPremisesWithUser(
-    roles = roles,
-    premisesEndDate = archiveDate,
-    premisesStatus = premisesStatus,
-  ) { user, jwt, premises ->
-    block(user, jwt, premises)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventBuilderTest.kt
@@ -637,7 +637,7 @@ class Cas3DomainEventBuilderTest {
       .withRoom(room)
       .produce()
 
-    val event = cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, user)
+    val event = cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, null, user)
 
     assertAll(
       {
@@ -670,7 +670,7 @@ class Cas3DomainEventBuilderTest {
       .produce()
 
     val error = assertThrows<IllegalStateException> {
-      cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, user)
+      cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, null, user)
     }
 
     assertThat(error.message).isEqualTo("Bedspace end date is null for bedspace id: ${bedspace.id}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventServiceTest.kt
@@ -134,17 +134,17 @@ class Cas3DomainEventServiceTest {
 
     // Archive event scheduled for today
     val endDateToday = LocalDate.now()
-    val dataToday = createCAS3BedspaceArchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, endDate = endDateToday)
+    val dataToday = createBedspaceArchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, null, endDate = endDateToday)
     val domainEventEntityToday = createArchiveDomainEvent(dataToday)
 
     // Unarchive event scheduled for yesterday
     val newStartDateYesterday = LocalDate.now().minusDays(1)
-    val dataYesterday = createCAS3BedspaceUnarchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, newStartDate = newStartDateYesterday)
+    val dataYesterday = createBedspaceUnarchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, newStartDate = newStartDateYesterday)
     val domainEventEntityYesterday = createUnarchiveDomainEvent(dataYesterday)
 
     // Archive event scheduled for tomorrow
     val endDateTomorrow = LocalDate.now().plusDays(1)
-    val dataTomorrow = createCAS3BedspaceArchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, endDate = endDateTomorrow)
+    val dataTomorrow = createBedspaceArchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, null, endDate = endDateTomorrow)
     val domainEventEntityTomorrow = createArchiveDomainEvent(dataTomorrow)
 
     every { domainEventRepositoryMock.findBedspacesDomainEventsByType(listOf(bedspaceId), listOf(DomainEventType.CAS3_BEDSPACE_ARCHIVED.toString(), DomainEventType.CAS3_BEDSPACE_UNARCHIVED.toString())) } returns listOf(
@@ -1673,6 +1673,7 @@ class Cas3DomainEventServiceTest {
       bedspaceId = bedspace.id,
       premisesId = premises.id,
       userId = user.id,
+      currentEndDate = bedspace.endDate,
       endDate = endDate,
     )
     val data = CAS3BedspaceArchiveEvent(
@@ -1693,12 +1694,12 @@ class Cas3DomainEventServiceTest {
       data = data,
     )
 
-    every { cas3DomainEventBuilderMock.getBedspaceArchiveEvent(eq(bedspace), eq(user)) } returns domainEvent
+    every { cas3DomainEventBuilderMock.getBedspaceArchiveEvent(eq(bedspace), null, eq(user)) } returns domainEvent
     every { domainEventRepositoryMock.save(any()) } returns null
     every { userService.getUserForRequest() } returns user
     every { userService.getUserForRequestOrNull() } returns user
 
-    cas3DomainEventService.saveBedspaceArchiveEvent(bedspace)
+    cas3DomainEventService.saveBedspaceArchiveEvent(bedspace, bedspace.endDate)
 
     verify(exactly = 1) {
       domainEventRepositoryMock.save(
@@ -2798,7 +2799,7 @@ class Cas3DomainEventServiceTest {
     DomainEventType.CAS3_BEDSPACE_ARCHIVED,
   )
 
-  private fun createCAS3BedspaceArchiveEvent(premisesId: UUID, bedspaceId: UUID, userId: UUID, endDate: LocalDate): CAS3BedspaceArchiveEvent {
+  private fun createBedspaceArchiveEvent(premisesId: UUID, bedspaceId: UUID, userId: UUID, currentEndDate: LocalDate?, endDate: LocalDate): CAS3BedspaceArchiveEvent {
     val eventId = UUID.randomUUID()
     val occurredAt = OffsetDateTime.now()
     return CAS3BedspaceArchiveEvent(
@@ -2809,6 +2810,7 @@ class Cas3DomainEventServiceTest {
         bedspaceId = bedspaceId,
         userId = userId,
         premisesId = premisesId,
+        currentEndDate = currentEndDate,
         endDate = endDate,
       ),
     )
@@ -2822,7 +2824,7 @@ class Cas3DomainEventServiceTest {
     DomainEventType.CAS3_BEDSPACE_UNARCHIVED,
   )
 
-  private fun createCAS3BedspaceUnarchiveEvent(premisesId: UUID, bedspaceId: UUID, userId: UUID, newStartDate: LocalDate): CAS3BedspaceUnarchiveEvent {
+  private fun createBedspaceUnarchiveEvent(premisesId: UUID, bedspaceId: UUID, userId: UUID, newStartDate: LocalDate): CAS3BedspaceUnarchiveEvent {
     val eventId = UUID.randomUUID()
     val occurredAt = OffsetDateTime.now()
     return CAS3BedspaceUnarchiveEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -26,7 +26,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var crn: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
   private var type: Yielded<DomainEventType> = { DomainEventType.APPROVED_PREMISES_APPLICATION_SUBMITTED }
   private var occurredAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(7) }
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(7) }
   private var data: Yielded<String> = { "{}" }
   private var service: Yielded<String> = { randomOf(listOf("CAS1", "CAS2", "CAS2V2", "CAS3")) }
   private var triggerSource: Yielded<TriggerSourceType?> = { null }


### PR DESCRIPTION
This PR ([PR CAS-1822](https://dsdmoj.atlassian.net/browse/CAS-1822)) cancels the scheduled archiving of bedspaces when  premises  scheduled archiving is canceled.

Added the current date to the bedspace archive domain event so that when a premises is archived, any scheduled future bedspace archives are updated to match the premises archive date.