### PR TITLE
CAS-1975 Premises search filtering by archived premises

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -71,7 +71,7 @@ SELECT
           )
         AND (
           (:premisesStatus = 'active' AND (tap.end_date IS NULL OR tap.end_date > CURRENT_DATE))
-          OR (:premisesStatus = 'archived' AND tap.end_date IS NOT NULL AND tap.end_date <= CURRENT_DATE)
+          OR (:premisesStatus = 'archived' AND (tap.end_date IS NOT NULL AND tap.end_date <= CURRENT_DATE) OR tap.start_date > CURRENT_DATE)
           OR (:premisesStatus IS NULL)
         )
       """,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesSearchTest.kt
@@ -275,6 +275,21 @@ class Cas3PremisesSearchTest : Cas3IntegrationTestBase() {
       }
 
       allPremises.addAll(archivedPremises)
+
+      val archivedPremisesWithStartDateInTheFuture = getListPremisesByStatus(
+        probationRegion = probationRegion,
+        probationDeliveryUnit = probationDeliveryUnit,
+        localAuthorityArea = localAuthorityArea,
+        numberOfPremises = 3,
+        propertyStatus = PropertyStatus.archived,
+        startDate = LocalDate.now().plusDays(3),
+      ).map { premises ->
+        val upcomingBedspacesSearchResult = createBedspacesAndBedspacesSearchResult(premises, Cas3BedspaceStatus.upcoming)
+        premisesSearchResult.add(createPremisesSearchResult(premises, (upcomingBedspacesSearchResult)))
+        premises
+      }
+
+      allPremises.addAll(archivedPremisesWithStartDateInTheFuture)
     }
 
     val premisesSearchResults = Cas3PremisesSearchResults(


### PR DESCRIPTION
This [PR CAS-1975 ](https://dsdmoj.atlassian.net/browse/CAS-1975) is to return a premises that is scheduled to be unarchived on a date later than today when searching for archived premises.