### PR TITLE
CAS3 V2 Create Bedspace API

### DIFF
--- a/script/migration/cas3/01__verify_data_migration_to_cas3_premises_table.sql
+++ b/script/migration/cas3/01__verify_data_migration_to_cas3_premises_table.sql
@@ -16,6 +16,6 @@ and c3p.address_line1 = p.address_line1
 and (c3p.address_line2 = p.address_line2 OR (c3p.address_line2 IS NULL AND p.address_line2 IS NULL))
 and (c3p.town = p.town OR (c3p.town IS NULL AND p.town IS NULL))
 and c3p.status = p.status
-and (c3p.start_date = tap.start_date
+and c3p.start_date = tap.start_date
 and (c3p.end_date = tap.end_date OR (c3p.end_date IS NULL AND tap.end_date IS NULL))
 and (c3p.notes = p.notes OR (c3p.notes IS NULL AND p.notes IS NULL));

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BedspaceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BedspaceController.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3Bedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3NewBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2BedspacesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3BedspaceTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+import java.util.UUID
+
+@Cas3Controller
+@RequestMapping("/cas3/v2", headers = ["X-Service-Name=temporary-accommodation"])
+class Cas3v2BedspaceController(
+  private val cas3v2PremisesService: Cas3v2PremisesService,
+  private val cas3v2BedspacesService: Cas3v2BedspacesService,
+  private val userAccessService: UserAccessService,
+  private val cas3BedspaceTransformer: Cas3BedspaceTransformer,
+) {
+
+  @PostMapping("/premises/{premisesId}/bedspaces")
+  fun createBedspace(
+    @PathVariable premisesId: UUID,
+    @RequestBody newBedspace: Cas3NewBedspace,
+  ): ResponseEntity<Cas3Bedspace> {
+    val premises = cas3v2PremisesService.getPremises(premisesId) ?: throw NotFoundProblem(premisesId, "Premises")
+    if (!userAccessService.currentUserCanViewPremises(premises)) {
+      throw ForbiddenProblem()
+    }
+    val bedspace = cas3v2BedspacesService.createBedspace(premises, newBedspace.reference, newBedspace.startDate, newBedspace.notes, newBedspace.characteristicIds)
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+      cas3BedspaceTransformer.transformJpaToApi(
+        jpa = extractEntityFromCasResult(bedspace),
+        status = Cas3BedspaceStatus.online,
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3PremisesEntity.kt
@@ -68,7 +68,9 @@ data class Cas3PremisesEntity(
   )
   var characteristics: MutableList<Cas3PremisesCharacteristicEntity>,
 
-)
+) {
+  fun isPremisesScheduledToArchive(): Boolean = status == PropertyStatus.archived && endDate != null && endDate!! > LocalDate.now()
+}
 
 @Repository
 interface Cas3PremisesRepository : JpaRepository<Cas3PremisesEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspacesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspacesService.kt
@@ -1,0 +1,114 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3ValidationMessage
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3PremisesService.Companion.MAX_DAYS_CREATE_BEDSPACE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3PremisesService.Companion.MAX_LENGTH_BEDSPACE_REFERENCE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.CasResultValidatedScope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Cas3FieldValidationError
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service
+class Cas3v2BedspacesService(
+  private val characteristicService: CharacteristicService,
+  private val cas3BedspacesRepository: Cas3BedspacesRepository,
+  private val cas3PremisesService: Cas3v2PremisesService,
+) {
+  @SuppressWarnings("MagicNumber")
+  fun createBedspace(
+    premises: Cas3PremisesEntity,
+    bedspaceReference: String,
+    startDate: LocalDate,
+    notes: String?,
+    characteristicIds: List<UUID>,
+  ): CasResult<Cas3BedspacesEntity> = validatedCasResult {
+    val trimmedReference = bedspaceReference.trim()
+    var bedspace = Cas3BedspacesEntity(
+      id = UUID.randomUUID(),
+      reference = trimmedReference,
+      notes = notes,
+      premises = premises,
+      characteristics = mutableListOf(),
+      startDate = startDate,
+      endDate = null,
+      createdAt = OffsetDateTime.now(),
+    )
+
+    if (isValidBedspaceReference(trimmedReference) &&
+      premises.bedspaces.any { bedspace -> bedspace.reference.equals(trimmedReference, ignoreCase = true) }
+    ) {
+      "$.reference" hasValidationError "bedspaceReferenceExists"
+    }
+
+    if (startDate.isBefore(LocalDate.now().minusDays(MAX_DAYS_CREATE_BEDSPACE))) {
+      "$.startDate" hasValidationError "invalidStartDateInThePast"
+    }
+
+    if (startDate.isAfter(LocalDate.now().plusDays(MAX_DAYS_CREATE_BEDSPACE))) {
+      "$.startDate" hasValidationError "invalidStartDateInTheFuture"
+    }
+
+    if (startDate.isBefore(premises.startDate)) {
+      return Cas3FieldValidationError(
+        mapOf(
+          "$.startDate" to Cas3ValidationMessage(
+            entityId = premises.id.toString(),
+            message = "startDateBeforePremisesStartDate",
+            value = premises.startDate.toString(),
+          ),
+        ),
+      )
+    }
+
+    val characteristicEntities = getAndValidateCharacteristics(characteristicIds, validationErrors)
+    if (validationErrors.any()) {
+      return fieldValidationError
+    }
+    bedspace.characteristics.addAll(characteristicEntities.filterNotNull())
+    bedspace = cas3BedspacesRepository.save(bedspace)
+
+    if (premises.isPremisesScheduledToArchive()) {
+      cas3PremisesService.unarchivePremisesAndSaveDomainEvent(premises, startDate)
+    }
+
+    return success(bedspace)
+  }
+
+  private fun getAndValidateCharacteristics(
+    characteristicIds: List<UUID>,
+    validationErrors: ValidationErrors,
+  ): List<Cas3BedspaceCharacteristicEntity?> = characteristicIds.mapIndexed { index, id ->
+    val entity = characteristicService.getCas3BedspaceCharacteristic(id)
+    if (entity == null) {
+      validationErrors["$.characteristics[$index]"] = "doesNotExist"
+    }
+    entity
+  }
+
+  private fun CasResultValidatedScope<Cas3BedspacesEntity>.isValidBedspaceReference(
+    trimmedReference: String,
+  ): Boolean {
+    if (trimmedReference.isEmpty()) {
+      "$.reference" hasValidationError "empty"
+    } else {
+      if (trimmedReference.length < MAX_LENGTH_BEDSPACE_REFERENCE) {
+        "$.reference" hasValidationError "bedspaceReferenceNotMeetMinimumLength"
+      }
+
+      if (!trimmedReference.any { it.isLetterOrDigit() }) {
+        "$.reference" hasValidationError "bedspaceReferenceMustIncludeLetterOrNumber"
+      }
+    }
+    return !validationErrors.any()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventBuilder.kt
@@ -6,6 +6,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Arri
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3DepartureEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3PremisesUnarchiveEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3PremisesUnarchiveEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.CAS3BookingCancelledEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.CAS3BookingCancelledEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.CAS3BookingCancelledUpdatedEvent
@@ -28,6 +31,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import java.net.URI
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.UUID
 
@@ -105,6 +109,31 @@ class Cas3v2DomainEventBuilder(
           notes = "",
           bookedBy = populateStaffMember(user),
         ),
+      ),
+    )
+  }
+
+  fun getPremisesUnarchiveEvent(
+    premises: Cas3PremisesEntity,
+    currentStartDate: LocalDate,
+    newStartDate: LocalDate,
+    currentEndDate: LocalDate,
+    user: UserEntity,
+  ): DomainEvent<CAS3PremisesUnarchiveEvent> {
+    val domainEventId = UUID.randomUUID()
+
+    return DomainEvent(
+      id = domainEventId,
+      applicationId = null,
+      bookingId = null,
+      crn = null,
+      nomsNumber = null,
+      occurredAt = Instant.now(),
+      data = CAS3PremisesUnarchiveEvent(
+        id = domainEventId,
+        timestamp = Instant.now(),
+        eventType = EventType.premisesUnarchived,
+        eventDetails = buildCAS3PremisesUnarchiveEventDetails(premises, currentStartDate, newStartDate, currentEndDate, user),
       ),
     )
   }
@@ -304,6 +333,20 @@ class Cas3v2DomainEventBuilder(
     applicationUrl = application.toUrl(),
     reasonDetail = null,
     recordedBy = user?.let { populateStaffMember(it) },
+  )
+
+  private fun buildCAS3PremisesUnarchiveEventDetails(
+    premises: Cas3PremisesEntity,
+    currentStartDate: LocalDate,
+    newStartDate: LocalDate,
+    currentEndDate: LocalDate,
+    user: UserEntity,
+  ) = CAS3PremisesUnarchiveEventDetails(
+    premisesId = premises.id,
+    userId = user.id,
+    currentStartDate = currentStartDate,
+    newStartDate = newStartDate,
+    currentEndDate = currentEndDate,
   )
 
   private fun populateStaffMember(it: UserEntity) = StaffMember(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
@@ -2,17 +2,35 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesRepository
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
 class Cas3v2PremisesService(
   private val cas3PremisesRepository: Cas3PremisesRepository,
   private val cas3BedspacesRepository: Cas3BedspacesRepository,
+  private val cas3v2DomainEventService: Cas3v2DomainEventService,
 ) {
   fun getPremises(premisesId: UUID): Cas3PremisesEntity? = cas3PremisesRepository.findByIdOrNull(premisesId)
   fun findBedspace(premisesId: UUID, bedspaceId: UUID): Cas3BedspacesEntity? = cas3BedspacesRepository.findCas3Bedspace(premisesId = premisesId, bedspaceId = bedspaceId)
+
+  fun unarchivePremisesAndSaveDomainEvent(premises: Cas3PremisesEntity, restartDate: LocalDate) {
+    val currentStartDate = premises.startDate
+    val currentEndDate = premises.endDate!!
+    premises.startDate = restartDate
+    premises.endDate = null
+    premises.status = PropertyStatus.active
+    cas3PremisesRepository.save(premises)
+    cas3v2DomainEventService.savePremisesUnarchiveEvent(
+      premises,
+      currentStartDate,
+      newStartDate = restartDate,
+      currentEndDate,
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
@@ -4,6 +4,8 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Characteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
@@ -15,6 +17,7 @@ import java.util.UUID
 @Service
 class CharacteristicService(
   val characteristicRepository: CharacteristicRepository,
+  val bedspaceCharacteristicRepository: Cas3BedspaceCharacteristicRepository,
 ) {
   fun getCharacteristic(characteristicId: UUID): CharacteristicEntity? = characteristicRepository.findByIdOrNull(characteristicId)
 
@@ -31,6 +34,8 @@ class CharacteristicService(
       else -> return false
     }
   }
+
+  fun getCas3BedspaceCharacteristic(characteristicId: UUID): Cas3BedspaceCharacteristicEntity? = bedspaceCharacteristicRepository.findByIdOrNull(characteristicId)
 
   fun getCas3Characteristics(): List<CharacteristicEntity> = characteristicRepository.findActiveByServiceScopeAndModelScope(
     ServiceName.temporaryAccommodation.value,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -43,6 +43,16 @@ class UserAccessService(
     else -> false
   }
 
+  fun currentUserCanViewPremises(premises: Cas3PremisesEntity): Boolean {
+    val user = userService.getUserForRequest()
+    return userCanAccessRegion(
+      user,
+      ServiceName.temporaryAccommodation,
+      premises.probationDeliveryUnit.probationRegion.id,
+    ) &&
+      user.hasRole(UserRole.CAS3_ASSESSOR)
+  }
+
   fun currentUserCanManagePremises(premises: PremisesEntity) = userCanManagePremises(userService.getUserForRequest(), premises)
 
   fun userCanManagePremises(user: UserEntity, premises: PremisesEntity) = when (premises) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BedspaceEntityFactory.kt
@@ -51,6 +51,10 @@ class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
     this.endDate = { endDate }
   }
 
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
   @SuppressWarnings("TooGenericExceptionThrown")
   override fun produce(): Cas3BedspacesEntity = Cas3BedspacesEntity(
     id = this.id(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3PremisesEntityFactory.kt
@@ -89,6 +89,14 @@ class Cas3PremisesEntityFactory : Factory<Cas3PremisesEntity> {
       .produce(),
   )
 
+  fun withStartDate(startDate: LocalDate) = apply {
+    this.startDate = { startDate }
+  }
+
+  fun withEndDate(endDate: LocalDate?) = apply {
+    this.endDate = { endDate }
+  }
+
   fun withCharacteristics(characteristics: MutableList<Cas3PremisesCharacteristicEntity>) = apply {
     this.characteristics = { characteristics }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenACas3Premises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenACas3Premises.kt
@@ -10,12 +10,19 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
 import java.util.UUID
 
-fun IntegrationTestBase.givenACas3Premises(probationRegion: ProbationRegionEntity) = givenACas3Premises(
+fun IntegrationTestBase.givenACas3Premises(
+  probationRegion: ProbationRegionEntity,
+  status: PropertyStatus = randomOf(PropertyStatus.entries),
+  endDate: LocalDate? = null,
+) = givenACas3Premises(
   probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
     withProbationRegion(probationRegion)
   },
+  status = status,
+  endDate = endDate,
 )
 
 fun IntegrationTestBase.givenACas3Premises(
@@ -28,6 +35,8 @@ fun IntegrationTestBase.givenACas3Premises(
   postCode: String = randomPostCode(),
   characteristics: List<Cas3PremisesCharacteristicEntity> = emptyList(),
   id: UUID = UUID.randomUUID(),
+  startDate: LocalDate = LocalDate.now().minusDays(180),
+  endDate: LocalDate? = null,
 ): Cas3PremisesEntity = cas3PremisesEntityFactory
   .produceAndPersist {
     withId(id)
@@ -37,4 +46,6 @@ fun IntegrationTestBase.givenACas3Premises(
     withStatus(status)
     withPostcode(postCode)
     withCharacteristics(characteristics.toMutableList())
+    withStartDate(startDate)
+    withEndDate(endDate)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspacesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspacesTest.kt
@@ -1,0 +1,222 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.Cas3IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenACas3Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3NewBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas3v2BedspacesTest : Cas3IntegrationTestBase() {
+
+  @Nested
+  inner class CreateBedspace {
+    @Test
+    fun `Create new bedspace for Premises returns 201 Created with correct body`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = givenACas3Premises(
+          user.probationRegion,
+          status = PropertyStatus.active,
+        )
+        val bedspaceCharacteristics = cas3BedspaceCharacteristicEntityFactory.produceAndPersistMultiple(5)
+        val newBedspace = Cas3NewBedspace(
+          reference = randomStringMultiCaseWithNumbers(10),
+          startDate = LocalDate.now(),
+          characteristicIds = bedspaceCharacteristics.map { it.id },
+          notes = randomStringLowerCase(100),
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bedspaces")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newBedspace)
+          .exchange()
+          .expectStatus()
+          .isCreated
+          .expectBody()
+          .jsonPath("reference").isEqualTo(newBedspace.reference)
+          .jsonPath("startDate").isEqualTo(newBedspace.startDate.toString())
+          .jsonPath("notes").isEqualTo(newBedspace.notes.toString())
+          .jsonPath("bedspaceCharacteristics[*].id").isEqualTo(bedspaceCharacteristics.map { it.id.toString() })
+          .jsonPath("bedspaceCharacteristics[*].name").isEqualTo(bedspaceCharacteristics.map { it.name })
+      }
+    }
+
+    @Test
+    fun `Create new bedspace in a scheduled to archive premises returns 201 Created with correct body and unarchive the premises`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = givenACas3Premises(
+          user.probationRegion,
+          status = PropertyStatus.archived,
+          endDate = LocalDate.now().plusDays(3),
+        )
+        val bedspaceCharacteristics = cas3BedspaceCharacteristicEntityFactory.produceAndPersistMultiple(5)
+        val newBedspace = Cas3NewBedspace(
+          reference = randomStringMultiCaseWithNumbers(10),
+          startDate = LocalDate.now().minusDays(2),
+          characteristicIds = bedspaceCharacteristics.map { it.id },
+          notes = randomStringLowerCase(100),
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bedspaces")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newBedspace)
+          .exchange()
+          .expectStatus()
+          .isCreated
+          .expectBody()
+          .jsonPath("reference").isEqualTo(newBedspace.reference)
+          .jsonPath("startDate").isEqualTo(LocalDate.now())
+          .jsonPath("notes").isEqualTo(newBedspace.notes.toString())
+          .jsonPath("bedspaceCharacteristics[*].id").isEqualTo(bedspaceCharacteristics.map { it.id.toString() })
+          .jsonPath("bedspaceCharacteristics[*].name").isEqualTo(bedspaceCharacteristics.map { it.name })
+
+        // verify premises is unarchived
+        val updatedPremises = cas3PremisesRepository.findById(premises.id).get()
+        assertThat(updatedPremises.status).isEqualTo(PropertyStatus.active)
+        assertThat(updatedPremises.startDate).isEqualTo(newBedspace.startDate)
+        assertThat(updatedPremises.endDate).isNull()
+
+        val premisesUnarchiveDomainEvents = domainEventRepository.findByCas3PremisesIdAndType(premises.id, DomainEventType.CAS3_PREMISES_UNARCHIVED)
+        assertThat(premisesUnarchiveDomainEvents).isNotNull()
+        assertThat(premisesUnarchiveDomainEvents.size).isEqualTo(1)
+      }
+    }
+
+    @Test
+    fun `When a new bedspace is created with no notes then it defaults to empty`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = givenACas3Premises(
+          user.probationRegion,
+          status = PropertyStatus.active,
+        )
+        val newBedspace = Cas3NewBedspace(
+          reference = randomStringMultiCaseWithNumbers(10),
+          startDate = LocalDate.now(),
+          characteristicIds = emptyList(),
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bedspaces")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newBedspace)
+          .exchange()
+          .expectStatus()
+          .isCreated
+          .expectBody()
+          .jsonPath("notes").isEmpty()
+      }
+    }
+
+    @Test
+    fun `When create a new bedspace without a reference returns 400`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = givenACas3Premises(
+          user.probationRegion,
+          status = PropertyStatus.active,
+        )
+        val newBedspace = Cas3NewBedspace(
+          reference = "",
+          startDate = LocalDate.now(),
+          characteristicIds = emptyList(),
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bedspaces")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newBedspace)
+          .exchange()
+          .expectStatus()
+          .is4xxClientError
+          .expectBody()
+          .jsonPath("title").isEqualTo("Bad Request")
+          .jsonPath("invalid-params[0].propertyName").isEqualTo("$.reference")
+          .jsonPath("invalid-params[0].errorType").isEqualTo("empty")
+      }
+    }
+
+    @Test
+    fun `When create a new bedspace with start date before premises start date returns 400`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = givenACas3Premises(
+          user.probationRegion,
+          status = PropertyStatus.active,
+        )
+        val newBedspace = Cas3NewBedspace(
+          reference = "",
+          startDate = premises.startDate.minusDays(3),
+          characteristicIds = emptyList(),
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bedspaces")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newBedspace)
+          .exchange()
+          .expectStatus()
+          .isBadRequest
+          .expectBody()
+          .jsonPath("$.title").isEqualTo("Bad Request")
+          .jsonPath("$.invalid-params[0].propertyName").isEqualTo("$.startDate")
+          .jsonPath("$.invalid-params[0].errorType").isEqualTo("startDateBeforePremisesStartDate")
+          .jsonPath("$.invalid-params[0].entityId").isEqualTo(premises.id.toString())
+          .jsonPath("$.invalid-params[0].value").isEqualTo(premises.startDate.toString())
+      }
+    }
+
+    @Test
+    fun `When create a new bedspace with an unknown characteristic returns 400`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = givenACas3Premises(
+          user.probationRegion,
+          status = PropertyStatus.active,
+        )
+        val newBedspace = Cas3NewBedspace(
+          reference = randomStringMultiCaseWithNumbers(7),
+          startDate = LocalDate.now(),
+          characteristicIds = mutableListOf(UUID.randomUUID()),
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bedspaces")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newBedspace)
+          .exchange()
+          .expectStatus()
+          .is4xxClientError
+          .expectBody()
+          .jsonPath("title").isEqualTo("Bad Request")
+          .jsonPath("invalid-params[0].errorType").isEqualTo("doesNotExist")
+      }
+    }
+
+    @Test
+    fun `Create new bedspace for a Premises that's not in the user's region returns 403 Forbidden`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { _, jwt ->
+        val premises = givenACas3Premises()
+        val newBedspace = Cas3NewBedspace(
+          reference = randomStringMultiCaseWithNumbers(10),
+          startDate = LocalDate.now(),
+          characteristicIds = emptyList(),
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises/${premises.id}/bedspaces")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newBedspace)
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BedspaceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BedspaceServiceTest.kt
@@ -1,0 +1,255 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.service.v2
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2BedspacesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas3v2BedspaceServiceTest {
+  private val mockCharacteristicServiceMock = mockk<CharacteristicService>()
+  private val mockCas3BedspacesRepository = mockk<Cas3BedspacesRepository>()
+  private val mockCas3v2PremisesService = mockk<Cas3v2PremisesService>()
+
+  private val cas3v2BedspacesService = Cas3v2BedspacesService(
+    mockCharacteristicServiceMock,
+    mockCas3BedspacesRepository,
+    mockCas3v2PremisesService,
+  )
+
+  @Nested
+  inner class CreateBedspace {
+    @Test
+    fun `When create a new bedspace returns Success with correct result when validation passed`() {
+      val (premises, bedspace) = createPremisesAndBedspace(
+        bedspaceStartDate = LocalDate.now().plusDays(5),
+      )
+
+      every { mockCas3BedspacesRepository.save(any()) } returns bedspace
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = bedspace.reference,
+        startDate = bedspace.startDate!!,
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.reference).isEqualTo(bedspace.reference)
+        assertThat(it.notes).isEqualTo(bedspace.notes)
+        assertThat(it.startDate).isEqualTo(bedspace.startDate)
+        assertThat(it.endDate).isEqualTo(bedspace.endDate)
+      }
+    }
+
+    @Test
+    fun `When create a new bedspace in a scheduled to archive premises returns Success and unarchive the premises`() {
+      val bedspaceStartDate = LocalDate.now().plusDays(5)
+      val (premises, bedspace) = createPremisesAndBedspace(
+        premisesStatus = PropertyStatus.archived,
+        premisesEndDate = LocalDate.now().plusDays(2),
+        bedspaceStartDate,
+      )
+
+      every { mockCas3BedspacesRepository.save(any()) } returns bedspace
+      every { mockCas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(any(), any()) } returns Unit
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = bedspace.reference,
+        startDate = bedspace.startDate!!,
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.reference).isEqualTo(bedspace.reference)
+        assertThat(it.notes).isEqualTo(bedspace.notes)
+        assertThat(it.startDate).isEqualTo(bedspace.startDate)
+        assertThat(it.endDate).isEqualTo(bedspace.endDate)
+      }
+
+      verify { mockCas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(eq(premises), eq(bedspaceStartDate)) }
+    }
+
+    @Test
+    fun `When create a new bedspace with empty bedspace reference returns FieldValidationError with the correct message`() {
+      val premises = createPremises(status = PropertyStatus.active)
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = "",
+        startDate = LocalDate.now().minusDays(7),
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.reference", "empty")
+    }
+
+    @Test
+    fun `When create a new bedspace with a start date more than 7 days in the past returns FieldValidationError with the correct message`() {
+      val premises = createPremises(status = PropertyStatus.active)
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = randomStringMultiCaseWithNumbers(10),
+        startDate = LocalDate.now().minusDays(10),
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.startDate", "invalidStartDateInThePast")
+    }
+
+    @Test
+    fun `When create a new bedspace with a start date more than 7 days in the future returns FieldValidationError with the correct message`() {
+      val premises = createPremises(status = PropertyStatus.active)
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = randomStringMultiCaseWithNumbers(10),
+        startDate = LocalDate.now().plusDays(15),
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.startDate", "invalidStartDateInTheFuture")
+    }
+
+    @Test
+    fun `When create a new bedspace with a start date before premises start date returns FieldValidationError with the correct message`() {
+      val premises = createPremises(status = PropertyStatus.active)
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = randomStringMultiCaseWithNumbers(10),
+        startDate = premises.startDate.minusDays(5),
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isCas3FieldValidationError().hasMessage("$.startDate", premises.id.toString(), "startDateBeforePremisesStartDate", premises.startDate.toString())
+    }
+
+    @Test
+    fun `When create a new bedspace with a non exist characteristic returns FieldValidationError with the correct message`() {
+      val premises = createPremises(status = PropertyStatus.active)
+
+      val nonExistCharacteristicId = UUID.randomUUID()
+
+      every { mockCharacteristicServiceMock.getCas3BedspaceCharacteristic(nonExistCharacteristicId) } returns null
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = randomStringMultiCaseWithNumbers(10),
+        startDate = LocalDate.now().plusDays(3),
+        notes = null,
+        characteristicIds = listOf(nonExistCharacteristicId),
+      )
+
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.characteristics[0]", "doesNotExist")
+    }
+
+    @Test
+    fun `When create a new bedspace with reference less than 3 characters returns FieldValidationError with the correct message`() {
+      val premises = Cas3PremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = "AB",
+        startDate = LocalDate.now().minusDays(1),
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.reference", "bedspaceReferenceNotMeetMinimumLength")
+    }
+
+    @Test
+    fun `When create a new bedspace with reference containing only special characters returns FieldValidationError with the correct message`() {
+      val premises = Cas3PremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = "!@#$%",
+        startDate = LocalDate.now().minusDays(1),
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.reference", "bedspaceReferenceMustIncludeLetterOrNumber")
+    }
+
+    @Test
+    fun `When create a new bedspace with duplicate reference returns FieldValidationError with the correct message`() {
+      val premises = Cas3PremisesEntityFactory()
+        .withDefaults()
+        .produce()
+
+      val existingBedspace = Cas3BedspaceEntityFactory()
+        .withPremises(premises)
+        .withReference("EXISTING_REF")
+        .produce()
+
+      premises.bedspaces.add(existingBedspace)
+
+      val result = cas3v2BedspacesService.createBedspace(
+        premises,
+        bedspaceReference = "existing_ref",
+        startDate = LocalDate.now().minusDays(1),
+        notes = null,
+        characteristicIds = emptyList(),
+      )
+
+      assertThatCasResult(result).isFieldValidationError().hasMessage("$.reference", "bedspaceReferenceExists")
+    }
+  }
+
+  private fun createPremisesAndBedspace(
+    premisesStatus: PropertyStatus = PropertyStatus.active,
+    premisesEndDate: LocalDate? = null,
+    bedspaceStartDate: LocalDate = LocalDate.now(),
+    bedspaceEndDate: LocalDate? = null,
+  ): Pair<Cas3PremisesEntity, Cas3BedspacesEntity> {
+    val premises = createPremises(status = premisesStatus, endDate = premisesEndDate)
+    val bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withStartDate(bedspaceStartDate)
+      .withEndDate(bedspaceEndDate)
+      .produce()
+    return Pair(premises, bedspace)
+  }
+
+  private fun createPremises(
+    id: UUID = UUID.randomUUID(),
+    status: PropertyStatus = PropertyStatus.active,
+    startDate: LocalDate = LocalDate.now().minusDays(180),
+    endDate: LocalDate? = null,
+  ) = Cas3PremisesEntityFactory()
+    .withDefaults()
+    .withId(id)
+    .withStatus(status)
+    .withStartDate(startDate)
+    .withEndDate(endDate)
+    .produce()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2PremisesServiceTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.service.v2
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2DomainEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2PremisesService
+import java.time.LocalDate
+
+class Cas3v2PremisesServiceTest {
+  private val mockPremisesRepository = mockk<Cas3PremisesRepository>()
+  private val mockCas3BedspacesRepository = mockk<Cas3BedspacesRepository>()
+  private val mockCas3DomainEventService = mockk<Cas3v2DomainEventService>()
+
+  private val cas3v2PremisesService = Cas3v2PremisesService(
+    mockPremisesRepository,
+    mockCas3BedspacesRepository,
+    mockCas3DomainEventService,
+  )
+
+  @Nested
+  inner class UnarchivePremises {
+    @Test
+    fun `When get a bedspace returns Success with correct result when validation passed`() {
+      val startDate = LocalDate.now().plusDays(1)
+      val endDate = LocalDate.now().plusDays(100)
+      val restartDate = LocalDate.now().plusDays(5)
+      val premises = Cas3PremisesEntityFactory()
+        .withDefaults()
+        .withStatus(PropertyStatus.archived)
+        .withNotes("test notes")
+        .withStartDate(startDate)
+        .withEndDate(endDate)
+        .produce()
+
+      val updatedPremises = premises.copy(
+        status = PropertyStatus.active,
+        startDate = restartDate,
+        endDate = null,
+      )
+
+      every { mockPremisesRepository.save(match { it.id == premises.id }) } returns updatedPremises
+      every { mockCas3DomainEventService.savePremisesUnarchiveEvent(eq(updatedPremises), premises.startDate, restartDate, premises.endDate!!) } returns Unit
+
+      cas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(premises, restartDate)
+
+      val slot = slot<Cas3PremisesEntity>()
+      verify(exactly = 1) {
+        mockPremisesRepository.save(capture(slot))
+      }
+
+      val savedPremises = slot.captured
+      assertAll(
+        { assertThat(savedPremises.id).isEqualTo(premises.id) },
+        { assertThat(savedPremises.notes).isEqualTo(premises.notes) },
+        { assertThat(savedPremises.status).isEqualTo(PropertyStatus.active) },
+        { assertThat(savedPremises.startDate).isEqualTo(restartDate) },
+        { assertThat(savedPremises.endDate).isNull() },
+      )
+
+      verify(exactly = 1) {
+        mockCas3DomainEventService.savePremisesUnarchiveEvent(eq(premises), eq(startDate), eq(restartDate), eq(endDate))
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.transformer
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -63,14 +62,18 @@ class Cas3BedspaceTransformerTest {
     )
   }
 
-  @Test
-  fun `transformJpaToApi transforms the BedspaceEntity into Cas3Bedspace correctly`() {
+  @ParameterizedTest
+  @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.transformer.Cas3BedspaceTransformerTest#startDateAndStatusProvider")
+  fun `transformJpaToApi transforms the BedspaceEntity into Cas3Bedspace correctly`(startDate: LocalDate) {
     val premises = Cas3PremisesEntityFactory()
       .withDefaults()
       .produce()
 
     val bedspace = Cas3BedspaceEntityFactory()
       .withPremises(premises)
+      .withStartDate(startDate)
+      .withEndDate(startDate.plusDays(180))
+      .withCreatedAt(OffsetDateTime.now().minusDays(100))
       .produce()
 
     val result = cas3BedspaceTransformer.transformJpaToApi(bedspace, Cas3BedspaceStatus.online)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -52,6 +52,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.repository.Cas2Stat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.repository.ExternalUserTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.repository.NomisUserTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceCharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3CancellationEntityFactory
@@ -70,6 +71,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3ArrivalEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3CancellationEntity
@@ -291,6 +294,9 @@ import java.util.UUID
 @ActiveProfiles("test")
 @Tag("integration")
 abstract class IntegrationTestBase {
+  @Autowired
+  private lateinit var cas3BedspaceCharacteristicRepository: Cas3BedspaceCharacteristicRepository
+
   @Autowired
   lateinit var cas1SpaceBookingRepository: Cas1SpaceBookingRepository
 
@@ -643,6 +649,7 @@ abstract class IntegrationTestBase {
   lateinit var assessmentClarificationNoteEntityFactory: PersistedFactory<AssessmentClarificationNoteEntity, UUID, AssessmentClarificationNoteEntityFactory>
   lateinit var assessmentReferralHistoryUserNoteEntityFactory: PersistedFactory<AssessmentReferralHistoryUserNoteEntity, UUID, AssessmentReferralHistoryUserNoteEntityFactory>
   lateinit var assessmentReferralHistorySystemNoteEntityFactory: PersistedFactory<AssessmentReferralHistorySystemNoteEntity, UUID, AssessmentReferralHistorySystemNoteEntityFactory>
+  lateinit var cas3BedspaceCharacteristicEntityFactory: PersistedFactory<Cas3BedspaceCharacteristicEntity, UUID, Cas3BedspaceCharacteristicEntityFactory>
   lateinit var characteristicEntityFactory: PersistedFactory<CharacteristicEntity, UUID, CharacteristicEntityFactory>
   lateinit var roomEntityFactory: PersistedFactory<RoomEntity, UUID, RoomEntityFactory>
   lateinit var bedEntityFactory: PersistedFactory<BedEntity, UUID, BedEntityFactory>
@@ -761,6 +768,7 @@ abstract class IntegrationTestBase {
     assessmentClarificationNoteEntityFactory = PersistedFactory({ AssessmentClarificationNoteEntityFactory() }, assessmentClarificationNoteRepository)
     assessmentReferralHistoryUserNoteEntityFactory = PersistedFactory({ AssessmentReferralHistoryUserNoteEntityFactory() }, assessmentReferralUserNoteRepository)
     assessmentReferralHistorySystemNoteEntityFactory = PersistedFactory({ AssessmentReferralHistorySystemNoteEntityFactory() }, assessmentReferralSystemNoteRepository)
+    cas3BedspaceCharacteristicEntityFactory = PersistedFactory({ Cas3BedspaceCharacteristicEntityFactory() }, cas3BedspaceCharacteristicRepository)
     characteristicEntityFactory = PersistedFactory({ CharacteristicEntityFactory() }, characteristicRepository)
     roomEntityFactory = PersistedFactory({ RoomEntityFactory() }, roomRepository)
     bedEntityFactory = PersistedFactory({ BedEntityFactory() }, bedRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CharacteristicServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CharacteristicServiceTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
@@ -17,8 +18,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicSe
 
 class CharacteristicServiceTest {
   private val characteristicRepository = mockk<CharacteristicRepository>()
-
-  private val characteristicService = CharacteristicService(characteristicRepository)
+  private val bedspaceCharacteristicRepository = mockk<Cas3BedspaceCharacteristicRepository>()
+  private val characteristicService = CharacteristicService(characteristicRepository, bedspaceCharacteristicRepository)
 
   @Test
   fun `serviceScopeMatches returns false if the characteristic has the wrong service scope`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -215,6 +215,32 @@ class UserAccessServiceTest {
   }
 
   @Test
+  fun `currentUserCanViewPremises returns true if the given premises is a Cas3Premises and the user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.currentUserCanViewPremises(cas3PremisesInUserRegion)).isTrue
+  }
+
+  @Test
+  fun `currentUserCanViewPremises returns false if the given premises is a Cas3Premises and the user has the CAS3_ASSESSOR role and cannot access the premises's probation region`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
+
+    assertThat(userAccessService.currentUserCanViewPremises(temporaryAccommodationPremisesNotInUserRegion)).isFalse
+  }
+
+  @Test
+  fun `currentUserCanViewPremises returns false if the given premises is a Cas3Premises and the user does not have a suitable role`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    assertThat(userAccessService.currentUserCanViewPremises(cas3PremisesInUserRegion)).isFalse
+    assertThat(userAccessService.currentUserCanViewPremises(cas3PremisesNotInUserRegion)).isFalse
+  }
+
+  @Test
   fun `currentUserCanViewPremises returns true if the given premises is a Temporary Accommodation premises and the current user has the CAS3_ASSESSOR role and can access the premises's probation region`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 


### PR DESCRIPTION
**New endpoint delivered**
<img width="2048" height="1152" alt="swags" src="https://github.com/user-attachments/assets/891fecaf-c290-4d62-bfde-25db9798715a" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `POST /cas3/v2/premises/{premisesId}/bedspaces`
2. This endpoint was modelled on the `POST /cas3/premises/{premisesId}/bedspaces` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models
