### PR TITLE
CAS-1968 Change startDate property to be nullable in Cas3Bedspace

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3Bedspace.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3Bedspace.kt
@@ -6,22 +6,13 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class Cas3Bedspace(
-
   val id: UUID,
-
   val reference: String,
-
-  val startDate: LocalDate,
-
+  val startDate: LocalDate?,
   val status: Cas3BedspaceStatus,
-
   val endDate: LocalDate? = null,
-
   val notes: String? = null,
-
   val characteristics: List<Characteristic>? = null,
-
   val bedspaceCharacteristics: List<Cas3BedspaceCharacteristic>? = null,
-
   val archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
@@ -15,7 +15,7 @@ class Cas3BedspaceTransformer(
   fun transformJpaToApi(bed: BedEntity, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
     id = bed.id,
     reference = bed.room.name,
-    startDate = bed.createdAt!!.toLocalDate(),
+    startDate = bed.createdAt?.toLocalDate(),
     endDate = bed.endDate,
     status = bed.getCas3BedspaceStatus(),
     notes = bed.room.notes,
@@ -26,7 +26,7 @@ class Cas3BedspaceTransformer(
   fun transformJpaToApi(jpa: Cas3BedspacesEntity, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
     id = jpa.id,
     reference = jpa.reference,
-    startDate = jpa.createdAt!!.toLocalDate(),
+    startDate = jpa.createdAt?.toLocalDate(),
     endDate = jpa.endDate,
     notes = jpa.notes,
     status = jpa.getBedspaceStatus(),


### PR DESCRIPTION
This PR CAS-1968 change the start date property temporary to nullable until we run the migration process then all bedspaces will have createdAt date. Then will set the startDate property back to be not nullable 