### PR TITLE
CAS3 V2 Future Manage reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3FutureBookingsReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3FutureBookingsReportRepository.kt
@@ -64,6 +64,60 @@ interface Cas3FutureBookingsReportRepository : JpaRepository<BookingEntity, UUID
     endDate: LocalDate,
     probationRegionId: UUID?,
   ): List<FutureBookingsReportData>
+
+  @Query(
+    """
+    SELECT
+        CAST(booking.id AS VARCHAR) AS bookingId,
+        CAST(app.id AS VARCHAR) AS referralId,
+        app.submitted_at AS referralDate,
+        cas3_app.risk_ratings->'roshRisks'->'value'->>'overallRisk' AS riskOfSeriousHarm,
+        cas3_app.is_registered_sex_offender AS registeredSexOffender,
+        cas3_app.is_history_of_sexual_offence AS historyOfSexualOffence,
+        cas3_app.is_concerning_sexual_behaviour AS concerningSexualBehaviour,
+        cas3_app.is_duty_to_refer_submitted AS dutyToReferMade,
+        cas3_app.duty_to_refer_submission_date AS dateDutyToReferMade,
+        cas3_app.duty_to_refer_local_authority_area_name AS dutyToReferLocalAuthorityAreaName,
+        probation_region.name AS probationRegionName,
+        probation_delivery_unit.name AS pduName,
+        local_authority_area.name AS localAuthorityAreaName,
+        premises.address_line1 AS addressLine1,
+        premises.postcode as postCode,
+        booking.crn AS crn,
+        cas3_app.eligibility_reason AS referralEligibilityReason,
+        cas3_app.prison_name_on_creation AS prisonNameOnCreation,
+        booking.arrival_date AS startDate,
+        cas3_app.arrival_date AS accommodationRequiredDate,
+        cas3_assessment.accommodation_required_from_date AS updatedAccommodationRequiredDate,
+        CAST(confirmation.id AS VARCHAR) AS confirmationId
+    FROM bookings booking
+    INNER JOIN cas3_premises premises ON premises.id = booking.premises_id
+    INNER JOIN probation_delivery_units pdu ON pdu.id = premises.probation_delivery_unit_id
+    INNER JOIN probation_regions probation_region ON probation_region.id = pdu.probation_region_id
+    LEFT JOIN local_authority_areas local_authority_area ON local_authority_area.id = premises.local_authority_area_id
+    LEFT JOIN applications app ON booking.application_id = app.id
+    LEFT JOIN temporary_accommodation_applications cas3_app ON booking.application_id = cas3_app.id
+    LEFT JOIN assessments assessment ON app.id = assessment.application_id
+    LEFT JOIN temporary_accommodation_assessments cas3_assessment on cas3_assessment.assessment_id = assessment.id
+    LEFT JOIN cas3_confirmations confirmation ON confirmation.booking_id = booking.id
+    LEFT JOIN cancellations cancellation ON cancellation.booking_id = booking.id
+    LEFT JOIN arrivals arrival ON arrival.booking_id = booking.id
+    LEFT JOIN probation_delivery_units probation_delivery_unit on probation_delivery_unit.id = cas3_app.probation_delivery_unit_id
+    WHERE
+      COALESCE(cas3_assessment.accommodation_required_from_date,cas3_app.arrival_date) <= :endDate
+      AND COALESCE(cas3_assessment.accommodation_required_from_date,cas3_app.arrival_date) >= :startDate
+      AND (CAST(:probationRegionId AS UUID) IS NULL OR pdu.probation_region_id = :probationRegionId)
+      AND cancellation.id IS NULL
+      AND arrival.id IS NULL
+    ORDER BY probation_region.name,probation_delivery_unit.name,cas3_app.arrival_date
+    """,
+    nativeQuery = true,
+  )
+  fun findAllFutureBookingsV2(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    probationRegionId: UUID?,
+  ): List<FutureBookingsReportData>
 }
 
 interface FutureBookingsReportData {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ReportService.kt
@@ -260,11 +260,18 @@ class Cas3ReportService(
 
   fun createFutureBookingReport(properties: FutureBookingsReportProperties, outputStream: OutputStream) {
     log.info("Beginning CAS3 Future Booking Report")
-    val bookingsInScope = cas3FutureBookingsReportRepository.findAllFutureBookings(
-      properties.startDate,
-      properties.endDate,
-      properties.probationRegionId,
-    )
+    val bookingsInScope = when (featureFlagService.getBooleanFlag("cas3-reports-with-new-bedspace-model-tables-enabled")) {
+      true -> cas3FutureBookingsReportRepository.findAllFutureBookingsV2(
+        properties.startDate,
+        properties.endDate,
+        properties.probationRegionId,
+      )
+      false -> cas3FutureBookingsReportRepository.findAllFutureBookings(
+        properties.startDate,
+        properties.endDate,
+        properties.probationRegionId,
+      )
+    }
 
     val crns = bookingsInScope.map { it.crn }.distinct().toSet()
     val personInfos = splitAndRetrievePersonInfo(crns)
@@ -285,11 +292,19 @@ class Cas3ReportService(
 
   fun createFutureBookingCsvReport(properties: FutureBookingsReportProperties, outputStream: OutputStream) {
     log.info("Beginning CAS3 Future Booking CSV Report")
-    val bookingsInScope = cas3FutureBookingsReportRepository.findAllFutureBookings(
-      properties.startDate,
-      properties.endDate,
-      properties.probationRegionId,
-    )
+    val bookingsInScope = when (featureFlagService.getBooleanFlag("cas3-reports-with-new-bedspace-model-tables-enabled")) {
+      true -> cas3FutureBookingsReportRepository.findAllFutureBookingsV2(
+        properties.startDate,
+        properties.endDate,
+        properties.probationRegionId,
+      )
+
+      false -> cas3FutureBookingsReportRepository.findAllFutureBookings(
+        properties.startDate,
+        properties.endDate,
+        properties.probationRegionId,
+      )
+    }
 
     val crns = bookingsInScope.map { it.crn }.distinct().toSet()
     val personInfos = splitAndRetrievePersonInfo(crns)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2ReportsTest.kt
@@ -1,13 +1,17 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.v2
 
+import com.opencsv.CSVReaderBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns.Remove
 import org.jetbrains.kotlinx.dataframe.api.convertTo
 import org.jetbrains.kotlinx.dataframe.api.sortBy
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.api.toList
+import org.jetbrains.kotlinx.dataframe.io.readCSV
 import org.jetbrains.kotlinx.dataframe.io.readExcel
+import org.jetbrains.kotlinx.dataframe.size
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -34,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.generator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedUsageReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedUsageType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BookingsReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.FutureBookingsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.PersonInformationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.TransitionalAccommodationReferralReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.properties.BookingsReportProperties
@@ -71,6 +76,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
+import java.io.StringReader
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -1833,8 +1839,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
 
           webTestClient.get()
             .uri("/cas3/reports/bedUsage?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
-            .header("Authorization", "Bearer $jwt")
-            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .headers(buildTemporaryAccommodationHeaders(jwt))
             .exchange()
             .expectStatus()
             .isOk
@@ -1847,6 +1852,748 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             }
         }
       }
+    }
+  }
+
+  @Nested
+  inner class GetFutureBookingsReport {
+    @Test
+    @SuppressWarnings("LongMethod")
+    fun `Get future bookings report returns OK with correct body`() {
+      givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+        givenAnOffender { offenderDetails, inmateDetails ->
+          val reportStartDate = LocalDate.now().minusDays(30)
+          val reportEndDate = LocalDate.now()
+
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(user.probationRegion)
+          }
+
+          // offender with accommodation required date within report dates
+          val premisesOneAccommodationRequiredDate = reportStartDate.plusDays(7)
+          val (premisesOne, bedspaceOne, applicationOne) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesOneAccommodationRequiredDate,
+            null,
+          )
+
+          val premisesTwoAccommodationRequiredDate = reportStartDate.plusDays(21)
+          val (premisesTwo, bedspaceTwo, applicationTwo) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesTwoAccommodationRequiredDate,
+            null,
+          )
+
+          // offender with accommodation required date before report start date
+          val premisesThreeAccommodationRequiredDate = reportStartDate.minusDays(60)
+          val (premisesThree, bedspaceThree, applicationThree) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesThreeAccommodationRequiredDate,
+            null,
+          )
+
+          // offender with accommodation required date out of report dates range
+          val premisesFourAccommodationRequiredDate = reportEndDate.plusDays(200)
+          val (premisesFour, bedspaceFour, applicationFour) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesFourAccommodationRequiredDate,
+            null,
+          )
+
+          // offender with updated accommodation required date within report dates range
+          val premisesFiveAccommodationRequiredDate = reportStartDate.minusDays(50)
+          val premisesFiveUpdatedAccommodationRequiredDate = reportStartDate.plusDays(23)
+          val (premisesFive, bedspaceFive, applicationFive) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesFiveAccommodationRequiredDate,
+            premisesFiveUpdatedAccommodationRequiredDate,
+          )
+
+          val premisesSixAccommodationRequiredDate = reportStartDate.plusDays(210)
+          val premisesSixUpdatedAccommodationRequiredDate = reportEndDate.plusDays(9)
+          val (premisesSix, bedspaceSix, applicationSix) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesSixAccommodationRequiredDate,
+            premisesSixUpdatedAccommodationRequiredDate,
+          )
+
+          // offender with updated accommodation required date out of report dates range
+          val premisesSevenAccommodationRequiredDate = reportStartDate.minusDays(6)
+          val (premisesSeven, bedspaceSeven, applicationSeven) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            reportEndDate.plusDays(3),
+            premisesSevenAccommodationRequiredDate,
+          )
+
+          // provisional booking
+          val bookingOne = createBooking(
+            applicationOne,
+            premisesOne,
+            bedspaceOne,
+            offenderDetails.otherIds.crn,
+            reportEndDate.plusDays(6),
+            reportEndDate.plusDays(30),
+          )
+
+          val bookingTwo = createBooking(
+            applicationFive,
+            premisesFive,
+            bedspaceFive,
+            offenderDetails.otherIds.crn,
+            reportStartDate.plusDays(3),
+            reportStartDate.plusDays(18),
+          )
+
+          val bookingThree = createBooking(
+            applicationSix,
+            premisesSix,
+            bedspaceSix,
+            offenderDetails.otherIds.crn,
+            reportStartDate.plusDays(13),
+            reportStartDate.plusDays(56),
+          )
+
+          // old booking
+          createBooking(
+            applicationThree,
+            premisesThree,
+            bedspaceThree,
+            offenderDetails.otherIds.crn,
+            reportStartDate.minusDays(90),
+            reportStartDate.minusDays(15),
+          )
+
+          // confirmed booking
+          val bookingFour = createBooking(
+            applicationTwo,
+            premisesTwo,
+            bedspaceTwo,
+            offenderDetails.otherIds.crn,
+            reportStartDate.randomDateAfter(10),
+            reportEndDate.randomDateAfter(20),
+          )
+          bookingFour.let {
+            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              withBooking(it)
+            }
+          }
+
+          // cancelled booking
+          createBooking(
+            applicationOne,
+            premisesOne,
+            bedspaceOne,
+            offenderDetails.otherIds.crn,
+            reportStartDate.plusDays(8),
+            reportStartDate.plusDays(30),
+          ).let {
+            it.cancellations = cas3CancellationEntityFactory.produceAndPersistMultiple(1) {
+              withBooking(it)
+              withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+            }.toMutableList()
+          }
+
+          // future confirmed booking
+          val bookingFive = createBooking(
+            applicationFive,
+            premisesFive,
+            bedspaceFive,
+            offenderDetails.otherIds.crn,
+            reportEndDate.randomDateAfter(10),
+            reportEndDate.randomDateAfter(40),
+          )
+          bookingFive.let {
+            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              withBooking(it)
+            }
+          }
+
+          // future booking out of report dates range
+          createBooking(
+            applicationFour,
+            premisesFour,
+            bedspaceFour,
+            offenderDetails.otherIds.crn,
+            reportEndDate.randomDateAfter(70),
+            reportEndDate.randomDateAfter(90),
+          )
+
+          // future confirmed booking out of report dates range
+          createBooking(
+            applicationFour,
+            premisesFour,
+            bedspaceFour,
+            offenderDetails.otherIds.crn,
+            reportEndDate.plusDays(90),
+            reportEndDate.plusDays(120),
+          ).let {
+            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              withBooking(it)
+            }
+          }
+
+          createBooking(
+            applicationSeven,
+            premisesSeven,
+            bedspaceSeven,
+            offenderDetails.otherIds.crn,
+            reportEndDate.plusDays(70),
+            reportEndDate.plusDays(85),
+          ).let {
+            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              withBooking(it)
+            }
+          }
+
+          apDeliusContextAddResponseToUserAccessCall(
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
+            user.deliusUsername,
+          )
+
+          webTestClient.get()
+            .uri("/cas3/reports/futureBookings?startDate=$reportStartDate&endDate=$reportEndDate&probationRegionId=${user.probationRegion.id}")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith {
+              val actual = DataFrame
+                .readExcel(it.responseBody!!.inputStream())
+                .convertTo<FutureBookingsReportRow>(Remove)
+
+              assertThat(actual.size().nrow).isEqualTo(5)
+
+              assertRow(
+                actual[0],
+                bookingTwo.id,
+                offenderDetails,
+                applicationFive,
+                premisesFive,
+                bookingTwo.arrivalDate,
+                premisesFiveAccommodationRequiredDate,
+                premisesFiveUpdatedAccommodationRequiredDate,
+                "Provisional",
+              )
+              assertRow(
+                actual[1],
+                bookingFive.id,
+                offenderDetails,
+                applicationFive,
+                premisesFive,
+                bookingFive.arrivalDate,
+                premisesFiveAccommodationRequiredDate,
+                premisesFiveUpdatedAccommodationRequiredDate,
+                "Confirmed",
+              )
+              assertRow(
+                actual[2],
+                bookingOne.id,
+                offenderDetails,
+                applicationOne,
+                premisesOne,
+                bookingOne.arrivalDate,
+                premisesOneAccommodationRequiredDate,
+                null,
+                "Provisional",
+              )
+              assertRow(
+                actual[3],
+                bookingFour.id,
+                offenderDetails,
+                applicationTwo,
+                premisesTwo,
+                bookingFour.arrivalDate,
+                premisesTwoAccommodationRequiredDate,
+                null,
+                "Confirmed",
+              )
+              assertRow(
+                actual[4],
+                bookingThree.id,
+                offenderDetails,
+                applicationSix,
+                premisesSix,
+                bookingThree.arrivalDate,
+                premisesSixAccommodationRequiredDate,
+                premisesSixUpdatedAccommodationRequiredDate,
+                "Provisional",
+              )
+            }
+        }
+      }
+    }
+
+    @Test
+    @SuppressWarnings("LongMethod")
+    fun `Get future bookings report in Csv format returns OK with correct body`() {
+      givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+        givenAnOffender { offenderDetails, inmateDetails ->
+          val reportStartDate = LocalDate.now().minusDays(30)
+          val reportEndDate = LocalDate.now()
+
+          val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(user.probationRegion)
+          }
+
+          // offender with accommodation required date within report dates
+          val premisesOneAccommodationRequiredDate = reportStartDate.plusDays(7)
+          val (premisesOne, bedspaceOne, applicationOne) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesOneAccommodationRequiredDate,
+            null,
+          )
+
+          val premisesTwoAccommodationRequiredDate = reportStartDate.plusDays(21)
+          val (premisesTwo, bedspaceTwo, applicationTwo) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesTwoAccommodationRequiredDate,
+            null,
+          )
+
+          // offender with accommodation required date before report start date
+          val premisesThreeAccommodationRequiredDate = reportStartDate.minusDays(60)
+          val (premisesThree, bedspaceThree, applicationThree) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesThreeAccommodationRequiredDate,
+            null,
+          )
+
+          // offender with accommodation required date out of report dates range
+          val premisesFourAccommodationRequiredDate = reportEndDate.plusDays(200)
+          val (premisesFour, bedspaceFour, applicationFour) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesFourAccommodationRequiredDate,
+            null,
+          )
+
+          // offender with updated accommodation required date within report dates range
+          val premisesFiveAccommodationRequiredDate = reportStartDate.minusDays(50)
+          val premisesFiveUpdatedAccommodationRequiredDate = reportStartDate.plusDays(23)
+          val (premisesFive, bedspaceFive, applicationFive) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesFiveAccommodationRequiredDate,
+            premisesFiveUpdatedAccommodationRequiredDate,
+          )
+
+          val premisesSixAccommodationRequiredDate = reportStartDate.plusDays(210)
+          val premisesSixUpdatedAccommodationRequiredDate = reportEndDate.plusDays(9)
+          val (premisesSix, bedspaceSix, applicationSix) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            premisesSixAccommodationRequiredDate,
+            premisesSixUpdatedAccommodationRequiredDate,
+          )
+
+          // offender with updated accommodation required date out of report dates range
+          val premisesSevenAccommodationRequiredDate = reportStartDate.minusDays(6)
+          val (premisesSeven, bedspaceSeven, applicationSeven) = createReferralAndAssessment(
+            user,
+            offenderDetails,
+            probationDeliveryUnit,
+            OffsetDateTime.now().randomDateTimeBefore(10),
+            reportEndDate.plusDays(3),
+            premisesSevenAccommodationRequiredDate,
+          )
+
+          // provisional booking
+          val bookingOne = createBooking(
+            applicationOne,
+            premisesOne,
+            bedspaceOne,
+            offenderDetails.otherIds.crn,
+            reportEndDate.plusDays(6),
+            reportEndDate.plusDays(30),
+          )
+
+          val bookingTwo = createBooking(
+            applicationFive,
+            premisesFive,
+            bedspaceFive,
+            offenderDetails.otherIds.crn,
+            reportStartDate.plusDays(3),
+            reportStartDate.plusDays(18),
+          )
+
+          val bookingThree = createBooking(
+            applicationSix,
+            premisesSix,
+            bedspaceSix,
+            offenderDetails.otherIds.crn,
+            reportStartDate.plusDays(13),
+            reportStartDate.plusDays(56),
+          )
+
+          // old booking
+          createBooking(
+            applicationThree,
+            premisesThree,
+            bedspaceThree,
+            offenderDetails.otherIds.crn,
+            reportStartDate.minusDays(90),
+            reportStartDate.minusDays(15),
+          )
+
+          // confirmed booking
+          val bookingFour = createBooking(
+            applicationTwo,
+            premisesTwo,
+            bedspaceTwo,
+            offenderDetails.otherIds.crn,
+            reportStartDate.randomDateAfter(10),
+            reportEndDate.randomDateAfter(20),
+          )
+          bookingFour.let {
+            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              withBooking(it)
+            }
+          }
+
+          // cancelled booking
+          createBooking(
+            applicationOne,
+            premisesOne,
+            bedspaceOne,
+            offenderDetails.otherIds.crn,
+            reportStartDate.plusDays(8),
+            reportStartDate.plusDays(30),
+          ).let {
+            it.cancellations = cas3CancellationEntityFactory.produceAndPersistMultiple(1) {
+              withBooking(it)
+              withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+            }.toMutableList()
+          }
+
+          // future confirmed booking
+          val bookingFive = createBooking(
+            applicationFive,
+            premisesFive,
+            bedspaceFive,
+            offenderDetails.otherIds.crn,
+            reportEndDate.randomDateAfter(10),
+            reportEndDate.randomDateAfter(40),
+          )
+          bookingFive.let {
+            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              withBooking(it)
+            }
+          }
+
+          // future booking out of report dates range
+          createBooking(
+            applicationFour,
+            premisesFour,
+            bedspaceFour,
+            offenderDetails.otherIds.crn,
+            reportEndDate.randomDateAfter(70),
+            reportEndDate.randomDateAfter(90),
+          )
+
+          // future confirmed booking out of report dates range
+          createBooking(
+            applicationFour,
+            premisesFour,
+            bedspaceFour,
+            offenderDetails.otherIds.crn,
+            reportEndDate.plusDays(90),
+            reportEndDate.plusDays(120),
+          ).let {
+            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              withBooking(it)
+            }
+          }
+
+          createBooking(
+            applicationSeven,
+            premisesSeven,
+            bedspaceSeven,
+            offenderDetails.otherIds.crn,
+            reportEndDate.plusDays(70),
+            reportEndDate.plusDays(85),
+          ).let {
+            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              withBooking(it)
+            }
+          }
+
+          apDeliusContextAddResponseToUserAccessCall(
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
+            user.deliusUsername,
+          )
+
+          webTestClient.get()
+            .uri("/cas3/reports/futureBookingsCsv?startDate=$reportStartDate&endDate=$reportEndDate&probationRegionId=${user.probationRegion.id}")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .consumeWith { response ->
+              val completeCsvString = response.responseBody!!.inputStream().bufferedReader().use { it.readText() }
+
+              val csvReader = CSVReaderBuilder(StringReader(completeCsvString)).build()
+              val headers = csvReader.readNext().toList()
+
+              assertReportHeader(headers)
+
+              val actual = DataFrame
+                .readCSV(completeCsvString.byteInputStream())
+                .convertTo<FutureBookingsReportRow>()
+                .toList()
+
+              assertThat(actual.size).isEqualTo(5)
+
+              assertReportRow(
+                actual[0],
+                bookingTwo.id,
+                offenderDetails,
+                applicationFive,
+                premisesFive,
+                bookingTwo.arrivalDate,
+                premisesFiveAccommodationRequiredDate,
+                premisesFiveUpdatedAccommodationRequiredDate,
+                "Provisional",
+              )
+
+              assertReportRow(
+                actual[1],
+                bookingFive.id,
+                offenderDetails,
+                applicationFive,
+                premisesFive,
+                bookingFive.arrivalDate,
+                premisesFiveAccommodationRequiredDate,
+                premisesFiveUpdatedAccommodationRequiredDate,
+                "Confirmed",
+              )
+
+              assertReportRow(
+                actual[2],
+                bookingOne.id,
+                offenderDetails,
+                applicationOne,
+                premisesOne,
+                bookingOne.arrivalDate,
+                premisesOneAccommodationRequiredDate,
+                null,
+                "Provisional",
+              )
+
+              assertReportRow(
+                actual[3],
+                bookingFour.id,
+                offenderDetails,
+                applicationTwo,
+                premisesTwo,
+                bookingFour.arrivalDate,
+                premisesTwoAccommodationRequiredDate,
+                null,
+                "Confirmed",
+              )
+
+              assertReportRow(
+                actual[4],
+                bookingThree.id,
+                offenderDetails,
+                applicationSix,
+                premisesSix,
+                bookingThree.arrivalDate,
+                premisesSixAccommodationRequiredDate,
+                premisesSixUpdatedAccommodationRequiredDate,
+                "Provisional",
+              )
+            }
+        }
+      }
+    }
+
+    @Suppress("LongParameterList")
+    fun assertRow(
+      row: DataRow<FutureBookingsReportRow>,
+      bookingId: UUID,
+      offenderDetails: OffenderDetailSummary,
+      application: TemporaryAccommodationApplicationEntity,
+      premises: Cas3PremisesEntity,
+      bookingStartDate: LocalDate,
+      accommodationRequiredDate: LocalDate,
+      updateAccommodationRequiredDate: LocalDate?,
+      bookingStatus: String,
+    ) {
+      val expectedPersonName = if (offenderDetails.middleNames.isNullOrEmpty()) {
+        "${offenderDetails.firstName} ${offenderDetails.surname}"
+      } else {
+        (listOf(offenderDetails.firstName) + offenderDetails.middleNames + offenderDetails.surname).joinToString(
+          " ",
+        )
+      }
+
+      assertThat(row["bookingId"]).isEqualTo(bookingId.toString())
+      assertThat(row["referralId"]).isEqualTo(application.id.toString())
+      assertThat(row["referralDate"]).isEqualTo(application.submittedAt?.toLocalDate())
+      assertThat(row["personName"]).isEqualTo(expectedPersonName)
+      assertThat(row["gender"]).isEqualTo(offenderDetails.gender)
+      assertThat(row["ethnicity"]).isEqualTo(offenderDetails.offenderProfile.ethnicity)
+      assertThat(row["dateOfBirth"]).isEqualTo(offenderDetails.dateOfBirth)
+      assertThat(row["riskOfSeriousHarm"]).isEqualTo("High")
+      assertThat(row["registeredSexOffender"]).isEqualTo(application.isRegisteredSexOffender.toYesNo())
+      assertThat(row["historyOfSexualOffence"]).isEqualTo(application.isHistoryOfSexualOffence.toYesNo())
+      assertThat(row["concerningSexualBehaviour"]).isEqualTo(application.isConcerningSexualBehaviour.toYesNo())
+      assertThat(row["dutyToReferMade"]).isEqualTo(application.isDutyToReferSubmitted.toYesNo())
+      assertThat(row["dateDutyToReferMade"]).isEqualTo(application.dutyToReferSubmissionDate)
+      assertThat(row["dutyToReferLocalAuthorityAreaName"]).isEqualTo(application.dutyToReferLocalAuthorityAreaName)
+      assertThat(row["probationRegion"]).isEqualTo(application.probationRegion.name)
+      assertThat(row["pdu"]).isEqualTo(application.probationDeliveryUnit?.name)
+      assertThat(row["localAuthority"]).isEqualTo(premises.localAuthorityArea?.name)
+      assertThat(row["addressLine1"]).isEqualTo(premises.addressLine1)
+      assertThat(row["postCode"]).isEqualTo(premises.postcode)
+      assertThat(row["crn"]).isEqualTo(application.crn)
+      assertThat(row["sourceOfReferral"]).isEqualTo(application.eligibilityReason)
+      assertThat(row["prisonAtReferral"]).isEqualTo(application.prisonNameOnCreation)
+      assertThat(row["startDate"]).isEqualTo(bookingStartDate)
+      assertThat(row["accommodationRequiredDate"]).isEqualTo(accommodationRequiredDate)
+      assertThat(row["updatedAccommodationRequiredDate"]).isEqualTo(updateAccommodationRequiredDate)
+      assertThat(row["bookingStatus"]).isEqualTo(bookingStatus)
+    }
+
+    fun assertReportHeader(headers: List<String>) {
+      assertThat(headers).contains("bookingId")
+      assertThat(headers).contains("referralId")
+      assertThat(headers).contains("referralDate")
+      assertThat(headers).contains("personName")
+      assertThat(headers).contains("gender")
+      assertThat(headers).contains("ethnicity")
+      assertThat(headers).contains("dateOfBirth")
+      assertThat(headers).contains("riskOfSeriousHarm")
+      assertThat(headers).contains("registeredSexOffender")
+      assertThat(headers).contains("historyOfSexualOffence")
+      assertThat(headers).contains("concerningSexualBehaviour")
+      assertThat(headers).contains("dutyToReferMade")
+      assertThat(headers).contains("dateDutyToReferMade")
+      assertThat(headers).contains("dutyToReferLocalAuthorityAreaName")
+      assertThat(headers).contains("probationRegion")
+      assertThat(headers).contains("pdu")
+      assertThat(headers).contains("localAuthority")
+      assertThat(headers).contains("addressLine1")
+      assertThat(headers).contains("postCode")
+      assertThat(headers).contains("crn")
+      assertThat(headers).contains("sourceOfReferral")
+      assertThat(headers).contains("prisonAtReferral")
+      assertThat(headers).contains("startDate")
+      assertThat(headers).contains("accommodationRequiredDate")
+      assertThat(headers).contains("updatedAccommodationRequiredDate")
+      assertThat(headers).contains("bookingStatus")
+    }
+
+    @Suppress("LongParameterList")
+    fun assertReportRow(
+      row: FutureBookingsReportRow,
+      bookingId: UUID,
+      offenderDetails: OffenderDetailSummary,
+      application: TemporaryAccommodationApplicationEntity,
+      premises: Cas3PremisesEntity,
+      bookingStartDate: LocalDate,
+      accommodationRequiredDate: LocalDate,
+      updateAccommodationRequiredDate: LocalDate?,
+      bookingStatus: String,
+    ) {
+      val expectedPersonName = if (offenderDetails.middleNames.isNullOrEmpty()) {
+        "${offenderDetails.firstName} ${offenderDetails.surname}"
+      } else {
+        (listOf(offenderDetails.firstName) + offenderDetails.middleNames + offenderDetails.surname).joinToString(
+          " ",
+        )
+      }
+
+      assertThat(row.bookingId).isEqualTo(bookingId.toString())
+      assertThat(row.referralId).isEqualTo(application.id.toString())
+      assertThat(row.referralDate).isEqualTo(application.submittedAt?.toLocalDate())
+      assertThat(row.personName).isEqualTo(expectedPersonName)
+      assertThat(row.gender).isEqualTo(offenderDetails.gender)
+      assertThat(row.ethnicity).isEqualTo(offenderDetails.offenderProfile.ethnicity)
+      assertThat(row.dateOfBirth).isEqualTo(offenderDetails.dateOfBirth)
+      assertThat(row.riskOfSeriousHarm).isEqualTo("High")
+      assertThat(row.registeredSexOffender).isEqualTo(application.isRegisteredSexOffender.toString())
+      assertThat(row.historyOfSexualOffence).isEqualTo(application.isHistoryOfSexualOffence.toString())
+      assertThat(row.concerningSexualBehaviour).isEqualTo(application.isConcerningSexualBehaviour.toString())
+      assertThat(row.dutyToReferMade).isEqualTo(application.isDutyToReferSubmitted.toString())
+      assertThat(row.dateDutyToReferMade).isEqualTo(application.dutyToReferSubmissionDate)
+      assertThat(row.dutyToReferLocalAuthorityAreaName).isEqualTo(application.dutyToReferLocalAuthorityAreaName)
+      assertThat(row.probationRegion).isEqualTo(application.probationRegion.name)
+      assertThat(row.pdu).isEqualTo(application.probationDeliveryUnit?.name)
+      assertThat(row.localAuthority).isEqualTo(premises.localAuthorityArea?.name)
+      assertThat(row.addressLine1).isEqualTo(premises.addressLine1)
+      assertThat(row.postCode).isEqualTo(premises.postcode)
+      assertThat(row.crn).isEqualTo(application.crn)
+      assertThat(row.sourceOfReferral).isEqualTo(application.eligibilityReason)
+      assertThat(row.prisonAtReferral).isEqualTo(application.prisonNameOnCreation)
+      assertThat(row.startDate).isEqualTo(bookingStartDate.toString())
+      assertThat(row.accommodationRequiredDate).isEqualTo(accommodationRequiredDate.toString())
+      assertThat(row.updatedAccommodationRequiredDate).isEqualTo(updateAccommodationRequiredDate)
+      assertThat(row.bookingStatus).isEqualTo(bookingStatus)
+    }
+
+    @SuppressWarnings("LongParameterList")
+    private fun createBooking(
+      application: TemporaryAccommodationApplicationEntity,
+      premises: Cas3PremisesEntity,
+      bedspace: Cas3BedspacesEntity,
+      crn: String,
+      arrivalDate: LocalDate,
+      departureDate: LocalDate,
+    ): Cas3BookingEntity = cas3BookingEntityFactory.produceAndPersist {
+      withApplication(application)
+      withPremises(premises)
+      withBedspace(bedspace)
+      withServiceName(ServiceName.temporaryAccommodation)
+      withCrn(crn)
+      withArrivalDate(arrivalDate)
+      withDepartureDate(departureDate)
     }
   }
 


### PR DESCRIPTION
**PR includes:**
* Refactor the `GET /cas3/reports/{reportName}` endpoint for the `futureBookings` and `futureBookingsCsv` report types 
* uses the `cas3-reports-with-new-bedspace-model-tables-enabled` feature-flag to determine whether to execute a query against the new `Bedspace model refactor` tables (or to execute against the tables currently queried in production when feature-flag off)
* executes the old or new query accordingly
* test coverage for the report against the new tables
