### PR TITLE
CAS3 Reports - Bed Usage Report Improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3ReportsController.kt
@@ -85,7 +85,7 @@ class Cas3ReportsController(
 
       bedUsage ->
         generateXlsxStreamingResponse { outputStream ->
-          cas3ReportService.createBedUsageReport(
+          cas3ReportService.createBedUsageReportV2(
             BedUsageReportProperties(
               ServiceName.temporaryAccommodation,
               startDate = startDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3VoidBedspace.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3VoidBedspace.kt
@@ -45,4 +45,9 @@ enum class Cas3VoidBedspaceStatus(@JsonValue val value: String) {
 enum class Cas3CostCentre(@JsonValue val value: String) {
   HMPPS("HMPPS"),
   SUPPLIER("SUPPLIER"),
+  ;
+
+  companion object {
+    fun from(value: String): Cas3CostCentre? = Cas3CostCentre.entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/generator/Cas3BedUsageReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/generator/Cas3BedUsageReportGenerator.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.generator
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3CostCentre
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedUsageReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedUsageType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.properties.BedUsageReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.util.toShortBase58
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BedUsageReportDataDTO
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.BookingTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilExclusiveEnd
+import java.util.UUID
+
+class Cas3BedUsageReportGenerator(
+  private val bookingTransformer: BookingTransformer,
+  private val workingDayService: WorkingDayService,
+) : ReportGenerator<BedUsageReportDataDTO, BedUsageReportRow, BedUsageReportProperties>(BedUsageReportRow::class) {
+  override fun filter(properties: BedUsageReportProperties): (BedUsageReportDataDTO) -> Boolean = {
+    (properties.probationRegionId == null || UUID.fromString(it.probationRegionId) == properties.probationRegionId)
+  }
+
+  override val convert: BedUsageReportDataDTO.(properties: BedUsageReportProperties) -> List<BedUsageReportRow> = {
+    val bedUsageReportRow = when (BedUsageType.from(this.type)) {
+      BedUsageType.Booking -> BedUsageReportRow(
+        probationRegion = this.probationRegionName,
+        pdu = this.pdu,
+        localAuthority = this.localAuthorityArea,
+        propertyRef = this.propertyRef,
+        addressLine1 = this.addressLine1,
+        town = this.town,
+        postCode = this.postCode,
+        bedspaceRef = this.bedspaceRef,
+        crn = this.crn,
+        type = BedUsageType.Booking,
+        startDate = this.startDate,
+        endDate = this.endDate,
+        durationOfBookingDays = this.startDate.getDaysUntilExclusiveEnd(this.endDate).size,
+        bookingStatus = bookingTransformer.determineTemporaryAccommodationStatus(
+          hasTurnaround = this.turnaroundId != null,
+          turnaroundWorkingDayCount = this.turnaroundWorkingDayCount,
+          departureDate = this.endDate,
+          hasCancellation = this.cancellationCount > 0,
+          hasDeparture = this.departureCount > 0,
+          hasArrival = this.arrivalCount > 0,
+          hasNonArrival = this.nonArrivalCount > 0,
+          hasConfirmation = this.confirmationCount > 0,
+        ),
+        voidCategory = null,
+        voidNotes = null,
+        costCentre = null,
+        uniquePropertyRef = UUID.fromString(this.uniquePropertyRef).toShortBase58(),
+        uniqueBedspaceRef = UUID.fromString(this.uniqueBedspaceRef).toShortBase58(),
+      )
+      BedUsageType.Turnaround -> {
+        val turnaroundStartDate = this.bookingDepartureDate.plusDays(1)
+        val endDate = workingDayService.addWorkingDays(this.bookingDepartureDate, this.turnaroundWorkingDayCount!!)
+        BedUsageReportRow(
+          probationRegion = this.probationRegionName,
+          pdu = this.pdu,
+          localAuthority = this.localAuthorityArea,
+          propertyRef = this.propertyRef,
+          addressLine1 = this.addressLine1,
+          town = this.town,
+          postCode = this.postCode,
+          bedspaceRef = this.bedspaceRef,
+          crn = this.crn,
+          type = BedUsageType.Turnaround,
+          startDate = turnaroundStartDate,
+          endDate = endDate,
+          durationOfBookingDays = turnaroundStartDate.getDaysUntilExclusiveEnd(endDate).size,
+          bookingStatus = null,
+          voidCategory = null,
+          voidNotes = null,
+          costCentre = null,
+          uniquePropertyRef = UUID.fromString(this.uniquePropertyRef).toShortBase58(),
+          uniqueBedspaceRef = UUID.fromString(this.uniqueBedspaceRef).toShortBase58(),
+        )
+      }
+      BedUsageType.Void -> BedUsageReportRow(
+        probationRegion = this.probationRegionName,
+        pdu = this.pdu,
+        localAuthority = this.localAuthorityArea,
+        propertyRef = this.propertyRef,
+        addressLine1 = this.addressLine1,
+        town = this.town,
+        postCode = this.postCode,
+        bedspaceRef = this.bedspaceRef,
+        crn = this.crn,
+        type = BedUsageType.Void,
+        startDate = this.startDate,
+        endDate = this.endDate,
+        durationOfBookingDays = this.startDate.getDaysUntilExclusiveEnd(this.endDate).size,
+        bookingStatus = null,
+        voidCategory = this.voidCategory,
+        voidNotes = this.voidNotes,
+        costCentre = if (this.costCentre != null) Cas3CostCentre.from(this.costCentre) else null,
+        uniquePropertyRef = UUID.fromString(this.uniquePropertyRef).toShortBase58(),
+        uniqueBedspaceRef = UUID.fromString(this.uniqueBedspaceRef).toShortBase58(),
+      )
+    }
+    listOf(bedUsageReportRow)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/model/BedUsageReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/model/BedUsageReportRow.kt
@@ -30,4 +30,10 @@ enum class BedUsageType {
   Booking,
   Turnaround,
   Void,
+  ;
+
+  companion object {
+    fun from(value: String): BedUsageType = entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
+      ?: throw IllegalArgumentException("Unknown BedUsageType: $value")
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/BedUsageRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/BedUsageRepository.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import java.time.LocalDate
 import java.util.UUID
 
 interface BedUsageRepository : JpaRepository<BedEntity, UUID> {
@@ -21,4 +22,230 @@ interface BedUsageRepository : JpaRepository<BedEntity, UUID> {
   fun findAllBedspaces(
     probationRegionId: UUID?,
   ): List<BedEntity>
+
+  @Query(
+    value = """
+        SELECT
+            b.id                    AS bedId,
+            boo.id                  AS bookingId,
+            pr.id                   AS probationRegionId,
+            pr.name                 AS probationRegionName,
+            pdu.name                AS pdu,
+            lau.name                AS localAuthorityArea,
+            p.name                  AS propertyRef,
+            p.address_line1         AS addressLine1,
+            p.town                  AS town,
+            p.postcode              AS postCode,
+            r.name                  AS bedspaceRef,
+            boo.crn                 AS crn,
+            'Booking'               AS type,
+            boo.departure_date      AS bookingDepartureDate,
+            boo.arrival_date        AS startDate,
+            boo.departure_date      AS endDate,
+            t.id                    AS turnaroundId,
+            t.working_day_count     AS turnaroundWorkingDayCount,
+            COUNT(DISTINCT c.id)    AS cancellationCount,
+            COUNT(DISTINCT d.id)    AS departureCount,
+            COUNT(DISTINCT a.id)    AS arrivalCount,
+            COUNT(DISTINCT na.id)   AS nonArrivalCount,
+            COUNT(DISTINCT conf.id) AS confirmationCount,
+            NULL                    AS voidCategory,
+            NULL                    AS voidNotes,
+            NULL                    AS costCentre,
+            p.id                    AS uniquePropertyRef,
+            r.id                    AS uniqueBedspaceRef
+        FROM temporary_accommodation_premises tap
+                 JOIN premises p ON p.id = tap.premises_id
+                 JOIN rooms r ON r.premises_id = p.id
+                 JOIN beds b ON b.room_id = r.id
+                 JOIN bookings boo ON boo.bed_id = b.id
+                 LEFT JOIN cas3_turnarounds t ON t.booking_id = boo.id
+                 LEFT JOIN cancellations c ON c.booking_id = boo.id
+                 LEFT JOIN departures d ON d.booking_id = boo.id
+                 LEFT JOIN arrivals a ON a.booking_id = boo.id
+                 LEFT JOIN non_arrivals na ON na.booking_id = boo.id
+                 LEFT JOIN cas3_confirmations conf ON conf.booking_id = boo.id
+                 LEFT JOIN probation_regions pr ON pr.id = p.probation_region_id
+                 LEFT JOIN probation_delivery_units pdu ON pdu.id = tap.probation_delivery_unit_id
+                 LEFT JOIN local_authority_areas lau ON lau.id = p.local_authority_area_id
+        WHERE p.service = 'temporary-accommodation'
+          AND p.probation_region_id = :probationRegionId
+          AND boo.arrival_date <= :endDate
+          AND boo.departure_date >= :startDate
+        GROUP BY
+            b.id, boo.id,
+            pr.id, pr.name,
+            pdu.name,
+            lau.name,
+            p.name, p.address_line1, p.town, p.postcode,
+            r.name,
+            boo.crn,
+            boo.departure_date,
+            boo.arrival_date,
+            t.id, t.working_day_count,
+            p.id,
+            r.id
+            
+        UNION
+        
+        SELECT 
+            b.id                AS bedId,
+            boo.id              AS bookingId,
+            pr.id               AS probationRegionId,
+            pr.name             AS probationRegionName,
+            pdu.name            AS pdu,
+            lau.name            AS localAuthorityArea,
+            p.name              AS propertyRef,
+            p.address_line1     AS addressLine1,
+            p.town              AS town,
+            p.postcode          AS postCode,
+            r.name              AS bedspaceRef,
+            NULL                AS crn,
+            'Turnaround'        AS type,
+            boo.departure_date  AS bookingDepartureDate,
+            NULL                AS startDate,
+            NULL                AS endDate,
+            t.id                AS turnaroundId,
+            t.working_day_count AS turnaroundWorkingDayCount,
+            0                   AS cancellationCount,
+            0                   AS departureCount,
+            0                   AS arrivalCount,
+            0                   AS nonArrivalCount,
+            0                   AS confirmationCount,
+            NULL                AS voidCategory,
+            NULL                AS voidNotes,
+            NULL                AS costCentre,
+            p.id                AS uniquePropertyRef,
+            r.id                AS uniqueBedspaceRef
+        FROM temporary_accommodation_premises tap
+                 JOIN premises p on p.id = tap.premises_id
+                 JOIN rooms r on r.premises_id = p.id
+                 JOIN beds b on b.room_id = r.id
+                 JOIN bookings boo on boo.bed_id = b.id
+                 JOIN cas3_turnarounds t on t.booking_id = boo.id
+                 LEFT JOIN probation_regions pr on pr.id = p.probation_region_id
+                 LEFT JOIN probation_delivery_units pdu ON pdu.id = tap.probation_delivery_unit_id
+                 LEFT JOIN local_authority_areas lau on lau.id = p.local_authority_area_id
+        WHERE p.service = 'temporary-accommodation'
+          AND p.probation_region_id = :probationRegionId
+          AND boo.arrival_date <= :endDate
+          AND boo.departure_date >= :startDate
+          
+        UNION
+        
+        SELECT 
+            b.id            AS bedId,
+            NULL            AS bookingId,
+            pr.id           AS probationRegionId,
+            pr.name         AS probationRegionName,
+            pdu.name        AS pdu,
+            lau.name        AS localAuthorityArea,
+            p.name          AS propertyRef,
+            p.address_line1 AS addressLine1,
+            p.town          AS town,
+            p.postcode      AS postCode,
+            r.name          AS bedspaceRef,
+            NULL            AS crn,
+            'Void'          AS type,
+            NULL            AS bookingDepartureDate,
+            lb.start_date   AS startDate,
+            lb.end_date     AS endDate,
+            NULL            AS turnaroundId,
+            NULL            AS turnaroundWorkingDayCount,
+            0               AS cancellationCount,
+            0               AS departureCount,
+            0               AS arrivalCount,
+            0               AS nonArrivalCount,
+            0               AS confirmationCount,
+            lbr.name        AS voidCategory,
+            lb.notes        AS voidNotes,
+            lb.cost_centre  AS costCentre,
+            p.id            AS uniquePropertyRef,
+            r.id            AS uniqueBedspaceRef
+        FROM temporary_accommodation_premises tap
+                 JOIN premises p on p.id = tap.premises_id
+                 JOIN rooms r on r.premises_id = p.id
+                 JOIN beds b on b.room_id = r.id
+                 JOIN cas3_void_bedspaces lb on lb.bed_id = b.id
+                 LEFT JOIN cas3_void_bedspace_reasons lbr on lbr.id = lb.cas3_void_bedspace_reason_id
+                 LEFT JOIN probation_regions pr on pr.id = p.probation_region_id
+                 LEFT JOIN probation_delivery_units pdu ON pdu.id = tap.probation_delivery_unit_id
+                 LEFT JOIN local_authority_areas lau on lau.id = p.local_authority_area_id
+        WHERE p.service = 'temporary-accommodation'
+          AND p.probation_region_id = :probationRegionId
+          AND lb.start_date <= :endDate
+          AND lb.end_date >= :startDate
+          AND lb.cancellation_date IS NULL
+          
+        ORDER BY bedId, bookingId
+        """,
+    nativeQuery = true,
+  )
+  fun findBedUsageReportData(
+    probationRegionId: UUID?,
+    startDate: LocalDate,
+    endDate: LocalDate,
+  ): List<BedUsageReportDataRow>
 }
+
+interface BedUsageReportDataRow {
+  val bedId: UUID
+  val bookingId: UUID?
+  val probationRegionId: String?
+  val probationRegionName: String?
+  val pdu: String?
+  val localAuthorityArea: String?
+  val propertyRef: String
+  val addressLine1: String
+  val town: String?
+  val postCode: String
+  val bedspaceRef: String
+  val crn: String?
+  val type: String
+  val bookingDepartureDate: LocalDate
+  val startDate: LocalDate
+  val endDate: LocalDate
+  val turnaroundId: UUID?
+  val turnaroundWorkingDayCount: Int?
+  val cancellationCount: Int
+  val departureCount: Int
+  val arrivalCount: Int
+  val nonArrivalCount: Int
+  val confirmationCount: Int
+  val voidCategory: String?
+  val voidNotes: String?
+  val costCentre: String?
+  val uniquePropertyRef: String
+  val uniqueBedspaceRef: String
+}
+
+data class BedUsageReportDataDTO(
+  val bedId: UUID,
+  val bookingId: UUID?,
+  val probationRegionId: String?,
+  val probationRegionName: String?,
+  val pdu: String?,
+  val localAuthorityArea: String?,
+  val propertyRef: String,
+  val addressLine1: String,
+  val town: String?,
+  val postCode: String,
+  val bedspaceRef: String,
+  val crn: String?,
+  val type: String,
+  val bookingDepartureDate: LocalDate,
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+  val turnaroundId: UUID?,
+  val turnaroundWorkingDayCount: Int?,
+  val cancellationCount: Int,
+  val departureCount: Int,
+  val arrivalCount: Int,
+  val nonArrivalCount: Int,
+  val confirmationCount: Int,
+  val voidCategory: String?,
+  val voidNotes: String?,
+  val costCentre: String?,
+  val uniquePropertyRef: String,
+  val uniqueBedspaceRef: String,
+)


### PR DESCRIPTION
This PR is a work in progress that improves the `Bed Usage Report`.

**Background**
* When doing work to create a new `Bedspace Usage Report` that uses the new `Bedsapce model refactor` tables, I noticed that there was an initial DB call to execute a query to get the beds and then for every bed we get back an extra db hit which executes a query to get the `related bookings` and another db hit which executes a query to get the `related lost-beds`.
* Once doing all of the above we map the data and also build turnaround rows form the bookings
* **The result of this** is that if we return `50 beds` we make `101 db calls` - not good!
* @daveawc and I investigated whether it ran on proprd which is did (slowly!) for `London region` for 3months but when we ran `All regions` for 3 months we got a `500 - sorry page`
* In speaking with our PM / DM they were aware of this issue and to mitigate this there is a hard rule that our end-users are aware of that they can only query 1 region at a time (for 2 months data max) This is how they execute this report in `production` to get what they need.

**PR includes**
* Introduce new `Cas3ReportService.createBedUsageReportV2()` function which the controller calls when generating the  `Bed Usage Report` (instead of calling the `Cas3ReportService.createBedUsageReport()` function)
* This `v2 solution` ensures we only ever make 1 db call - I extended the query so that it retrieves all data (inc. what we get from the addition 2 DB hits per row in v1 solution)
* The current tests (inc. integration tests) pass

**Next steps feature flag:**
1.  We should introduce a feature flag `bed_usage_report_v2` that when switched on hits the new `Cas3ReportService.createBedUsageReportV2()` function and otherwise executes the pre-existing `Cas3ReportService.createBedUsageReport()` function
2. We should switch the feature flag on in `preprod` env only initially so that we can test the report thoroughly there and not block API releases while testing is carried out

**Next steps extending solution:**
1. The integration tests are a bit light at the moment as the data setup currently in the test is 1 booking and then make sure we get back a report file with correctly formatted data
2. I would suggest extending this integration test to setup the following test data:
* 5 bookings
* 5 Lost beds
* 5 turnarounds
3. I would make sure that the test data above includes all the scenarios to cover the business logic we run over the results we get from the 1 db call (and the data ordering) - 15 records should be fine to cover everything
4. Make sure the report file we get back is as expectedd with the correct `Booking` then `Turnaround` then `Void` as expected

**Why have we parked this?**
* We need to prioritise the work we are doing for `Bedspace model refactor` and if this becomes a pre-requisite not only do we need to deliver all of the `Next steps` outlined above but we also need to do a lot of testing on this in `preprod`.