### PR TITLE
CAS-1910: C3 BE Set out of region fields for applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ApplicationService.kt
@@ -91,15 +91,16 @@ class Cas3ApplicationService(
       dutyToReferLocalAuthorityAreaName = submitApplication.dutyToReferLocalAuthorityAreaName
       personReleaseDate = submitApplication.personReleaseDate
       prisonReleaseTypes = submitApplication.prisonReleaseTypes?.joinToString(",")
-      probationDeliveryUnit = submitApplication.probationDeliveryUnitId?.let {
-        probationDeliveryUnitRepository.findByIdOrNull(it)
+      probationRegion = when (submitApplication.outOfRegionProbationRegionId) {
+        null -> user.probationRegion
+        else -> probationRegionRepository.findByIdOrNull(submitApplication.outOfRegionProbationRegionId)!!
       }
-      outOfRegionProbationRegion = submitApplication.outOfRegionProbationRegionId?.let {
-        probationRegionRepository.findByIdOrNull(it)
+      probationDeliveryUnit = when (submitApplication.outOfRegionPduId) {
+        null -> probationDeliveryUnitRepository.findByIdOrNull(submitApplication.probationDeliveryUnitId)
+        else -> probationDeliveryUnitRepository.findByIdOrNull(submitApplication.outOfRegionPduId)
       }
-      outOfRegionProbationDeliveryUnit = submitApplication.outOfRegionPduId?.let {
-        probationDeliveryUnitRepository.findByIdOrNull(it)
-      }
+      previousReferralProbationRegion = submitApplication.outOfRegionProbationRegionId?.let { user.probationRegion }
+      previousReferralProbationDeliveryUnit = submitApplication.outOfRegionPduId?.let { probationDeliveryUnitRepository.findByIdOrNull(submitApplication.probationDeliveryUnitId)!! }
     }
 
     assessmentService.createTemporaryAccommodationAssessment(application, submitApplication.summaryData!!)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -504,7 +504,7 @@ class TemporaryAccommodationApplicationEntity(
   val riskRatings: PersonRisks?,
   @ManyToOne
   @JoinColumn(name = "probation_region_id")
-  val probationRegion: ProbationRegionEntity,
+  var probationRegion: ProbationRegionEntity,
   var arrivalDate: OffsetDateTime?,
   var isRegisteredSexOffender: Boolean?,
   var isHistoryOfSexualOffence: Boolean?,
@@ -526,11 +526,11 @@ class TemporaryAccommodationApplicationEntity(
   @JoinColumn(name = "probation_delivery_unit_id")
   var probationDeliveryUnit: ProbationDeliveryUnitEntity?,
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "out_of_region_probation_region_id")
-  var outOfRegionProbationRegion: ProbationRegionEntity?,
+  @JoinColumn(name = "previous_referral_probation_region_id")
+  var previousReferralProbationRegion: ProbationRegionEntity?,
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "out_of_region_probation_delivery_unit_id")
-  var outOfRegionProbationDeliveryUnit: ProbationDeliveryUnitEntity?,
+  @JoinColumn(name = "previous_referral_probation_delivery_unit_id")
+  var previousReferralProbationDeliveryUnit: ProbationDeliveryUnitEntity?,
 ) : ApplicationEntity(
   id,
   crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/ApplicationService.kt
@@ -208,8 +208,8 @@ class ApplicationService(
     isConcerningArsonBehaviour = null,
     prisonReleaseTypes = null,
     probationDeliveryUnit = null,
-    outOfRegionProbationRegion = null,
-    outOfRegionProbationDeliveryUnit = null,
+    previousReferralProbationRegion = null,
+    previousReferralProbationDeliveryUnit = null,
   )
 
   fun updateApprovedPremisesApplicationStatus(applicationId: UUID, status: ApprovedPremisesApplicationStatus) {

--- a/src/main/resources/db/migration/all/20250917125404000__c3_rename_out_of_region_columns.sql
+++ b/src/main/resources/db/migration/all/20250917125404000__c3_rename_out_of_region_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE temporary_accommodation_applications
+    RENAME COLUMN out_of_region_probation_region_id TO previous_referral_probation_region_id;
+
+ALTER TABLE temporary_accommodation_applications
+    RENAME COLUMN out_of_region_probation_delivery_unit_id TO previous_referral_probation_delivery_unit_id;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/TemporaryAccommodationApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/TemporaryAccommodationApplicationEntityFactory.kt
@@ -55,8 +55,8 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   private var dutyToReferOutcome: Yielded<String?> = { null }
   private var prisonReleaseTypes: Yielded<String?> = { null }
   private var probationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity?> = { null }
-  private var outOfRegionProbationRegion: Yielded<ProbationRegionEntity?> = { null }
-  private var outOfRegionProbationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity?> = { null }
+  private var previousReferralProbationRegion: Yielded<ProbationRegionEntity?> = { null }
+  private var previousReferralProbationDeliveryUnit: Yielded<ProbationDeliveryUnitEntity?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -207,11 +207,11 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
   }
 
   fun withOutOfRegionProbationRegion(probationRegion: ProbationRegionEntity?) = apply {
-    this.outOfRegionProbationRegion = { probationRegion }
+    this.previousReferralProbationRegion = { probationRegion }
   }
 
   fun withoutOfRegionProbationDeliveryUnit(outOfRegionProbationDeliveryUnit: ProbationDeliveryUnitEntity?) = apply {
-    this.outOfRegionProbationDeliveryUnit = { outOfRegionProbationDeliveryUnit }
+    this.previousReferralProbationDeliveryUnit = { outOfRegionProbationDeliveryUnit }
   }
 
   override fun produce(): TemporaryAccommodationApplicationEntity = TemporaryAccommodationApplicationEntity(
@@ -248,8 +248,8 @@ class TemporaryAccommodationApplicationEntityFactory : Factory<TemporaryAccommod
     name = this.name(),
     prisonReleaseTypes = this.prisonReleaseTypes(),
     probationDeliveryUnit = this.probationDeliveryUnit(),
-    outOfRegionProbationRegion = this.outOfRegionProbationRegion(),
-    outOfRegionProbationDeliveryUnit = this.outOfRegionProbationDeliveryUnit(),
+    previousReferralProbationRegion = this.previousReferralProbationRegion(),
+    previousReferralProbationDeliveryUnit = this.previousReferralProbationDeliveryUnit(),
   )
 
   fun withDefaults() = TemporaryAccommodationApplicationEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3ApplicationTest.kt
@@ -1263,17 +1263,15 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
           assertThat(persistedAssessment.summaryData).isEqualTo("{\"num\":50,\"text\":\"Out of region test!\"}")
           assertThat(persistedApplication.name).isEqualTo(offenderName)
 
-          assertThat(persistedApplication.probationRegion.id).isEqualTo(submittingUser.probationRegion.id)
-          assertThat(persistedApplication.probationDeliveryUnit!!.id).isEqualTo(mainProbationDeliveryUnit.id)
+          assertThat(persistedApplication.probationRegion.id).isEqualTo(outOfRegionProbationRegion.id)
+          assertThat(persistedApplication.probationDeliveryUnit!!.id).isEqualTo(outOfRegionProbationDeliveryUnit.id)
 
-          assertThat(persistedApplication.outOfRegionProbationRegion).isNotNull
-          assertThat(persistedApplication.outOfRegionProbationRegion!!.id).isEqualTo(outOfRegionProbationRegion.id)
-          assertThat(persistedApplication.outOfRegionProbationRegion!!.name).isEqualTo("Out Of Region Probation Region")
+          assertThat(persistedApplication.previousReferralProbationRegion).isNotNull
+          assertThat(persistedApplication.previousReferralProbationRegion!!.id).isEqualTo(submittingUser.probationRegion.id)
 
-          assertThat(persistedApplication.outOfRegionProbationDeliveryUnit).isNotNull
-          assertThat(persistedApplication.outOfRegionProbationDeliveryUnit!!.id).isEqualTo(outOfRegionProbationDeliveryUnit.id)
-          assertThat(persistedApplication.outOfRegionProbationDeliveryUnit!!.name).isEqualTo("Out Of Region PDU")
-          assertThat(persistedApplication.outOfRegionProbationDeliveryUnit!!.probationRegion.id).isEqualTo(outOfRegionProbationRegion.id)
+          assertThat(persistedApplication.previousReferralProbationDeliveryUnit).isNotNull
+          assertThat(persistedApplication.previousReferralProbationDeliveryUnit!!.id).isEqualTo(mainProbationDeliveryUnit.id)
+          assertThat(persistedApplication.previousReferralProbationDeliveryUnit!!.probationRegion.id).isEqualTo(submittingUser.probationRegion.id)
         }
       }
     }
@@ -1326,8 +1324,8 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
           assertThat(persistedApplication.probationRegion.id).isEqualTo(submittingUser.probationRegion.id)
           assertThat(persistedApplication.probationDeliveryUnit!!.id).isEqualTo(probationDeliveryUnit.id)
 
-          assertThat(persistedApplication.outOfRegionProbationRegion).isNull()
-          assertThat(persistedApplication.outOfRegionProbationDeliveryUnit).isNull()
+          assertThat(persistedApplication.previousReferralProbationRegion).isNull()
+          assertThat(persistedApplication.previousReferralProbationDeliveryUnit).isNull()
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
@@ -428,6 +428,10 @@ class Cas3ApplicationServiceTest {
         .withYieldedApArea { ApAreaEntityFactory().produce() }
         .produce()
 
+      val mainPdu = mockk<uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity>()
+      every { mainPdu.id } returns UUID.randomUUID()
+      every { mainPdu.name } returns "Main PDU"
+
       val outOfRegionPdu = mockk<uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity>()
       every { outOfRegionPdu.id } returns UUID.randomUUID()
       every { outOfRegionPdu.name } returns "Out Of Region PDU"
@@ -435,6 +439,7 @@ class Cas3ApplicationServiceTest {
       val application = TemporaryAccommodationApplicationEntityFactory()
         .withCreatedByUser(user)
         .withProbationRegion(user.probationRegion)
+        .withProbationDeliveryUnit(mainPdu)
         .withOutOfRegionProbationRegion(outOfRegionProbationRegion)
         .withoutOfRegionProbationDeliveryUnit(outOfRegionPdu)
         .produce()
@@ -443,11 +448,11 @@ class Cas3ApplicationServiceTest {
 
       val savedApplication = mockApplicationRepository.save(application)
 
-      assertThat(savedApplication.outOfRegionProbationRegion).isNotNull
-      assertThat(savedApplication.outOfRegionProbationRegion!!.id).isEqualTo(outOfRegionProbationRegion.id)
-      assertThat(savedApplication.outOfRegionProbationDeliveryUnit).isNotNull
-      assertThat(savedApplication.outOfRegionProbationDeliveryUnit!!.id).isEqualTo(outOfRegionPdu.id)
-      assertThat(savedApplication.outOfRegionProbationDeliveryUnit!!.name).isEqualTo("Out Of Region PDU")
+      assertThat(savedApplication.previousReferralProbationRegion).isNotNull
+      assertThat(savedApplication.previousReferralProbationRegion!!.id).isEqualTo(outOfRegionProbationRegion.id)
+      assertThat(savedApplication.previousReferralProbationDeliveryUnit).isNotNull
+      assertThat(savedApplication.previousReferralProbationDeliveryUnit!!.id).isEqualTo(outOfRegionPdu.id)
+      assertThat(savedApplication.previousReferralProbationDeliveryUnit!!.name).isEqualTo("Out Of Region PDU")
 
       verify { mockApplicationRepository.save(application) }
     }
@@ -465,8 +470,8 @@ class Cas3ApplicationServiceTest {
 
       val savedApplication = mockApplicationRepository.save(application)
 
-      assertThat(savedApplication.outOfRegionProbationRegion).isNull()
-      assertThat(savedApplication.outOfRegionProbationDeliveryUnit).isNull()
+      assertThat(savedApplication.previousReferralProbationRegion).isNull()
+      assertThat(savedApplication.previousReferralProbationDeliveryUnit).isNull()
 
       assertThat(savedApplication.probationRegion).isNotNull
       assertThat(savedApplication.probationRegion.id).isEqualTo(user.probationRegion.id)


### PR DESCRIPTION
The Pull Request updates the naming for certain fields and database columns related to "out of region" probation regions and delivery units, replacing them with "previous referral" terminology throughout the codebase. Changes span service logic, database schema, entity models, factories, and tests to align with this updated terminology.

- Service logic: Adjusted methods to adopt "previous referral" fields instead of "out of region."
- Database schema: Renamed columns in the temporary_accommodation_applications table.
- Entity changes: Updated application-related models for new field names.
- Factory changes: Reflect changes in entity factories to match updated field names.
- Test updates: Modified both unit and integration tests to align with changes and ensure proper assertion checks.