### PR TITLE
CAS-1980: Update archived premises end date from bedspace

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
@@ -16,6 +16,7 @@ enum class MigrationJobType(@get:JsonValue val value: String) {
   updateCas3ApplicationOffenderName("update_cas3_application_offender_name"),
   updateCas3BookingOffenderName("update_cas3_booking_offender_name"),
   updateCas3PremisesStartDate("update_cas3_premises_start_date"),
+  updateCas3ArchivedPremisesEndDate("update_cas3_archived_premises_end_date"),
   updateCas3PremisesCreatedAt("update_cas3_premises_created_at"),
   updateCas3BedspaceCreatedAt("update_cas3_bedspace_created_at"),
   updateCas3DomainEventTypeForPersonDepartedUpdated("update_cas3_domain_event_type_for_person_departed_updated"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateArchivedPremisesEndDateJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateArchivedPremisesEndDateJob.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration
+
+import jakarta.persistence.EntityManager
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+
+@Component
+class Cas3UpdateArchivedPremisesEndDateJob(
+  private val entityManager: EntityManager,
+  private val migrationLogger: MigrationLogger,
+  private val premisesRepository: PremisesRepository,
+  private val bedRepository: BedRepository,
+) : MigrationJob() {
+  override val shouldRunInTransaction = false
+
+  @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught", "NestedBlockDepth")
+  override fun process(pageSize: Int) {
+    var hasNext = true
+    var slice: Slice<TemporaryAccommodationPremisesEntity>
+    var currentSlice = setOf<String>()
+
+    try {
+      while (hasNext) {
+        migrationLogger.info("Getting page for max page size $pageSize")
+        slice = premisesRepository.findCas3ArchivedPremisesWithoutEndDate(PageRequest.of(0, pageSize))
+
+        currentSlice = slice.map { it.id.toString() }.toSet()
+
+        for (premises in slice.content) {
+          if (premises.endDate == null) {
+            migrationLogger.info("Updating archived premises end_date for premises id ${premises.id}")
+            val lastBed = bedRepository.findByRoomPremisesId(premises.id).sortedByDescending { it.endDate }.firstOrNull()
+            if (lastBed != null) {
+              premises.endDate = lastBed.endDate
+              premisesRepository.save(premises)
+              migrationLogger.info("Updated end_date for premises id ${premises.id} from bedspace end_date ${lastBed.endDate}")
+            } else {
+              migrationLogger.info("Unable to find bedspace with end_date for premises id ${premises.id}")
+            }
+          } else {
+            migrationLogger.info("Premises end_date already set for premises id ${premises.id}")
+          }
+        }
+        entityManager.clear()
+        hasNext = slice.hasNext()
+      }
+    } catch (exception: Exception) {
+      migrationLogger.error("Unable to update archived premises end_date with ids ${currentSlice.joinToString()}", exception)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PremisesEntity.kt
@@ -104,6 +104,19 @@ SELECT
     nativeQuery = true,
   )
   fun findTemporaryAccommodationPremisesByService(service: String, pageable: Pageable): Slice<TemporaryAccommodationPremisesEntity>
+
+  @Query(
+    """
+    SELECT *
+    FROM temporary_accommodation_premises tap
+    INNER JOIN premises p ON tap.premises_id = p.id
+    WHERE p.status = 'archived'
+    AND tap.end_date IS NULL
+    ORDER BY p.id
+    """,
+    nativeQuery = true,
+  )
+  fun findCas3ArchivedPremisesWithoutEndDate(pageable: Pageable): Slice<TemporaryAccommodationPremisesEntity>
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2Statu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.BookingStatusMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3MigrateNewBedspaceModelDataJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateApplicationOffenderNameJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateArchivedPremisesEndDateJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateBedspaceCreatedDateJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateBookingOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob
@@ -57,6 +58,7 @@ class MigrationJobService(
         MigrationJobType.updateCas3ApplicationOffenderName -> getBean(Cas3UpdateApplicationOffenderNameJob::class)
         MigrationJobType.updateCas3BookingOffenderName -> getBean(Cas3UpdateBookingOffenderNameJob::class)
         MigrationJobType.updateCas3PremisesStartDate -> getBean(Cas3UpdatePremisesStartDateJob::class)
+        MigrationJobType.updateCas3ArchivedPremisesEndDate -> getBean(Cas3UpdateArchivedPremisesEndDateJob::class)
         MigrationJobType.updateCas3PremisesCreatedAt -> getBean(Cas3UpdatePremisesCreatedDateJob::class)
         MigrationJobType.updateCas3BedspaceCreatedAt -> getBean(Cas3UpdateBedspaceCreatedDateJob::class)
         MigrationJobType.updateCas3DomainEventTypeForPersonDepartedUpdated -> getBean(Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob::class)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3UpdateArchivedPremisesEndDateJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3UpdateArchivedPremisesEndDateJobTest.kt
@@ -1,0 +1,163 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.migration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PropertyStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import java.time.LocalDate
+
+class Cas3UpdateArchivedPremisesEndDateJobTest : MigrationJobTestBase() {
+
+  @Autowired
+  private lateinit var premisesRepository: PremisesRepository
+
+  private fun createPremisesWithoutEndDate(user: UserEntity, status: PropertyStatus = PropertyStatus.archived): TemporaryAccommodationPremisesEntity {
+    val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+      withProbationRegion(user.probationRegion)
+    }
+
+    return temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion { user.probationRegion }
+      withProbationDeliveryUnit(probationDeliveryUnit)
+      withStatus(status)
+      withEndDate(null)
+    }
+  }
+
+  private fun createPremisesWithEndDate(user: UserEntity, endDate: LocalDate, status: PropertyStatus = PropertyStatus.archived): TemporaryAccommodationPremisesEntity {
+    val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+      withProbationRegion(user.probationRegion)
+    }
+
+    return temporaryAccommodationPremisesEntityFactory.produceAndPersist {
+      withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+      withYieldedProbationRegion { user.probationRegion }
+      withProbationDeliveryUnit(probationDeliveryUnit)
+      withStatus(status)
+      withEndDate(endDate)
+    }
+  }
+
+  @Test
+  fun `updates premises end date from the latest bedspace end date`() {
+    givenAUser { user, _ ->
+      val premises = createPremisesWithoutEndDate(user)
+
+      val earlierEndDate = LocalDate.now().plusDays(5)
+      val laterEndDate = LocalDate.now().plusDays(10)
+
+      bedEntityFactory.produceAndPersist {
+        withRoom(
+          roomEntityFactory.produceAndPersist {
+            withPremises(premises)
+          },
+        )
+        withEndDate(earlierEndDate)
+      }
+
+      bedEntityFactory.produceAndPersist {
+        withRoom(
+          roomEntityFactory.produceAndPersist {
+            withPremises(premises)
+          },
+        )
+        withEndDate(laterEndDate)
+      }
+
+      assertThat(premises.endDate).isNull()
+
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3ArchivedPremisesEndDate)
+
+      val updatedPremises = premisesRepository.findById(premises.id).get() as TemporaryAccommodationPremisesEntity
+
+      assertThat(updatedPremises.endDate).isEqualTo(laterEndDate)
+    }
+  }
+
+  @Test
+  fun `does not update premises that already have end dates`() {
+    givenAUser { user, _ ->
+      val existingEndDate = LocalDate.now().plusDays(3)
+      val premises = createPremisesWithEndDate(user, existingEndDate)
+
+      val laterEndDate = LocalDate.now().plusDays(10)
+      bedEntityFactory.produceAndPersist {
+        withRoom(
+          roomEntityFactory.produceAndPersist {
+            withPremises(premises)
+          },
+        )
+        withEndDate(laterEndDate)
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3ArchivedPremisesEndDate)
+
+      val updatedPremises = premisesRepository.findById(premises.id).get() as TemporaryAccommodationPremisesEntity
+
+      assertThat(updatedPremises.endDate).isEqualTo(existingEndDate)
+    }
+  }
+
+  @Test
+  fun `does not update premises when no bedspaces exist`() {
+    givenAUser { user, _ ->
+      val premises = createPremisesWithoutEndDate(user)
+
+      assertThat(premises.endDate).isNull()
+
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3ArchivedPremisesEndDate)
+
+      val updatedPremises = premisesRepository.findById(premises.id).get() as TemporaryAccommodationPremisesEntity
+
+      assertThat(updatedPremises.endDate).isNull()
+    }
+  }
+
+  @Test
+  fun `updates archived premises but not active premises`() {
+    givenAUser { user, _ ->
+      val archivedPremises = createPremisesWithoutEndDate(user, PropertyStatus.archived)
+      val bedEndDate = LocalDate.now().plusDays(10)
+
+      bedEntityFactory.produceAndPersist {
+        withRoom(
+          roomEntityFactory.produceAndPersist {
+            withPremises(archivedPremises)
+          },
+        )
+        withEndDate(bedEndDate)
+      }
+
+      val activePremises = createPremisesWithoutEndDate(user, PropertyStatus.active)
+
+      bedEntityFactory.produceAndPersist {
+        withRoom(
+          roomEntityFactory.produceAndPersist {
+            withPremises(activePremises)
+          },
+        )
+        withEndDate(bedEndDate)
+      }
+
+      assertThat(archivedPremises.endDate).isNull()
+      assertThat(activePremises.endDate).isNull()
+      assertThat(archivedPremises.status).isEqualTo(PropertyStatus.archived)
+      assertThat(activePremises.status).isEqualTo(PropertyStatus.active)
+
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3ArchivedPremisesEndDate)
+
+      val updatedArchivedPremises = premisesRepository.findById(archivedPremises.id).get() as TemporaryAccommodationPremisesEntity
+      val updatedActivePremises = premisesRepository.findById(activePremises.id).get() as TemporaryAccommodationPremisesEntity
+
+      assertThat(updatedArchivedPremises.endDate).isEqualTo(bedEndDate)
+      assertThat(updatedActivePremises.endDate).isNull()
+    }
+  }
+}


### PR DESCRIPTION
This Pull Request adds a new costCentre property to multiple parts of the application, including database models, services, and reporting components.

Main Changes

- Added a costCentre field in the Cas3VoidBedspaceEntity class.
- Updated the BedUsageReportGenerator to handle costCentre in various report formats.
- Modified the BedUsageReportRow to include a new costCentre field.
- Extended the Cas3PremisesService and Cas3v2VoidBedspaceService to utilize the costCentre property.
- Created a new database migration script to add the cost_centre column to the cas3_void_bedspaces table with value constraints ('SUPPLIER' or 'HMPPS').