### PR TITLE
CAS3 V2 Update Bedspace API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
@@ -28,8 +28,8 @@ data class Cas3BedspacesEntity(
   @JoinColumn(name = "premises_id")
   val premises: Cas3PremisesEntity,
 
-  val reference: String,
-  val notes: String?,
+  var reference: String,
+  var notes: String?,
   val startDate: LocalDate?,
   val endDate: LocalDate?,
   val createdAt: OffsetDateTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas3PremisesAndBedspace.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACas3PremisesAndBedspace.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenACas3Premises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import java.time.LocalDate
@@ -15,6 +16,7 @@ fun IntegrationTestBase.givenCas3PremisesAndBedspace(
     probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
       withProbationRegion(user.probationRegion)
     },
+    status = Cas3PremisesStatus.online,
   ),
   bedspace: Cas3BedspacesEntity = cas3BedspaceEntityFactory.produceAndPersist {
     withReference("test-bed")


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" height="1152" alt="Screenshot 2025-09-15 at 15 15 01 (2)" src="https://github.com/user-attachments/assets/f0d67217-22bc-4ecc-b251-091db68f2262" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `PUT /cas3/v2/premises/{premisesId}/bedspaces/{bedspaceId}`
2. This endpoint was modelled on the `PUT /cas3/premises/{premisesId}/bedspaces/{bedspaceId}` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models
