### PR TITLE
CAS-1962 Return premises start date in validation message

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -639,7 +639,15 @@ class Cas3PremisesService(
     }
 
     if (endDate.isBefore(premises.startDate)) {
-      return "$.endDate" hasSingleValidationError "endDateBeforePremisesStartDate"
+      return Cas3FieldValidationError(
+        mapOf(
+          "$.endDate" to Cas3ValidationMessage(
+            entityId = premises.id.toString(),
+            message = "endDateBeforePremisesStartDate",
+            value = premises.startDate.toString(),
+          ),
+        ),
+      )
     }
 
     cas3DomainEventService.getPremisesActiveDomainEvents(premises.id, listOf(CAS3_PREMISES_ARCHIVED))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
@@ -2891,6 +2891,8 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
           .jsonPath("$.title").isEqualTo("Bad Request")
           .jsonPath("$.invalid-params[0].propertyName").isEqualTo("\$.endDate")
           .jsonPath("$.invalid-params[0].errorType").isEqualTo("endDateBeforePremisesStartDate")
+          .jsonPath("$.invalid-params[0].entityId").isEqualTo(premises.id.toString())
+          .jsonPath("$.invalid-params[0].value").isEqualTo(premises.startDate.toString())
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
@@ -1145,7 +1145,7 @@ class Cas3PremisesServiceTest {
 
       val result = premisesService.archivePremises(premises, premises.startDate.minusDays(1))
 
-      assertThatCasResult(result).isFieldValidationError().hasMessage("$.endDate", "endDateBeforePremisesStartDate")
+      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.endDate", premises.id.toString(), "endDateBeforePremisesStartDate", premises.startDate.toString())
     }
 
     @Test


### PR DESCRIPTION
This [PR CAS-1962](https://dsdmoj.atlassian.net/browse/CAS-1962) is when archive a premises if the start date is before end date will return the start date with the validation message

