### PR TITLE
CAS-1965 Change startDate premises to be the premises created date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3Premises.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3Premises.kt
@@ -23,7 +23,7 @@ data class Cas3Premises(
   val totalUpcomingBedspaces: Int,
   val totalArchivedBedspaces: Int,
   val characteristics: List<Characteristic>? = null,
-  val startDate: LocalDate,
+  val startDate: LocalDate?,
   val endDate: LocalDate? = null,
   val notes: String? = null,
   val turnaroundWorkingDays: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3PremisesTransformer.kt
@@ -28,7 +28,7 @@ class Cas3PremisesTransformer(
     probationRegion = probationRegionTransformer.transformJpaToApi(premisesEntity.probationRegion),
     probationDeliveryUnit = premisesEntity.probationDeliveryUnit?.let { probationDeliveryUnitTransformer.transformJpaToApi(it) }!!,
     characteristics = premisesEntity.characteristics.map(characteristicTransformer::transformJpaToApi).sortedBy { it.id },
-    startDate = premisesEntity.startDate,
+    startDate = premisesEntity.createdAt?.toLocalDate(),
     endDate = premisesEntity.endDate,
     status = getPremisesStatus(premisesEntity),
     notes = premisesEntity.notes,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3PremisesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3PremisesTransformerTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class Cas3PremisesTransformerTest {
@@ -59,6 +60,8 @@ class Cas3PremisesTransformerTest {
       .withCharacteristics(characteristics)
       .withStatus(PropertyStatus.active)
       .produce()
+
+    premises.createdAt = OffsetDateTime.now().minusDays(360)
 
     // online bedspaces
     createRoomWithOneBedspace(premises, LocalDate.now().minusDays(5), null)
@@ -110,7 +113,7 @@ class Cas3PremisesTransformerTest {
         probationRegion = probationRegion,
         probationDeliveryUnit = probationDeliveryUnit,
         characteristics = listOf(characteristic),
-        startDate = premises.startDate,
+        startDate = premises.createdAt?.toLocalDate(),
         endDate = premises.endDate,
         status = Cas3PremisesStatus.online,
         notes = premises.notes,
@@ -141,6 +144,8 @@ class Cas3PremisesTransformerTest {
       .withProbationDeliveryUnit(probationDeliveryUnitEntity)
       .withStatus(PropertyStatus.active)
       .produce()
+
+    premises.createdAt = OffsetDateTime.now().minusDays(130)
 
     // online bedspaces
     createRoomWithOneBedspace(premises, LocalDate.now().minusDays(7), null)
@@ -176,7 +181,7 @@ class Cas3PremisesTransformerTest {
         probationRegion = probationRegion,
         probationDeliveryUnit = probationDeliveryUnit,
         characteristics = emptyList(),
-        startDate = premises.startDate,
+        startDate = premises.createdAt?.toLocalDate(),
         endDate = premises.endDate,
         status = Cas3PremisesStatus.online,
         notes = premises.notes,


### PR DESCRIPTION
This [PR CAS-1965](https://dsdmoj.atlassian.net/browse/CAS-1965) is to set the startDate property for premises to the created premises date  