### PR TITLE
CAS-1968 Return bedspace created date in bedspace start date property

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceStatus
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -41,7 +42,15 @@ data class Cas3BedspacesEntity(
     inverseJoinColumns = [JoinColumn(name = "bedspace_characteristics_id")],
   )
   var characteristics: MutableList<Cas3BedspaceCharacteristicEntity>,
-)
+) {
+  fun isBedspaceUpcoming() = this.startDate?.isAfter(LocalDate.now()) ?: false
+  fun isBedspaceArchived() = this.endDate != null && this.endDate!! <= LocalDate.now()
+  fun getBedspaceStatus() = when {
+    this.isBedspaceUpcoming() -> Cas3BedspaceStatus.upcoming
+    this.isBedspaceArchived() -> Cas3BedspaceStatus.archived
+    else -> Cas3BedspaceStatus.online
+  }
+}
 
 @Repository
 interface Cas3BedspacesRepository : JpaRepository<Cas3BedspacesEntity, UUID> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3Bedspace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceArchiveAction
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
 
@@ -16,7 +15,7 @@ class Cas3BedspaceTransformer(
   fun transformJpaToApi(bed: BedEntity, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
     id = bed.id,
     reference = bed.room.name,
-    startDate = bed.startDate!!,
+    startDate = bed.createdAt!!.toLocalDate(),
     endDate = bed.endDate,
     status = bed.getCas3BedspaceStatus(),
     notes = bed.room.notes,
@@ -27,10 +26,10 @@ class Cas3BedspaceTransformer(
   fun transformJpaToApi(jpa: Cas3BedspacesEntity, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
     id = jpa.id,
     reference = jpa.reference,
-    startDate = jpa.startDate!!,
+    startDate = jpa.createdAt!!.toLocalDate(),
     endDate = jpa.endDate,
     notes = jpa.notes,
-    status = Cas3BedspaceStatus.online, // sets online as default for now - will change when we get there
+    status = jpa.getBedspaceStatus(),
     bedspaceCharacteristics = jpa.characteristics.map(cas3BedspaceCharacteristicTransformer::transformJpaToApi),
     archiveHistory = archiveHistory,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -192,7 +192,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
   protected fun createCas3Bedspace(bed: BedEntity, room: RoomEntity, bedspaceStatus: Cas3BedspaceStatus, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
     id = bed.id,
     reference = room.name,
-    startDate = bed.startDate!!,
+    startDate = bed.createdAt!!.toLocalDate(),
     characteristics = room.characteristics.map { characteristic ->
       Characteristic(
         id = characteristic.id,


### PR DESCRIPTION
This [PR CAS-1968](https://dsdmoj.atlassian.net/browse/CAS-1968) is to return the bedspace create date in the start date bedspace property