### PR TITLE
CAS-1918 Unarchive only the latest bedspace with the same reference

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -1159,8 +1159,10 @@ class Cas3PremisesService(
     val unarchivePremises = unarchivePremisesAndSaveDomainEvent(premises, restartDate)
 
     val bedspaces = bedspaceRepository.findByRoomPremisesId(premises.id)
-    bedspaces.forEach { bedspace ->
-      unarchiveBedspaceAndSaveDomainEvent(bedspace, restartDate)
+    val uniqueBedspaces = bedspaces.groupBy { b -> b.room.name }
+    uniqueBedspaces.forEach { bedspaces ->
+      val lastBedspace = bedspaces.value.sortedByDescending { it.createdAt }.first()
+      unarchiveBedspaceAndSaveDomainEvent(lastBedspace, restartDate)
     }
 
     success(unarchivePremises)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenATemporaryAccommodationPremises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenATemporaryAccommodationPremises.kt
@@ -126,6 +126,7 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesComplete(
   roles: List<UserRole> = emptyList(),
   bedspaceCount: Int = 1,
   premisesStatus: PropertyStatus = PropertyStatus.active,
+  premisesStartDate: LocalDate = LocalDate.now().minusDays(180),
   premisesEndDate: LocalDate? = null,
   bedStartDates: List<LocalDate> = emptyList(),
   bedEndDates: List<LocalDate?> = emptyList(),
@@ -145,8 +146,9 @@ fun IntegrationTestBase.givenATemporaryAccommodationPremisesComplete(
       roomCharacteristics = roomCharacteristics,
     ) { premises, rooms, beds ->
       // Update premises with status and end date if provided
-      if (premisesStatus != premises.status || premisesEndDate != premises.endDate) {
+      if (premisesStatus != premises.status || premisesEndDate != premises.endDate || premisesStartDate != premises.startDate) {
         premises.status = premisesStatus
+        premises.startDate = premisesStartDate
         premises.endDate = premisesEndDate
         temporaryAccommodationPremisesRepository.save(premises)
       }


### PR DESCRIPTION
This [PR CAS-1918](https://dsdmoj.atlassian.net/browse/CAS-1918) is to unarchive only the latest bedspace with the same reference when unarchive a premises 

