### PR TITLE
Refactor: Rename to cas1 load error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1ProfileResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1ProfileResponse.kt
@@ -17,7 +17,7 @@ data class Cas1ProfileResponse(
         The potential error encountered while loading the profile,Null if no error occurred.
     """,
   )
-  val loadError: LoadError? = null,
+  val loadError: Cas1LoadError? = null,
 
   @Schema(
     example = "null",
@@ -27,7 +27,7 @@ data class Cas1ProfileResponse(
 ) {
 
   @Suppress("ktlint:standard:enum-entry-name-case", "EnumNaming")
-  enum class LoadError(@get:JsonValue val value: String) {
+  enum class Cas1LoadError(@get:JsonValue val value: String) {
 
     @Schema(description = "The user's staff record was not found.")
     staffRecordNotFound("staff_record_not_found"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ProfileController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ProfileController.kt
@@ -43,7 +43,7 @@ class Cas1ProfileController(
         }
       }
 
-      is UserService.GetUserResponse.StaffProbationRegionNotSupported -> Cas1ProfileResponse.LoadError.unsupportedProbationRegion
+      is UserService.GetUserResponse.StaffProbationRegionNotSupported -> Cas1ProfileResponse.Cas1LoadError.unsupportedProbationRegion
     }
 
     val responseToReturn =
@@ -61,8 +61,8 @@ class Cas1ProfileController(
   }
 
   private fun transformCas1ProfileResponseToApi(userName: String, userResponse: UserService.GetUserResponse): Cas1ProfileResponse = when (userResponse) {
-    UserService.GetUserResponse.StaffRecordNotFound -> Cas1ProfileResponse(userName, Cas1ProfileResponse.LoadError.staffRecordNotFound)
-    is UserService.GetUserResponse.StaffProbationRegionNotSupported -> Cas1ProfileResponse(userName, Cas1ProfileResponse.LoadError.unsupportedProbationRegion)
+    UserService.GetUserResponse.StaffRecordNotFound -> Cas1ProfileResponse(userName, Cas1ProfileResponse.Cas1LoadError.staffRecordNotFound)
+    is UserService.GetUserResponse.StaffProbationRegionNotSupported -> Cas1ProfileResponse(userName, Cas1ProfileResponse.Cas1LoadError.unsupportedProbationRegion)
     is UserService.GetUserResponse.Success -> Cas1ProfileResponse(userName, user = userTransformer.transformCas1JpaToApi(userResponse.user))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ProfileTest.kt
@@ -189,7 +189,7 @@ class Cas1ProfileTest : IntegrationTestBase() {
         .responseBody!!
 
       assertThat(response.deliusUsername).isEqualTo(deliusUsername)
-      assertThat(response.loadError).isEqualTo(Cas1ProfileResponse.LoadError.staffRecordNotFound)
+      assertThat(response.loadError).isEqualTo(Cas1ProfileResponse.Cas1LoadError.staffRecordNotFound)
     }
 
     @Test
@@ -357,7 +357,7 @@ class Cas1ProfileTest : IntegrationTestBase() {
           objectMapper.writeValueAsString(
             Cas1ProfileResponse(
               deliusUsername = "nonStaffUser",
-              loadError = Cas1ProfileResponse.LoadError.staffRecordNotFound,
+              loadError = Cas1ProfileResponse.Cas1LoadError.staffRecordNotFound,
               null,
             ),
           ),
@@ -395,7 +395,7 @@ class Cas1ProfileTest : IntegrationTestBase() {
         .returnResult()
         .responseBody!!
 
-      assertThat(response.loadError).isEqualTo(Cas1ProfileResponse.LoadError.unsupportedProbationRegion)
+      assertThat(response.loadError).isEqualTo(Cas1ProfileResponse.Cas1LoadError.unsupportedProbationRegion)
     }
   }
 


### PR DESCRIPTION
- Updated the name from `loaderror` to `cas1 load error` to address OpenAPI override issues.

