### PR TITLE
CAS3 V2 Get bedspace-totals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BedspaceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BedspaceController.kt
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3Bedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesBedspaceTotals
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Bedspaces
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3NewBedspace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3UpdateBedspace
@@ -65,6 +67,23 @@ class Cas3v2BedspaceController(
       totalUpcomingBedspaces = totalBedspaceByStatus.upcomingBedspaces,
       totalArchivedBedspaces = totalBedspaceByStatus.archivedBedspaces,
     )
+    return ResponseEntity.ok(result)
+  }
+
+  @GetMapping("/premises/{premisesId}/bedspace-totals")
+  fun getBedspaceTotals(@PathVariable premisesId: UUID): ResponseEntity<Cas3PremisesBedspaceTotals> {
+    val premises = getAndCheckUserCanViewPremises(premisesId)
+    val totalBedspaceByStatus = extractEntityFromCasResult(cas3v2BedspacesService.getBedspaceTotals(premises))
+
+    val result = Cas3PremisesBedspaceTotals(
+      id = premises.id,
+      status = if (premises.isPremisesArchived()) Cas3PremisesStatus.archived else Cas3PremisesStatus.online,
+      premisesEndDate = premises.endDate,
+      totalOnlineBedspaces = totalBedspaceByStatus.onlineBedspaces,
+      totalUpcomingBedspaces = totalBedspaceByStatus.upcomingBedspaces,
+      totalArchivedBedspaces = totalBedspaceByStatus.archivedBedspaces,
+    )
+
     return ResponseEntity.ok(result)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3PremisesEntity.kt
@@ -70,6 +70,7 @@ data class Cas3PremisesEntity(
 
 ) {
   fun isPremisesScheduledToArchive(): Boolean = status == Cas3PremisesStatus.archived && endDate != null && endDate!! > LocalDate.now()
+  fun isPremisesArchived(): Boolean = (endDate != null && endDate!! <= LocalDate.now()) || startDate.isAfter(LocalDate.now())
 }
 
 @Repository


### PR DESCRIPTION
**New endpoint delivered**

<img width="1728" height="1117" alt="swags" src="https://github.com/user-attachments/assets/238e8c8a-d7ca-4f39-8c55-485358884f48" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `PUT /cas3/v2/premises/{premisesId}/bedspace-totals`
2. This endpoint was modelled on the `PUT /cas3/premises/{premisesId}/bedspace-totals` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models
