### PR TITLE
Tidy Cas1PlacementRequestTest

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PlacementRequestSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PlacementRequestSummaryTransformer.kt
@@ -29,20 +29,6 @@ class Cas1PlacementRequestSummaryTransformer(
     firstBookingArrivalDate = jpa.getBookingArrivalDate(),
   )
 
-  fun transformPlacementRequestJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult): Cas1PlacementRequestSummary = Cas1PlacementRequestSummary(
-    requestedPlacementDuration = jpa.duration,
-    requestedPlacementArrivalDate = jpa.expectedArrival,
-    id = jpa.id,
-    person = personTransformer.transformModelToPersonApi(personInfo),
-    placementRequestStatus = getStatus(jpa),
-    isParole = jpa.isParole,
-    personTier = jpa.application.riskRatings?.tier?.value?.level,
-    applicationId = jpa.application.id,
-    applicationSubmittedDate = jpa.application.submittedAt?.toLocalDate(),
-    firstBookingPremisesName = jpa.booking?.premises?.name,
-    firstBookingArrivalDate = jpa.booking?.arrivalDate,
-  )
-
   fun getStatus(placementRequest: PlacementRequestEntity): PlacementRequestStatus {
     if (placementRequest.hasActiveBooking()) {
       return PlacementRequestStatus.matched

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
@@ -276,11 +276,11 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
-                    transformPlacementRequestJpaToApi(
+                    transformNotMatchedPlacementRequestJpaToApiSummary(
                       unmatchedPlacementRequest,
                       PersonInfoResult.Success.Full(unmatchedOffender.otherIds.crn, unmatchedOffender, unmatchedInmate),
                     ),
-                    transformPlacementRequestJpaToApi(
+                    transformNotMatchedPlacementRequestJpaToApiSummary(
                       withdrawnPlacementRequest,
                       PersonInfoResult.Success.Full(unmatchedOffender.otherIds.crn, unmatchedOffender, unmatchedInmate),
                     ),
@@ -474,7 +474,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
-                    transformPlacementRequestJpaToApi(
+                    transformNotMatchedPlacementRequestJpaToApiSummary(
                       placementRequest,
                       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                     ),
@@ -504,7 +504,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
-                    transformPlacementRequestJpaToApi(
+                    transformNotMatchedPlacementRequestJpaToApiSummary(
                       placementRequest,
                       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                     ),
@@ -534,11 +534,11 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  transformPlacementRequestJpaToApi(
+                  transformNotMatchedPlacementRequestJpaToApiSummary(
                     placementRequest5thJan,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
-                  transformPlacementRequestJpaToApi(
+                  transformNotMatchedPlacementRequestJpaToApiSummary(
                     placementRequest10thJan,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -567,11 +567,11 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  transformPlacementRequestJpaToApi(
+                  transformNotMatchedPlacementRequestJpaToApiSummary(
                     placementRequest1stJan,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
-                  transformPlacementRequestJpaToApi(
+                  transformNotMatchedPlacementRequestJpaToApiSummary(
                     placementRequest5thJan,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -600,7 +600,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  transformPlacementRequestJpaToApi(
+                  transformNotMatchedPlacementRequestJpaToApiSummary(
                     placementRequestA1,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -633,7 +633,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  transformPlacementRequestJpaToApi(
+                  transformNotMatchedPlacementRequestJpaToApiSummary(
                     placementRequestA1,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -661,7 +661,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  transformPlacementRequestJpaToApi(
+                  transformNotMatchedPlacementRequestJpaToApiSummary(
                     standardRelease,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -689,7 +689,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  transformPlacementRequestJpaToApi(
+                  transformNotMatchedPlacementRequestJpaToApiSummary(
                     parole,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -731,7 +731,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
-                    transformPlacementRequestJpaToApi(
+                    transformNotMatchedPlacementRequestJpaToApiSummary(
                       placementOffender1On5thJanTierA2Parole,
                       PersonInfoResult.Success.Full(offender1Details.otherIds.crn, offender1Details, inmate1Details),
                     ),
@@ -1066,31 +1066,19 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
       }
     }
 
-    fun transformPlacementRequestJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult): Cas1PlacementRequestSummary = Cas1PlacementRequestSummary(
+    fun transformNotMatchedPlacementRequestJpaToApiSummary(jpa: PlacementRequestEntity, personInfo: PersonInfoResult): Cas1PlacementRequestSummary = Cas1PlacementRequestSummary(
       requestedPlacementDuration = jpa.duration,
       requestedPlacementArrivalDate = jpa.expectedArrival,
       id = jpa.id,
       person = personTransformer.transformModelToPersonApi(personInfo),
-      placementRequestStatus = getStatus(jpa),
+      placementRequestStatus = PlacementRequestStatus.notMatched,
       isParole = jpa.isParole,
       personTier = jpa.application.riskRatings?.tier?.value?.level,
       applicationId = jpa.application.id,
       applicationSubmittedDate = jpa.application.submittedAt?.toLocalDate(),
-      firstBookingPremisesName = jpa.booking?.premises?.name,
-      firstBookingArrivalDate = jpa.booking?.arrivalDate,
+      firstBookingPremisesName = null,
+      firstBookingArrivalDate = null,
     )
-
-    fun getStatus(placementRequest: PlacementRequestEntity): PlacementRequestStatus {
-      if (placementRequest.hasActiveBooking()) {
-        return PlacementRequestStatus.matched
-      }
-
-      if (placementRequest.bookingNotMades.any()) {
-        return PlacementRequestStatus.unableToMatch
-      }
-
-      return PlacementRequestStatus.notMatched
-    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PlacementRequestSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PlacementRequestSummary.PlacementRequestStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequest
@@ -36,7 +37,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -48,7 +48,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestDetailTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1PlacementRequestSummaryTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsListOfObjects
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -56,13 +55,7 @@ import java.time.OffsetDateTime
 class Cas1PlacementRequestTest : IntegrationTestBase() {
 
   @Autowired
-  lateinit var cas1PlacementRequestSummaryTransformer: Cas1PlacementRequestSummaryTransformer
-
-  @Autowired
   lateinit var personTransformer: PersonTransformer
-
-  @Autowired
-  lateinit var realPlacementRequestRepository: PlacementRequestRepository
 
   lateinit var probationRegion: ProbationRegionEntity
 
@@ -283,11 +276,11 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
-                    cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                    transformPlacementRequestJpaToApi(
                       unmatchedPlacementRequest,
                       PersonInfoResult.Success.Full(unmatchedOffender.otherIds.crn, unmatchedOffender, unmatchedInmate),
                     ),
-                    cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                    transformPlacementRequestJpaToApi(
                       withdrawnPlacementRequest,
                       PersonInfoResult.Success.Full(unmatchedOffender.otherIds.crn, unmatchedOffender, unmatchedInmate),
                     ),
@@ -481,7 +474,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
-                    cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                    transformPlacementRequestJpaToApi(
                       placementRequest,
                       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                     ),
@@ -511,7 +504,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
-                    cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                    transformPlacementRequestJpaToApi(
                       placementRequest,
                       PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                     ),
@@ -541,11 +534,11 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                  transformPlacementRequestJpaToApi(
                     placementRequest5thJan,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
-                  cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                  transformPlacementRequestJpaToApi(
                     placementRequest10thJan,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -574,11 +567,11 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                  transformPlacementRequestJpaToApi(
                     placementRequest1stJan,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
-                  cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                  transformPlacementRequestJpaToApi(
                     placementRequest5thJan,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -607,7 +600,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                  transformPlacementRequestJpaToApi(
                     placementRequestA1,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -640,7 +633,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                  transformPlacementRequestJpaToApi(
                     placementRequestA1,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -668,7 +661,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                  transformPlacementRequestJpaToApi(
                     standardRelease,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -696,7 +689,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
             .json(
               objectMapper.writeValueAsString(
                 listOf(
-                  cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                  transformPlacementRequestJpaToApi(
                     parole,
                     PersonInfoResult.Success.Full(offenderDetails.otherIds.crn, offenderDetails, inmateDetails),
                   ),
@@ -738,7 +731,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               .json(
                 objectMapper.writeValueAsString(
                   listOf(
-                    cas1PlacementRequestSummaryTransformer.transformPlacementRequestJpaToApi(
+                    transformPlacementRequestJpaToApi(
                       placementOffender1On5thJanTierA2Parole,
                       PersonInfoResult.Success.Full(offender1Details.otherIds.crn, offender1Details, inmate1Details),
                     ),
@@ -1071,6 +1064,32 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
         withIsWithdrawn(isWithdrawn)
         withIsParole(isParole)
       }
+    }
+
+    fun transformPlacementRequestJpaToApi(jpa: PlacementRequestEntity, personInfo: PersonInfoResult): Cas1PlacementRequestSummary = Cas1PlacementRequestSummary(
+      requestedPlacementDuration = jpa.duration,
+      requestedPlacementArrivalDate = jpa.expectedArrival,
+      id = jpa.id,
+      person = personTransformer.transformModelToPersonApi(personInfo),
+      placementRequestStatus = getStatus(jpa),
+      isParole = jpa.isParole,
+      personTier = jpa.application.riskRatings?.tier?.value?.level,
+      applicationId = jpa.application.id,
+      applicationSubmittedDate = jpa.application.submittedAt?.toLocalDate(),
+      firstBookingPremisesName = jpa.booking?.premises?.name,
+      firstBookingArrivalDate = jpa.booking?.arrivalDate,
+    )
+
+    fun getStatus(placementRequest: PlacementRequestEntity): PlacementRequestStatus {
+      if (placementRequest.hasActiveBooking()) {
+        return PlacementRequestStatus.matched
+      }
+
+      if (placementRequest.bookingNotMades.any()) {
+        return PlacementRequestStatus.unableToMatch
+      }
+
+      return PlacementRequestStatus.notMatched
     }
   }
 


### PR DESCRIPTION
* Move a transform function that was only used by tests from `main` into the corresponding tests
* Simplify the function to reflect that it’s only used when comparing placement requests pending match.