### PR TITLE
CAS-1976 Return the scheduled unarchive date for premises and bedspaces

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3Bedspace.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3Bedspace.kt
@@ -11,6 +11,7 @@ data class Cas3Bedspace(
   val startDate: LocalDate?,
   val status: Cas3BedspaceStatus,
   val endDate: LocalDate? = null,
+  val scheduleUnarchiveDate: LocalDate? = null,
   val notes: String? = null,
   val characteristics: List<Characteristic>? = null,
   val bedspaceCharacteristics: List<Cas3BedspaceCharacteristic>? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3Premises.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3Premises.kt
@@ -25,6 +25,7 @@ data class Cas3Premises(
   val characteristics: List<Characteristic>? = null,
   val startDate: LocalDate,
   val endDate: LocalDate? = null,
+  val scheduleUnarchiveDate: LocalDate? = null,
   val notes: String? = null,
   val turnaroundWorkingDays: Int? = null,
   val archiveHistory: List<Cas3PremisesArchiveAction>? = emptyList(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
@@ -8,27 +8,29 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CharacteristicTransformer
+import java.time.LocalDate
 
 @Component
 class Cas3BedspaceTransformer(
   private val characteristicTransformer: CharacteristicTransformer,
   private val cas3BedspaceCharacteristicTransformer: Cas3BedspaceCharacteristicTransformer,
 ) {
-  fun transformJpaToApi(bed: BedEntity, status: Cas3BedspaceStatus, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
-    id = bed.id,
-    reference = bed.room.name,
-    startDate = bed.createdAt?.toLocalDate(),
-    endDate = bed.endDate,
+  fun transformJpaToApi(bedspace: BedEntity, status: Cas3BedspaceStatus, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
+    id = bedspace.id,
+    reference = bedspace.room.name,
+    startDate = bedspace.createdAt.toLocalDate(),
+    endDate = bedspace.endDate,
+    scheduleUnarchiveDate = isBedspaceScheduledToUnarchive(bedspace),
     status = status,
-    notes = bed.room.notes,
-    characteristics = bed.room.characteristics.map(characteristicTransformer::transformJpaToApi),
+    notes = bedspace.room.notes,
+    characteristics = bedspace.room.characteristics.map(characteristicTransformer::transformJpaToApi),
     archiveHistory = archiveHistory,
   )
 
   fun transformJpaToApi(jpa: Cas3BedspacesEntity, status: Cas3BedspaceStatus, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
     id = jpa.id,
     reference = jpa.reference,
-    startDate = jpa.createdAt?.toLocalDate(),
+    startDate = jpa.createdAt.toLocalDate(),
     endDate = jpa.endDate,
     notes = jpa.notes,
     status = status,
@@ -41,4 +43,6 @@ class Cas3BedspaceTransformer(
     reference = jpa.reference,
     endDate = jpa.endDate,
   )
+
+  fun isBedspaceScheduledToUnarchive(bedspace: BedEntity) = bedspace.startDate?.takeIf { it.isAfter(LocalDate.now()) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3PremisesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3PremisesTransformer.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.Characterist
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.LocalAuthorityAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationRegionTransformer
+import java.time.LocalDate
 
 @Component
 class Cas3PremisesTransformer(
@@ -35,6 +36,7 @@ class Cas3PremisesTransformer(
     characteristics = premisesEntity.characteristics.map(characteristicTransformer::transformJpaToApi).sortedBy { it.id },
     startDate = premisesEntity.createdAt.toLocalDate(),
     endDate = premisesEntity.endDate,
+    scheduleUnarchiveDate = isPremisesScheduleToUnarchive(premisesEntity),
     status = getPremisesStatus(premisesEntity),
     notes = premisesEntity.notes,
     turnaroundWorkingDays = premisesEntity.turnaroundWorkingDays,
@@ -49,4 +51,6 @@ class Cas3PremisesTransformer(
   } else {
     Cas3PremisesStatus.online
   }
+
+  private fun isPremisesScheduleToUnarchive(premises: TemporaryAccommodationPremisesEntity) = premises.startDate.takeIf { it.isAfter(LocalDate.now()) }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -189,7 +189,13 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     )
   }
 
-  protected fun createCas3Bedspace(bed: BedEntity, room: RoomEntity, bedspaceStatus: Cas3BedspaceStatus, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
+  protected fun createCas3Bedspace(
+    bed: BedEntity,
+    room: RoomEntity,
+    bedspaceStatus: Cas3BedspaceStatus,
+    scheduleUnarchiveDate: LocalDate? = null,
+    archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList(),
+  ) = Cas3Bedspace(
     id = bed.id,
     reference = room.name,
     startDate = bed.createdAt!!.toLocalDate(),
@@ -204,6 +210,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     },
     endDate = bed.endDate,
     status = bedspaceStatus,
+    scheduleUnarchiveDate = scheduleUnarchiveDate,
     notes = room.notes,
     archiveHistory = archiveHistory,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PremisesTest.kt
@@ -1218,6 +1218,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
           premises.probationDeliveryUnit!!,
           premises.localAuthorityArea!!,
           Cas3PremisesStatus.archived,
+          premises.startDate,
           totalOnlineBedspaces = 0,
           totalUpcomingBedspaces = 0,
           totalArchivedBedspaces = 0,
@@ -1280,6 +1281,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
       probationDeliveryUnit: ProbationDeliveryUnitEntity,
       localAuthorityArea: LocalAuthorityAreaEntity,
       status: Cas3PremisesStatus,
+      scheduleUnarchiveDate: LocalDate? = null,
       totalOnlineBedspaces: Int,
       totalUpcomingBedspaces: Int,
       totalArchivedBedspaces: Int,
@@ -1299,6 +1301,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
       ),
       startDate = premises.createdAt.toLocalDate(),
       endDate = premises.endDate,
+      scheduleUnarchiveDate = scheduleUnarchiveDate,
       status = status,
       characteristics = premises.characteristics.sortedBy { it.id }.map { characteristic ->
         Characteristic(
@@ -1338,7 +1341,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
 
         // upcoming bedspaces
         val bedspaceThree = createBedspaceInPremises(premises, startDate = LocalDate.now().plusDays(5), endDate = null)
-        expectedBedspaces.add(createCas3Bedspace(bedspaceThree, bedspaceThree.room, Cas3BedspaceStatus.upcoming))
+        expectedBedspaces.add(createCas3Bedspace(bedspaceThree, bedspaceThree.room, Cas3BedspaceStatus.upcoming, bedspaceThree.startDate))
 
         // archived bedspaces
         val bedspaceFour = createBedspaceInPremises(
@@ -1408,7 +1411,7 @@ class Cas3PremisesTest : Cas3IntegrationTestBase() {
 
         // upcoming bedspaces
         val bedspaceThree = createBedspaceInPremises(premises, startDate = LocalDate.now().randomDateAfter(30), endDate = null)
-        expectedBedspaces.add(createCas3Bedspace(bedspaceThree, bedspaceThree.room, Cas3BedspaceStatus.upcoming))
+        expectedBedspaces.add(createCas3Bedspace(bedspaceThree, bedspaceThree.room, Cas3BedspaceStatus.upcoming, bedspaceThree.startDate))
 
         // archived bedspaces
         val bedspaceFour = createBedspaceInPremises(premises, startDate = LocalDate.now().minusMonths(4), endDate = LocalDate.now().minusDays(1))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
@@ -28,7 +28,7 @@ class Cas3BedspaceTransformerTest {
 
   @ParameterizedTest
   @MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.transformer.Cas3BedspaceTransformerTest#startDateAndStatusProvider")
-  fun `transformJpaToApi transforms the BedEntity into Cas3Bedspace correctly`(startDate: LocalDate, status: Cas3BedspaceStatus) {
+  fun `transformJpaToApi transforms the BedEntity into Cas3Bedspace correctly`(startDate: LocalDate, status: Cas3BedspaceStatus, scheduledUnarchiveDate: LocalDate?) {
     val premises = TemporaryAccommodationPremisesEntityFactory()
       .withUnitTestControlTestProbationAreaAndLocalAuthority()
       .produce()
@@ -55,6 +55,7 @@ class Cas3BedspaceTransformerTest {
         reference = room.name,
         startDate = bed.createdAt!!.toLocalDate(),
         endDate = bed.endDate,
+        scheduleUnarchiveDate = scheduledUnarchiveDate,
         status = status,
         notes = room.notes,
         characteristics = emptyList(),
@@ -94,9 +95,9 @@ class Cas3BedspaceTransformerTest {
   companion object {
     @JvmStatic
     fun startDateAndStatusProvider() = Stream.of(
-      Arguments.of(LocalDate.now().minusDays(90).toString(), Cas3BedspaceStatus.online),
-      Arguments.of(LocalDate.now().minusDays(300).toString(), Cas3BedspaceStatus.archived),
-      Arguments.of(LocalDate.now().plusDays(7).toString(), Cas3BedspaceStatus.upcoming),
+      Arguments.of(LocalDate.now().minusDays(90).toString(), Cas3BedspaceStatus.online, null),
+      Arguments.of(LocalDate.now().minusDays(300).toString(), Cas3BedspaceStatus.archived, null),
+      Arguments.of(LocalDate.now().plusDays(7).toString(), Cas3BedspaceStatus.upcoming, LocalDate.now().plusDays(7).toString()),
     )
   }
 }


### PR DESCRIPTION
This [PR CAS-1976](https://dsdmoj.atlassian.net/browse/CAS-1976) is to return the scheduled unarchive date for premises and bedspaces when calling the Api end points:

- GET /premises/{premisesId}
- GET /premises/{premisesId}/bedspaces/{bedspaceId}
- GET /premises/{premisesId}/bedspaces
