### PR TITLE
Add ClientCachingOAuth2AuthorizedClientService

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/Application.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/Application.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+const val SYSTEM_USERNAME = "COMMUNITY_ACCOMMODATION_API"
+
 @SpringBootApplication
 class Application
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientId
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.SYSTEM_USERNAME
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.apply
+import kotlin.collections.set
+import kotlin.let
+
+class ClientCachingOAuth2AuthorizedClientService(
+  private val clientRegistrationRepository: ClientRegistrationRepository,
+) : OAuth2AuthorizedClientService {
+  private val authorizedClients: MutableMap<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> = ConcurrentHashMap()
+
+  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+    clientRegistrationId: String,
+    principalName: String,
+  ): T? = clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.let {
+    @Suppress("UNCHECKED_CAST")
+    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as T
+  }
+
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {
+    authorizedClients[
+      OAuth2AuthorizedClientId(authorizedClient.clientRegistration.registrationId, SYSTEM_USERNAME),
+    ] = authorizedClient
+  }
+
+  override fun removeAuthorizedClient(clientRegistrationId: String, principalName: String) {
+    clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.apply {
+      authorizedClients.remove(OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME))
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
@@ -36,7 +35,7 @@ class WebClientConfiguration(
 
   @Bean
   fun authorizedClientManager(clients: ClientRegistrationRepository): OAuth2AuthorizedClientManager {
-    val service: OAuth2AuthorizedClientService = InMemoryOAuth2AuthorizedClientService(clients)
+    val service: OAuth2AuthorizedClientService = ClientCachingOAuth2AuthorizedClientService(clients)
     val manager = AuthorizedClientServiceOAuth2AuthorizedClientManager(clients, service)
     val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
       .clientCredentials()


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/APS-2712

### **Custom `OAuth2AuthorizedClientService` Implementation**
This implementation introduces a custom `OAuth2AuthorizedClientService` that caches `client_credentials` tokens in-memory for a specific system user (`SYSTEM_USERNAME`).

- Tokens are always fetched on behalf of a system user, so the cache is keyed by `OAuth2AuthorizedClientId(clientId, SYSTEM_USERNAME)`.
- Prevents redundant token re-fetching by caching tokens in a `ConcurrentHashMap`.
- The cache is in-memory and will be cleared on application restart.

