### PR TITLE
chore/CAS-2004-drop-constraints-for-cas-2-merge

### DIFF
--- a/src/main/resources/db/migration/all/20250930135641__remove_constraints_for_cas_2_merge.sql
+++ b/src/main/resources/db/migration/all/20250930135641__remove_constraints_for_cas_2_merge.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas_2_application_notes DROP CONSTRAINT IF EXISTS has_user;

--- a/src/main/resources/db/migration/all/20250930135641__remove_constraints_for_cas_2_merge.sql
+++ b/src/main/resources/db/migration/all/20250930135641__remove_constraints_for_cas_2_merge.sql
@@ -1,1 +1,2 @@
 ALTER TABLE cas_2_application_notes DROP CONSTRAINT IF EXISTS has_user;
+ALTER TABLE cas_2_status_updates ALTER COLUMN assessor_id DROP NOT NULL;


### PR DESCRIPTION
This drops a constraint that was preventing cas2 application notes table from being able to have the nomis and external user id empty (as we only want the cas2 one filled). It's added before the main PR as a non-breaking change.