### PR TITLE
CAS-1919 Premises status archived when start date in future

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3PremisesTransformer.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.Characterist
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
+import java.time.LocalDate
 
 @Component
 class Cas3PremisesTransformer(
@@ -39,7 +40,9 @@ class Cas3PremisesTransformer(
     archiveHistory = archiveHistory,
   )
 
-  private fun getPremisesStatus(premises: TemporaryAccommodationPremisesEntity) = if (premises.isPremisesArchived()) {
+  private fun getPremisesStatus(premises: TemporaryAccommodationPremisesEntity) = if (premises.isPremisesArchived() ||
+    premises.startDate.isAfter(LocalDate.now())
+  ) {
     Cas3PremisesStatus.archived
   } else {
     Cas3PremisesStatus.online


### PR DESCRIPTION
This [PR CAS-1919](https://dsdmoj.atlassian.net/browse/CAS-1919) is to return premises status as archived when premises start date is in the future