### PR TITLE
CAS-1978 Unarchive bedspace when the premises is online

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -1525,7 +1525,7 @@ class Cas3PremisesService(
 
   private fun unarchivePremisesAndSaveDomainEvent(premises: TemporaryAccommodationPremisesEntity, restartDate: LocalDate): TemporaryAccommodationPremisesEntity {
     val currentStartDate = premises.startDate
-    val currentEndDate = premises.endDate!!
+    val currentEndDate = premises.endDate
     premises.startDate = restartDate
     premises.endDate = null
     premises.status = PropertyStatus.active

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventBuilder.kt
@@ -117,7 +117,7 @@ class Cas3v2DomainEventBuilder(
     premises: Cas3PremisesEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
-    currentEndDate: LocalDate,
+    currentEndDate: LocalDate?,
     user: UserEntity,
   ): DomainEvent<CAS3PremisesUnarchiveEvent> {
     val domainEventId = UUID.randomUUID()
@@ -339,7 +339,7 @@ class Cas3v2DomainEventBuilder(
     premises: Cas3PremisesEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
-    currentEndDate: LocalDate,
+    currentEndDate: LocalDate?,
     user: UserEntity,
   ) = CAS3PremisesUnarchiveEventDetails(
     premisesId = premises.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventService.kt
@@ -254,7 +254,7 @@ class Cas3v2DomainEventService(
   }
 
   @Transactional
-  fun savePremisesUnarchiveEvent(premises: Cas3PremisesEntity, currentStartDate: LocalDate, newStartDate: LocalDate, currentEndDate: LocalDate) {
+  fun savePremisesUnarchiveEvent(premises: Cas3PremisesEntity, currentStartDate: LocalDate, newStartDate: LocalDate, currentEndDate: LocalDate?) {
     val user = userService.getUserForRequest()
     val domainEvent = cas3v2DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate, user)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
@@ -21,7 +21,7 @@ class Cas3v2PremisesService(
 
   fun unarchivePremisesAndSaveDomainEvent(premises: Cas3PremisesEntity, restartDate: LocalDate) {
     val currentStartDate = premises.startDate
-    val currentEndDate = premises.endDate!!
+    val currentEndDate = premises.endDate
     premises.startDate = restartDate
     premises.endDate = null
     premises.status = PropertyStatus.active

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -198,7 +198,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
   ) = Cas3Bedspace(
     id = bed.id,
     reference = room.name,
-    startDate = bed.createdAt!!.toLocalDate(),
+    startDate = bed.createdAt.toLocalDate(),
     characteristics = room.characteristics.map { characteristic ->
       Characteristic(
         id = characteristic.id,


### PR DESCRIPTION
This PR is to make current premises end date nullable for unarchive premises domain event