### PR TITLE
CAS3 V2 Create Turnaround API

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingTest.kt
@@ -11,6 +11,7 @@ import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewConfirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewTurnaround
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenACas3Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
@@ -28,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.withConflictMessage
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.withNotFoundMessage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
@@ -1102,7 +1104,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .is4xxClientError
-          .withConflictMessage("A Booking already exists for dates from 2022-07-15 to 2022-08-22 which overlaps with the desired dates: ${existingBooking.id}")
+          .withConflictMessage("A Booking already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingBooking.id}")
       }
     }
   }
@@ -1174,7 +1176,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
       givenAnOffender { offenderDetails, _ ->
         val (premises, bedspace) = givenCas3PremisesAndBedspace(user)
         val (_, assessment) = givenCas3ApplicationAndAssessment(user, offenderDetails)
-        val existingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
+        val existingVoidBedspace = cas3VoidBedspaceEntityFactory.produceAndPersist {
           withBedspace(bedspace)
           withStartDate(LocalDate.parse("2022-07-15"))
           withEndDate(LocalDate.parse("2022-08-15"))
@@ -1199,7 +1201,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           .exchange()
           .expectStatus()
           .is4xxClientError
-          .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingLostBed.id}")
+          .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${existingVoidBedspace.id}")
       }
     }
   }
@@ -1396,7 +1398,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
         givenAnOffender { offenderDetails, _ ->
           val (premises, bedspace) = givenCas3PremisesAndBedspace(user)
 
-          val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
+          val conflictingVoidBedspace = cas3VoidBedspaceEntityFactory.produceAndPersist {
             withBedspace(bedspace)
             withStartDate(LocalDate.parse("2022-07-15"))
             withEndDate(LocalDate.parse("2022-08-15"))
@@ -1427,7 +1429,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .is4xxClientError
-            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
+            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingVoidBedspace.id}")
         }
       }
     }
@@ -1680,10 +1682,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
               ),
             )
             .exchange()
-            .expectStatus()
-            .isNotFound
-            .expectBody()
-            .jsonPath("$.detail").isEqualTo("No Premises with an ID of $notFoundPremises could be found")
+            .withNotFoundMessage(message = "No Premises with an ID of $notFoundPremises could be found")
         }
       }
     }
@@ -1791,10 +1790,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             ),
           )
           .exchange()
-          .expectStatus()
-          .isNotFound
-          .expectBody()
-          .jsonPath("$.detail").isEqualTo("No Premises with an ID of $notFoundPremisesId could be found")
+          .withNotFoundMessage(message = "No Premises with an ID of $notFoundPremisesId could be found")
       }
     }
 
@@ -2203,10 +2199,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
               ),
             )
             .exchange()
-            .expectStatus()
-            .isNotFound
-            .expectBody()
-            .jsonPath("$.detail").isEqualTo("No Premises with an ID of $notFoundPremisesId could be found")
+            .withNotFoundMessage(message = "No Premises with an ID of $notFoundPremisesId could be found")
         }
       }
     }
@@ -2339,10 +2332,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             ),
           )
           .exchange()
-          .expectStatus()
-          .isNotFound
-          .expectBody()
-          .jsonPath("$.detail").isEqualTo("No Premises with an ID of $notFoundPremisesId could be found")
+          .withNotFoundMessage(message = "No Premises with an ID of $notFoundPremisesId could be found")
       }
     }
   }
@@ -2443,7 +2433,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         givenAnOffender { offenderDetails, _ ->
           val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
-          val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
+          val conflictingVoidBedspace = cas3VoidBedspaceEntityFactory.produceAndPersist {
             withBedspace(bedspace)
             withStartDate(LocalDate.parse("2022-07-15"))
             withEndDate(LocalDate.parse("2022-08-15"))
@@ -2472,7 +2462,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .is4xxClientError
-            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
+            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingVoidBedspace.id}")
         }
       }
     }
@@ -2482,7 +2472,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
       givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
         givenAnOffender { offenderDetails, _ ->
           val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
-          val conflictingLostBed = cas3VoidBedspaceEntityFactory.produceAndPersist {
+          val conflictingVoidBedspace = cas3VoidBedspaceEntityFactory.produceAndPersist {
             withBedspace(bedspace)
             withStartDate(LocalDate.parse("2022-07-15"))
             withEndDate(LocalDate.parse("2022-08-15"))
@@ -2517,7 +2507,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .is4xxClientError
-            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingLostBed.id}")
+            .withConflictMessage("A Void Bedspace already exists for dates from 2022-07-15 to 2022-08-15 which overlaps with the desired dates: ${conflictingVoidBedspace.id}")
         }
       }
     }
@@ -2587,6 +2577,165 @@ class Cas3v2BookingTest : IntegrationTestBase() {
         val actualBooking = bookingRepository.findByIdOrNull(booking.id)
         assertThat(actualBooking?.departureDate).isEqualTo(LocalDate.parse(newDate))
         assertThat(actualBooking?.originalDepartureDate).isEqualTo(booking.departureDate)
+      }
+    }
+  }
+
+  @Nested
+  inner class CreateTurnaround {
+    @Test
+    fun `Create Turnaround returns 404 Not Found if the premises was not found`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${UUID.randomUUID()}/bookings/${UUID.randomUUID()}/turnarounds")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(NewTurnaround(workingDays = 2))
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+
+    @Test
+    fun `Create Turnaround returns 404 Not Found if the booking was not found on the premises`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        val (premises, _) = givenCas3PremisesAndBedspace(userEntity)
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bookings/${UUID.randomUUID()}/turnarounds")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(NewTurnaround(workingDays = 2))
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+
+    @Test
+    fun `Create Turnaround returns 400 Bad Request if the number of working days is not a positive integer`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+        }
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/turnarounds")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(NewTurnaround(workingDays = -1))
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBody()
+          .jsonPath("invalid-params[0].propertyName").isEqualTo("$.workingDays")
+          .jsonPath("invalid-params[0].errorType").isEqualTo("isNotAPositiveInteger")
+      }
+    }
+
+    @Test
+    fun `Create Turnaround returns 404 Not Found if a premises that does not exist `() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+        }
+
+        val notFoundPremisesId = UUID.randomUUID()
+        webTestClient.post()
+          .uri("/cas3/v2/premises/$notFoundPremisesId/bookings/${booking.id}/turnarounds")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(NewTurnaround(workingDays = 2))
+          .exchange()
+          .withNotFoundMessage(message = "No Premises with an ID of $notFoundPremisesId could be found")
+      }
+    }
+
+    @Test
+    fun `Create Turnaround returns 409 Conflict if the turnaround overlaps with an existing booking`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withArrivalDate(LocalDate.of(2023, 2, 3))
+          withDepartureDate(LocalDate.of(2023, 5, 3))
+        }
+        val conflictingBooking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withArrivalDate(LocalDate.of(2023, 5, 5))
+          withDepartureDate(LocalDate.of(2023, 8, 5))
+        }
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/turnarounds")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(NewTurnaround(workingDays = 2))
+          .exchange()
+          .expectStatus()
+          .is4xxClientError
+          .withConflictMessage("A Booking already exists for dates from 2023-05-05 to 2023-08-05 which overlaps with the desired dates: ${conflictingBooking.id}")
+      }
+    }
+
+    @Test
+    fun `Create Turnaround returns 409 Conflict if the turnaround overlaps with an existing void bedspace`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withArrivalDate(LocalDate.of(2023, 2, 3))
+          withDepartureDate(LocalDate.of(2023, 5, 3))
+        }
+        val conflictingVoidBedspace = cas3VoidBedspaceEntityFactory.produceAndPersist {
+          withBedspace(bedspace)
+          withStartDate(LocalDate.of(2023, 5, 5))
+          withEndDate(LocalDate.of(2023, 5, 19))
+          withYieldedReason {
+            cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
+          }
+        }
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/turnarounds")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(NewTurnaround(workingDays = 2))
+          .exchange()
+          .expectStatus()
+          .is4xxClientError
+          .withConflictMessage("A Void Bedspace already exists for dates from 2023-05-05 to 2023-05-19 which overlaps with the desired dates: ${conflictingVoidBedspace.id}")
+      }
+    }
+
+    @Test
+    fun `Create Turnaround returns 200 OK with the created turnaround`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { userEntity, jwt ->
+        val (premises, bedspace) = givenCas3PremisesAndBedspace(userEntity)
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+        }
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}/turnarounds")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(NewTurnaround(workingDays = 2))
+          .exchange()
+          .expectStatus()
+          .isCreated
+          .expectBody()
+          .jsonPath("$.bookingId").isEqualTo(booking.id.toString())
+          .jsonPath("$.workingDays").isEqualTo(2)
       }
     }
   }


### PR DESCRIPTION
**New endpoint delivered**

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `POST /cas3/v2/premises/{premisesId}/bookings/{bookingId}/turnarounds`
2. This endpoint was modelled on the `POST /cas3/premises/{premisesId}/bedspaces` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models
