### PR TITLE
CAS3 V2 Application Referrals report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/TransitionalAccommodationReferralReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/TransitionalAccommodationReferralReportRepository.kt
@@ -71,6 +71,70 @@ interface TransitionalAccommodationReferralReportRepository : JpaRepository<Book
     endDate: LocalDate,
     probationRegionId: UUID?,
   ): List<TransitionalAccommodationReferralReportData>
+
+  @Query(
+    """
+    SELECT cast(a.id as text) AS assessmentId,
+      CAST(ap.id as text) AS referralId,
+      ap.created_at AS referralCreatedDate,
+      ap.crn AS crn,
+      ap.submitted_at AS referralSubmittedDate,
+      taa.risk_ratings->'roshRisks'->'value'->>'overallRisk' AS riskOfSeriousHarm,
+      taa.is_registered_sex_offender AS registeredSexOffender,
+      taa.is_history_of_sexual_offence as historyOfSexualOffence,
+      taa.is_concerning_sexual_behaviour as concerningSexualBehaviour,     
+      taa.needs_accessible_property AS needForAccessibleProperty,
+      taa.has_history_of_arson AS historyOfArsonOffence,
+      taa.is_concerning_arson_behaviour as concerningArsonBehaviour,      
+      taa.is_duty_to_refer_submitted AS dutyToReferMade,
+      taa.duty_to_refer_submission_date AS dateDutyToReferMade,
+      taa.duty_to_refer_local_authority_area_name AS dutyToReferLocalAuthorityAreaName,
+      taa.duty_to_refer_outcome AS dutyToReferOutcome,
+      probation_region.name AS probationRegionName,
+      a.decision AS assessmentDecision,
+      rrr.name AS referralRejectionReason,
+      aa.referral_rejection_reason_detail AS referralRejectionReasonDetail,
+      a.submitted_at AS assessmentSubmittedDate,
+      CAST(b.id AS text) AS bookingId,
+      taa.is_eligible AS isReferralEligibleForCas3,
+      taa.eligibility_reason AS referralEligibilityReason,
+      ap.noms_number as nomsNumber,
+      taa.arrival_date as accommodationRequiredDate,
+      taa.prison_name_on_creation as prisonNameOnCreation,
+      taa.person_release_date as personReleaseDate,
+      premises.town as town,
+      premises.postcode as postCode,
+      pdu.name as pduName,
+      taa.prison_release_types as prisonReleaseTypes,
+      tass.release_date as updatedReleaseDate,
+      tass.accommodation_required_from_date as updatedAccommodationRequiredFromDate,
+      previous_probation_region.name as previousReferralProbationRegionName,
+      previous_pdu.name as previousReferralPduName
+    FROM temporary_accommodation_assessments aa
+    JOIN assessments a on aa.assessment_id = a.id AND a.service='temporary-accommodation' AND a.reallocated_at IS NULL
+    JOIN temporary_accommodation_assessments tass on tass.assessment_id = a.id
+    JOIN applications ap on a.application_id = ap.id AND ap.service='temporary-accommodation'
+    LEFT JOIN temporary_accommodation_applications taa on ap.id = taa.id
+    LEFT JOIN probation_regions probation_region ON probation_region.id = taa.probation_region_id
+    LEFT JOIN probation_delivery_units pdu ON taa.probation_delivery_unit_id = pdu.id
+    LEFT JOIN probation_regions previous_probation_region ON previous_probation_region.id = taa.previous_referral_probation_region_id
+    LEFT JOIN probation_delivery_units previous_pdu ON previous_pdu.id = taa.previous_referral_probation_delivery_unit_id
+    LEFT JOIN bookings b on b.application_id = ap.id AND b.service='temporary-accommodation'
+    LEFT JOIN cas3_premises premises ON premises.id = b.premises_id
+    LEFT JOIN referral_rejection_reasons rrr ON aa.referral_rejection_reason_id = rrr.id
+    WHERE
+      a.service = 'temporary-accommodation'
+      AND ap.submitted_at BETWEEN :startDate AND :endDate
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR probation_region.id = :probationRegionId)
+    ORDER BY ap.submitted_at
+    """,
+    nativeQuery = true,
+  )
+  fun findAllReferralsV2(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    probationRegionId: UUID?,
+  ): List<TransitionalAccommodationReferralReportData>
 }
 
 interface TransitionalAccommodationReferralReportData {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ReportService.kt
@@ -73,11 +73,18 @@ class Cas3ReportService(
     outputStream: OutputStream,
   ) {
     log.info("Beginning CAS3 Application Referrals Report")
-    val referralsInScope = transitionalAccommodationReferralReportRowRepository.findAllReferrals(
-      startDate = properties.startDate,
-      endDate = properties.endDate,
-      probationRegionId = properties.probationRegionId,
-    )
+    val referralsInScope = when (featureFlagService.getBooleanFlag("cas3-reports-with-new-bedspace-model-tables-enabled")) {
+      true -> transitionalAccommodationReferralReportRowRepository.findAllReferralsV2(
+        startDate = properties.startDate,
+        endDate = properties.endDate,
+        probationRegionId = properties.probationRegionId,
+      )
+      false -> transitionalAccommodationReferralReportRowRepository.findAllReferrals(
+        startDate = properties.startDate,
+        endDate = properties.endDate,
+        probationRegionId = properties.probationRegionId,
+      )
+    }
 
     log.info("${referralsInScope.size} referrals found.")
 


### PR DESCRIPTION
**PR includes:**
* Refactor the `GET /cas3/reports/{reportName}` endpoint for the `referral` report type
* uses the `cas3-reports-with-new-bedspace-model-tables-enabled` feature-flag to determine whether to execute a query against the new `Bedspace model refactor` tables (or to execute against the tables currently queried in production when feature-flag off)
* executes the old or new query accordingly
* test coverage for the report against the new tables
