### PR TITLE
APS-2577 - Remove delius dependency in placement app backfill

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.allocations.UserAllocator
 import java.time.Clock
-import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -294,7 +293,6 @@ class Cas1PlacementApplicationService(
     cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(
       placementApplication,
       withdrawalContext,
-      eventOccurredAt = Instant.now(clock),
     )
     cas1PlacementApplicationEmailService.placementApplicationWithdrawn(
       placementApplication = placementApplication,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationDomainEventServiceTest.kt
@@ -40,7 +40,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.Cas1Pl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.Clock
-import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecision as ApiDecision
@@ -210,7 +209,6 @@ class Cas1PlacementApplicationDomainEventServiceTest {
             WithdrawableEntityType.PlacementApplication,
             placementApplication.id,
           ),
-          Instant.now(),
         )
       }.hasMessage("Only withdrawals triggered by users are supported")
     }
@@ -221,8 +219,6 @@ class Cas1PlacementApplicationDomainEventServiceTest {
       every { domainEventTransformer.toWithdrawnBy(user) } returns withdrawnBy
       every { domainEventService.savePlacementApplicationWithdrawnEvent(any()) } returns Unit
 
-      val now = Instant.now()
-
       service.placementApplicationWithdrawn(
         placementApplication,
         withdrawalContext = WithdrawalContext(
@@ -230,7 +226,6 @@ class Cas1PlacementApplicationDomainEventServiceTest {
           WithdrawableEntityType.PlacementApplication,
           placementApplication.id,
         ),
-        eventOccurredAt = now,
       )
 
       verify(exactly = 1) {
@@ -240,7 +235,7 @@ class Cas1PlacementApplicationDomainEventServiceTest {
             assertThat(it.applicationId).isEqualTo(application.id)
             assertThat(it.crn).isEqualTo(CRN)
             assertThat(it.nomsNumber).isEqualTo(application.nomsNumber)
-            assertThat(it.occurredAt).isEqualTo(now)
+            assertThat(it.occurredAt).isWithinTheLastMinute()
             assertThat(it.metadata).containsEntry(MetaDataName.CAS1_PLACEMENT_APPLICATION_ID, placementApplication.id.toString())
 
             val eventDetails = it.data.eventDetails

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationServiceTest.kt
@@ -1002,7 +1002,7 @@ class Cas1PlacementApplicationServiceTest {
 
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
-      every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(placementApplication, withdrawalContext, any()) } returns Unit
+      every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(placementApplication, withdrawalContext) } returns Unit
       every { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(any(), any(), any()) } returns Unit
 
       val result = cas1PlacementApplicationService.withdrawPlacementApplication(
@@ -1035,7 +1035,7 @@ class Cas1PlacementApplicationServiceTest {
 
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
-      every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(any(), any(), any()) } returns Unit
+      every { cas1PlacementApplicationDomainEventService.placementApplicationWithdrawn(any(), any()) } returns Unit
       every { cas1PlacementApplicationEmailService.placementApplicationWithdrawn(any(), any(), any()) } returns Unit
 
       val result = cas1PlacementApplicationService.withdrawPlacementApplication(


### PR DESCRIPTION
Before this commit all staff references in ‘match request withdrawn’ domain events must exist in delius for the Backfill Automatic Placement Applications job to complete. This commit removes that dependency, copying the ‘withdrawn by’ information from the corresponding ‘match request withdrawn’ domain event.

