### PR TITLE
Sync new bed's created_date functionality to CAS3 V2 bedspace endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
@@ -30,9 +30,10 @@ data class Cas3BedspacesEntity(
 
   var reference: String,
   var notes: String?,
-  val startDate: LocalDate?,
+  val startDate: LocalDate,
   val endDate: LocalDate?,
   val createdAt: OffsetDateTime,
+  val createdDate: LocalDate,
 
   @ManyToMany
   @JoinTable(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3MigrateNewBedspaceModelDataJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3MigrateNewBedspaceModelDataJob.kt
@@ -108,9 +108,10 @@ class Cas3MigrateNewBedspaceModelDataJob(
           premises = cas3Premises,
           reference = room.name,
           notes = room.notes,
-          startDate = bed.startDate,
+          startDate = bed.startDate!!,
           endDate = bed.endDate,
           createdAt = bed.createdAt,
+          createdDate = bed.createdDate!!,
           characteristics = emptyList<Cas3BedspaceCharacteristicEntity>().toMutableList(),
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspacesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspacesService.kt
@@ -57,6 +57,7 @@ class Cas3v2BedspacesService(
       characteristics = mutableListOf(),
       startDate = startDate,
       endDate = null,
+      createdDate = startDate,
       createdAt = OffsetDateTime.now(),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BedspaceTransformer.kt
@@ -30,7 +30,7 @@ class Cas3BedspaceTransformer(
   fun transformJpaToApi(jpa: Cas3BedspacesEntity, status: Cas3BedspaceStatus, archiveHistory: List<Cas3BedspaceArchiveAction> = emptyList()) = Cas3Bedspace(
     id = jpa.id,
     reference = jpa.reference,
-    startDate = jpa.createdAt.toLocalDate(),
+    startDate = jpa.createdDate,
     endDate = jpa.endDate,
     scheduleUnarchiveDate = isBedspaceScheduledToUnarchive(jpa),
     notes = jpa.notes,

--- a/src/main/resources/db/migration/all/20250916160010__cas3_bedspaces_table_add_created_date_column.sql
+++ b/src/main/resources/db/migration/all/20250916160010__cas3_bedspaces_table_add_created_date_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cas3_bedspaces
+ADD COLUMN created_date DATE NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BedspaceEntityFactory.kt
@@ -19,9 +19,10 @@ class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
   private var characteristics: Yielded<MutableList<Cas3BedspaceCharacteristicEntity>> = { mutableListOf() }
   private var reference: Yielded<String> = { randomStringUpperCase(6) }
   private var notes: Yielded<String?> = { null }
-  private var startDate: Yielded<LocalDate?> = { LocalDate.now().randomDateBefore(6) }
+  private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
   private var endDate: Yielded<LocalDate?> = { LocalDate.now().randomDateAfter(6) }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
+  private var createdDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -43,7 +44,7 @@ class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
     this.notes = { notes }
   }
 
-  fun withStartDate(startDate: LocalDate?) = apply {
+  fun withStartDate(startDate: LocalDate) = apply {
     this.startDate = { startDate }
   }
 
@@ -53,6 +54,10 @@ class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
 
   fun withCreatedAt(createdAt: OffsetDateTime) = apply {
     this.createdAt = { createdAt }
+  }
+
+  fun withCreatedDate(createdDate: LocalDate) = apply {
+    this.createdDate = { createdDate }
   }
 
   @SuppressWarnings("TooGenericExceptionThrown")
@@ -65,5 +70,6 @@ class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
     startDate = this.startDate(),
     endDate = this.endDate(),
     createdAt = this.createdAt(),
+    createdDate = this.createdDate(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -91,6 +91,8 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
         bedEntityFactory.produceAndPersist {
           withRoom(room)
           withEndDate(endDate)
+          withStartDate(LocalDate.now().minusDays(90))
+          withCreatedDate(LocalDate.now().minusDays(90))
         }.apply {
           premise.rooms
             .first { it.id == room.id }
@@ -226,7 +228,7 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
   ) = Cas3Bedspace(
     id = bedspace.id,
     reference = bedspace.reference,
-    startDate = bedspace.createdAt!!.toLocalDate(),
+    startDate = bedspace.createdDate,
     bedspaceCharacteristics = bedspace.characteristics.map { characteristic ->
       Cas3BedspaceCharacteristic(
         id = characteristic.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3MigrateNewBedspaceModelDataJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3MigrateNewBedspaceModelDataJobTest.kt
@@ -133,6 +133,7 @@ class Cas3MigrateNewBedspaceModelDataJobTest : Cas3IntegrationTestBase() {
       assertThat(bedspace.endDate).isEqualTo(expectedBedToMatch.endDate)
       assertThat(bedspace.startDate).isEqualTo(expectedBedToMatch.startDate)
       assertThat(bedspace.createdAt).isEqualTo(expectedBedToMatch.createdAt)
+      assertThat(bedspace.createdDate).isEqualTo(expectedBedToMatch.createdDate)
       assertThatBedspaceCharacteristicsMatch(bedspace, expectedRoomToMatch)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3VoidBedspaceJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3VoidBedspaceJobTest.kt
@@ -54,6 +54,8 @@ class Cas3VoidBedspaceJobTest : MigrationJobTestBase() {
                 withPremises(premises)
               },
             )
+            withStartDate(LocalDate.now().minusDays(90))
+            withCreatedDate(LocalDate.now().minusDays(90))
           },
         )
         withPremises(premises)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspacesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspacesTest.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.LocalDate
-import java.time.OffsetDateTime
 import java.util.UUID
 
 class Cas3v2BedspacesTest : Cas3IntegrationTestBase() {
@@ -71,10 +70,11 @@ class Cas3v2BedspacesTest : Cas3IntegrationTestBase() {
           status = Cas3PremisesStatus.archived,
           endDate = LocalDate.now().plusDays(3),
         )
+        val bedspaceStartDate = LocalDate.now().minusDays(2)
         val bedspaceCharacteristics = cas3BedspaceCharacteristicEntityFactory.produceAndPersistMultiple(5)
         val newBedspace = Cas3NewBedspace(
           reference = randomStringMultiCaseWithNumbers(10),
-          startDate = LocalDate.now().minusDays(2),
+          startDate = bedspaceStartDate,
           characteristicIds = bedspaceCharacteristics.map { it.id },
           notes = randomStringLowerCase(100),
         )
@@ -88,7 +88,7 @@ class Cas3v2BedspacesTest : Cas3IntegrationTestBase() {
           .isCreated
           .expectBody()
           .jsonPath("reference").isEqualTo(newBedspace.reference)
-          .jsonPath("startDate").isEqualTo(LocalDate.now())
+          .jsonPath("startDate").isEqualTo(bedspaceStartDate)
           .jsonPath("notes").isEqualTo(newBedspace.notes.toString())
           .jsonPath("bedspaceCharacteristics[*].id").isEqualTo(bedspaceCharacteristics.map { it.id.toString() })
           .jsonPath("bedspaceCharacteristics[*].name").isEqualTo(bedspaceCharacteristics.map { it.name })
@@ -248,7 +248,6 @@ class Cas3v2BedspacesTest : Cas3IntegrationTestBase() {
             withPremises(premises)
             withStartDate(LocalDate.now().minusMonths(6))
             withEndDate(null)
-            withCreatedAt(OffsetDateTime.now().minusMonths(7))
           }.let {
             createCas3Bedspace(it, Cas3BedspaceStatus.online)
           },
@@ -256,7 +255,6 @@ class Cas3v2BedspacesTest : Cas3IntegrationTestBase() {
             withPremises(premises)
             withStartDate(LocalDate.now().minusMonths(5))
             withEndDate(LocalDate.now().plusDays(5))
-            withCreatedAt(OffsetDateTime.now().minusMonths(5))
           }.let {
             createCas3Bedspace(it, Cas3BedspaceStatus.online)
           },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BedspaceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BedspaceServiceTest.kt
@@ -74,6 +74,7 @@ class Cas3v2BedspaceServiceTest {
         assertThat(it.notes).isEqualTo(bedspace.notes)
         assertThat(it.startDate).isEqualTo(bedspace.startDate)
         assertThat(it.endDate).isEqualTo(bedspace.endDate)
+        assertThat(it.createdDate).isEqualTo(bedspace.createdDate)
       }
     }
 
@@ -439,6 +440,7 @@ class Cas3v2BedspaceServiceTest {
         notes = updateBedspaceNotes,
         premises = premises,
         characteristics = updateBedspaceCharacteristic.toMutableList(),
+        createdDate = bedspace.createdDate,
       )
 
       every { mockCas3BedspacesRepository.findCas3Bedspace(premises.id, bedspace.id) } returns bedspace
@@ -586,6 +588,7 @@ class Cas3v2BedspaceServiceTest {
     val bedspace = Cas3BedspaceEntityFactory()
       .withPremises(premises)
       .withStartDate(bedspaceStartDate)
+      .withCreatedDate(bedspaceStartDate)
       .withEndDate(bedspaceEndDate)
       .produce()
     return Pair(premises, bedspace)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BedspaceTransformerTest.kt
@@ -85,7 +85,7 @@ class Cas3BedspaceTransformerTest {
       Cas3Bedspace(
         id = bedspace.id,
         reference = bedspace.reference,
-        startDate = bedspace.createdAt.toLocalDate(),
+        startDate = bedspace.createdDate,
         endDate = bedspace.endDate,
         notes = bedspace.notes,
         scheduleUnarchiveDate = scheduledUnarchiveDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/VoidBedspacesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/VoidBedspacesTest.kt
@@ -86,6 +86,8 @@ class VoidBedspacesTest : IntegrationTestBase() {
                 withYieldedPremises { premises }
               }
             }
+            withStartDate(LocalDate.now().minusDays(90))
+            withCreatedDate(LocalDate.now().minusDays(90))
           },
         )
         withPremises(premises)
@@ -278,8 +280,6 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withPremises(premises)
       }
 
-      val expectedJson = objectMapper.writeValueAsString(cas3VoidBedspacesTransformer.transformJpaToApi(voidBedspaces))
-
       webTestClient.get()
         .uri("/premises/${premises.id}/lost-beds/${voidBedspaces.id}")
         .header("Authorization", "Bearer $jwt")
@@ -462,14 +462,6 @@ class VoidBedspacesTest : IntegrationTestBase() {
         },
       )
       withPremises(premises)
-    }
-
-    val bed = bedEntityFactory.produceAndPersist {
-      withYieldedRoom {
-        roomEntityFactory.produceAndPersist {
-          withYieldedPremises { premises }
-        }
-      }
     }
 
     webTestClient.put()
@@ -734,8 +726,6 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withPremises(premises)
       }
 
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
-
       webTestClient.post()
         .uri("/premises/${premises.id}/lost-beds/${voidBedspaces.id}/cancellations")
         .header("Authorization", "Bearer $jwt")
@@ -749,7 +739,7 @@ class VoidBedspacesTest : IntegrationTestBase() {
         .isOk
         .expectBody()
         .jsonPath("$.notes").isEqualTo("Some cancellation notes")
-        .jsonPath("$.createdAt").value(withinSeconds(5L), OffsetDateTime::class.java)
+        .jsonPath("$.createdAt").value(OffsetDateTime::class.java, withinSeconds(5L))
     }
   }
 
@@ -776,8 +766,6 @@ class VoidBedspacesTest : IntegrationTestBase() {
         withYieldedBed { bed }
         withPremises(premises)
       }
-
-      val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()
 
       webTestClient.post()
         .uri("/premises/${premises.id}/lost-beds/${voidBedspaces.id}/cancellations")


### PR DESCRIPTION
Sync changes in [this PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/4273) to equivalent CAS3 V2 bedspace endpoints