### PR TITLE
CAS-1911: C3 BE Set cost centre in api response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3VoidBedspacesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3VoidBedspacesTransformer.kt
@@ -24,6 +24,7 @@ class Cas3VoidBedspacesTransformer(
     bedId = jpa.bed!!.id,
     bedName = jpa.bed!!.name,
     roomName = jpa.bed!!.room.name,
+    costCentre = jpa.costCentre,
   )
 
   private fun determineStatus(jpa: Cas3VoidBedspaceEntity) = when {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3VoidBedspacesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3VoidBedspacesTransformerTest.kt
@@ -81,7 +81,9 @@ class Cas3VoidBedspacesTransformerTest {
       }
       .withYieldedPremises { premises }
       .withYieldedBed { bed }
-      .produce()
+      .produce().apply {
+        costCentre = Cas3CostCentre.HMPPS
+      }
 
     @Test
     fun `Void Bedspace entity is correctly transformed`() {
@@ -105,6 +107,7 @@ class Cas3VoidBedspacesTransformerTest {
       assertThat(result.bedId).isEqualTo(bed.id)
       assertThat(result.bedName).isEqualTo(bed.name)
       assertThat(result.roomName).isEqualTo(room.name)
+      assertThat(result.costCentre).isEqualTo(voidBedspace.costCentre)
     }
 
     @Test
@@ -145,6 +148,7 @@ class Cas3VoidBedspacesTransformerTest {
       assertThat(result.bedId).isEqualTo(bed.id)
       assertThat(result.bedName).isEqualTo(bed.name)
       assertThat(result.roomName).isEqualTo(room.name)
+      assertThat(result.costCentre).isEqualTo(voidBedspace.costCentre)
     }
   }
 


### PR DESCRIPTION
Summary

This Pull Request adds a new field, costCentre, to the Cas3VoidBedspacesTransformer functionality and updates its associated test cases to ensure the new field is correctly handled.

Main Changes

- Code Changes:
  - Added a new attribute, costCentre, to the toResponse transformation method in the Cas3VoidBedspacesTransformer class.
- Test Updates:
  - Updated the Cas3VoidBedspacesTransformerTest to include assertions for the costCentre field in multiple test cases.
Adjusted a test entity to populate the costCentre field during setup.