### PR TITLE
APS-2657 - Add staff code lookup for keyworker backfill

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/UserEntity.kt
@@ -39,6 +39,9 @@ interface UserRepository :
 
   fun findByDeliusUsername(deliusUsername: String): UserEntity?
 
+  @Query("SELECT DISTINCT u FROM UserEntity u where UPPER(u.deliusStaffCode) IN :staffCodes")
+  fun findByDeliusStaffCodeIn(staffCodes: List<String>): List<UserEntity>
+
   fun findByDeliusStaffCode(staffCode: String): UserEntity?
 
   @Query("SELECT DISTINCT u FROM UserEntity u join u.roles r where r.role = :role and u.isActive = true")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1KeyWorkerStaffCodeLookupEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1KeyWorkerStaffCodeLookupEntity.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface Cas1KeyWorkerStaffCodeLookupRepository : JpaRepository<Cas1KeyWorkerStaffCodeLookupEntity, UUID> {
+  @Query("SELECT l FROM Cas1KeyWorkerStaffCodeLookupEntity l WHERE UPPER(l.staffCode1) = UPPER(:staffCode)")
+  fun findByStaffCode1(staffCode: String): Cas1KeyWorkerStaffCodeLookupEntity?
+}
+
+@Entity
+@Table(name = "cas1_key_worker_staff_code_lookup")
+data class Cas1KeyWorkerStaffCodeLookupEntity(
+  @Id
+  @Column("staff_code_1")
+  val staffCode1: String,
+  @Column("staff_code_2")
+  val staffCode2: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingManagementService.kt
@@ -40,6 +40,7 @@ class Cas1BookingManagementService(
   private val nonArrivalReasonRepository: NonArrivalReasonRepository,
   private val lockableCas1SpaceBookingEntityRepository: LockableCas1SpaceBookingEntityRepository,
   private val userService: UserService,
+  private val cas1KeyWorkerService: Cas1KeyWorkerService,
   private val cas1ChangeRequestService: Cas1ChangeRequestService,
   private val springEventPublisher: SpringEventPublisher,
 ) {
@@ -198,7 +199,7 @@ class Cas1BookingManagementService(
     }
 
     val staffCodeAndUser = if (keyWorker.staffCode != null) {
-      val user = userService.findByDeliusStaffCode(keyWorker.staffCode)
+      val user = cas1KeyWorkerService.findByDeliusStaffCode(keyWorker.staffCode)
 
       if (user == null) {
         log.warn("Could not find user for staffCode ${keyWorker.staffCode} when assigning keyworker")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1KeyWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1KeyWorkerService.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1KeyWorkerStaffCodeLookupRepository
+
+@Service
+class Cas1KeyWorkerService(
+  val cas1KeyWorkerStaffCodeLookupRepository: Cas1KeyWorkerStaffCodeLookupRepository,
+  val userRepository: UserRepository,
+) {
+
+  fun findByDeliusStaffCode(staffCode: String): UserEntity? {
+    val staffCodes = listOfNotNull(
+      staffCode,
+      cas1KeyWorkerStaffCodeLookupRepository.findByStaffCode1(staffCode)?.staffCode2,
+    )
+
+    return userRepository.findByDeliusStaffCodeIn(staffCodes.map { it.uppercase() }).firstOrNull()
+  }
+}

--- a/src/main/resources/db/migration/all/20250819091228__add_keyworker_staff_code_lookup.sql
+++ b/src/main/resources/db/migration/all/20250819091228__add_keyworker_staff_code_lookup.sql
@@ -1,0 +1,4 @@
+CREATE TABLE cas1_key_worker_staff_code_lookup (
+    staff_code_1 text NOT NULL,
+    staff_code_2 text NOT NULL
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingManagementServiceTest.kt
@@ -45,6 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1BookingManagementService.DepartureInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ChangeRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1KeyWorkerService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1SpaceBookingManagementDomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.springevent.ArrivalRecorded
@@ -86,6 +87,9 @@ class Cas1BookingManagementServiceTest {
 
   @MockK
   lateinit var userService: UserService
+
+  @MockK
+  lateinit var cas1KeyWorkerService: Cas1KeyWorkerService
 
   @MockK
   lateinit var cas1ChangeRequestService: Cas1ChangeRequestService
@@ -1136,7 +1140,7 @@ class Cas1BookingManagementServiceTest {
 
     @Test
     fun `Returns validation error if no staff record exists with the given staff code, when staff code provided directly`() {
-      every { userService.findByDeliusStaffCode("StaffCode1") } returns null
+      every { cas1KeyWorkerService.findByDeliusStaffCode("StaffCode1") } returns null
       every {
         staffMemberService.getStaffMemberByCode("StaffCode1")
       } returns CasResult.NotFound("staff", "qcode")
@@ -1204,7 +1208,7 @@ class Cas1BookingManagementServiceTest {
 
       every { spaceBookingRepository.save(capture(updatedSpaceBookingCaptor)) } returnsArgument 0
       every { cas1SpaceBookingManagementDomainEventService.keyWorkerAssigned(any(), any(), any(), any()) } returns Unit
-      every { userService.findByDeliusStaffCode("StaffCode1") } returns null
+      every { cas1KeyWorkerService.findByDeliusStaffCode("StaffCode1") } returns null
 
       val staffDetail = StaffDetailFactory.staffDetail(
         code = "StaffCode1",
@@ -1249,7 +1253,7 @@ class Cas1BookingManagementServiceTest {
       every { cas1SpaceBookingManagementDomainEventService.keyWorkerAssigned(any(), any(), any(), any()) } returns Unit
 
       val user = UserEntityFactory().withDefaults().withDeliusStaffCode("StaffCode1").produce()
-      every { userService.findByDeliusStaffCode("StaffCode1") } returns user
+      every { cas1KeyWorkerService.findByDeliusStaffCode("StaffCode1") } returns user
 
       val staffDetail = StaffDetailFactory.staffDetail(
         code = "StaffCode1",


### PR DESCRIPTION
The staff codes returned for keyworkers from `approved-premises/qcode/staff` are not neccessarily the same staff codes used in the users table.

This commit introduces a lookup table to map between the differening staff codes that is then used when linking keyworker assignments to users.

