### PR TITLE
chore: Prevent pipeline concurrency cancellation on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   gradle_build:


### PR DESCRIPTION
This will prevent newer pipelines from cancelling those that are already running when on the main branch.

This is already in place in the UI repositories: https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/main/.github/workflows/test.yml#L11

