### PR TITLE
Move probation integration e2e test user seeding

### DIFF
--- a/src/main/resources/db/seed/dev+test/01__temporary_accommodation_users.csv
+++ b/src/main/resources/db/seed/dev+test/01__temporary_accommodation_users.csv
@@ -1,4 +1,3 @@
 delius_username,notes,roles,qualifications,remove_existing_roles_and_qualifications
 temporary-accommodation-training-2,Used by CAS3 E2E and manual testing,"CAS3_ASSESSOR,CAS3_REPORTER",,YES
 temporary-accommodation-training-1,Used by CAS3 E2E and manual testing,CAS3_REFERRER,,YES
-AutomatedTestUser,Used by probation-integration E2E. We leave existing roles to avoid wiping out CAS1 qualifications,CAS3_REFERRER,,NO

--- a/src/main/resources/db/seed/dev+test/02__approved_premises_users.csv
+++ b/src/main/resources/db/seed/dev+test/02__approved_premises_users.csv
@@ -1,0 +1,2 @@
+delius_username,notes,roles,qualifications,remove_existing_roles_and_qualifications,cru_management_area_override
+AutomatedTestUser,Used by probation-integration E2E. We leave existing roles to avoid wiping out CAS1 qualifications,CAS3_REFERRER,,NO


### PR DESCRIPTION
Seeding of the probation integration e2e test user intermittently fails, which rolls back the entire seed job.

This commit moves that seeding into a standalone seed file, so if that fails, other seeded users are still created

