### PR TITLE
CAS-2003 Fix issue when canceling scheduled archive bedspace

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2DomainEventService.kt
@@ -103,6 +103,7 @@ class Cas2DomainEventService(
         occurredAt = domainEvent.occurredAt.atOffset(ZoneOffset.UTC),
         createdAt = OffsetDateTime.now(),
         cas3CancelledAt = null,
+        cas3TransactionId = null,
         data = objectMapper.writeValueAsString(domainEvent.data),
         service = "CAS2",
         triggerSource = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3BedspaceArchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3BedspaceArchiveEvent.kt
@@ -5,24 +5,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.eve
 
 data class CAS3BedspaceArchiveEvent(
   val eventDetails: CAS3BedspaceArchiveEventDetails,
-
   override val id: java.util.UUID,
-
   override val timestamp: java.time.Instant,
-
   override val eventType: EventType,
+  val bedspaceId: java.util.UUID,
+  val premisesId: java.util.UUID,
+  val transactionId: java.util.UUID,
 ) : CAS3Event
 
 data class CAS3BedspaceArchiveEventDetails(
-
-  val bedspaceId: java.util.UUID,
-
-  val premisesId: java.util.UUID,
-
   val endDate: java.time.LocalDate,
-
   val currentEndDate: java.time.LocalDate?,
-
   val userId: java.util.UUID,
-
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3BedspaceUnarchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3BedspaceUnarchiveEvent.kt
@@ -5,25 +5,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.eve
 
 data class CAS3BedspaceUnarchiveEvent(
   val eventDetails: CAS3BedspaceUnarchiveEventDetails,
-
   override val id: java.util.UUID,
-
   override val timestamp: java.time.Instant,
-
   override val eventType: EventType,
+  val bedspaceId: java.util.UUID,
+  val premisesId: java.util.UUID,
+  val transactionId: java.util.UUID,
 ) : CAS3Event
 
 data class CAS3BedspaceUnarchiveEventDetails(
-
-  val bedspaceId: java.util.UUID,
-
-  val premisesId: java.util.UUID,
-
   val userId: java.util.UUID,
-
   val currentStartDate: java.time.LocalDate,
-
   val currentEndDate: java.time.LocalDate,
-
   val newStartDate: java.time.LocalDate,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesArchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesArchiveEvent.kt
@@ -11,10 +11,11 @@ class CAS3PremisesArchiveEvent(
   override val id: UUID,
   override val timestamp: Instant,
   override val eventType: EventType,
+  val premisesId: UUID,
+  val transactionId: UUID,
 ) : CAS3Event
 
 data class CAS3PremisesArchiveEventDetails(
-  val premisesId: UUID,
   val userId: UUID,
   val endDate: LocalDate,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesUnarchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesUnarchiveEvent.kt
@@ -11,10 +11,11 @@ data class CAS3PremisesUnarchiveEvent(
   override val id: UUID,
   override val timestamp: Instant,
   override val eventType: EventType,
+  val premisesId: UUID,
+  val transactionId: UUID,
 ) : CAS3Event
 
 data class CAS3PremisesUnarchiveEventDetails(
-  val premisesId: UUID,
   val userId: UUID,
   val currentStartDate: LocalDate,
   val newStartDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3DomainEventBuilder.kt
@@ -39,7 +39,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
@@ -208,6 +207,7 @@ class Cas3DomainEventBuilder(
     premisesId: UUID,
     currentEndDate: LocalDate?,
     user: UserEntity,
+    transactionId: UUID,
   ): DomainEvent<CAS3BedspaceArchiveEvent> {
     val domainEventId = UUID.randomUUID()
 
@@ -224,7 +224,10 @@ class Cas3DomainEventBuilder(
         id = domainEventId,
         timestamp = Instant.now(),
         eventType = EventType.bedspaceArchived,
-        eventDetails = buildCAS3BedspaceArchiveEventDetails(bedspace, premisesId, currentEndDate, user),
+        bedspaceId = bedspace.id,
+        premisesId = premisesId,
+        transactionId = transactionId,
+        eventDetails = buildCAS3BedspaceArchiveEventDetails(bedspace, currentEndDate, user),
       ),
     )
   }
@@ -233,6 +236,7 @@ class Cas3DomainEventBuilder(
     premises: TemporaryAccommodationPremisesEntity,
     endDate: LocalDate,
     user: UserEntity,
+    transactionId: UUID,
   ): DomainEvent<CAS3PremisesArchiveEvent> {
     val domainEventId = UUID.randomUUID()
 
@@ -247,7 +251,9 @@ class Cas3DomainEventBuilder(
         id = domainEventId,
         timestamp = Instant.now(),
         eventType = EventType.premisesArchived,
-        eventDetails = buildCAS3PremisesArchiveEventDetails(premises, endDate, user),
+        premisesId = premises.id,
+        transactionId = transactionId,
+        eventDetails = buildCAS3PremisesArchiveEventDetails(endDate, user),
       ),
     )
   }
@@ -258,6 +264,7 @@ class Cas3DomainEventBuilder(
     newStartDate: LocalDate,
     currentEndDate: LocalDate?,
     user: UserEntity,
+    transactionId: UUID,
   ): DomainEvent<CAS3PremisesUnarchiveEvent> {
     val domainEventId = UUID.randomUUID()
 
@@ -272,7 +279,9 @@ class Cas3DomainEventBuilder(
         id = domainEventId,
         timestamp = Instant.now(),
         eventType = EventType.premisesUnarchived,
-        eventDetails = buildCAS3PremisesUnarchiveEventDetails(premises, currentStartDate, newStartDate, currentEndDate, user),
+        premisesId = premises.id,
+        transactionId = transactionId,
+        eventDetails = buildCAS3PremisesUnarchiveEventDetails(currentStartDate, newStartDate, currentEndDate, user),
       ),
     )
   }
@@ -283,6 +292,7 @@ class Cas3DomainEventBuilder(
     currentStartDate: LocalDate,
     currentEndDate: LocalDate,
     user: UserEntity,
+    transactionId: UUID,
   ): DomainEvent<CAS3BedspaceUnarchiveEvent> {
     val domainEventId = UUID.randomUUID()
 
@@ -297,7 +307,10 @@ class Cas3DomainEventBuilder(
         id = domainEventId,
         timestamp = Instant.now(),
         eventType = EventType.bedspaceUnarchived,
-        eventDetails = buildCAS3BedspaceUnarchiveEventDetails(bedspace, premisesId, currentStartDate, currentEndDate, user),
+        bedspaceId = bedspace.id,
+        premisesId = premisesId,
+        transactionId = transactionId,
+        eventDetails = buildCAS3BedspaceUnarchiveEventDetails(bedspace, currentStartDate, currentEndDate, user),
       ),
     )
   }
@@ -477,23 +490,19 @@ class Cas3DomainEventBuilder(
   )
 
   private fun buildCAS3PremisesArchiveEventDetails(
-    premises: PremisesEntity,
     endDate: LocalDate,
     user: UserEntity,
   ) = CAS3PremisesArchiveEventDetails(
-    premisesId = premises.id,
     userId = user.id,
     endDate = endDate,
   )
 
   private fun buildCAS3PremisesUnarchiveEventDetails(
-    premises: PremisesEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
     currentEndDate: LocalDate?,
     user: UserEntity,
   ) = CAS3PremisesUnarchiveEventDetails(
-    premisesId = premises.id,
     userId = user.id,
     currentStartDate = currentStartDate,
     newStartDate = newStartDate,
@@ -502,30 +511,24 @@ class Cas3DomainEventBuilder(
 
   private fun buildCAS3BedspaceArchiveEventDetails(
     bedspace: BedEntity,
-    premisesId: UUID,
     currentEndDate: LocalDate?,
     user: UserEntity,
   ) = CAS3BedspaceArchiveEventDetails(
-    bedspaceId = bedspace.id,
     userId = user.id,
     currentEndDate = currentEndDate,
     endDate = bedspace.endDate!!,
-    premisesId = premisesId,
   )
 
   private fun buildCAS3BedspaceUnarchiveEventDetails(
     bedspace: BedEntity,
-    premisesId: UUID,
     currentStartDate: LocalDate,
     currentEndDate: LocalDate,
     user: UserEntity,
   ) = CAS3BedspaceUnarchiveEventDetails(
-    bedspaceId = bedspace.id,
     userId = user.id,
     currentStartDate = currentStartDate,
     currentEndDate = currentEndDate,
     newStartDate = bedspace.startDate!!,
-    premisesId = premisesId,
   )
 
   private fun buildCAS3BookingCancelledEventDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspacesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspacesService.kt
@@ -95,7 +95,8 @@ class Cas3v2BedspacesService(
     bedspace = cas3BedspacesRepository.save(bedspace)
 
     if (premises.isPremisesScheduledToArchive()) {
-      cas3PremisesService.unarchivePremisesAndSaveDomainEvent(premises, startDate)
+      val domainEventTransactionId = UUID.randomUUID()
+      cas3PremisesService.unarchivePremisesAndSaveDomainEvent(premises, startDate, domainEventTransactionId)
     }
 
     return success(bedspace)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventBuilder.kt
@@ -119,6 +119,7 @@ class Cas3v2DomainEventBuilder(
     newStartDate: LocalDate,
     currentEndDate: LocalDate?,
     user: UserEntity,
+    transactionId: UUID,
   ): DomainEvent<CAS3PremisesUnarchiveEvent> {
     val domainEventId = UUID.randomUUID()
 
@@ -133,7 +134,9 @@ class Cas3v2DomainEventBuilder(
         id = domainEventId,
         timestamp = Instant.now(),
         eventType = EventType.premisesUnarchived,
-        eventDetails = buildCAS3PremisesUnarchiveEventDetails(premises, currentStartDate, newStartDate, currentEndDate, user),
+        premisesId = premises.id,
+        transactionId = transactionId,
+        eventDetails = buildCAS3PremisesUnarchiveEventDetails(currentStartDate, newStartDate, currentEndDate, user),
       ),
     )
   }
@@ -336,13 +339,11 @@ class Cas3v2DomainEventBuilder(
   )
 
   private fun buildCAS3PremisesUnarchiveEventDetails(
-    premises: Cas3PremisesEntity,
     currentStartDate: LocalDate,
     newStartDate: LocalDate,
     currentEndDate: LocalDate?,
     user: UserEntity,
   ) = CAS3PremisesUnarchiveEventDetails(
-    premisesId = premises.id,
     userId = user.id,
     currentStartDate = currentStartDate,
     newStartDate = newStartDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2PremisesService.kt
@@ -15,7 +15,7 @@ class Cas3v2PremisesService(
 ) {
   fun getPremises(premisesId: UUID): Cas3PremisesEntity? = cas3PremisesRepository.findByIdOrNull(premisesId)
 
-  fun unarchivePremisesAndSaveDomainEvent(premises: Cas3PremisesEntity, restartDate: LocalDate) {
+  fun unarchivePremisesAndSaveDomainEvent(premises: Cas3PremisesEntity, restartDate: LocalDate, transactionId: UUID) {
     val currentStartDate = premises.startDate
     val currentEndDate = premises.endDate
     premises.startDate = restartDate
@@ -27,6 +27,7 @@ class Cas3v2PremisesService(
       currentStartDate,
       newStartDate = restartDate,
       currentEndDate,
+      transactionId,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -103,9 +103,27 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
 
   fun findByType(type: DomainEventType): List<DomainEventEntity>
 
-  fun findFirstByCas3BedspaceIdAndTypeOrderByCreatedAtDesc(cas3BedspaceId: UUID, type: DomainEventType): DomainEventEntity?
+  @Query(
+    """
+    SELECT d
+    FROM DomainEventEntity d
+    WHERE d.cas3BedspaceId in :cas3BedspaceId and d.type = :type and d.cas3CancelledAt is null
+    ORDER BY d.createdAt desc
+    Limit 1
+    """,
+  )
+  fun findLastCas3BedspaceActiveDomainEventByBedspaceIdAndType(cas3BedspaceId: UUID, type: DomainEventType): DomainEventEntity?
 
-  fun findFirstByCas3PremisesIdAndTypeOrderByCreatedAtDesc(cas3PremisesId: UUID, type: DomainEventType): DomainEventEntity?
+  @Query(
+    """
+    SELECT d
+    FROM DomainEventEntity d
+    WHERE d.cas3PremisesId in :cas3PremisesId and d.type = :type and d.cas3CancelledAt is null
+    ORDER BY d.createdAt desc
+    Limit 1
+    """,
+  )
+  fun findLastCas3PremisesActiveDomainEventByPremisesIdAndType(cas3PremisesId: UUID, type: DomainEventType): DomainEventEntity?
 
   @Query(
     """
@@ -114,7 +132,9 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
     WHERE d.cas3BedspaceId in :cas3BedspaceIds and d.type in :bedspaceDomainEventTypes and d.cas3CancelledAt is null
     """,
   )
-  fun findBedspacesActiveDomainEventsByType(cas3BedspaceIds: List<UUID>, bedspaceDomainEventTypes: List<String>): List<DomainEventEntity>
+  fun findCas3BedspacesActiveDomainEventsByType(cas3BedspaceIds: List<UUID>, bedspaceDomainEventTypes: List<String>): List<DomainEventEntity>
+
+  fun findByCas3TransactionIdAndType(cas3TransactionId: UUID, type: DomainEventType): List<DomainEventEntity>
 
   fun findByAssessmentIdAndType(assessmentId: UUID, type: DomainEventType): List<DomainEventEntity>
 
@@ -164,6 +184,8 @@ data class DomainEventEntity(
   val createdAt: OffsetDateTime,
   @Column(name = "cas3_cancelled_at")
   val cas3CancelledAt: OffsetDateTime?,
+  @Column(name = "cas3_transaction_id")
+  val cas3TransactionId: UUID?,
   @Type(JsonType::class)
   val data: String,
   val service: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -327,6 +327,7 @@ class Cas1DomainEventService(
         nomsNumber = domainEvent.nomsNumber,
         metadata = domainEvent.metadata,
         schemaVersion = domainEvent.schemaVersion,
+        cas3TransactionId = null,
       ),
     )
 

--- a/src/main/resources/db/migration/all/2025092316055134__c3_domain_events_add_cas3_transaction_id.sql
+++ b/src/main/resources/db/migration/all/2025092316055134__c3_domain_events_add_cas3_transaction_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE domain_events
+    ADD COLUMN IF NOT EXISTS cas3_transaction_id UUID NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3IntegrationTestBase.kt
@@ -198,10 +198,12 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     newStartDate: LocalDate,
     currentEndDate: LocalDate,
     cancelledAt: OffsetDateTime? = null,
+    transactionId: UUID = UUID.randomUUID(),
   ) = domainEventFactory.produceAndPersist {
     withService(ServiceName.temporaryAccommodation)
     withCas3PremisesId(premises.id)
     withType(DomainEventType.CAS3_PREMISES_UNARCHIVED)
+    withCas3TransactionId(transactionId)
     withCas3CancelledAt(cancelledAt)
     withData(
       objectMapper.writeValueAsString(
@@ -209,9 +211,10 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
           id = UUID.randomUUID(),
           timestamp = Instant.now(),
           eventType = EventType.premisesUnarchived,
+          premisesId = premises.id,
+          transactionId = transactionId,
           eventDetails =
           CAS3PremisesUnarchiveEventDetails(
-            premisesId = premises.id,
             userId = userEntity.id,
             currentStartDate = currentStartDate,
             newStartDate = newStartDate,
@@ -227,10 +230,12 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     userEntity: UserEntity,
     date: LocalDate,
     cancelledAt: OffsetDateTime? = null,
+    transactionId: UUID = UUID.randomUUID(),
   ) = domainEventFactory.produceAndPersist {
     withService(ServiceName.temporaryAccommodation)
     withCas3PremisesId(premises.id)
     withType(DomainEventType.CAS3_PREMISES_ARCHIVED)
+    withCas3TransactionId(transactionId)
     withCas3CancelledAt(cancelledAt)
     withData(
       objectMapper.writeValueAsString(
@@ -238,9 +243,10 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
           id = UUID.randomUUID(),
           timestamp = Instant.now(),
           eventType = EventType.premisesArchived,
+          premisesId = premises.id,
+          transactionId = transactionId,
           eventDetails =
           CAS3PremisesArchiveEventDetails(
-            premisesId = premises.id,
             userId = userEntity.id,
             endDate = date,
           ),
@@ -358,10 +364,13 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     currentEndDate: LocalDate?,
     endDate: LocalDate,
     cancelledAt: OffsetDateTime? = null,
+    transactionId: UUID = UUID.randomUUID(),
   ) = domainEventFactory.produceAndPersist {
     withService(ServiceName.temporaryAccommodation)
     withCas3BedspaceId(bedspaceId)
+    withCas3PremisesId(premisesId)
     withType(DomainEventType.CAS3_BEDSPACE_ARCHIVED)
+    withCas3TransactionId(transactionId)
     withCas3CancelledAt(cancelledAt)
     withData(
       objectMapper.writeValueAsString(
@@ -369,10 +378,11 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
           id = UUID.randomUUID(),
           timestamp = OffsetDateTime.now().toInstant(),
           eventType = EventType.bedspaceArchived,
+          bedspaceId = bedspaceId,
+          premisesId = premisesId,
+          transactionId = transactionId,
           eventDetails = CAS3BedspaceArchiveEventDetails(
-            bedspaceId = bedspaceId,
             userId = userId,
-            premisesId = premisesId,
             currentEndDate = currentEndDate,
             endDate = endDate,
           ),
@@ -388,10 +398,13 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     userId: UUID,
     newStartDate: LocalDate,
     cancelledAt: OffsetDateTime? = null,
+    transactionId: UUID = UUID.randomUUID(),
   ) = domainEventFactory.produceAndPersist {
     withService(ServiceName.temporaryAccommodation)
     withCas3BedspaceId(bedspace.id)
+    withCas3PremisesId(premisesId)
     withType(DomainEventType.CAS3_BEDSPACE_UNARCHIVED)
+    withCas3TransactionId(transactionId)
     withCas3CancelledAt(cancelledAt)
     withData(
       objectMapper.writeValueAsString(
@@ -399,9 +412,10 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
           id = UUID.randomUUID(),
           timestamp = OffsetDateTime.now().toInstant(),
           eventType = EventType.bedspaceUnarchived,
+          bedspaceId = bedspace.id,
+          premisesId = premisesId,
+          transactionId = transactionId,
           eventDetails = CAS3BedspaceUnarchiveEventDetails(
-            bedspaceId = bedspace.id,
-            premisesId = premisesId,
             userId = userId,
             currentStartDate = bedspace.startDate!!,
             currentEndDate = bedspace.endDate!!,
@@ -419,10 +433,13 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
     userId: UUID,
     newStartDate: LocalDate,
     cancelledAt: OffsetDateTime? = null,
+    transactionId: UUID = UUID.randomUUID(),
   ) = domainEventFactory.produceAndPersist {
     withService(ServiceName.temporaryAccommodation)
     withCas3BedspaceId(bedspace.id)
+    withCas3PremisesId(premisesId)
     withType(DomainEventType.CAS3_BEDSPACE_UNARCHIVED)
+    withCas3TransactionId(transactionId)
     withCas3CancelledAt(cancelledAt)
     withData(
       objectMapper.writeValueAsString(
@@ -430,9 +447,10 @@ abstract class Cas3IntegrationTestBase : IntegrationTestBase() {
           id = UUID.randomUUID(),
           timestamp = OffsetDateTime.now().toInstant(),
           eventType = EventType.bedspaceUnarchived,
+          bedspaceId = bedspace.id,
+          premisesId = premisesId,
+          transactionId = transactionId,
           eventDetails = CAS3BedspaceUnarchiveEventDetails(
-            bedspaceId = bedspace.id,
-            premisesId = premisesId,
             userId = userId,
             currentStartDate = bedspace.startDate!!,
             currentEndDate = bedspace.endDate!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3DomainEventBuilderTest.kt
@@ -552,8 +552,9 @@ class Cas3DomainEventBuilderTest {
       .withStartDate(newStartDate)
       .withRoom(room)
       .produce()
+    val transactionId = UUID.randomUUID()
 
-    val event = cas3DomainEventBuilder.getBedspaceUnarchiveEvent(bedspace, premises.id, currentStartDate, currentEndDate, user)
+    val event = cas3DomainEventBuilder.getBedspaceUnarchiveEvent(bedspace, premises.id, currentStartDate, currentEndDate, user, transactionId)
 
     assertAll({
       assertThat(event.applicationId).isNull()
@@ -561,11 +562,12 @@ class Cas3DomainEventBuilderTest {
       assertThat(event.crn).isNull()
       assertThat(event.nomsNumber).isNull()
       assertThat(event.data.eventType).isEqualTo(EventType.bedspaceUnarchived)
-      assertThat(event.data.eventDetails.bedspaceId).isEqualTo(bedspaceId)
+      assertThat(event.data.bedspaceId).isEqualTo(bedspaceId)
       assertThat(event.data.eventDetails.userId).isEqualTo(user.id)
       assertThat(event.data.eventDetails.currentEndDate).isEqualTo(currentEndDate)
       assertThat(event.data.eventDetails.currentStartDate).isEqualTo(currentStartDate)
       assertThat(event.data.eventDetails.newStartDate).isEqualTo(newStartDate)
+      assertThat(event.data.transactionId).isEqualTo(transactionId)
     })
   }
 
@@ -575,8 +577,9 @@ class Cas3DomainEventBuilderTest {
     val probationRegion = probationRegionEntity()
     val premises = createCas3PremisesEntity(probationRegion)
     val user = userEntity(probationRegion)
+    val transactionId = UUID.randomUUID()
 
-    val event = cas3DomainEventBuilder.getPremisesArchiveEvent(premises, endDate, user)
+    val event = cas3DomainEventBuilder.getPremisesArchiveEvent(premises, endDate, user, transactionId)
 
     assertAll({
       assertThat(event.applicationId).isNull()
@@ -584,12 +587,13 @@ class Cas3DomainEventBuilderTest {
       assertThat(event.crn).isNull()
       assertThat(event.nomsNumber).isNull()
       assertThat(event.data.eventType).isEqualTo(EventType.premisesArchived)
-      assertThat(event.data.eventDetails.premisesId).isEqualTo(premises.id)
+      assertThat(event.data.premisesId).isEqualTo(premises.id)
       assertThat(event.data.eventDetails.userId).isEqualTo(user.id)
       assertThat(event.data.eventDetails.endDate).isEqualTo(endDate)
       assertThat(event.occurredAt).isWithinTheLastMinute()
       assertThat(event.data.timestamp).isWithinTheLastMinute()
       assertThat(event.id).isEqualTo(event.data.id)
+      assertThat(event.data.transactionId).isEqualTo(transactionId)
     })
   }
 
@@ -602,8 +606,9 @@ class Cas3DomainEventBuilderTest {
     val premises = createCas3PremisesEntity(probationRegion)
     premises.endDate = currentEndDate
     val user = userEntity(probationRegion)
+    val transactionId = UUID.randomUUID()
 
-    val event = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate, user)
+    val event = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate, user, transactionId)
 
     assertAll({
       assertThat(event.applicationId).isNull()
@@ -611,13 +616,14 @@ class Cas3DomainEventBuilderTest {
       assertThat(event.crn).isNull()
       assertThat(event.nomsNumber).isNull()
       assertThat(event.data.eventType).isEqualTo(EventType.premisesUnarchived)
-      assertThat(event.data.eventDetails.premisesId).isEqualTo(premises.id)
+      assertThat(event.data.premisesId).isEqualTo(premises.id)
       assertThat(event.data.eventDetails.userId).isEqualTo(user.id)
       assertThat(event.data.eventDetails.currentStartDate).isEqualTo(currentStartDate)
       assertThat(event.data.eventDetails.newStartDate).isEqualTo(newStartDate)
       assertThat(event.occurredAt).isWithinTheLastMinute()
       assertThat(event.data.timestamp).isWithinTheLastMinute()
       assertThat(event.id).isEqualTo(event.data.id)
+      assertThat(event.data.transactionId).isEqualTo(transactionId)
     })
   }
 
@@ -636,8 +642,9 @@ class Cas3DomainEventBuilderTest {
       .withEndDate(endDate)
       .withRoom(room)
       .produce()
+    val transactionId = UUID.randomUUID()
 
-    val event = cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, premises.id, null, user)
+    val event = cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, premises.id, null, user, transactionId)
 
     assertAll(
       {
@@ -646,10 +653,11 @@ class Cas3DomainEventBuilderTest {
         assertThat(event.crn).isNull()
         assertThat(event.nomsNumber).isNull()
         assertThat(event.data.eventType).isEqualTo(EventType.bedspaceArchived)
-        assertThat(event.data.eventDetails.bedspaceId).isEqualTo(bedspaceId)
-        assertThat(event.data.eventDetails.premisesId).isEqualTo(premises.id)
+        assertThat(event.data.bedspaceId).isEqualTo(bedspaceId)
+        assertThat(event.data.premisesId).isEqualTo(premises.id)
         assertThat(event.data.eventDetails.userId).isEqualTo(user.id)
         assertThat(event.data.eventDetails.endDate).isEqualTo(endDate)
+        assertThat(event.data.transactionId).isEqualTo(transactionId)
       },
     )
   }
@@ -668,9 +676,10 @@ class Cas3DomainEventBuilderTest {
       .withRoom(room)
       .withEndDate(null)
       .produce()
+    val transactionId = UUID.randomUUID()
 
     val error = assertThrows<IllegalStateException> {
-      cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, premises.id, null, user)
+      cas3DomainEventBuilder.getBedspaceArchiveEvent(bedspace, premises.id, null, user, transactionId)
     }
 
     assertThat(error.message).isEqualTo("Bedspace end date is null for bedspace id: ${bedspace.id}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BedspaceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BedspaceServiceTest.kt
@@ -90,7 +90,7 @@ class Cas3v2BedspaceServiceTest {
       )
 
       every { mockCas3BedspacesRepository.save(any()) } returns bedspace
-      every { mockCas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(any(), any()) } returns Unit
+      every { mockCas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(any(), any(), any()) } returns Unit
 
       val result = cas3v2BedspacesService.createBedspace(
         premises,
@@ -109,7 +109,7 @@ class Cas3v2BedspaceServiceTest {
 
       verify(exactly = 1) {
         mockCas3BedspacesRepository.save(any())
-        mockCas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(eq(premises), eq(bedspaceStartDate))
+        mockCas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(eq(premises), eq(bedspaceStartDate), any())
       }
     }
 
@@ -274,17 +274,38 @@ class Cas3v2BedspaceServiceTest {
 
       // Archive event scheduled for six months ago
       val endDateSixMonthsAgoArchive = LocalDate.now().minusMonths(6)
-      val dataSixMonthsAgoArchive = createBedspaceArchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, currentEndDate = null, endDate = endDateSixMonthsAgoArchive)
+      val dataSixMonthsAgoArchive = createBedspaceArchiveEvent(
+        premisesId = premisesId,
+        bedspaceId = bedspaceId,
+        userId = userId,
+        currentEndDate = null,
+        endDate = endDateSixMonthsAgoArchive,
+        transactionId = UUID.randomUUID(),
+      )
       val domainEventSixMonthsAgo = createBedspaceArchiveDomainEvent(dataSixMonthsAgoArchive)
 
       // Archive event scheduled for four months ago
       val endDateFourMonthsAgoArchive = LocalDate.now().minusMonths(4)
-      val dataFourMonthsAgoArchive = createBedspaceArchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, currentEndDate = null, endDate = endDateFourMonthsAgoArchive)
+      val dataFourMonthsAgoArchive = createBedspaceArchiveEvent(
+        premisesId = premisesId,
+        bedspaceId = bedspaceId,
+        userId = userId,
+        currentEndDate = null,
+        endDate = endDateFourMonthsAgoArchive,
+        transactionId = UUID.randomUUID(),
+      )
       val domainEventFourMonthsAgo = createBedspaceArchiveDomainEvent(dataFourMonthsAgoArchive)
 
       // Archive event scheduled one week ago
       val endDateOneWeekAgoArchive = LocalDate.now().minusWeeks(1)
-      val dataOneWeekAgoArchive = createBedspaceArchiveEvent(premisesId = premisesId, bedspaceId = bedspaceId, userId = userId, currentEndDate = null, endDate = endDateOneWeekAgoArchive)
+      val dataOneWeekAgoArchive = createBedspaceArchiveEvent(
+        premisesId = premisesId,
+        bedspaceId = bedspaceId,
+        userId = userId,
+        currentEndDate = null,
+        endDate = endDateOneWeekAgoArchive,
+        transactionId = UUID.randomUUID(),
+      )
       val domainEventOneWeekAgo = createBedspaceArchiveDomainEvent(dataOneWeekAgoArchive)
 
       // Unarchive event scheduled for five months ago
@@ -296,6 +317,7 @@ class Cas3v2BedspaceServiceTest {
         newStartDate = newStartDateFiveMonthsAgoUnarchive,
         currentStartDate = LocalDate.now().minusMonths(10),
         currentEndDate = LocalDate.now().minusMonths(6),
+        transactionId = UUID.randomUUID(),
       )
       val domainEventFiveMonthsAgo = createBedspaceUnarchiveDomainEvent(dataFiveMonthsAgoUnarchive)
 
@@ -308,6 +330,7 @@ class Cas3v2BedspaceServiceTest {
         newStartDate = newStartDateSixWeeksAgoUnarchive,
         currentStartDate = LocalDate.now().minusMonths(6),
         currentEndDate = LocalDate.now().minusMonths(4),
+        transactionId = UUID.randomUUID(),
       )
       val domainEventSixWeeksAgo = createBedspaceUnarchiveDomainEvent(dataSixWeeksAgoUnarchive)
 
@@ -320,6 +343,7 @@ class Cas3v2BedspaceServiceTest {
         newStartDate = newStartDateIn3DaysUnarchive,
         currentStartDate = LocalDate.now().minusWeeks(6),
         currentEndDate = LocalDate.now().minusWeeks(1),
+        transactionId = UUID.randomUUID(),
       )
       val domainEventIn3Days = createBedspaceUnarchiveDomainEvent(dataIn3DaysUnarchive)
 
@@ -378,6 +402,7 @@ class Cas3v2BedspaceServiceTest {
         userId = userId,
         currentEndDate = null,
         endDate = LocalDate.now().minusMonths(1),
+        transactionId = UUID.randomUUID(),
       )
       val bedOneArchiveDomainEventOneMonthAgo = createBedspaceArchiveDomainEvent(bedOneArchiveEventOneMonthAgo)
 
@@ -387,6 +412,7 @@ class Cas3v2BedspaceServiceTest {
         userId = userId,
         currentEndDate = null,
         endDate = LocalDate.now().minusWeeks(1),
+        transactionId = UUID.randomUUID(),
       )
       val bedOneArchiveDomainEventOneWeekAgo = createBedspaceArchiveDomainEvent(bedOneArchiveEventOneWeekAgo)
 
@@ -396,6 +422,7 @@ class Cas3v2BedspaceServiceTest {
         userId = userId,
         currentEndDate = null,
         endDate = LocalDate.now().minusWeeks(2),
+        transactionId = UUID.randomUUID(),
       )
       val bedThreeArchiveDomainEventTwoMonthsAgo = createBedspaceArchiveDomainEvent(bedThreeArchiveEventTwoMonthsAgo)
 
@@ -406,6 +433,7 @@ class Cas3v2BedspaceServiceTest {
         newStartDate = LocalDate.now().minusWeeks(2),
         currentStartDate = LocalDate.now().minusWeeks(7),
         currentEndDate = LocalDate.now().minusWeeks(3),
+        transactionId = UUID.randomUUID(),
       )
       val bedOneUnarchiveDomainEventTwoWeeksAgo = createUnarchiveDomainEvent(bedOneUnarchiveEventTwoWeeksAgo)
 
@@ -416,6 +444,7 @@ class Cas3v2BedspaceServiceTest {
         newStartDate = LocalDate.now().minusWeeks(1),
         currentStartDate = LocalDate.now().minusWeeks(4),
         currentEndDate = LocalDate.now().minusWeeks(2),
+        transactionId = UUID.randomUUID(),
       )
       val bedThreeUnarchiveDomainEventOneWeeksAgo = createUnarchiveDomainEvent(bedThreeUnarchiveEventTwoWeeksAgo)
 
@@ -517,10 +546,18 @@ class Cas3v2BedspaceServiceTest {
         newStartDate = bedspaceUnarchiveDate,
         LocalDate.now().minusWeeks(3),
         LocalDate.now().minusWeeks(1),
+        transactionId = UUID.randomUUID(),
       )
       val bedspaceUnarchiveDomainEvent = createBedspaceUnarchiveDomainEvent(bedspaceUnarchiveEvent)
 
-      val bedspaceArchiveEvent = createBedspaceArchiveEvent(premisesId = premises.id, bedspaceId = bedspace.id, userId = UUID.randomUUID(), currentEndDate = null, endDate = LocalDate.now().minusDays(21))
+      val bedspaceArchiveEvent = createBedspaceArchiveEvent(
+        premisesId = premises.id,
+        bedspaceId = bedspace.id,
+        userId = UUID.randomUUID(),
+        currentEndDate = null,
+        endDate = LocalDate.now().minusDays(21),
+        transactionId = UUID.randomUUID(),
+      )
       val bedspaceArchiveDomainEvent = createBedspaceArchiveDomainEvent(bedspaceArchiveEvent)
 
       every { mockCas3v2DomainEventService.getBedspaceActiveDomainEvents(bedspace.id, listOf(CAS3_BEDSPACE_UNARCHIVED)) } returns listOf(bedspaceUnarchiveDomainEvent)
@@ -734,24 +771,33 @@ class Cas3v2BedspaceServiceTest {
 
   private fun createUnarchiveDomainEvent(data: CAS3BedspaceUnarchiveEvent) = createDomainEvent(
     data.id,
-    data.eventDetails.premisesId,
-    data.eventDetails.bedspaceId,
+    data.premisesId,
+    data.bedspaceId,
     data.timestamp.atOffset(ZoneOffset.UTC),
     objectMapper.writeValueAsString(data),
     CAS3_BEDSPACE_UNARCHIVED,
   )
 
   @SuppressWarnings("LongParameterList")
-  private fun createBedspaceUnarchiveEvent(premisesId: UUID, bedspaceId: UUID, userId: UUID, newStartDate: LocalDate, currentStartDate: LocalDate, currentEndDate: LocalDate): CAS3BedspaceUnarchiveEvent {
+  private fun createBedspaceUnarchiveEvent(
+    premisesId: UUID,
+    bedspaceId: UUID,
+    userId: UUID,
+    newStartDate: LocalDate,
+    currentStartDate: LocalDate,
+    currentEndDate: LocalDate,
+    transactionId: UUID,
+  ): CAS3BedspaceUnarchiveEvent {
     val eventId = UUID.randomUUID()
     val occurredAt = OffsetDateTime.now()
     return CAS3BedspaceUnarchiveEvent(
       id = eventId,
       timestamp = occurredAt.toInstant(),
       eventType = EventType.bedspaceUnarchived,
+      bedspaceId = bedspaceId,
+      premisesId = premisesId,
+      transactionId = transactionId,
       eventDetails = CAS3BedspaceUnarchiveEventDetails(
-        bedspaceId = bedspaceId,
-        premisesId = premisesId,
         userId = userId,
         currentStartDate = currentStartDate,
         currentEndDate = currentEndDate,
@@ -762,24 +808,26 @@ class Cas3v2BedspaceServiceTest {
 
   private fun createBedspaceUnarchiveDomainEvent(data: CAS3BedspaceUnarchiveEvent) = createDomainEvent(
     data.id,
-    data.eventDetails.premisesId,
-    data.eventDetails.bedspaceId,
+    data.premisesId,
+    data.bedspaceId,
     data.timestamp.atOffset(ZoneOffset.UTC),
     objectMapper.writeValueAsString(data),
     CAS3_BEDSPACE_UNARCHIVED,
   )
 
-  private fun createBedspaceArchiveEvent(premisesId: UUID, bedspaceId: UUID, userId: UUID, currentEndDate: LocalDate?, endDate: LocalDate): CAS3BedspaceArchiveEvent {
+  @SuppressWarnings("LongParameterList")
+  private fun createBedspaceArchiveEvent(premisesId: UUID, bedspaceId: UUID, userId: UUID, currentEndDate: LocalDate?, endDate: LocalDate, transactionId: UUID): CAS3BedspaceArchiveEvent {
     val eventId = UUID.randomUUID()
     val occurredAt = OffsetDateTime.now()
     return CAS3BedspaceArchiveEvent(
       id = eventId,
       timestamp = occurredAt.toInstant(),
       eventType = EventType.bedspaceArchived,
+      bedspaceId = bedspaceId,
+      premisesId = premisesId,
+      transactionId = transactionId,
       eventDetails = CAS3BedspaceArchiveEventDetails(
-        bedspaceId = bedspaceId,
         userId = userId,
-        premisesId = premisesId,
         currentEndDate = currentEndDate,
         endDate = endDate,
       ),
@@ -788,8 +836,8 @@ class Cas3v2BedspaceServiceTest {
 
   private fun createBedspaceArchiveDomainEvent(data: CAS3BedspaceArchiveEvent) = createDomainEvent(
     data.id,
-    data.eventDetails.premisesId,
-    data.eventDetails.bedspaceId,
+    data.premisesId,
+    data.bedspaceId,
     data.timestamp.atOffset(ZoneOffset.UTC),
     objectMapper.writeValueAsString(data),
     CAS3_BEDSPACE_ARCHIVED,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2DomainEventBuilderTest.kt
@@ -127,8 +127,9 @@ class Cas3v2DomainEventBuilderTest {
     val premises = cas3PremisesEntity(probationRegion)
     premises.endDate = currentEndDate
     val user = userEntity(probationRegion)
+    val domainEventTransactionId = UUID.randomUUID()
 
-    val event = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate, user)
+    val event = cas3DomainEventBuilder.getPremisesUnarchiveEvent(premises, currentStartDate, newStartDate, currentEndDate, user, domainEventTransactionId)
 
     assertAll({
       assertThat(event.applicationId).isNull()
@@ -136,7 +137,8 @@ class Cas3v2DomainEventBuilderTest {
       assertThat(event.crn).isNull()
       assertThat(event.nomsNumber).isNull()
       assertThat(event.data.eventType).isEqualTo(EventType.premisesUnarchived)
-      assertThat(event.data.eventDetails.premisesId).isEqualTo(premises.id)
+      assertThat(event.data.premisesId).isEqualTo(premises.id)
+      assertThat(event.data.transactionId).isEqualTo(domainEventTransactionId)
       assertThat(event.data.eventDetails.userId).isEqualTo(user.id)
       assertThat(event.data.eventDetails.currentStartDate).isEqualTo(currentStartDate)
       assertThat(event.data.eventDetails.newStartDate).isEqualTo(newStartDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2PremisesServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2PremisesService
 import java.time.LocalDate
+import java.util.UUID
 
 class Cas3v2PremisesServiceTest {
   private val mockPremisesRepository = mockk<Cas3PremisesRepository>()
@@ -47,9 +48,9 @@ class Cas3v2PremisesServiceTest {
       )
 
       every { mockPremisesRepository.save(match { it.id == premises.id }) } returns updatedPremises
-      every { mockCas3DomainEventService.savePremisesUnarchiveEvent(eq(updatedPremises), premises.startDate, restartDate, premises.endDate!!) } returns Unit
+      every { mockCas3DomainEventService.savePremisesUnarchiveEvent(eq(updatedPremises), premises.startDate, restartDate, premises.endDate!!, any()) } returns Unit
 
-      cas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(premises, restartDate)
+      cas3v2PremisesService.unarchivePremisesAndSaveDomainEvent(premises, restartDate, UUID.randomUUID())
 
       val slot = slot<Cas3PremisesEntity>()
       verify(exactly = 1) {
@@ -66,7 +67,7 @@ class Cas3v2PremisesServiceTest {
       )
 
       verify(exactly = 1) {
-        mockCas3DomainEventService.savePremisesUnarchiveEvent(eq(premises), eq(startDate), eq(restartDate), eq(endDate))
+        mockCas3DomainEventService.savePremisesUnarchiveEvent(eq(premises), eq(startDate), eq(restartDate), eq(endDate), any())
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/DomainEventEntityFactory.kt
@@ -36,6 +36,7 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
   private var schemaVersion: Yielded<Int?> = { null }
   private var applicationOrigin: Yielded<ApplicationOrigin?> = { null }
   private var cas3CancelledAt: Yielded<OffsetDateTime?> = { null }
+  private var cas3TransactionId: Yielded<UUID?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -83,6 +84,10 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
 
   fun withCas3CancelledAt(cancelledAt: OffsetDateTime?) = apply {
     this.cas3CancelledAt = { cancelledAt }
+  }
+
+  fun withCas3TransactionId(cas3TransactionId: UUID?) = apply {
+    this.cas3TransactionId = { cas3TransactionId }
   }
 
   fun withData(data: String) = apply {
@@ -148,5 +153,6 @@ class DomainEventEntityFactory : Factory<DomainEventEntity> {
     cas3PremisesId = this.cas3PremisesId(),
     cas3BedspaceId = this.cas3BedspaceId(),
     cas3CancelledAt = this.cas3CancelledAt(),
+    cas3TransactionId = this.cas3TransactionId(),
   )
 }


### PR DESCRIPTION
This [PR CAS-2003](https://dsdmoj.atlassian.net/browse/CAS-2003) is to fix an issue when cancel schedule archiving a bedspace. This include:
- Create a new column in domain events table cas3_transaction_id to truck related domain events
- Change the process to check related archive/unarchive transactions
- Move cas3PremisesId and cas3BedspaceId to the domain event level in the entities
- Change the queries to retun only not cancelled domain events
- Update unitests and integration tests