### PR TITLE
Switch from bitnami/redis docker image to redis docker image for integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
       SPRING_DATA_REDIS_PORT: 6379
     services:
       redis:
-        image: "bitnami/redis:7.2.5"
+        image: "redis:latest"
         ports:
           - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=5

--- a/script/test-database/docker-compose.test.yml
+++ b/script/test-database/docker-compose.test.yml
@@ -19,7 +19,7 @@ services:
       - ./init-database.sh:/docker-entrypoint-initdb.d/init-database.sh
 
   integration_test_redis:
-    image: "bitnami/redis:7.2.5"
+    image: "redis:latest"
     container_name: approved-premises-redis-test
     environment:
       - ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
This was blocking the pipeline (when it tried to run integration tests):

<img width="1728" height="1117" alt="Screenshot 2025-09-17 at 15 18 16" src="https://github.com/user-attachments/assets/95cac412-8bdf-4f22-aadc-283278aabee0" />

This is because the version of the `bitnami/redis` docker image is no longer supported. Decided it was a good opportunity to move to the official `redis` docker image