### PR TITLE
Disable ossIndex within dependencyCheck task.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,6 +219,7 @@ detekt {
 
 dependencyCheck {
   suppressionFile = ".dependencycheckignore.xml"
+  analyzers.ossIndex.enabled = false
 }
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {


### PR DESCRIPTION
[OSS Index provides an additional vulnerability database](https://dependency-check.github.io/DependencyCheck/analyzers/oss-index-analyzer.html). An auth key is now requried for this database, which we don’t currently have configured.  This commit disables this analyser to ensure dependency check runs continue to work.