### PR TITLE
CAS3 V2 Get Bedspaces API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
@@ -61,4 +61,6 @@ interface Cas3BedspacesRepository : JpaRepository<Cas3BedspacesEntity, UUID> {
   """,
   )
   fun findArchivedBedspaceByBedspaceIdAndDate(bedspaceId: UUID, endDate: LocalDate): Cas3BedspacesEntity?
+
+  fun findByPremisesId(premisesId: UUID): List<Cas3BedspacesEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventService.kt
@@ -42,6 +42,7 @@ import uk.gov.justice.hmpps.sqs.MissingTopicException
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.UUID
 import kotlin.reflect.KClass
 
 @SuppressWarnings("TooManyFunctions", "TooGenericExceptionThrown", "")
@@ -286,4 +287,14 @@ class Cas3v2DomainEventService(
     CAS3BedspaceUnarchiveEvent::class -> DomainEventType.CAS3_BEDSPACE_UNARCHIVED
     else -> throw RuntimeException("Unrecognised domain event type: ${type.qualifiedName}")
   }
+
+  fun getBedspacesActiveDomainEvents(ids: List<UUID>, bedspaceDomainEventTypes: List<DomainEventType>): List<DomainEventEntity> = domainEventRepository.findBedspacesActiveDomainEventsByType(
+    cas3BedspaceIds = ids,
+    bedspaceDomainEventTypes = bedspaceDomainEventTypes.map { it.toString() },
+  )
+
+  fun getBedspaceActiveDomainEvents(id: UUID, bedspaceDomainEventTypes: List<DomainEventType>): List<DomainEventEntity> = domainEventRepository.findBedspacesActiveDomainEventsByType(
+    listOf(id),
+    bedspaceDomainEventTypes.map { it.toString() },
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
@@ -32,6 +32,7 @@ class Cas3BedspaceTransformer(
     reference = jpa.reference,
     startDate = jpa.createdAt.toLocalDate(),
     endDate = jpa.endDate,
+    scheduleUnarchiveDate = isBedspaceScheduledToUnarchive(jpa),
     notes = jpa.notes,
     status = status,
     bedspaceCharacteristics = jpa.characteristics.map(cas3BedspaceCharacteristicTransformer::transformJpaToApi),
@@ -45,4 +46,5 @@ class Cas3BedspaceTransformer(
   )
 
   fun isBedspaceScheduledToUnarchive(bedspace: BedEntity) = bedspace.startDate?.takeIf { it.isAfter(LocalDate.now()) }
+  fun isBedspaceScheduledToUnarchive(bedspace: Cas3BedspacesEntity) = bedspace.startDate?.takeIf { it.isAfter(LocalDate.now()) }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
@@ -65,28 +65,31 @@ class Cas3BedspaceTransformerTest {
 
   @ParameterizedTest
   @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.transformer.Cas3BedspaceTransformerTest#startDateAndStatusProvider")
-  fun `transformJpaToApi transforms the BedspaceEntity into Cas3Bedspace correctly`(startDate: LocalDate) {
+  fun `transformJpaToApi transforms the BedspaceEntity into Cas3Bedspace correctly`(startDate: LocalDate, status: Cas3BedspaceStatus, scheduledUnarchiveDate: LocalDate?) {
     val premises = Cas3PremisesEntityFactory()
       .withDefaults()
       .produce()
 
     val bedspace = Cas3BedspaceEntityFactory()
       .withPremises(premises)
+      .withReference(randomStringMultiCaseWithNumbers(10))
+      .withNotes(randomStringLowerCase(100))
       .withStartDate(startDate)
       .withEndDate(startDate.plusDays(180))
       .withCreatedAt(OffsetDateTime.now().minusDays(100))
       .produce()
 
-    val result = cas3BedspaceTransformer.transformJpaToApi(bedspace, Cas3BedspaceStatus.online)
+    val result = cas3BedspaceTransformer.transformJpaToApi(bedspace, status)
 
     assertThat(result).isEqualTo(
       Cas3Bedspace(
         id = bedspace.id,
         reference = bedspace.reference,
-        startDate = bedspace.createdAt!!.toLocalDate(),
+        startDate = bedspace.createdAt.toLocalDate(),
         endDate = bedspace.endDate,
         notes = bedspace.notes,
-        status = Cas3BedspaceStatus.online,
+        scheduleUnarchiveDate = scheduledUnarchiveDate,
+        status = status,
         bedspaceCharacteristics = bedspace.characteristics.map(cas3BedspaceCharacteristicTransformer::transformJpaToApi),
       ),
     )


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" height="1152" alt="Screenshot 2025-09-11 at 12 47 34 (2)" src="https://github.com/user-attachments/assets/096fcf86-d95b-4508-8250-5ffc9d823215" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `GET /cas3/v2/premises/{premisesId}/bedspaces`
2. This endpoint was modelled on the `GET /cas3/premises/{premisesId}/bedspaces` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models
