### PR TITLE
CAS3 V2 Booking gap report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BookingGapReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BookingGapReportRepository.kt
@@ -137,6 +137,135 @@ where gap_days > 0
 order by probation_region,pdu_name,premises_name,bed_name,gap
 """.trimIndent()
 
+val GAP_RANGES_QUERY_V2 = """
+with bedspaces as (select
+                       bedspace.id,
+                       premises.name as premises_name,
+                       bedspace.reference as room_name,
+                       probation_regions.name as probation_region,
+                       pdu.name as pdu_name,
+                       bedspace.end_date
+                   from cas3_bedspaces bedspace
+                            inner join cas3_premises premises on bedspace.premises_id = premises.id
+                            inner join probation_delivery_units pdu on pdu.id = premises.probation_delivery_unit_id
+                            inner join probation_regions on probation_regions.id = pdu.probation_region_id
+                   where (bedspace.end_date is null or bedspace.end_date >= :startDate) and bedspace.created_at <= :endDate
+),
+ all_bookings as (select
+                      bed_id,
+                      arrival_date,
+                      departure_date,
+                      (select working_day_count
+                       from cas3_turnarounds
+                       where cas3_turnarounds.id = (
+                           select id
+                           from cas3_turnarounds
+                           where  cas3_turnarounds.booking_id = bookings.id
+                           order by cas3_turnarounds.created_at desc
+                           limit 1)) turnaround_days
+                  from bookings
+                  left join cancellations on  cancellations.booking_id = bookings.id
+                  where bookings.service = 'temporary-accommodation' and cancellations.id is null and arrival_date <= :endDate and departure_date >= :startDate and arrival_date != departure_date),
+ bedspace_bookings as (select 
+                        bedspaces.id as bed_id,
+                        premises_name,
+                        room_name,
+                        probation_region,
+                        pdu_name,
+                        arrival_date,
+                        departure_date,
+                        turnaround_days
+                 from bedspaces
+                 inner join all_bookings on bedspaces.id = all_bookings.bed_id
+                 order by premises_name,room_name,arrival_date),
+ bedspace_voids as(select
+                     bedspace_id as bed_id,
+                     premises_name,
+                     room_name,
+                     probation_region,
+                     pdu_name,
+                     voids.start_date,
+                     voids.end_date
+                  from cas3_void_bedspaces voids
+                  inner join bedspaces on voids.bedspace_id = bedspaces.id
+                  where voids.start_date <= :endDate and voids.end_date >= :startDate
+ ),
+ bedspace_unavailable_dates as(
+    select
+        bed_id,
+        premises_name,
+        room_name,
+        probation_region,
+        pdu_name,
+        arrival_date as start_date,
+        departure_date as end_date,
+        turnaround_days
+    from bedspace_bookings
+    where arrival_date is not null and departure_date is not null
+    union all
+    select bedspace_voids.*, 0 as turnaround_days
+    from bedspace_voids),
+ bedspace_unavailable_ranges as (select
+                                   bed_id,
+                                   probation_region,
+                                   pdu_name,
+                                   premises_name,
+                                   room_name,
+                                   range_agg(daterange(start_date, end_date,'[]')) as unavailable_days_range,
+                                   range_agg(daterange(start_date, end_date-1,'[]')) as unavailable_days,
+                                   lower(range_agg(daterange(start_date, end_date))) as date_min,
+                                   upper(range_agg(daterange(start_date, end_date))) as date_max
+                               from bedspace_unavailable_dates
+                               where start_date != end_date
+                               group by bed_id,probation_region, pdu_name, premises_name, room_name
+                               order by bed_id,probation_region, pdu_name, premises_name, room_name),
+bedspace_gaps as (select
+                   probation_region,
+                   pdu_name,
+                   premises_name,
+                   room_name,
+                   unnest(multirange(daterange(least(date_min,:startDate), greatest(date_max,:endDate))) - unavailable_days_range) as gap_range,
+                   unnest(multirange(daterange(least(date_min,:startDate), greatest(date_max,:endDate))) - unavailable_days) as gap
+               from bedspace_unavailable_ranges
+               union all
+               -- bedspace do not have bookings or voids during the report period
+               select
+                   probation_region,
+                   pdu_name,
+                   premises_name,
+                   room_name,
+                   daterange(:startDate,:endDate) as gap_range,
+                   daterange(:startDate,:endDate) as gap
+               from bedspaces
+               where bedspaces.id not in (select bed_id from bedspace_bookings)
+                 and bedspaces.id not in (select bed_id from bedspace_voids)),
+bedspace_gaps_and_days as (select distinct
+                            bedspace_gaps.probation_region,
+                            bedspace_gaps.pdu_name,
+                            bedspace_gaps.premises_name,
+                            bedspace_gaps.room_name as bed_name,
+                            coalesce(bedspace_gaps.gap_range,bedspace_gaps.gap)::text as gap,
+                            case
+                                when upper(gap) = :endDate then upper(gap) + 1
+                                else upper(gap)
+                                end -
+                            case
+                                when lower(gap) = :startDate then lower(gap)
+                                else lower(gap) + 1
+                                end as gap_days,
+                                (select turnaround_days
+                                    from bedspace_bookings
+                                    where bedspace_bookings.premises_name = bedspace_gaps.premises_name and bedspace_bookings.room_name = bedspace_gaps.room_name
+                                    limit 1
+                                    ) as turnaround_days
+                        from bedspace_gaps)
+
+select *
+from bedspace_gaps_and_days
+where gap_days > 0
+order by probation_region,pdu_name,premises_name,bed_name,gap
+""".trimIndent()
+
 @Repository
 class Cas3BookingGapReportRepository(
   val reportJdbcTemplate: ReportJdbcTemplate,
@@ -149,6 +278,19 @@ class Cas3BookingGapReportRepository(
     jbdcResultSetConsumer: JdbcResultSetConsumer,
   ) = reportJdbcTemplate.query(
     GAP_RANGES_QUERY.trimIndent(),
+    mapOf<String, Any>(
+      "startDate" to startDate,
+      "endDate" to endDate,
+    ),
+    jbdcResultSetConsumer,
+  )
+
+  fun generateBookingGapReportV2(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    jbdcResultSetConsumer: JdbcResultSetConsumer,
+  ) = reportJdbcTemplate.query(
+    GAP_RANGES_QUERY_V2.trimIndent(),
     mapOf<String, Any>(
       "startDate" to startDate,
       "endDate" to endDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ReportService.kt
@@ -250,11 +250,18 @@ class Cas3ReportService(
     CsvJdbcResultSetConsumer(
       outputStream = outputStream,
     ).use { consumer ->
-      cas3BookingGapReportRepository.generateBookingGapReport(
-        properties.startDate,
-        properties.endDate,
-        consumer,
-      )
+      when (featureFlagService.getBooleanFlag("cas3-reports-with-new-bedspace-model-tables-enabled")) {
+        true -> cas3BookingGapReportRepository.generateBookingGapReportV2(
+          properties.startDate,
+          properties.endDate,
+          consumer,
+        )
+        false -> cas3BookingGapReportRepository.generateBookingGapReport(
+          properties.startDate,
+          properties.endDate,
+          consumer,
+        )
+      }
     }
   }
 


### PR DESCRIPTION
**PR includes:**
* Refactor the `GET /cas3/reports/{reportName}` endpoint for the `bookingGap` report type
* uses the `cas3-reports-with-new-bedspace-model-tables-enabled` feature-flag to determine whether to execute a query against the new `Bedspace model refactor` tables (or to execute against the tables currently queried in production when feature-flag off)
* executes the old or new query accordingly
* test coverage for the report against the new tables
