### PR TITLE
CAS-1978 Unarchive bedspace when the premises is online

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesUnarchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesUnarchiveEvent.kt
@@ -8,24 +8,15 @@ import java.util.UUID
 
 data class CAS3PremisesUnarchiveEvent(
   val eventDetails: CAS3PremisesUnarchiveEventDetails,
-
   override val id: UUID,
-
   override val timestamp: Instant,
-
   override val eventType: EventType,
 ) : CAS3Event
 
 data class CAS3PremisesUnarchiveEventDetails(
-
   val premisesId: UUID,
-
   val userId: UUID,
-
   val currentStartDate: LocalDate,
-
   val newStartDate: LocalDate,
-
-  val currentEndDate: LocalDate,
-
+  val currentEndDate: LocalDate?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
@@ -255,7 +255,7 @@ class Cas3DomainEventBuilder(
     premises: TemporaryAccommodationPremisesEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
-    currentEndDate: LocalDate,
+    currentEndDate: LocalDate?,
     user: UserEntity,
   ): DomainEvent<CAS3PremisesUnarchiveEvent> {
     val domainEventId = UUID.randomUUID()
@@ -488,7 +488,7 @@ class Cas3DomainEventBuilder(
     premises: PremisesEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
-    currentEndDate: LocalDate,
+    currentEndDate: LocalDate?,
     user: UserEntity,
   ) = CAS3PremisesUnarchiveEventDetails(
     premisesId = premises.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventService.kt
@@ -239,7 +239,7 @@ class Cas3DomainEventService(
   }
 
   @Transactional
-  fun savePremisesUnarchiveEvent(premises: TemporaryAccommodationPremisesEntity, currentStartDate: LocalDate, newStartDate: LocalDate, currentEndDate: LocalDate) {
+  fun savePremisesUnarchiveEvent(premises: TemporaryAccommodationPremisesEntity, currentStartDate: LocalDate, newStartDate: LocalDate, currentEndDate: LocalDate?) {
     val user = userService.getUserForRequest()
     val domainEvent = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate, user)
 


### PR DESCRIPTION
This [PR CAS-1978 ](https://dsdmoj.atlassian.net/browse/CAS-1978) is to enable schedule unarchive bedspace in a premises that is online