### PR TITLE
CAS-1912: Add Out of Region column to report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/generator/TransitionalAccommodationReferralReportGenerator.kt
@@ -56,6 +56,10 @@ class TransitionalAccommodationReferralReportGenerator :
             null -> referralData.pduName
             else -> referralData.previousReferralPduName
           },
+          outOfRegion = when (referralData.previousReferralProbationRegionName) {
+            null -> "No"
+            else -> "Yes"
+          },
           destinationRegion = referralData.previousReferralProbationRegionName?.let { referralData.probationRegionName },
           destinationPdu = referralData.previousReferralPduName?.let { referralData.pduName },
           referralSubmittedDate = referralData.referralSubmittedDate?.toLocalDate(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/model/TransitionalAccommodationReferralReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/model/TransitionalAccommodationReferralReportRow.kt
@@ -27,6 +27,7 @@ data class TransitionalAccommodationReferralReportRow(
   val postCode: String?,
   val probationRegion: String,
   val pdu: String?,
+  val outOfRegion: String?,
   val destinationRegion: String?,
   val destinationPdu: String?,
   val referralSubmittedDate: LocalDate?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ReportServiceTest.kt
@@ -195,6 +195,7 @@ class Cas3ReportServiceTest {
     val columnNames = dataFrame.columnNames()
     Assertions.assertThat(columnNames).contains("destinationRegion")
     Assertions.assertThat(columnNames).contains("destinationPdu")
+    Assertions.assertThat(columnNames).contains("outOfRegion")
 
     Assertions.assertThat(dataFrame.rowsCount()).isEqualTo(1)
     val row = dataFrame[0]
@@ -202,6 +203,7 @@ class Cas3ReportServiceTest {
     Assertions.assertThat(row["pdu"]).isEqualTo("Previous PDU Name")
     Assertions.assertThat(row["destinationRegion"]).isEqualTo("region")
     Assertions.assertThat(row["destinationPdu"]).isEqualTo("pduName")
+    Assertions.assertThat(row["outOfRegion"]).isEqualTo("Yes")
 
     verify {
       mockTransitionalAccommodationReferralReportRowRepository.findAllReferrals(
@@ -245,6 +247,7 @@ class Cas3ReportServiceTest {
     val columnNames = dataFrame.columnNames()
     Assertions.assertThat(columnNames).contains("destinationRegion")
     Assertions.assertThat(columnNames).contains("destinationPdu")
+    Assertions.assertThat(columnNames).contains("outOfRegion")
 
     Assertions.assertThat(dataFrame.rowsCount()).isEqualTo(1)
     val row = dataFrame[0]
@@ -252,6 +255,7 @@ class Cas3ReportServiceTest {
     Assertions.assertThat(row["pdu"]).isEqualTo("pduName")
     Assertions.assertThat(row["destinationRegion"]).isNull()
     Assertions.assertThat(row["destinationPdu"]).isNull()
+    Assertions.assertThat(row["outOfRegion"]).isEqualTo("No")
 
     verify {
       mockTransitionalAccommodationReferralReportRowRepository.findAllReferrals(


### PR DESCRIPTION
This Pull Request introduces a new field, outOfRegion, to the transitional accommodation referral report generation process. The field indicates if a referral is out of the region previous to its destination.

Main Changes
- Added outOfRegion Field:
  - Introduced logic to determine the value based on referral data in TransitionalAccommodationReferralReportGenerator.kt.
  - Updated the data model in TransitionalAccommodationReferralReportRow.kt to include the new field.
- Updated Unit Tests:
  - Modified Cas3ReportServiceTest.kt to ensure this new field is correctly handled and validated in test cases by checking its presence and associated values.