### PR TITLE
CAS-1969 Change the logic to determine if a bedspace is archived or upcoming

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -1609,15 +1609,7 @@ class Cas3PremisesService(
     Cas3PremisesStatus.online -> PropertyStatus.active.toString()
   }
 
-  private fun isCas3BedspaceArchived(bedspace: BedEntity) = (bedspace.endDate != null && bedspace.endDate!! <= LocalDate.now()) ||
-    (
-      bedspace.startDate!! > LocalDate.now() &&
-        cas3DomainEventService.getBedspaceActiveDomainEvents(bedspace.id, listOf(DomainEventType.CAS3_BEDSPACE_ARCHIVED)).any()
-      )
+  private fun isCas3BedspaceArchived(bedspace: BedEntity) = (bedspace.endDate != null && bedspace.endDate!! <= LocalDate.now())
 
-  private fun isCas3BedspaceUpcoming(bedspace: BedEntity) = (bedspace.startDate?.isAfter(LocalDate.now()) ?: false) &&
-    cas3DomainEventService.getBedspaceActiveDomainEvents(
-      bedspace.id,
-      listOf(DomainEventType.CAS3_BEDSPACE_UNARCHIVED),
-    ).isEmpty()
+  private fun isCas3BedspaceUpcoming(bedspace: BedEntity) = (bedspace.startDate?.isAfter(LocalDate.now()) ?: false)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
@@ -179,7 +179,7 @@ class Cas3PremisesServiceTest {
     }
 
     @Test
-    fun `Get bedspace status returns archive status when the bedspace is scheduled to be unarchive in the future`() {
+    fun `Get bedspace status returns upcoming status when the bedspace is scheduled to be unarchive in the future`() {
       val premises = createPremisesEntity()
       val bedspaceUnarchiveDate = LocalDate.now().plusDays(3)
       val bedspace = createBedspace(premises, bedspaceUnarchiveDate)
@@ -195,7 +195,7 @@ class Cas3PremisesServiceTest {
 
       val result = premisesService.getBedspaceStatus(bedspace)
 
-      assertThat(result).isEqualTo(Cas3BedspaceStatus.archived)
+      assertThat(result).isEqualTo(Cas3BedspaceStatus.upcoming)
     }
 
     @Test


### PR DESCRIPTION
This PR is to change the logic to return if a bedspace is in upcoming or archived status. Its a temporary change until we find a better approach to deal with existing bedspaces that they don't have archive history