### PR TITLE
CAS-2003 Migration jobfor archive/unarchive CAS3 domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
@@ -25,4 +25,5 @@ enum class MigrationJobType(@get:JsonValue val value: String) {
   cas1BackfillAutomaticPlacementApplications("cas1_backfill_automatic_placement_applications"),
   cas1BackfillKeyWorkerUserAssignments("cas1_backfill_key_worker_user_assignments"),
   cas1CapacityPerformanceTest("cas1_capacity_performance_test"),
+  updateCas3DomainEventArchiveUnarchiveTransaction("update_cas3_domain_event_archive_unarchive_transaction"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateArchiveUnarchiveDomainEventTransactionJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateArchiveUnarchiveDomainEventTransactionJob.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType.CAS3_BEDSPACE_ARCHIVED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType.CAS3_BEDSPACE_UNARCHIVED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType.CAS3_PREMISES_ARCHIVED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType.CAS3_PREMISES_UNARCHIVED
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationLogger
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Component
+class Cas3UpdateArchiveUnarchiveDomainEventTransactionJob(
+  private val domainEventRepository: DomainEventRepository,
+  private val migrationLogger: MigrationLogger,
+) : MigrationJob() {
+  override val shouldRunInTransaction = true
+
+  @SuppressWarnings("MagicNumber", "TooGenericExceptionCaught")
+  override fun process(pageSize: Int) {
+    val domainEvents = domainEventRepository.findCas3DomainEventsByTypeWithoutTransactionId(
+      listOf(
+        CAS3_PREMISES_ARCHIVED,
+        CAS3_PREMISES_UNARCHIVED,
+        CAS3_BEDSPACE_ARCHIVED,
+        CAS3_BEDSPACE_UNARCHIVED,
+      ),
+    )
+
+    val premisesIds = domainEvents.map { it.id }.toList()
+
+    try {
+      migrationLogger.info("Updating CAS3 archive/unarchive domain events with premises Ids ${premisesIds.map { it }}")
+      var lastDomainEventPremisesId: UUID? = null
+      var lastDomainEventCreatedAt: OffsetDateTime? = null
+      var currentTransactionId: UUID? = null
+
+      domainEvents.forEach { domainEvent ->
+        val isNewPremises = lastDomainEventPremisesId != domainEvent.cas3PremisesId
+        val isSameTransaction = (
+          lastDomainEventCreatedAt != null &&
+            domainEvent.createdAt <= lastDomainEventCreatedAt.plusMinutes(3) &&
+            lastDomainEventPremisesId == domainEvent.cas3PremisesId
+          )
+
+        if (isNewPremises || !isSameTransaction) {
+          currentTransactionId = UUID.randomUUID()
+        }
+
+        val updatedDomainEvent = domainEvent.copy(cas3TransactionId = currentTransactionId)
+        domainEventRepository.save(updatedDomainEvent)
+
+        lastDomainEventPremisesId = domainEvent.cas3PremisesId
+        lastDomainEventCreatedAt = domainEvent.createdAt
+      }
+
+      migrationLogger.info("Updating CAS3 archive/unarchive domain events with premises Ids ${premisesIds.map { it }} is completed")
+    } catch (exception: Exception) {
+      migrationLogger.error("Unable to update domain events with premises Ids ${premisesIds.joinToString()}", exception)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3BedspaceArchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3BedspaceArchiveEvent.kt
@@ -10,7 +10,7 @@ data class CAS3BedspaceArchiveEvent(
   override val eventType: EventType,
   val bedspaceId: java.util.UUID,
   val premisesId: java.util.UUID,
-  val transactionId: java.util.UUID,
+  val transactionId: java.util.UUID?,
 ) : CAS3Event
 
 data class CAS3BedspaceArchiveEventDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesArchiveEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/CAS3PremisesArchiveEvent.kt
@@ -12,7 +12,7 @@ class CAS3PremisesArchiveEvent(
   override val timestamp: Instant,
   override val eventType: EventType,
   val premisesId: UUID,
-  val transactionId: UUID,
+  val transactionId: UUID?,
 ) : CAS3Event
 
 data class CAS3PremisesArchiveEventDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -147,6 +147,16 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
   )
   fun findPremisesActiveDomainEventsByType(cas3PremisesId: UUID, premisesDomainEventTypes: List<String>): List<DomainEventEntity>
 
+  @Query(
+    """
+      SELECT d
+      FROM DomainEventEntity d
+      WHERE d.type in :premisesDomainEventTypes and d.cas3TransactionId is NULL
+      ORDER BY d.cas3PremisesId,d.createdAt
+      """,
+  )
+  fun findCas3DomainEventsByTypeWithoutTransactionId(premisesDomainEventTypes: List<DomainEventType>): List<DomainEventEntity>
+
   @Modifying
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2Statu
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.BookingStatusMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3MigrateNewBedspaceModelDataJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateApplicationOffenderNameJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateArchiveUnarchiveDomainEventTransactionJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateBookingOffenderNameJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3UpdateDomainEventTypeForPersonDepartureUpdatedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3VoidBedspaceJob
@@ -63,6 +64,7 @@ class MigrationJobService(
         MigrationJobType.cas1BackfillAutomaticPlacementApplications -> getBean(Cas1BackfillAutomaticPlacementApplicationsJob::class)
         MigrationJobType.cas1BackfillKeyWorkerUserAssignments -> getBean(Cas1BackfillKeyWorkerUserAssignmentsJob::class)
         MigrationJobType.cas1CapacityPerformanceTest -> getBean(Cas1CapacityPerformanceTestJob::class)
+        MigrationJobType.updateCas3DomainEventArchiveUnarchiveTransaction -> getBean(Cas3UpdateArchiveUnarchiveDomainEventTransactionJob::class)
       }
 
       if (job.shouldRunInTransaction) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3UpdateArchiveUnarchiveDomainEventTransactionJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3UpdateArchiveUnarchiveDomainEventTransactionJobTest.kt
@@ -1,0 +1,206 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.migration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3BedspaceArchiveEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3BedspaceArchiveEventDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3PremisesArchiveEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.CAS3PremisesArchiveEventDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.events.EventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas3UpdateArchiveUnarchiveDomainEventTransactionJobTest : MigrationJobTestBase() {
+  @Test
+  fun `all archive and unarchive domain events are updated with transaction Id`() {
+    val probationRegion = givenAProbationRegion()
+
+    val user = userEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+    }
+
+    val premisesOne = UUID.randomUUID()
+    val premisesTwo = UUID.randomUUID()
+    val premisesThree = UUID.randomUUID()
+    val premisesFour = UUID.randomUUID()
+    val premisesFive = UUID.randomUUID()
+
+    val premisesOneArchiveDomainEvent =
+      createPremisesArchiveDomainEvent(premisesOne, user, LocalDate.now().minusDays(15))
+    updateCreatedAtDomainEvent(premisesOneArchiveDomainEvent, OffsetDateTime.now().minusDays(15))
+
+    val premisesTwoArchiveDomainEvent =
+      createPremisesArchiveDomainEvent(premisesTwo, user, LocalDate.now().minusDays(10))
+    updateCreatedAtDomainEvent(premisesTwoArchiveDomainEvent, OffsetDateTime.now().minusDays(10))
+
+    val premisesThreeArchiveDomainEvent = createPremisesArchiveDomainEvent(
+      premisesThree,
+      user,
+      LocalDate.now().minusDays(7),
+      OffsetDateTime.now().minusDays(3),
+    )
+    updateCreatedAtDomainEvent(premisesThreeArchiveDomainEvent, OffsetDateTime.now().minusDays(7))
+
+    val bedspaceOnePremisesThree = UUID.randomUUID()
+    val bedspaceOnePremisesThreeArchiveDomainEvent = createBedspaceArchiveDomainEvent(
+      bedspaceOnePremisesThree,
+      premisesThree,
+      user.id,
+      null,
+      LocalDate.now().minusDays(7),
+    )
+    updateCreatedAtDomainEvent(
+      bedspaceOnePremisesThreeArchiveDomainEvent,
+      OffsetDateTime.now().minusDays(7).minusMinutes(1),
+    )
+
+    val bedspaceTwoPremisesThree = UUID.randomUUID()
+    val bedspaceTwoPremisesThreeArchiveDomainEvent = createBedspaceArchiveDomainEvent(
+      bedspaceTwoPremisesThree,
+      premisesThree,
+      user.id,
+      null,
+      LocalDate.now().minusDays(7),
+    )
+    updateCreatedAtDomainEvent(
+      bedspaceTwoPremisesThreeArchiveDomainEvent,
+      OffsetDateTime.now().minusDays(7).plusSeconds(30),
+    )
+
+    val bedspaceOnePremisesFour = UUID.randomUUID()
+    val bedspaceOnePremisesFourArchiveDomainEvent = createBedspaceArchiveDomainEvent(
+      bedspaceOnePremisesFour,
+      premisesFour,
+      user.id,
+      null,
+      LocalDate.now().plusDays(7),
+    )
+    updateCreatedAtDomainEvent(bedspaceOnePremisesFourArchiveDomainEvent, OffsetDateTime.now().minusDays(2))
+
+    val premisesFourArchiveDomainEvent = createPremisesArchiveDomainEvent(
+      premisesFour,
+      user,
+      LocalDate.now().plusDays(7),
+      OffsetDateTime.now().minusDays(3),
+    )
+    updateCreatedAtDomainEvent(premisesFourArchiveDomainEvent, OffsetDateTime.now().minusDays(1))
+
+    val premisesFiveArchiveDomainEvent = createPremisesArchiveDomainEvent(
+      premisesFive,
+      user,
+      LocalDate.now().plusDays(7),
+      transactionId = UUID.randomUUID(),
+    )
+    updateCreatedAtDomainEvent(premisesFiveArchiveDomainEvent, OffsetDateTime.now().minusDays(6))
+
+    migrationJobService.runMigrationJob(MigrationJobType.updateCas3DomainEventArchiveUnarchiveTransaction, 10)
+
+    val domainEvents = domainEventRepository.findByTypes(
+      listOf(
+        DomainEventType.CAS3_BEDSPACE_ARCHIVED,
+        DomainEventType.CAS3_BEDSPACE_UNARCHIVED,
+        DomainEventType.CAS3_PREMISES_ARCHIVED,
+        DomainEventType.CAS3_PREMISES_UNARCHIVED,
+      ),
+    )
+
+    domainEvents.forEach {
+      assertThat(it.cas3TransactionId).isNotNull()
+    }
+
+    assertDomainEventByTransactionId(premisesOneArchiveDomainEvent.id, 1)
+
+    assertDomainEventByTransactionId(premisesTwoArchiveDomainEvent.id, 1)
+
+    assertDomainEventByTransactionId(premisesThreeArchiveDomainEvent.id, 3)
+
+    assertDomainEventByTransactionId(premisesFourArchiveDomainEvent.id, 1)
+
+    assertDomainEventByTransactionId(bedspaceOnePremisesFourArchiveDomainEvent.id, 1)
+
+    assertDomainEventByTransactionId(premisesFiveArchiveDomainEvent.id, 1)
+  }
+
+  private fun assertDomainEventByTransactionId(domainEventId: UUID, count: Int) {
+    val domainEvent = domainEventRepository.findById(domainEventId).get()
+    val domainEvents = domainEventRepository.findByCas3TransactionId(domainEvent.cas3TransactionId!!)
+    assertThat(domainEvents.size).isEqualTo(count)
+  }
+
+  private fun updateCreatedAtDomainEvent(domainEvent: DomainEventEntity, createdAt: OffsetDateTime) {
+    val updatedDomainEvent = domainEvent.copy(createdAt = createdAt)
+    domainEventRepository.save(updatedDomainEvent)
+  }
+
+  private fun createPremisesArchiveDomainEvent(
+    premisesId: UUID,
+    userEntity: UserEntity,
+    date: LocalDate,
+    cancelledAt: OffsetDateTime? = null,
+    transactionId: UUID? = null,
+  ) = domainEventFactory.produceAndPersist {
+    withService(ServiceName.temporaryAccommodation)
+    withCas3PremisesId(premisesId)
+    withType(DomainEventType.CAS3_PREMISES_ARCHIVED)
+    withCas3CancelledAt(cancelledAt)
+    withData(
+      objectMapper.writeValueAsString(
+        CAS3PremisesArchiveEvent(
+          id = UUID.randomUUID(),
+          timestamp = Instant.now(),
+          eventType = EventType.premisesArchived,
+          premisesId = premisesId,
+          transactionId = transactionId,
+          eventDetails =
+          CAS3PremisesArchiveEventDetails(
+            userId = userEntity.id,
+            endDate = date,
+          ),
+        ),
+      ),
+    )
+  }
+
+  @SuppressWarnings("LongParameterList")
+  private fun createBedspaceArchiveDomainEvent(
+    bedspaceId: UUID,
+    premisesId: UUID,
+    userId: UUID,
+    currentEndDate: LocalDate?,
+    endDate: LocalDate,
+    cancelledAt: OffsetDateTime? = null,
+    transactionId: UUID? = null,
+  ) = domainEventFactory.produceAndPersist {
+    withService(ServiceName.temporaryAccommodation)
+    withCas3BedspaceId(bedspaceId)
+    withCas3PremisesId(premisesId)
+    withType(DomainEventType.CAS3_BEDSPACE_ARCHIVED)
+    withCas3CancelledAt(cancelledAt)
+    withData(
+      objectMapper.writeValueAsString(
+        CAS3BedspaceArchiveEvent(
+          id = UUID.randomUUID(),
+          timestamp = OffsetDateTime.now().toInstant(),
+          eventType = EventType.bedspaceArchived,
+          bedspaceId = bedspaceId,
+          premisesId = premisesId,
+          transactionId = transactionId,
+          eventDetails = CAS3BedspaceArchiveEventDetails(
+            userId = userId,
+            currentEndDate = currentEndDate,
+            endDate = endDate,
+          ),
+        ),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3PremisesServiceTest.kt
@@ -4013,7 +4013,7 @@ class Cas3PremisesServiceTest {
     data = objectMapper.writeValueAsString(data),
     type = CAS3_PREMISES_ARCHIVED,
     premisesId = data.premisesId,
-    transactionId = data.transactionId,
+    transactionId = data.transactionId!!,
   )
 
   @SuppressWarnings("LongParameterList")
@@ -4084,7 +4084,7 @@ class Cas3PremisesServiceTest {
     data.timestamp.atOffset(ZoneOffset.UTC),
     objectMapper.writeValueAsString(data),
     CAS3_BEDSPACE_ARCHIVED,
-    data.transactionId,
+    data.transactionId!!,
   )
 
   @SuppressWarnings("LongParameterList")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DomainEventTestRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
@@ -14,4 +15,14 @@ interface DomainEventTestRepository : JpaRepository<DomainEventEntity, UUID> {
   fun findByApplicationIdAndType(applicationId: UUID, type: DomainEventType): List<DomainEventEntity>
   fun findByCas3PremisesIdAndType(cas3PremisesId: UUID, type: DomainEventType): List<DomainEventEntity>
   fun findByCas3BedspaceId(cas3BedspaceId: UUID): List<DomainEventEntity>
+  fun findByCas3TransactionId(cas3TransactionId: UUID): List<DomainEventEntity>
+
+  @Query(
+    """
+      SELECT d 
+      FROM  DomainEventEntity d 
+      WHERE d.type in :domainEventTypes
+      """,
+  )
+  fun findByTypes(domainEventTypes: List<DomainEventType>): List<DomainEventEntity>
 }


### PR DESCRIPTION
This PR CAS-2003 is create a migration job to populate transaction Id for archive/unarchive CAS3 domain events