### PR TITLE
Feature/cas 1954 premises post

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BedspaceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BedspaceController.kt
@@ -54,7 +54,7 @@ class Cas3v2BedspaceController(
     val premises = getAndCheckUserCanViewPremises(premisesId)
     val bedspaces = cas3v2BedspacesService.getPremisesBedspaces(premises.id)
     val bedspacesArchiveHistory = cas3v2BedspacesService.getBedspacesArchiveHistory(bedspaces.map { it.id })
-    val totalBedspaceByStatus = extractEntityFromCasResult(cas3v2BedspacesService.getBedspaceTotals(premises))
+    val totalBedspaceByStatus = extractEntityFromCasResult(cas3v2PremisesService.getBedspaceTotals(premises.id))
     val result = Cas3Bedspaces(
       bedspaces = bedspaces.map { bedspace ->
         val bedspaceStatus = cas3v2BedspacesService.getBedspaceStatus(bedspace)
@@ -73,7 +73,7 @@ class Cas3v2BedspaceController(
   @GetMapping("/premises/{premisesId}/bedspace-totals")
   fun getBedspaceTotals(@PathVariable premisesId: UUID): ResponseEntity<Cas3PremisesBedspaceTotals> {
     val premises = getAndCheckUserCanViewPremises(premisesId)
-    val totalBedspaceByStatus = extractEntityFromCasResult(cas3v2BedspacesService.getBedspaceTotals(premises))
+    val totalBedspaceByStatus = extractEntityFromCasResult(cas3v2PremisesService.getBedspaceTotals(premises.id))
 
     val result = Cas3PremisesBedspaceTotals(
       id = premises.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2PremisesController.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3NewPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3PremisesTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+
+@Cas3Controller
+@RequestMapping("/cas3/v2", headers = ["X-Service-Name=temporary-accommodation"])
+class Cas3v2PremisesController(
+  private val cas3UserAccessService: Cas3UserAccessService,
+  private val cas3v2PremisesService: Cas3v2PremisesService,
+  private val cas3PremisesTransformer: Cas3PremisesTransformer,
+) {
+
+  @PostMapping("/premises")
+  fun createPremises(@RequestBody body: Cas3NewPremises): ResponseEntity<Cas3Premises> {
+    if (!cas3UserAccessService.currentUserCanAccessRegion(body.probationRegionId)) {
+      throw ForbiddenProblem()
+    }
+
+    val premises = extractEntityFromCasResult(
+      cas3v2PremisesService.createNewPremises(
+        reference = body.reference,
+        addressLine1 = body.addressLine1,
+        addressLine2 = body.addressLine2,
+        town = body.town,
+        postcode = body.postcode,
+        localAuthorityAreaId = body.localAuthorityAreaId,
+        probationRegionId = body.probationRegionId,
+        probationDeliveryUnitId = body.probationDeliveryUnitId,
+        characteristicIds = body.characteristicIds,
+        notes = body.notes,
+        turnaroundWorkingDays = body.turnaroundWorkingDays,
+      ),
+    )
+
+    val totalBedspacesByStatus = extractEntityFromCasResult(cas3v2PremisesService.getBedspaceTotals(premises.id))
+
+    return ResponseEntity(
+      cas3PremisesTransformer.toCas3Premises(premises, totalBedspacesByStatus),
+      HttpStatus.CREATED,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3PremisesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3PremisesEntity.kt
@@ -73,9 +73,15 @@ data class Cas3PremisesEntity(
   var lastUpdatedAt: OffsetDateTime? = null,
 
 ) {
+
   fun isPremisesScheduledToArchive(): Boolean = status == Cas3PremisesStatus.archived && endDate != null && endDate!! > LocalDate.now()
   fun isPremisesArchived(): Boolean = (endDate != null && endDate!! <= LocalDate.now()) || startDate.isAfter(LocalDate.now())
 }
 
 @Repository
-interface Cas3PremisesRepository : JpaRepository<Cas3PremisesEntity, UUID>
+interface Cas3PremisesRepository : JpaRepository<Cas3PremisesEntity, UUID> {
+  fun existsByNameIgnoreCaseAndProbationDeliveryUnitId(
+    name: String,
+    probationDeliveryUnitId: UUID,
+  ): Boolean
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3NewPremises.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3NewPremises.kt
@@ -8,7 +8,7 @@ data class Cas3NewPremises(
   val postcode: String,
   val probationRegionId: UUID,
   val probationDeliveryUnitId: UUID,
-  val characteristicIds: List<UUID>,
+  val characteristicIds: List<UUID> = emptyList(),
   val addressLine2: String? = null,
   val town: String? = null,
   val localAuthorityAreaId: UUID? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspacesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspacesService.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3Premise
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3PremisesService.Companion.MAX_LENGTH_BEDSPACE_REFERENCE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesTotalBedspacesByStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.CasResultValidatedScope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
@@ -24,9 +23,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult.Cas3FieldValidationError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.BedspaceStatusHelper
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.BedspaceStatusHelper.isCas3BedspaceArchived
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.BedspaceStatusHelper.isCas3BedspaceOnline
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.BedspaceStatusHelper.isCas3BedspaceUpcoming
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -194,19 +190,6 @@ class Cas3v2BedspacesService(
       }.sortedBy { it.date }
 
     return CasResult.Success(archiveHistory)
-  }
-
-  fun getBedspaceTotals(premises: Cas3PremisesEntity): CasResult.Success<TemporaryAccommodationPremisesTotalBedspacesByStatus> {
-    val bedspaces = cas3BedspacesRepository.findByPremisesId(premises.id)
-
-    return CasResult.Success(
-      TemporaryAccommodationPremisesTotalBedspacesByStatus(
-        premisesId = premises.id,
-        bedspaces.count { isCas3BedspaceOnline(it.startDate, it.endDate) },
-        bedspaces.count { isCas3BedspaceUpcoming(it.startDate) },
-        bedspaces.count { isCas3BedspaceArchived(it.endDate) },
-      ),
-    )
   }
 
   fun getBedspaceStatus(bedspace: Cas3BedspacesEntity) = BedspaceStatusHelper.getBedspaceStatus(bedspace.startDate, bedspace.endDate)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
@@ -2,16 +2,33 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.validatePremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesTotalBedspacesByStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.CasResultValidatedScope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.BedspaceStatusHelper.isCas3BedspaceArchived
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.BedspaceStatusHelper.isCas3BedspaceOnline
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.BedspaceStatusHelper.isCas3BedspaceUpcoming
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
 class Cas3v2PremisesService(
   private val cas3PremisesRepository: Cas3PremisesRepository,
   private val cas3v2DomainEventService: Cas3v2DomainEventService,
+  private val localAuthorityAreaRepository: LocalAuthorityAreaRepository,
+  private val probationDeliveryUnitRepository: ProbationDeliveryUnitRepository,
+  private val cas3PremisesCharacteristicRepository: Cas3PremisesCharacteristicRepository,
 ) {
   fun getPremises(premisesId: UUID): Cas3PremisesEntity? = cas3PremisesRepository.findByIdOrNull(premisesId)
 
@@ -28,6 +45,97 @@ class Cas3v2PremisesService(
       newStartDate = restartDate,
       currentEndDate,
       transactionId,
+    )
+  }
+
+  @Transactional
+  fun createNewPremises(
+    reference: String,
+    addressLine1: String,
+    addressLine2: String?,
+    town: String?,
+    postcode: String,
+    localAuthorityAreaId: UUID?,
+    probationRegionId: UUID,
+    probationDeliveryUnitId: UUID,
+    characteristicIds: List<UUID>,
+    notes: String?,
+    turnaroundWorkingDays: Int?,
+  ): CasResult<Cas3PremisesEntity> = validatedCasResult {
+    val localAuthorityArea = localAuthorityAreaId?.let { localAuthorityAreaRepository.findByIdOrNull(it) }
+    val probationDeliveryUnit =
+      probationDeliveryUnitRepository.findByIdAndProbationRegionId(probationDeliveryUnitId, probationRegionId)
+
+    validatePremises(
+      probationDeliveryUnit?.probationRegion,
+      localAuthorityAreaId,
+      localAuthorityArea,
+      probationDeliveryUnit,
+      reference,
+      addressLine1,
+      postcode,
+      turnaroundWorkingDays,
+    ) {
+      isUniqueName(reference = reference, probationDeliveryUnitId = probationDeliveryUnitId)
+    }
+
+    val validatedPremisesCharacteristics = getValidatedCharacteristics(characteristicIds)
+
+    if (validationErrors.any()) {
+      return fieldValidationError
+    }
+
+    val premises = Cas3PremisesEntity(
+      id = UUID.randomUUID(),
+      name = reference,
+      addressLine1 = addressLine1,
+      addressLine2 = addressLine2,
+      town = town,
+      postcode = postcode,
+      localAuthorityArea = localAuthorityArea,
+      notes = notes.orEmpty(),
+      status = Cas3PremisesStatus.online,
+      probationDeliveryUnit = probationDeliveryUnit!!,
+      characteristics = validatedPremisesCharacteristics.toMutableList(),
+      turnaroundWorkingDays = turnaroundWorkingDays ?: 2,
+      bookings = mutableListOf(),
+      bedspaces = mutableListOf(),
+      startDate = LocalDate.now(),
+      endDate = null,
+      createdAt = OffsetDateTime.now(),
+      lastUpdatedAt = null,
+    )
+
+    cas3PremisesRepository.save(premises)
+    return success(premises)
+  }
+
+  private fun CasResultValidatedScope<Cas3PremisesEntity>.getValidatedCharacteristics(premisesCharacteristicIds: List<UUID>): List<Cas3PremisesCharacteristicEntity> {
+    val validatedCharacteristics =
+      cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(premisesCharacteristicIds)
+
+    val validatedCharacteristicIds = validatedCharacteristics.map { it.id }
+
+    premisesCharacteristicIds.forEach {
+      if (!validatedCharacteristicIds.contains(it)) {
+        validationErrors["$.premisesCharacteristics[$it]"] = "doesNotExist"
+      }
+    }
+    return validatedCharacteristics
+  }
+
+  private fun isUniqueName(reference: String, probationDeliveryUnitId: UUID): Boolean = !cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(reference, probationDeliveryUnitId)
+
+  fun getBedspaceTotals(premisesId: UUID): CasResult.Success<TemporaryAccommodationPremisesTotalBedspacesByStatus> {
+    val premises = cas3PremisesRepository.findByIdOrNull(premisesId)
+
+    return CasResult.Success(
+      TemporaryAccommodationPremisesTotalBedspacesByStatus(
+        premisesId = premises!!.id,
+        premises.bedspaces.count { isCas3BedspaceOnline(it.startDate, it.endDate) },
+        premises.bedspaces.count { isCas3BedspaceUpcoming(it.startDate) },
+        premises.bedspaces.count { isCas3BedspaceArchived(it.endDate) },
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2PremisesTest.kt
@@ -1,0 +1,229 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.InvalidParam
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3NewPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.failsWithValidationMessages
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomPostCode
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+
+class Cas3v2PremisesTest : IntegrationTestBase() {
+
+  fun createCharacteristics(count: Int = 1): List<Cas3PremisesCharacteristicEntity> = cas3PremisesCharacteristicEntityFactory.produceAndPersistMultiple(count).sortedBy { it.name }
+
+  fun createPdu(probationRegionEntity: ProbationRegionEntity) = probationDeliveryUnitFactory.produceAndPersist {
+    withProbationRegion(probationRegionEntity)
+  }
+
+  @Nested
+  inner class CreatePremises {
+    @Test
+    fun `Create new premises returns 201 Created with correct body`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val characteristics = createCharacteristics(5)
+        val pdu = createPdu(user.probationRegion)
+
+        val newPremises = Cas3NewPremises(
+          reference = randomStringMultiCaseWithNumbers(10),
+          addressLine1 = randomStringMultiCaseWithNumbers(25),
+          addressLine2 = randomStringMultiCaseWithNumbers(12),
+          town = randomStringMultiCaseWithNumbers(10),
+          postcode = randomPostCode(),
+          localAuthorityAreaId = localAuthorityArea.id,
+          probationRegionId = user.probationRegion.id,
+          probationDeliveryUnitId = pdu.id,
+          characteristicIds = characteristics.map { it.id },
+          notes = randomStringLowerCase(100),
+          turnaroundWorkingDays = 3,
+        )
+
+        val result = webTestClient.post()
+          .uri("/cas3/v2/premises")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newPremises)
+          .exchange()
+          .expectStatus()
+          .isCreated
+          .bodyAsObject<Cas3Premises>()
+
+        assertAll({
+          assertThat(result.id).isNotNull
+          assertThat(result.reference).isEqualTo(newPremises.reference)
+          assertThat(result.addressLine1).isEqualTo(newPremises.addressLine1)
+          assertThat(result.addressLine2).isEqualTo(newPremises.addressLine2)
+          assertThat(result.town).isEqualTo(newPremises.town)
+          assertThat(result.postcode).isEqualTo(newPremises.postcode)
+          assertThat(result.localAuthorityArea!!.id).isEqualTo(localAuthorityArea.id)
+          assertThat(result.probationRegion.id).isEqualTo(newPremises.probationRegionId)
+          assertThat(result.probationDeliveryUnit.id).isEqualTo(newPremises.probationDeliveryUnitId)
+          assertThat(result.notes).isEqualTo(newPremises.notes)
+          assertThat(result.turnaroundWorkingDays).isEqualTo(newPremises.turnaroundWorkingDays)
+          assertThat(result.characteristics).isNull()
+          assertThat(result.premisesCharacteristics).hasSize(5)
+          assertThat(result.premisesCharacteristics).containsAll(characteristics.map { it.toCas3PremisesCharacteristic() })
+          assertThat(result.status).isEqualTo(Cas3PremisesStatus.online)
+          assertThat(result.totalOnlineBedspaces).isEqualTo(0)
+          assertThat(result.totalUpcomingBedspaces).isEqualTo(0)
+          assertThat(result.totalArchivedBedspaces).isEqualTo(0)
+          assertThat(result.startDate).isEqualTo(LocalDate.now())
+          assertThat(result.endDate).isNull()
+          assertThat(result.scheduleUnarchiveDate).isNull()
+          assertThat(result.archiveHistory).isEmpty()
+        })
+      }
+    }
+
+    @Test
+    fun `When a new premises is created with default values for optional properties returns 201 Created with correct body`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val pdu = createPdu(user.probationRegion)
+
+        val newPremises = Cas3NewPremises(
+          reference = randomStringMultiCaseWithNumbers(10),
+          addressLine1 = randomStringMultiCaseWithNumbers(25),
+          addressLine2 = null,
+          town = null,
+          postcode = randomPostCode(),
+          localAuthorityAreaId = null,
+          probationRegionId = user.probationRegion.id,
+          probationDeliveryUnitId = pdu.id,
+          characteristicIds = emptyList(),
+          notes = null,
+          turnaroundWorkingDays = null,
+        )
+
+        val result = webTestClient.post()
+          .uri("/cas3/v2/premises")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newPremises)
+          .exchange()
+          .expectStatus()
+          .isCreated
+          .bodyAsObject<Cas3Premises>()
+
+        assertAll({
+          assertThat(result.id).isNotNull
+          assertThat(result.reference).isEqualTo(newPremises.reference)
+          assertThat(result.addressLine1).isEqualTo(newPremises.addressLine1)
+          assertThat(result.addressLine2).isNull()
+          assertThat(result.town).isNull()
+          assertThat(result.postcode).isEqualTo(newPremises.postcode)
+          assertThat(result.localAuthorityArea).isNull()
+          assertThat(result.probationRegion.id).isEqualTo(newPremises.probationRegionId)
+          assertThat(result.probationDeliveryUnit.id).isEqualTo(newPremises.probationDeliveryUnitId)
+          assertThat(result.notes).isEmpty()
+          assertThat(result.turnaroundWorkingDays).isEqualTo(2)
+          assertThat(result.characteristics).isNull()
+          assertThat(result.premisesCharacteristics).isEmpty()
+          assertThat(result.status).isEqualTo(Cas3PremisesStatus.online)
+          assertThat(result.totalOnlineBedspaces).isEqualTo(0)
+          assertThat(result.totalUpcomingBedspaces).isEqualTo(0)
+          assertThat(result.totalArchivedBedspaces).isEqualTo(0)
+          assertThat(result.startDate).isEqualTo(LocalDate.now())
+          assertThat(result.endDate).isNull()
+          assertThat(result.scheduleUnarchiveDate).isNull()
+          assertThat(result.archiveHistory).isEmpty()
+        })
+      }
+    }
+
+    @Test
+    fun `Create new premises returns error when premises name already used in probation region`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val characteristics = createCharacteristics(5)
+        val pdu = createPdu(user.probationRegion)
+        val (anotherUser, anotherJwt) = givenAUser(
+          roles = listOf(UserRole.CAS3_ASSESSOR),
+        )
+
+        val reference = randomStringMultiCaseWithNumbers(25).uppercase()
+
+        val newPremises = Cas3NewPremises(
+          reference = reference,
+          addressLine1 = randomStringMultiCaseWithNumbers(25),
+          addressLine2 = randomStringMultiCaseWithNumbers(12),
+          town = randomStringMultiCaseWithNumbers(10),
+          postcode = randomPostCode(),
+          localAuthorityAreaId = localAuthorityArea.id,
+          probationRegionId = user.probationRegion.id,
+          probationDeliveryUnitId = pdu.id,
+          characteristicIds = characteristics.map { it.id },
+          notes = randomStringLowerCase(100),
+          turnaroundWorkingDays = 3,
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newPremises)
+          .exchange()
+          .expectStatus()
+          .isCreated
+
+        // fails with same name and pdu, ignores case of reference
+        webTestClient.post()
+          .uri("/cas3/v2/premises")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newPremises.copy(reference = reference.lowercase()))
+          .exchange()
+          .expectStatus()
+          .is4xxClientError
+          .failsWithValidationMessages(InvalidParam(propertyName = "$.reference", errorType = "notUnique"))
+
+        // passes with same name but different pdu
+        webTestClient.post()
+          .uri("/cas3/v2/premises")
+          .headers(buildTemporaryAccommodationHeaders(anotherJwt))
+          .bodyValue(
+            newPremises.copy(
+              probationRegionId = anotherUser.probationRegion.id,
+              probationDeliveryUnitId = anotherUser.probationDeliveryUnit!!.id,
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isCreated
+      }
+    }
+
+    @Test
+    fun `Create new Premises that's not in the user's region returns 403 Forbidden`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val anotherProbationRegion = probationRegionEntityFactory.produceAndPersist()
+        val pdu = createPdu(user.probationRegion)
+
+        val newPremises = Cas3NewPremises(
+          reference = randomStringMultiCaseWithNumbers(10),
+          addressLine1 = randomStringMultiCaseWithNumbers(25),
+          postcode = randomPostCode(),
+          probationRegionId = anotherProbationRegion.id,
+          probationDeliveryUnitId = pdu.id,
+          characteristicIds = emptyList(),
+        )
+
+        webTestClient.post()
+          .uri("/cas3/v2/premises")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(newPremises)
+          .exchange()
+          .expectStatus()
+          .isForbidden
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2PremisesServiceTest.kt
@@ -1,30 +1,326 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.service.v2
 
 import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesCharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2PremisesService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
+@ExtendWith(MockKExtension::class)
 class Cas3v2PremisesServiceTest {
-  private val mockPremisesRepository = mockk<Cas3PremisesRepository>()
-  private val mockCas3DomainEventService = mockk<Cas3v2DomainEventService>()
 
-  private val cas3v2PremisesService = Cas3v2PremisesService(
-    mockPremisesRepository,
-    mockCas3DomainEventService,
-  )
+  @MockK
+  lateinit var cas3PremisesRepository: Cas3PremisesRepository
+
+  @MockK
+  lateinit var cas3DomainEventService: Cas3v2DomainEventService
+
+  @MockK
+  lateinit var localAuthorityAreaRepository: LocalAuthorityAreaRepository
+
+  @MockK
+  lateinit var probationDeliveryUnitRepository: ProbationDeliveryUnitRepository
+
+  @MockK
+  lateinit var cas3PremisesCharacteristicRepository: Cas3PremisesCharacteristicRepository
+
+  @InjectMockKs
+  lateinit var cas3v2PremisesService: Cas3v2PremisesService
+
+  @Nested
+  inner class CreateNewPremises {
+
+    @Test
+    fun `has validation errors when incorrect values are used`() {
+      every { localAuthorityAreaRepository.findByIdOrNull(any()) } returns null
+      every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(any(), any()) } returns null
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(any()) } returns emptyList()
+
+      val characteristicId = UUID.randomUUID()
+
+      val result = cas3v2PremisesService.createNewPremises(
+        reference = "",
+        addressLine1 = "",
+        addressLine2 = "",
+        town = "",
+        postcode = "",
+        localAuthorityAreaId = UUID.randomUUID(),
+        probationRegionId = UUID.randomUUID(),
+        probationDeliveryUnitId = UUID.randomUUID(),
+        characteristicIds = mutableListOf(characteristicId),
+        notes = null,
+        turnaroundWorkingDays = -1,
+      )
+
+      assertThatCasResult(result).isFieldValidationError()
+        .hasMessage("$.reference", "empty")
+        .hasMessage("$.address", "empty")
+        .hasMessage("$.postcode", "empty")
+        .hasMessage("$.localAuthorityAreaId", "doesNotExist")
+        .hasMessage("$.probationRegionId", "doesNotExist")
+        .hasMessage("$.probationDeliveryUnitId", "doesNotExist")
+        .hasMessage("$.premisesCharacteristics[$characteristicId]", "doesNotExist")
+        .hasMessage("$.turnaroundWorkingDays", "isNotAPositiveInteger")
+        .withNumberOfMessages(8)
+
+      verify(exactly = 0) { cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(any(), any()) }
+    }
+
+    @Test
+    fun `has validation error when reference is not unique`() {
+      every { localAuthorityAreaRepository.findByIdOrNull(any()) } returns mockk<LocalAuthorityAreaEntity>()
+
+      val mockPdu = mockk<ProbationDeliveryUnitEntity>()
+      every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(any(), any()) } returns mockPdu
+      every { mockPdu.probationRegion } returns mockk<ProbationRegionEntity>()
+      every { cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(any(), any()) } returns true
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(any()) } returns emptyList()
+
+      val pduId = UUID.randomUUID()
+
+      val result = cas3v2PremisesService.createNewPremises(
+        reference = "notunique",
+        addressLine1 = "asd",
+        addressLine2 = "asd",
+        town = "asd",
+        postcode = "asd",
+        localAuthorityAreaId = null,
+        probationRegionId = UUID.randomUUID(),
+        probationDeliveryUnitId = pduId,
+        characteristicIds = mutableListOf(),
+        notes = null,
+        turnaroundWorkingDays = 0,
+      )
+
+      verify(exactly = 1) {
+        cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(
+          "notunique",
+          pduId,
+        )
+      }
+
+      assertThatCasResult(result).isFieldValidationError()
+        .hasMessage("$.reference", "notUnique")
+        .withNumberOfMessages(1)
+    }
+
+    @Test
+    fun `returns CasResult-Success when validation is passed`() {
+      val laa = LocalAuthorityEntityFactory().produce()
+      val pdu = ProbationDeliveryUnitEntityFactory().withDefaults().produce()
+      val cas3PremisesCharacteristic = Cas3PremisesCharacteristicEntityFactory().produce()
+
+      val premisesName = "newName"
+
+      every { localAuthorityAreaRepository.findByIdOrNull(laa.id) } returns laa
+      every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(pdu.id, pdu.probationRegion.id) } returns pdu
+      every {
+        cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(premisesName, pdu.id)
+      } returns false
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(listOf(cas3PremisesCharacteristic.id)) } returns listOf(
+        cas3PremisesCharacteristic,
+      )
+
+      val premisesSlot = slot<Cas3PremisesEntity>()
+      every { cas3PremisesRepository.save(capture(premisesSlot)) } answers { premisesSlot.captured }
+
+      val result = cas3v2PremisesService.createNewPremises(
+        reference = premisesName,
+        addressLine1 = "asd1",
+        addressLine2 = "asd2",
+        town = "asd3",
+        postcode = "asd4",
+        localAuthorityAreaId = laa.id,
+        probationRegionId = pdu.probationRegion.id,
+        probationDeliveryUnitId = pdu.id,
+        characteristicIds = listOf(cas3PremisesCharacteristic.id),
+        notes = "some new notes",
+        turnaroundWorkingDays = 9,
+      )
+
+      assertAll({
+        val capturedPremises = premisesSlot.captured
+        assertThat(capturedPremises.id).isNotNull
+        assertThat(capturedPremises.name).isEqualTo(premisesName)
+        assertThat(capturedPremises.addressLine1).isEqualTo("asd1")
+        assertThat(capturedPremises.addressLine2).isEqualTo("asd2")
+        assertThat(capturedPremises.town).isEqualTo("asd3")
+        assertThat(capturedPremises.postcode).isEqualTo("asd4")
+        assertThat(capturedPremises.localAuthorityArea).isEqualTo(laa)
+        assertThat(capturedPremises.notes).isEqualTo("some new notes")
+        assertThat(capturedPremises.status).isEqualTo(Cas3PremisesStatus.online)
+        assertThat(capturedPremises.probationDeliveryUnit).isEqualTo(pdu)
+        assertThat(capturedPremises.characteristics).isEqualTo(mutableListOf(cas3PremisesCharacteristic))
+        assertThat(capturedPremises.turnaroundWorkingDays).isEqualTo(9)
+        assertThat(capturedPremises.bookings).isEmpty()
+        assertThat(capturedPremises.bedspaces).isEmpty()
+        assertThat(capturedPremises.startDate).isEqualTo(LocalDate.now())
+        assertThat(capturedPremises.endDate).isNull()
+        assertThat(capturedPremises.createdAt).isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.SECONDS))
+        assertThat(capturedPremises.lastUpdatedAt).isNull()
+
+        assertThatCasResult(result).isSuccess().with {
+          assertThat(it).isEqualTo(capturedPremises)
+        }
+      })
+
+      verify(exactly = 1) { localAuthorityAreaRepository.findByIdOrNull(laa.id) }
+      verify(exactly = 1) {
+        probationDeliveryUnitRepository.findByIdAndProbationRegionId(pdu.id, pdu.probationRegion.id)
+      }
+      verify(exactly = 1) {
+        cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(premisesName, pdu.id)
+      }
+    }
+
+    @Test
+    fun `turnaround working days defaults to 2 when null is provided`() {
+      val laa = LocalAuthorityEntityFactory().produce()
+      val pdu = ProbationDeliveryUnitEntityFactory().withDefaults().produce()
+      val cas3PremisesCharacteristic = Cas3PremisesCharacteristicEntityFactory().produce()
+
+      val premisesName = "newName"
+
+      every { localAuthorityAreaRepository.findByIdOrNull(laa.id) } returns laa
+      every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(pdu.id, pdu.probationRegion.id) } returns pdu
+      every {
+        cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(premisesName, pdu.id)
+      } returns false
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(listOf(cas3PremisesCharacteristic.id)) } returns listOf(
+        cas3PremisesCharacteristic,
+      )
+
+      val premisesSlot = slot<Cas3PremisesEntity>()
+      every { cas3PremisesRepository.save(capture(premisesSlot)) } answers { premisesSlot.captured }
+
+      val result = cas3v2PremisesService.createNewPremises(
+        reference = premisesName,
+        addressLine1 = "asd1",
+        addressLine2 = "asd2",
+        town = "asd3",
+        postcode = "asd4",
+        localAuthorityAreaId = laa.id,
+        probationRegionId = pdu.probationRegion.id,
+        probationDeliveryUnitId = pdu.id,
+        characteristicIds = listOf(cas3PremisesCharacteristic.id),
+        notes = "",
+        turnaroundWorkingDays = null,
+      )
+
+      assertAll({
+        val capturedPremises = premisesSlot.captured
+        assertThat(capturedPremises.turnaroundWorkingDays).isEqualTo(2)
+        assertThatCasResult(result).isSuccess().with {
+          assertThat(it.turnaroundWorkingDays).isEqualTo(2)
+        }
+      })
+    }
+  }
+
+  @Nested
+  inner class BedspaceTotals {
+
+    val premises = Cas3PremisesEntityFactory().withDefaults().produce()
+
+    val onlineBedspace =
+      Cas3BedspaceEntityFactory()
+        .withStartDate(LocalDate.now().minusDays(10))
+        .withEndDate(LocalDate.now().plusDays(10))
+        .withPremises(premises)
+        .produce()
+
+    val archivedBedspace =
+      Cas3BedspaceEntityFactory()
+        .withStartDate(LocalDate.now().minusDays(10))
+        .withEndDate(LocalDate.now().minusDays(5))
+        .withPremises(premises)
+        .produce()
+
+    val upcomingBedspace =
+      Cas3BedspaceEntityFactory()
+        .withStartDate(LocalDate.now().plusDays(10))
+        .withEndDate(LocalDate.now().plusDays(100))
+        .withPremises(premises)
+        .produce()
+
+    val onlineBedspace2 =
+      Cas3BedspaceEntityFactory()
+        .withStartDate(LocalDate.now().minusDays(10))
+        .withEndDate(LocalDate.now().plusDays(10))
+        .withPremises(premises)
+        .produce()
+
+    val archivedBedspace2 =
+      Cas3BedspaceEntityFactory()
+        .withStartDate(LocalDate.now().minusDays(10))
+        .withEndDate(LocalDate.now().minusDays(5))
+        .withPremises(premises)
+        .produce()
+
+    val upcomingBedspace2 =
+      Cas3BedspaceEntityFactory()
+        .withStartDate(LocalDate.now().plusDays(10))
+        .withEndDate(LocalDate.now().plusDays(100))
+        .withPremises(premises)
+        .produce()
+
+    @Test
+    fun `returns correct totals when premises has mixed bedspaces`() {
+      premises.bedspaces = mutableListOf(onlineBedspace, onlineBedspace2, archivedBedspace, archivedBedspace2, upcomingBedspace, upcomingBedspace2)
+      every { cas3PremisesRepository.findByIdOrNull(premises.id) } returns premises
+
+      val result = cas3v2PremisesService.getBedspaceTotals(premises.id)
+
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.onlineBedspaces).isEqualTo(2)
+        assertThat(it.upcomingBedspaces).isEqualTo(2)
+        assertThat(it.archivedBedspaces).isEqualTo(2)
+      }
+    }
+
+    @Test
+    fun `returns all zeros when premises has no bedspaces`() {
+      premises.bedspaces = mutableListOf()
+      every { cas3PremisesRepository.findByIdOrNull(premises.id) } returns premises
+      val result = cas3v2PremisesService.getBedspaceTotals(premises.id)
+
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.onlineBedspaces).isEqualTo(0)
+        assertThat(it.upcomingBedspaces).isEqualTo(0)
+        assertThat(it.archivedBedspaces).isEqualTo(0)
+      }
+    }
+  }
 
   @Nested
   inner class UnarchivePremises {
@@ -47,14 +343,14 @@ class Cas3v2PremisesServiceTest {
         endDate = null,
       )
 
-      every { mockPremisesRepository.save(match { it.id == premises.id }) } returns updatedPremises
-      every { mockCas3DomainEventService.savePremisesUnarchiveEvent(eq(updatedPremises), premises.startDate, restartDate, premises.endDate!!, any()) } returns Unit
+      every { cas3PremisesRepository.save(match { it.id == premises.id }) } returns updatedPremises
+      every { cas3DomainEventService.savePremisesUnarchiveEvent(eq(updatedPremises), premises.startDate, restartDate, premises.endDate!!, any()) } returns Unit
 
       cas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(premises, restartDate, UUID.randomUUID())
 
       val slot = slot<Cas3PremisesEntity>()
       verify(exactly = 1) {
-        mockPremisesRepository.save(capture(slot))
+        cas3PremisesRepository.save(capture(slot))
       }
 
       val savedPremises = slot.captured
@@ -67,7 +363,7 @@ class Cas3v2PremisesServiceTest {
       )
 
       verify(exactly = 1) {
-        mockCas3DomainEventService.savePremisesUnarchiveEvent(eq(premises), eq(startDate), eq(restartDate), eq(endDate), any())
+        cas3DomainEventService.savePremisesUnarchiveEvent(eq(premises), eq(startDate), eq(restartDate), eq(endDate), any())
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/util/CasResultAssertions.kt
@@ -149,9 +149,12 @@ class CasResultFieldValidationErrorAssertions<T>(actual: CasResult.FieldValidati
   ) {
   fun hasMessage(field: String, expectedMessage: String): CasResultFieldValidationErrorAssertions<T> {
     val validationMessages = actual.validationMessages
-
     assertThat(validationMessages).containsEntry(field, expectedMessage)
-
+    return this
+  }
+  fun withNumberOfMessages(expectedMessageCount: Int): CasResultFieldValidationErrorAssertions<T> {
+    val validationMessages = actual.validationMessages
+    assertThat(validationMessages).hasSize(expectedMessageCount)
     return this
   }
 }


### PR DESCRIPTION
This PR Introduces the POST endpoint to create a premises. It's duplicating logic from `/cas3/premises/` to `/cas3/v2/premises`. There were a number of preceding PR's that refactored the existing code and improved reusability.