### PR TITLE
CAS-1877: C3 BE Check premises can be archived

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PremisesController.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3ArchiveBe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3ArchivePremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3Bedspace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspacesReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesBedspaceTotals
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3UpdatePremises
@@ -145,6 +146,20 @@ class Cas3PremisesController(
     val archiveHistory = extractEntityFromCasResult(cas3PremisesService.getPremisesArchiveHistory(premises))
 
     return ResponseEntity.ok(cas3PremisesTransformer.transformDomainToApi(premises, archiveHistory))
+  }
+
+  @GetMapping("/premises/{premisesId}/can-archive")
+  fun canArchivePremises(@PathVariable premisesId: UUID): ResponseEntity<Cas3BedspacesReference> {
+    val premises = cas3PremisesService.getPremises(premisesId)
+      ?: throw NotFoundProblem(premisesId, "Premises")
+
+    if (!userAccessService.currentUserCanViewPremises(premises)) {
+      throw ForbiddenProblem()
+    }
+
+    val result = cas3PremisesService.canArchivePremisesInFuture(premisesId)
+
+    return ResponseEntity.ok(result)
   }
 
   @GetMapping("/premises/{premisesId}/bedspace-totals")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BedspacesReference.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BedspacesReference.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import java.util.UUID
+
+data class Cas3BedspacesReference(
+  val affectedBedspaces: List<Cas3BedspaceReference> = emptyList(),
+)
+
+data class Cas3BedspaceReference(
+  val id: UUID,
+  val reference: String,
+)


### PR DESCRIPTION
This Pull Request introduces functionality to check whether a premises in the system can be archived. It includes enhancements in both controller and service layers, query logic updates, and corresponding integration and unit tests.

Main Changes:

- Controller Updates: Added a new endpoint GET /premises/{premisesId}/can-archive to assess if a premises can be archived, returning relevant affected bedspaces.
- Service Updates: Introduced a method canArchivePremises in Cas3PremisesService to determine archive eligibility based on bookings and voids within the premises.
- Repository Additions:
  - Added two queries for filtering bookings and void bedspaces based on their statuses, dates, and other conditions.
- Model Changes: Introduced a new data class Cas3CanArchivePremises and Cas3AffectedBedspace to encapsulate the result of the archive eligibility check.
- Test Suite Enhancements:
  - Added comprehensive integration tests for the new archive functionality.
  - Updated unit tests for the service to include mock tests of the new functionality.