### PR TITLE
Send emails last in Cas1AssessmentService

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentService.kt
@@ -287,13 +287,17 @@ class Cas1AssessmentService(
     assessment.agreeWithShortNoticeReason = agreeWithShortNoticeReason
     assessment.agreeWithShortNoticeReasonComments = agreeWithShortNoticeReasonComments
     assessment.reasonForLateApplication = reasonForLateApplication
-
     assessment.document = document
     assessment.submittedAt = acceptedAt
     assessment.decision = AssessmentDecision.ACCEPTED
 
     applicationStatusService.assessmentUpdated(assessment)
+
     val savedAssessment = approvedPremisesAssessmentRepository.save(assessment)
+    val application = savedAssessment.application as ApprovedPremisesApplicationEntity
+
+    val caseSummary = getOffenderDetails(application.crn, LaoStrategy.NeverRestricted)
+      ?: throw RuntimeException("Offender details not found for CRN: ${application.crn} when creating Application Assessed Domain Event")
 
     /*
     Note - these placement requirements are required for all subsequent placement applications linked
@@ -311,11 +315,6 @@ class Cas1AssessmentService(
         notes,
       )
     }
-
-    val application = savedAssessment.application as ApprovedPremisesApplicationEntity
-
-    val caseSummary = getOffenderDetails(application.crn, LaoStrategy.NeverRestricted)
-      ?: throw RuntimeException("Offender details not found for CRN: ${application.crn} when creating Application Assessed Domain Event")
 
     cas1AssessmentDomainEventService.assessmentAccepted(
       application = application,


### PR DESCRIPTION
This is a very slight refactor to ensure upstream calls are made in `Cas1AssessmentService.acceptAssessment` before we attempt to send any emails or raise domain events. (this will become more important in a subsequent refactor)

