### PR TITLE
Feature/CAS-1951 premises put

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PremisesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PremisesController.kt
@@ -185,6 +185,7 @@ class Cas3PremisesController(
     return ResponseEntity.ok(result)
   }
 
+  @Deprecated("This endpoint will be removed in v2. Use /cas3/v2/premises")
   @PostMapping(
     "/premises",
     consumes = [MediaType.APPLICATION_JSON_VALUE],
@@ -215,6 +216,7 @@ class Cas3PremisesController(
     return ResponseEntity(cas3PremisesTransformer.transformDomainToApi(premises, totalBedspacesByStatus), HttpStatus.CREATED)
   }
 
+  @Deprecated("This endpoint will be removed in v2. Use /cas3/v2/premises/{premisesId}")
   @Transactional
   @PutMapping("/premises/{premisesId}")
   fun updatePremises(@PathVariable premisesId: UUID, @RequestBody body: Cas3UpdatePremises): ResponseEntity<Cas3Premises> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3UpdatePremises.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3UpdatePremises.kt
@@ -3,26 +3,15 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
 import java.util.UUID
 
 data class Cas3UpdatePremises(
-
   val reference: String,
-
   val addressLine1: String,
-
   val postcode: String,
-
   val probationRegionId: UUID,
-
   val probationDeliveryUnitId: UUID,
-
   val characteristicIds: List<UUID>,
-
   val addressLine2: String? = null,
-
   val town: String? = null,
-
   val localAuthorityAreaId: UUID? = null,
-
   val notes: String? = null,
-
   val turnaroundWorkingDayCount: Int,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2PremisesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2PremisesServiceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
@@ -58,13 +59,204 @@ class Cas3v2PremisesServiceTest {
   lateinit var cas3v2PremisesService: Cas3v2PremisesService
 
   @Nested
+  inner class UpdatePremises {
+    private val premises = Cas3PremisesEntityFactory().withDefaults().produce()
+    private val probationRegion = premises.probationDeliveryUnit.probationRegion
+    private val laa = premises.localAuthorityArea!!
+    private val pdu = premises.probationDeliveryUnit
+    private val cas3PremisesCharacteristic = Cas3PremisesCharacteristicEntityFactory().produce()
+
+    @BeforeEach
+    fun setup() {
+      every { cas3PremisesRepository.findByIdOrNull(premises.id) } returns premises
+      every { cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(any(), any()) } returns false
+      every { localAuthorityAreaRepository.findByIdOrNull(laa.id) } returns laa
+      every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(pdu.id, probationRegion.id) } returns pdu
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(listOf(cas3PremisesCharacteristic.id)) } returns mutableListOf(
+        cas3PremisesCharacteristic,
+      )
+    }
+
+    @Test
+    fun `When update a premises returns Success with correct result when validation passed`() {
+      val premisesSlot = slot<Cas3PremisesEntity>()
+      every { cas3PremisesRepository.save(capture(premisesSlot)) } answers { premisesSlot.captured }
+
+      val updatedName = "updatedName"
+      val result = cas3v2PremisesService.updatePremises(
+        premisesId = premises.id,
+        reference = updatedName,
+        addressLine1 = "asd1",
+        addressLine2 = "asd2",
+        town = "asd3",
+        postcode = "asd4",
+        localAuthorityAreaId = laa.id,
+        probationRegionId = pdu.probationRegion.id,
+        probationDeliveryUnitId = pdu.id,
+        characteristicIds = listOf(cas3PremisesCharacteristic.id),
+        notes = "some new notes",
+        turnaroundWorkingDays = 9,
+      )
+
+      assertAll({
+        val capturedPremises = premisesSlot.captured
+        assertThat(capturedPremises.id).isEqualTo(premises.id)
+        assertThat(capturedPremises.name).isEqualTo(updatedName)
+        assertThat(capturedPremises.addressLine1).isEqualTo("asd1")
+        assertThat(capturedPremises.addressLine2).isEqualTo("asd2")
+        assertThat(capturedPremises.town).isEqualTo("asd3")
+        assertThat(capturedPremises.postcode).isEqualTo("asd4")
+        assertThat(capturedPremises.localAuthorityArea).isEqualTo(laa)
+        assertThat(capturedPremises.notes).isEqualTo("some new notes")
+        assertThat(capturedPremises.status).isEqualTo(Cas3PremisesStatus.online)
+        assertThat(capturedPremises.probationDeliveryUnit).isEqualTo(pdu)
+        assertThat(capturedPremises.characteristics).isEqualTo(mutableListOf(cas3PremisesCharacteristic))
+        assertThat(capturedPremises.turnaroundWorkingDays).isEqualTo(9)
+        assertThat(capturedPremises.bookings).isEmpty()
+        assertThat(capturedPremises.bedspaces).isEmpty()
+        assertThat(capturedPremises.startDate).isEqualTo(premises.startDate)
+        assertThat(capturedPremises.endDate).isNull()
+        assertThat(capturedPremises.createdAt).isEqualTo(premises.createdAt)
+        assertThat(capturedPremises.lastUpdatedAt).isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.SECONDS))
+
+        assertThatCasResult(result).isSuccess().with {
+          assertThat(it.first).isEqualTo(capturedPremises)
+        }
+      })
+
+      verify(exactly = 1) { cas3PremisesRepository.findByIdOrNull(premises.id) }
+      verify(exactly = 1) { localAuthorityAreaRepository.findByIdOrNull(laa.id) }
+      verify(exactly = 1) {
+        probationDeliveryUnitRepository.findByIdAndProbationRegionId(pdu.id, pdu.probationRegion.id)
+      }
+      verify(exactly = 1) {
+        cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(updatedName, pdu.id)
+      }
+    }
+
+    @Test
+    fun `has validation errors when incorrect values are used`() {
+      every { localAuthorityAreaRepository.findByIdOrNull(any()) } returns null
+      every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(any(), any()) } returns null
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(any()) } returns mutableListOf()
+
+      val characteristicId = UUID.randomUUID()
+
+      val result = cas3v2PremisesService.updatePremises(
+        premisesId = premises.id,
+        reference = "",
+        addressLine1 = "",
+        addressLine2 = "",
+        town = "",
+        postcode = "",
+        localAuthorityAreaId = UUID.randomUUID(),
+        probationRegionId = UUID.randomUUID(),
+        probationDeliveryUnitId = pdu.id,
+        characteristicIds = mutableListOf(characteristicId),
+        notes = null,
+        turnaroundWorkingDays = -1,
+      )
+
+      assertThatCasResult(result).isFieldValidationError()
+        .hasMessage("$.reference", "empty")
+        .hasMessage("$.address", "empty")
+        .hasMessage("$.postcode", "empty")
+        .hasMessage("$.localAuthorityAreaId", "doesNotExist")
+        .hasMessage("$.probationRegionId", "doesNotExist")
+        .hasMessage("$.probationDeliveryUnitId", "doesNotExist")
+        .hasMessage("$.premisesCharacteristics[$characteristicId]", "doesNotExist")
+        .hasMessage("$.turnaroundWorkingDays", "isNotAPositiveInteger")
+        .withNumberOfMessages(8)
+
+      verify(exactly = 0) { cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(any(), any()) }
+    }
+
+    @Test
+    fun `has validation errors when given probationDeliveryUnitId does not match premises`() {
+      every { localAuthorityAreaRepository.findByIdOrNull(any()) } returns null
+      every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(any(), any()) } returns null
+
+      val result = cas3v2PremisesService.updatePremises(
+        premisesId = premises.id,
+        reference = "",
+        addressLine1 = "",
+        addressLine2 = "",
+        town = "",
+        postcode = "",
+        localAuthorityAreaId = UUID.randomUUID(),
+        probationRegionId = UUID.randomUUID(),
+        probationDeliveryUnitId = UUID.randomUUID(),
+        characteristicIds = mutableListOf(),
+        notes = null,
+        turnaroundWorkingDays = 2,
+      )
+
+      assertThatCasResult(result).isFieldValidationError()
+        .hasMessage("$.probationDeliveryUnitId", "premisesNotInProbationDeliveryUnit")
+        .withNumberOfMessages(1)
+    }
+
+    @Test
+    fun `has validation error when reference is not unique`() {
+      val notUniqueName = "notUnique"
+      every {
+        cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(
+          notUniqueName,
+          pdu.id,
+        )
+      } returns true
+
+      val result = cas3v2PremisesService.updatePremises(
+        premisesId = premises.id,
+        reference = "notUnique",
+        addressLine1 = "address1",
+        addressLine2 = "",
+        town = "",
+        postcode = "asd4",
+        localAuthorityAreaId = laa.id,
+        probationRegionId = pdu.probationRegion.id,
+        probationDeliveryUnitId = pdu.id,
+        characteristicIds = listOf(cas3PremisesCharacteristic.id),
+        notes = null,
+        turnaroundWorkingDays = 2,
+      )
+
+      assertThatCasResult(result).isFieldValidationError()
+        .hasMessage("$.reference", "notUnique")
+        .withNumberOfMessages(1)
+    }
+
+    @Test
+    fun `returns Not Found when premises does not exist`() {
+      every { cas3PremisesRepository.findByIdOrNull(any()) } returns null
+      val invalidId = UUID.randomUUID()
+      val result = cas3v2PremisesService.updatePremises(
+        premisesId = invalidId,
+        reference = "",
+        addressLine1 = "",
+        addressLine2 = "",
+        town = "",
+        postcode = "",
+        localAuthorityAreaId = UUID.randomUUID(),
+        probationRegionId = UUID.randomUUID(),
+        probationDeliveryUnitId = UUID.randomUUID(),
+        characteristicIds = mutableListOf(),
+        notes = null,
+        turnaroundWorkingDays = -1,
+      )
+
+      assertThatCasResult(result).isNotFound("Cas3Premises", invalidId)
+    }
+  }
+
+  @Nested
   inner class CreateNewPremises {
 
     @Test
     fun `has validation errors when incorrect values are used`() {
       every { localAuthorityAreaRepository.findByIdOrNull(any()) } returns null
       every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(any(), any()) } returns null
-      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(any()) } returns emptyList()
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(any()) } returns mutableListOf()
 
       val characteristicId = UUID.randomUUID()
 
@@ -104,7 +296,7 @@ class Cas3v2PremisesServiceTest {
       every { probationDeliveryUnitRepository.findByIdAndProbationRegionId(any(), any()) } returns mockPdu
       every { mockPdu.probationRegion } returns mockk<ProbationRegionEntity>()
       every { cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(any(), any()) } returns true
-      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(any()) } returns emptyList()
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(any()) } returns mutableListOf()
 
       val pduId = UUID.randomUUID()
 
@@ -147,7 +339,7 @@ class Cas3v2PremisesServiceTest {
       every {
         cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(premisesName, pdu.id)
       } returns false
-      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(listOf(cas3PremisesCharacteristic.id)) } returns listOf(
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(listOf(cas3PremisesCharacteristic.id)) } returns mutableListOf(
         cas3PremisesCharacteristic,
       )
 
@@ -190,7 +382,7 @@ class Cas3v2PremisesServiceTest {
         assertThat(capturedPremises.lastUpdatedAt).isNull()
 
         assertThatCasResult(result).isSuccess().with {
-          assertThat(it).isEqualTo(capturedPremises)
+          assertThat(it.first).isEqualTo(capturedPremises)
         }
       })
 
@@ -216,7 +408,7 @@ class Cas3v2PremisesServiceTest {
       every {
         cas3PremisesRepository.existsByNameIgnoreCaseAndProbationDeliveryUnitId(premisesName, pdu.id)
       } returns false
-      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(listOf(cas3PremisesCharacteristic.id)) } returns listOf(
+      every { cas3PremisesCharacteristicRepository.findActiveCharacteristicsByIdIn(listOf(cas3PremisesCharacteristic.id)) } returns mutableListOf(
         cas3PremisesCharacteristic,
       )
 
@@ -240,8 +432,8 @@ class Cas3v2PremisesServiceTest {
       assertAll({
         val capturedPremises = premisesSlot.captured
         assertThat(capturedPremises.turnaroundWorkingDays).isEqualTo(2)
-        assertThatCasResult(result).isSuccess().with {
-          assertThat(it.turnaroundWorkingDays).isEqualTo(2)
+        assertThatCasResult(result).isSuccess().with { (createdPremises, _) ->
+          assertThat(createdPremises.turnaroundWorkingDays).isEqualTo(2)
         }
       })
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -1018,6 +1018,12 @@ abstract class InitialiseDatabasePerClassTestBase : IntegrationTestBase() {
   }
 }
 
+fun WebTestClient.ResponseSpec.withForbiddenMessage(message: String = "You are not authorized to access this endpoint"): WebTestClient.BodyContentSpec = this.expectStatus()
+  .isForbidden.expectBody()
+  .jsonPath("title").isEqualTo("Forbidden")
+  .jsonPath("status").isEqualTo(403)
+  .jsonPath("detail").isEqualTo(message)
+
 fun WebTestClient.ResponseSpec.withNotFoundMessage(message: String): WebTestClient.BodyContentSpec = this.expectStatus()
   .isNotFound.expectBody()
   .jsonPath("title").isEqualTo("Not Found")


### PR DESCRIPTION
Lift and shift and slight refactor. 
* Added extra validation to check a premises belongs to a pdu, as there was nothing previously, so I think maybe you could update a premises in a different PDU if you provided the PDU for your user.
* Also combined all existing validation unit tests into fewer tests. 
* changed the getBedspaceTotals methods to do the calculation in the service, and return as a pair, to save the extra db call