### PR TITLE
CAS-1977 Change the creation date bedspace to the selected by the user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1SeedRoomsFromCsvJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1SeedRoomsFromCsvJob.kt
@@ -149,6 +149,7 @@ class ApprovedPremisesRoomsSeedJob(
         name = "${row.roomNumber} - ${row.bedCount}",
         code = row.bedCode,
         room = room,
+        createdDate = null,
         startDate = null,
         endDate = null,
         createdAt = OffsetDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
@@ -229,6 +229,7 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
         name = bed.bedName,
         code = bed.bedCode,
         room = room,
+        createdDate = null,
         startDate = null,
         endDate = null,
         createdAt = OffsetDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3PremisesService.kt
@@ -553,6 +553,7 @@ class Cas3PremisesService(
       name = "default-bed",
       code = null,
       room = room,
+      createdDate = startDate,
       startDate = startDate,
       endDate = null,
       createdAt = OffsetDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
@@ -18,7 +18,7 @@ class Cas3BedspaceTransformer(
   fun transformJpaToApi(bedspace: BedEntity, status: Cas3BedspaceStatus, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
     id = bedspace.id,
     reference = bedspace.room.name,
-    startDate = bedspace.createdAt.toLocalDate(),
+    startDate = bedspace.createdDate,
     endDate = bedspace.endDate,
     scheduleUnarchiveDate = isBedspaceScheduledToUnarchive(bedspace),
     status = status,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BedEntity.kt
@@ -216,6 +216,7 @@ data class BedEntity(
   @ManyToOne
   @JoinColumn(name = "room_id")
   val room: RoomEntity,
+  val createdDate: LocalDate?,
   val startDate: LocalDate?,
   /**
    * For CAS1 this is inclusive (i.e. bed is not available on the end date)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/RoomService.kt
@@ -188,6 +188,7 @@ class RoomService(
       name = bedName,
       code = null,
       room = room,
+      createdDate = null,
       startDate = LocalDate.now(),
       endDate = bedEndDate,
       createdAt = OffsetDateTime.now(),

--- a/src/main/resources/db/migration/all/20250916113531000__add_created_date_to_beds.sql
+++ b/src/main/resources/db/migration/all/20250916113531000__add_created_date_to_beds.sql
@@ -1,0 +1,2 @@
+ALTER TABLE beds
+ADD COLUMN created_date DATE NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -121,6 +121,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
 
     val bedspace = bedEntityFactory.produceAndPersist {
       withRoom(room)
+      withCreatedDate(startDate)
       withStartDate(startDate)
       withEndDate(endDate)
     }.apply {
@@ -200,7 +201,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
   ) = Cas3Bedspace(
     id = bed.id,
     reference = room.name,
-    startDate = bed.createdAt.toLocalDate(),
+    startDate = bed.createdDate,
     characteristics = room.characteristics.map { characteristic ->
       Characteristic(
         id = characteristic.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
@@ -742,6 +742,7 @@ class Cas3PremisesServiceTest {
 
       assertThatCasResult(result).isSuccess().with { bed ->
         assertThat(bed.name).isEqualTo("default-bed")
+        assertThat(bed.createdDate).isEqualTo(bedspace.createdDate)
         assertThat(bed.startDate).isEqualTo(bedspace.startDate)
         assertThat(bed.room).isEqualTo(room)
         assertThat(bed.room.premises).isEqualTo(premises)
@@ -942,6 +943,7 @@ class Cas3PremisesServiceTest {
         id = bedspace.id,
         name = "default-bed",
         code = bedspace.code,
+        createdDate = bedspace.createdDate,
         startDate = bedspace.startDate,
         endDate = bedspace.endDate,
         room = updatedRoom,
@@ -1386,6 +1388,7 @@ class Cas3PremisesServiceTest {
 
       val bedspace = BedEntityFactory()
         .withRoom(room)
+        .withCreatedDate(startDate)
         .withStartDate(startDate)
         .withEndDate(endDate)
         .produce()
@@ -3037,6 +3040,7 @@ class Cas3PremisesServiceTest {
       val scheduledToUnarchiveBedspace = BedEntityFactory()
         .withId(bedspaceId)
         .withYieldedRoom { room }
+        .withCreatedDate(LocalDate.now().plusDays(10))
         .withStartDate(LocalDate.now().plusDays(10))
         .withEndDate(null)
         .produce()
@@ -3101,6 +3105,7 @@ class Cas3PremisesServiceTest {
       val scheduledToUnarchiveBedspace = BedEntityFactory()
         .withId(bedspaceId)
         .withYieldedRoom { room }
+        .withCreatedDate(LocalDate.now().plusDays(10))
         .withStartDate(LocalDate.now().plusDays(10))
         .withEndDate(null)
         .produce()
@@ -3125,6 +3130,7 @@ class Cas3PremisesServiceTest {
       val scheduledToUnarchiveBedspace = BedEntityFactory()
         .withId(bedspaceId)
         .withYieldedRoom { room }
+        .withCreatedDate(startDate)
         .withStartDate(startDate)
         .withEndDate(null)
         .produce()
@@ -3522,6 +3528,7 @@ class Cas3PremisesServiceTest {
         .produce()
 
       val bed = BedEntityFactory()
+        .withCreatedDate(LocalDate.parse("2022-01-15"))
         .withStartDate(LocalDate.parse("2022-01-15"))
         .withYieldedRoom { room }
         .produce()
@@ -3566,6 +3573,7 @@ class Cas3PremisesServiceTest {
 
       val bed = BedEntityFactory()
         .withYieldedRoom { room }
+        .withCreatedDate(LocalDate.parse("2022-08-10"))
         .withStartDate(LocalDate.parse("2022-08-10"))
         .withEndDate(LocalDate.parse("2022-08-24"))
         .produce()
@@ -3606,6 +3614,7 @@ class Cas3PremisesServiceTest {
 
       val bed = BedEntityFactory()
         .withYieldedRoom { room }
+        .withCreatedDate(LocalDate.parse("2022-08-10"))
         .withStartDate(LocalDate.parse("2022-08-10"))
         .withEndDate(LocalDate.parse("2022-08-30"))
         .produce()
@@ -3646,6 +3655,7 @@ class Cas3PremisesServiceTest {
 
       val bed = BedEntityFactory()
         .withYieldedRoom { room }
+        .withCreatedDate(LocalDate.parse("2022-08-10"))
         .withStartDate(LocalDate.parse("2022-08-10"))
         .withEndDate(LocalDate.parse("2022-08-24"))
         .produce()
@@ -3738,6 +3748,7 @@ class Cas3PremisesServiceTest {
         }
         .withBed(
           BedEntityFactory().apply {
+            withCreatedDate(LocalDate.parse("2022-02-15"))
             withStartDate(LocalDate.parse("2022-02-15"))
             withYieldedRoom {
               RoomEntityFactory().apply {
@@ -3786,6 +3797,7 @@ class Cas3PremisesServiceTest {
             withPremises(premisesEntity)
           }.produce()
         }
+        withCreatedDate(LocalDate.parse("2022-08-10"))
         withStartDate(LocalDate.parse("2022-08-10"))
         withEndDate(LocalDate.parse("2022-08-30"))
       }.produce()
@@ -3829,6 +3841,7 @@ class Cas3PremisesServiceTest {
             withPremises(premisesEntity)
           }.produce()
         }
+        withCreatedDate(LocalDate.parse("2022-08-10"))
         withStartDate(LocalDate.parse("2022-08-10"))
         withEndDate(LocalDate.parse("2022-08-24"))
       }.produce()
@@ -3872,6 +3885,7 @@ class Cas3PremisesServiceTest {
             withPremises(premisesEntity)
           }.produce()
         }
+        withCreatedDate(LocalDate.parse("2022-08-10"))
         withStartDate(LocalDate.parse("2022-08-10"))
         withEndDate(LocalDate.parse("2022-08-24"))
       }.produce()
@@ -4199,6 +4213,7 @@ class Cas3PremisesServiceTest {
 
     return BedEntityFactory()
       .withRoom(room)
+      .withCreatedDate(startDate)
       .withStartDate(startDate)
       .withEndDate(endDate)
       .produce()
@@ -4206,6 +4221,7 @@ class Cas3PremisesServiceTest {
 
   private fun createBedspace(room: RoomEntity, startDate: LocalDate = LocalDate.now().minusDays(180), endDate: LocalDate? = null) = BedEntityFactory()
     .withRoom(room)
+    .withCreatedDate(startDate)
     .withStartDate(startDate)
     .withEndDate(endDate)
     .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
@@ -53,7 +53,7 @@ class Cas3BedspaceTransformerTest {
       Cas3Bedspace(
         id = bed.id,
         reference = room.name,
-        startDate = bed.createdAt!!.toLocalDate(),
+        startDate = bed.createdDate,
         endDate = bed.endDate,
         scheduleUnarchiveDate = scheduledUnarchiveDate,
         status = status,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoomEntityFactory.kt
@@ -82,6 +82,7 @@ class BedEntityFactory : Factory<BedEntity> {
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(8) }
   private var code: Yielded<String?> = { randomStringMultiCaseWithNumbers(6) }
   private var room: Yielded<RoomEntity>? = null
+  private var createdDate: Yielded<LocalDate>? = null
   private var startDate: Yielded<LocalDate> = { LocalDate.now().minusDays(90) }
   private var endDate: Yielded<LocalDate?>? = null
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
@@ -114,6 +115,10 @@ class BedEntityFactory : Factory<BedEntity> {
     this.room = room
   }
 
+  fun withCreatedDate(createdDate: LocalDate) = apply {
+    this.createdDate = { createdDate }
+  }
+
   fun withStartDate(startDate: LocalDate) = apply {
     this.startDate = { startDate }
   }
@@ -136,6 +141,7 @@ class BedEntityFactory : Factory<BedEntity> {
     code = this.code(),
     room = this.room?.invoke() ?: throw java.lang.RuntimeException("Must provide a room"),
     endDate = this.endDate?.invoke(),
+    createdDate = this.createdDate?.invoke(),
     startDate = this.startDate?.invoke(),
     createdAt = this.createdAt.invoke(),
   )


### PR DESCRIPTION
This [PR CAS-1977](https://dsdmoj.atlassian.net/browse/CAS-1977) is to change the creation date bedspace to the date selected by the user instead of the creation date

